### PR TITLE
Improve expression evaluation

### DIFF
--- a/src/scripting/Elsa.Scripting.JavaScript/Services/JavaScriptExpressionEvaluator.cs
+++ b/src/scripting/Elsa.Scripting.JavaScript/Services/JavaScriptExpressionEvaluator.cs
@@ -110,6 +110,10 @@ namespace Elsa.Scripting.JavaScript.Services
             {
                 var obj = value.AsObject().ToObject();
                 var type = targetType ?? obj.GetType();
+
+                if (type == typeof(string))
+                    return Convert.ToString(obj);
+                
                 var json = JsonConvert.SerializeObject(obj, serializerSettings);
                 return JsonConvert.DeserializeObject(json, type, serializerSettings);
             }


### PR DESCRIPTION
- Checks if the target type is a string while the source type is an object, in which case the object is converted to its string representation instead of trying to be deserialized.
- Adds exception handling around expression evaluation.