### PR TITLE
Changed Variables.cs to full IDictionary with ConcurrentDictionary<string, object> backing-store

### DIFF
--- a/src/core/Elsa.Abstractions/Models/Variables.cs
+++ b/src/core/Elsa.Abstractions/Models/Variables.cs
@@ -1,12 +1,32 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace Elsa.Models
 {
-    public class Variables : Dictionary<string, JToken>
+    public class Variables : IDictionary<string, JToken>
     {
         public static readonly Variables Empty = new Variables();
+        private ConcurrentDictionary<string, object> objects = new ConcurrentDictionary<string, object>();
+
+        public ICollection<string> Keys => objects.Keys;
+
+        public ICollection<JToken> Values
+        {
+            get
+            {
+                return objects.Values.Select(o => GetJToken(o)).ToList();
+            }
+        }
+
+        public int Count => objects.Count;
+
+        public bool IsReadOnly => false;
+
 
         public Variables()
         {
@@ -24,24 +44,80 @@ namespace Elsa.Models
             }
         }
 
+        public JToken this[string key]
+        {
+            get
+            {
+                return GetJToken(key);
+            }
+            set
+            {
+                Set(key, value);
+            }
+        }
+
+        private void Set(string key, object value)
+        {
+            objects.TryAdd(key, value);
+        }
+
+        private JToken GetJToken(string key)
+        {
+            object value;
+            JToken token;
+            objects.TryGetValue(key, out value);
+
+            if (value != null && value.GetType() != typeof(JToken))
+                token = JToken.FromObject(value);
+            else
+                token = (JToken)value;
+
+            return token;
+        }
+
+        private JToken GetJToken(object value)
+        {
+            JToken token;
+           
+            if (value != null && value.GetType() != typeof(JToken))
+                token = JToken.FromObject(value);
+            else
+                token = (JToken)value;
+
+            return token;
+        }
+
+        public bool ContainsKey(string key)
+        {
+            return objects.ContainsKey(key);
+        }
+
         public JToken GetVariable(string name)
         {
             return ContainsKey(name) ? this[name] : default;
         }
 
+        public object GetVariable(string name, Type type)
+        {
+            object value;
+            objects.TryGetValue(name, out value);
+            return value == null ? default : value;
+        }
+
         public T GetVariable<T>(string name)
         {
-            var value = ContainsKey(name) ? this[name] : default;
-
-            return value == null ? default : value.ToObject<T>();
+            object value;
+            objects.TryGetValue(name, out value);
+            return value == null ? default : (T)value;
         }
 
         public JToken SetVariable(string name, object value)
         {
-            return this[name] = JToken.FromObject(value);
+            objects.TryAdd(name, value);
+            return GetJToken(value);
         }
 
-        public void SetVariables(Variables variables) => 
+        public void SetVariables(Variables variables) =>
             SetVariables((IEnumerable<KeyValuePair<string, JToken>>)variables);
 
         public void SetVariables(IEnumerable<KeyValuePair<string, JToken>> variables)
@@ -53,6 +129,81 @@ namespace Elsa.Models
         public bool HasVariable(string name)
         {
             return ContainsKey(name);
+        }
+
+        public void Add(string key, JToken value)
+        {
+            Set(key, value);
+        }
+
+        bool IDictionary<string, JToken>.ContainsKey(string key)
+        {
+            return objects.ContainsKey(key);
+        }
+
+        public bool Remove(string key)
+        {
+            object outRemove;
+            return objects.TryRemove(key, out outRemove);
+        }
+
+        public bool TryGetValue(string key, out JToken value)
+        {
+            object valueObject;
+            bool found = objects.TryGetValue(key, out valueObject);
+
+            if (found)
+                value = GetJToken(valueObject);
+            else
+                value = null;
+
+            return found;
+        }
+
+        public void Add(KeyValuePair<string, JToken> item)
+        {
+            objects.TryAdd(item.Key, item.Value);
+        }
+
+        public void Clear()
+        {
+            objects.Clear();
+        }
+
+        public bool Contains(KeyValuePair<string, JToken> item)
+        {
+            KeyValuePair<string, object> searchItem = new KeyValuePair<string, object>(item.Key, item.Value);
+            return objects.Contains(searchItem);
+        }
+
+        public void CopyTo(KeyValuePair<string, JToken>[] array, int arrayIndex)
+        {
+            var newArray =
+            objects.Select(
+                kv =>
+                new KeyValuePair<string, JToken>(kv.Key, GetJToken(kv.Key))
+                ).ToArray();
+
+            newArray.CopyTo(array, arrayIndex);
+        }
+
+        public bool Remove(KeyValuePair<string, JToken> item)
+        {
+            object removeObject;
+            return objects.TryRemove(item.Key, out removeObject);
+        }
+
+        public IEnumerator<KeyValuePair<string, JToken>> GetEnumerator()
+        {
+            return objects.Select(
+                  kv =>
+                  new KeyValuePair<string, JToken>(kv.Key, GetJToken(kv.Key))
+                  ).GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
         }
     }
 }

--- a/src/core/Elsa.Abstractions/Models/WorkflowExecutionScope.cs
+++ b/src/core/Elsa.Abstractions/Models/WorkflowExecutionScope.cs
@@ -12,11 +12,7 @@ namespace Elsa.Models
         public JToken LastResult { get; set; }
         public Variables Variables { get; }
 
-        public void SetVariable(string variableName, object value)
-        {
-            Variables[variableName] = JToken.FromObject(value);
-        }
-
+        public void SetVariable(string variableName, object value) => Variables.SetVariable(variableName, value);
         public T GetVariable<T>(string name) => Variables.GetVariable<T>(name);
         public JToken GetVariable(string name) => Variables.GetVariable(name);
     }


### PR DESCRIPTION
Changed Variables.cs to full IDictionary with ConcurrentDictionary<string, object> backing-store
This should be a 1:1 drop in and work even in resumed flows.
Now i get objects (the originals) and you get JTokens *CoughSweat*

BTW i think it may perform better because convert to jtoken is only done when needed. (Dont kill me if not)

This should even be a lit more thread-safe - (there should be some locks somewhere i think to be 100% safe....)

Lotsa shoulds... :-D Could you give it a look please? This would straighten the GetVariable mess in my flows and reduces converts a lot...