### PR TITLE
Message correlation

### DIFF
--- a/src/core/Elsa.Core/Persistence/Memory/MemoryWorkflowInstanceStore.cs
+++ b/src/core/Elsa.Core/Persistence/Memory/MemoryWorkflowInstanceStore.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -10,7 +11,7 @@ namespace Elsa.Persistence.Memory
     public class MemoryWorkflowInstanceStore : IWorkflowInstanceStore
     {
         private readonly IDictionary<string, WorkflowInstance> workflowInstances =
-            new Dictionary<string, WorkflowInstance>();
+            new ConcurrentDictionary<string, WorkflowInstance>();
 
         public Task SaveAsync(WorkflowInstance instance, CancellationToken cancellationToken)
         {
@@ -51,7 +52,7 @@ namespace Elsa.Persistence.Memory
             var query = workflowInstances.Values.AsQueryable();
 
             query = query.Where(x => x.Status == WorkflowStatus.Executing);
-            
+
             if (!string.IsNullOrWhiteSpace(correlationId))
                 query = query.Where(x => x.CorrelationId == correlationId);
 
@@ -63,7 +64,7 @@ namespace Elsa.Persistence.Memory
         }
 
         public Task<IEnumerable<WorkflowInstance>> ListByStatusAsync(
-            string definitionId, 
+            string definitionId,
             WorkflowStatus status,
             CancellationToken cancellationToken)
         {

--- a/src/samples/Sample08/Messages/CreateOrder.cs
+++ b/src/samples/Sample08/Messages/CreateOrder.cs
@@ -1,9 +1,13 @@
+using System;
 using Sample08.Models;
 
 namespace Sample08.Messages
 {
     public class CreateOrder
     {
+        // Convention based property for message correlation
+        // https://masstransit-project.com/MassTransit/usage/messages.html#message-correlation
+        public Guid CorrelationId { get; set; }
         public Order Order { get; set; }
     }
 }

--- a/src/samples/Sample08/Messages/OrderShipped.cs
+++ b/src/samples/Sample08/Messages/OrderShipped.cs
@@ -1,9 +1,13 @@
+using System;
 using Sample08.Models;
 
 namespace Sample08.Messages
 {
     public class OrderShipped
     {
+        // Convention based property for message correlation
+        // https://masstransit-project.com/MassTransit/usage/messages.html#message-correlation
+        public Guid CorrelationId { get; set; }
         public Order Order { get; set; }
     }
 }

--- a/src/samples/Sample08/Workflows/CreateOrderWorkflow.cs
+++ b/src/samples/Sample08/Workflows/CreateOrderWorkflow.cs
@@ -7,6 +7,7 @@ using Elsa.Activities.Http.Activities;
 using Elsa.Activities.MassTransit.Activities;
 using Elsa.Activities.ControlFlow;
 using Elsa.Activities.ControlFlow.Activities;
+using Elsa.Activities.Workflows.Activities;
 using Elsa.Expressions;
 using Elsa.Scripting.JavaScript;
 using Elsa.Services;
@@ -35,9 +36,10 @@ namespace Sample08.Workflows
                         activity.ValueExpression = new JavaScriptExpression<object>("lastResult().Content");
                     }
                 )
+                .Then<Correlate>(activity => activity.ValueExpression = new LiteralExpression(Guid.NewGuid().ToString("N")))
                 .Then<SendMassTransitMessage>(activity =>
                     {
-                        activity.Message = new JavaScriptExpression<CreateOrder>("return {order: order};");
+                        activity.Message = new JavaScriptExpression<CreateOrder>("return { correlationId: correlationId(), order: order};");
                         activity.MessageType = typeof(CreateOrder);
                     }
                 )


### PR DESCRIPTION
Looks like it is really important to correlate MassTransit messages to workflow instances. I have updated the demo to show this, as I ran a few in parallel and several errors were occurring.