### PR TITLE
Added lastExpressionResult() javascript function #180

### DIFF
--- a/src/core/Elsa.Abstractions/Models/WorkflowExecutionScope.cs
+++ b/src/core/Elsa.Abstractions/Models/WorkflowExecutionScope.cs
@@ -8,6 +8,7 @@ namespace Elsa.Models
         }
 
         public Variable LastResult { get; set; }
+        public Variable LastExpressionResult { get; set; }
         public Variables Variables { get; }
 
         public void SetVariable(string variableName, object value) => Variables.SetVariable(variableName, value);

--- a/src/core/Elsa.Abstractions/Services/Models/WorkflowExecutionContext.cs
+++ b/src/core/Elsa.Abstractions/Services/Models/WorkflowExecutionContext.cs
@@ -83,6 +83,8 @@ namespace Elsa.Services.Models
         public void SetLastResult(object value) => SetLastResult(new Variable(value));
         public void SetLastResult(Variable value) => CurrentScope.LastResult = value;
 
+        public void SetLastExpressionResult(object value) => CurrentScope.LastExpressionResult = new Variable(value);
+
         public void Start()
         {
             Workflow.StartedAt = clock.GetCurrentInstant();

--- a/src/core/Elsa.Core/Expressions/LiteralEvaluator.cs
+++ b/src/core/Elsa.Core/Expressions/LiteralEvaluator.cs
@@ -20,9 +20,14 @@ namespace Elsa.Expressions
         public Task<object> EvaluateAsync(string expression, Type type, WorkflowExecutionContext workflowExecutionContext, CancellationToken cancellationToken)
         {
             if (string.IsNullOrWhiteSpace(expression))
+            {
+                workflowExecutionContext.SetLastExpressionResult(default(object));
                 return Task.FromResult(default(object));
-            
-            return Task.FromResult(expression.Parse(type));
+            }
+
+            object convertedResult = expression.Parse(type);
+            workflowExecutionContext.SetLastExpressionResult(convertedResult);
+            return Task.FromResult(convertedResult);
         }
     }
 }

--- a/src/scripting/Elsa.Scripting.JavaScript/Handlers/CommonJavaScriptEngineHandler.cs
+++ b/src/scripting/Elsa.Scripting.JavaScript/Handlers/CommonJavaScriptEngineHandler.cs
@@ -21,6 +21,7 @@ namespace Elsa.Scripting.JavaScript.Handlers
             engine.SetValue("input", (Func<string, object>) (name => workflow.Input.GetVariable(name)));
             engine.SetValue("variable", (Func<string, object>) (name => executionContext.CurrentScope.GetVariable(name)));
             engine.SetValue("lastResult", (Func<string, object>) (name => executionContext.CurrentScope.LastResult?.Value));
+            engine.SetValue("lastExpressionResult", (Func<string, object>) (name => executionContext.CurrentScope.LastExpressionResult?.Value));
             engine.SetValue("correlationId", (Func<object>) (() => executionContext.Workflow.CorrelationId));
             engine.SetValue("currentCulture", (Func<object>) (() => CultureInfo.InvariantCulture));
             engine.SetValue("newGuid", (Func<string>) (() => Guid.NewGuid().ToString()));

--- a/src/scripting/Elsa.Scripting.JavaScript/Services/JavaScriptExpressionEvaluator.cs
+++ b/src/scripting/Elsa.Scripting.JavaScript/Services/JavaScriptExpressionEvaluator.cs
@@ -49,7 +49,10 @@ namespace Elsa.Scripting.JavaScript.Services
             await ConfigureEngineAsync(engine, workflowExecutionContext, cancellationToken);
             engine.Execute(expression);
 
-            return ConvertValue(engine.GetCompletionValue(), type);
+            object convertedResult = ConvertValue(engine.GetCompletionValue(), type);
+            workflowExecutionContext.SetLastExpressionResult(convertedResult);
+
+            return convertedResult;
         }
 
         private async Task ConfigureEngineAsync(Engine engine, WorkflowExecutionContext workflowExecutionContext, CancellationToken cancellationToken)

--- a/src/scripting/Elsa.Scripting.Liquid/Services/LiquidExpressionEvaluator.cs
+++ b/src/scripting/Elsa.Scripting.Liquid/Services/LiquidExpressionEvaluator.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Elsa.Scripting.Liquid.Extensions;
@@ -28,7 +28,9 @@ namespace Elsa.Scripting.Liquid.Services
         {
             var templateContext = await CreateTemplateContextAsync(workflowExecutionContext);
             var result = await liquidTemplateManager.RenderAsync(expression, templateContext);
-            return string.IsNullOrWhiteSpace(result) ? default : type != null ? Convert.ChangeType(result, type) : result;
+            object convertedResult = string.IsNullOrWhiteSpace(result) ? default : type != null ? Convert.ChangeType(result, type) : result;
+            workflowExecutionContext.SetLastExpressionResult(convertedResult);
+            return convertedResult;
         }
 
         private async Task<TemplateContext> CreateTemplateContextAsync(WorkflowExecutionContext workflowContext)


### PR DESCRIPTION
Not sure if there's a nicer way to get the Evaluators to set the last expression result other than copying in to each evaluate function.

Tested all existing evaluators with following workflow snippet:
```
.Then<WriteLine>(x => x.TextExpression = new LiteralExpression("literal"))
.Then<WriteLine>(x => x.TextExpression = new JavaScriptExpression<string>("'Last expression: ' + lastExpressionResult()"))

.Then<WriteLine>(x => x.TextExpression = new LiquidExpression<string>("liquid"))
.Then<WriteLine>(x => x.TextExpression = new JavaScriptExpression<string>("'Last expression: ' + lastExpressionResult()"))

.Then<WriteLine>(x => x.TextExpression = new JavaScriptExpression<string>("'javascript'"))
.Then<WriteLine>(x => x.TextExpression = new JavaScriptExpression<string>("'Last expression: ' + lastExpressionResult()"))
```

Output:
```
literal
Last expression: literal
liquid
Last expression: liquid
javascript
Last expression: javascript
```