### PR TITLE
Updated Halt task to resume on first pass if set

### DIFF
--- a/src/core/Elsa.Core/Results/HaltResult.cs
+++ b/src/core/Elsa.Core/Results/HaltResult.cs
@@ -25,7 +25,7 @@ namespace Elsa.Results
             if (workflowContext.IsFirstPass && ContinueOnFirstPass)
             {
                 var activityInvoker = workflowContext.ServiceProvider.GetRequiredService<IActivityInvoker>();
-                var result = await activityInvoker.ExecuteAsync(workflowContext, activity, cancellationToken);
+                var result = await activityInvoker.ResumeAsync(workflowContext, activity, cancellationToken);
                 
                 workflowContext.IsFirstPass = false;
 


### PR DESCRIPTION
When continue on first pass is set, the workflow should resume instead of execute the halt task again.