### PR TITLE
Fixed bug where multiple activity registrations of the same type would cause duplicate key exception

### DIFF
--- a/src/core/Elsa.Core/Services/ActivityResolver.cs
+++ b/src/core/Elsa.Core/Services/ActivityResolver.cs
@@ -18,7 +18,7 @@ namespace Elsa.Services
                 () =>
                 {
                     var activities = activitiesFunc();
-                    return activities.Select(x => x.GetType()).ToDictionary(x => x.Name);
+                    return activities.Select(x => x.GetType()).Distinct().ToDictionary(x => x.Name);
                 });
         }
 

--- a/src/samples/Sample12/Program.cs
+++ b/src/samples/Sample12/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Elsa.Activities.Console.Extensions;
@@ -48,7 +48,6 @@ namespace Sample12
             return new ServiceCollection()
                 .AddElsa()
                 .AddConsoleActivities()
-                .AddUserTaskActivities()
                 .AddWorkflow<UserTaskWorkflow>()
                 .BuildServiceProvider();
         }


### PR DESCRIPTION
To reproduce, run Sample12 on 1.1.1 branch and you'll get a duplicate key exception.

The registration was being performed twice, once by AddElsa() and again by AddUserTasks(). You could probably remove the AddUserTasks() extension method altogether.