### PR TITLE
Fixed issue where named activities couldn't be used with Then()

### DIFF
--- a/src/core/Elsa.Core/WorkflowBuilders/WorkflowBuilder.cs
+++ b/src/core/Elsa.Core/WorkflowBuilders/WorkflowBuilder.cs
@@ -80,7 +80,7 @@ namespace Elsa.WorkflowBuilders
             var activityBuilder = new ActivityBuilder(this, activityBlueprint);
             var activityDescriptor = ActivityDescriber.Describe<T>();
             
-            activity.Name = name;
+            activityBuilder.Name = name;
             activityBuilder.DisplayName = activityDescriptor.DisplayName;
             activityBuilder.Description = activityDescriptor.Description;
             activityBuilders.Add(activityBuilder);


### PR DESCRIPTION
To reproduce, run Sample12 after pulling in previous PR. You'll get a "sequence contains no elements" error.