### PR TITLE
Add Dockerfile and docker-compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+﻿.git
+.idea
+node_modules
+*/samples*
+*/doc*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM mcr.microsoft.com/dotnet/core/sdk:3.0 AS build-env
+WORKDIR /app
+
+COPY . ./
+
+WORKDIR /app/src/dashboard/Elsa.Dashboard/Theme/argon-dashboard
+
+RUN apt-get update -yq \
+    && apt-get install build-essential -y \
+    && apt-get install curl gnupg -yq \
+    && curl -sL https://deb.nodesource.com/setup_10.x | bash \
+    && apt-get install nodejs -yq
+
+RUN npm install
+RUN npm install --global gulp-cli
+RUN npm rebuild node-sass --force
+RUN gulp build
+
+WORKDIR /app
+RUN dotnet publish Elsa.sln -c Release -o out
+
+FROM mcr.microsoft.com/dotnet/core/aspnet:3.0
+WORKDIR /app
+COPY --from=build-env /app/out .
+ENTRYPOINT ["dotnet", "Elsa.Dashboard.Web.dll"]

--- a/Elsa.sln
+++ b/Elsa.sln
@@ -13,6 +13,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "solution", "solution", "{71
 		.gitignore = .gitignore
 		Nuget.Config = Nuget.Config
 		README.md = README.md
+		.dockerignore = .dockerignore
+		docker-compose.yaml = docker-compose.yaml
+		Dockerfile = Dockerfile
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Elsa.Abstractions", "src\core\Elsa.Abstractions\Elsa.Abstractions.csproj", "{3130C574-557C-4DA2-933E-AED7A9EBE48A}"
@@ -66,6 +69,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Activities.Workflows", "src\activities\Elsa.Activities.Workflows\Elsa.Activities.Workflows.csproj", "{1BB8EC9E-AEBD-438B-9FA7-B7FA78999D7D}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa", "src\core\Elsa\Elsa.csproj", "{ED2A4FE5-821B-46F7-B72F-E66DE0D66C93}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Dashboard.Web", "src\dashboard\Elsa.Dashboard.Web\Elsa.Dashboard.Web.csproj", "{7179277B-E692-43CA-8243-3FE4FC2DD1EA}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -157,6 +162,10 @@ Global
 		{ED2A4FE5-821B-46F7-B72F-E66DE0D66C93}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{ED2A4FE5-821B-46F7-B72F-E66DE0D66C93}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{ED2A4FE5-821B-46F7-B72F-E66DE0D66C93}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7179277B-E692-43CA-8243-3FE4FC2DD1EA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7179277B-E692-43CA-8243-3FE4FC2DD1EA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7179277B-E692-43CA-8243-3FE4FC2DD1EA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7179277B-E692-43CA-8243-3FE4FC2DD1EA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -189,6 +198,7 @@ Global
 		{3FC85C9D-CC20-4F54-9936-029F19FBFBE1} = {B43B546E-23F3-46E8-ACB7-D04F05CDA180}
 		{1BB8EC9E-AEBD-438B-9FA7-B7FA78999D7D} = {B43B546E-23F3-46E8-ACB7-D04F05CDA180}
 		{ED2A4FE5-821B-46F7-B72F-E66DE0D66C93} = {35F44BE9-13D0-417C-A01A-F0787BEE6DC3}
+		{7179277B-E692-43CA-8243-3FE4FC2DD1EA} = {8B87D79A-F0DE-4F88-81D3-8C8C69108ADB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8B0975FD-7050-48B0-88C5-48C33378E158}

--- a/Samples.sln
+++ b/Samples.sln
@@ -13,6 +13,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "solution", "solution", "{71
 		.gitignore = .gitignore
 		Nuget.Config = Nuget.Config
 		README.md = README.md
+		docker-compose.yaml = docker-compose.yaml
+		Dockerfile = Dockerfile
+		.dockerignore = .dockerignore
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Elsa.Abstractions", "src\core\Elsa.Abstractions\Elsa.Abstractions.csproj", "{3130C574-557C-4DA2-933E-AED7A9EBE48A}"

--- a/Samples.sln
+++ b/Samples.sln
@@ -111,6 +111,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Activities.Reflection"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sample20", "src\samples\Sample20\Sample20.csproj", "{9B238B75-5A68-48B1-973A-59F0EFAB0A8B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Dashboard.Web", "src\dashboard\Elsa.Dashboard.Web\Elsa.Dashboard.Web.csproj", "{AE0363D2-3630-4CDD-86A1-7D6A717361BD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -285,6 +287,10 @@ Global
 		{9B238B75-5A68-48B1-973A-59F0EFAB0A8B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9B238B75-5A68-48B1-973A-59F0EFAB0A8B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9B238B75-5A68-48B1-973A-59F0EFAB0A8B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AE0363D2-3630-4CDD-86A1-7D6A717361BD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AE0363D2-3630-4CDD-86A1-7D6A717361BD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AE0363D2-3630-4CDD-86A1-7D6A717361BD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AE0363D2-3630-4CDD-86A1-7D6A717361BD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -339,6 +345,7 @@ Global
 		{2AEA0028-96D6-4823-A88F-24294E4BA4E8} = {5E5E1E84-DDBC-40D6-B891-0D563A15A44A}
 		{258F624E-98D7-4498-AE2E-F612D8ECA763} = {B43B546E-23F3-46E8-ACB7-D04F05CDA180}
 		{9B238B75-5A68-48B1-973A-59F0EFAB0A8B} = {5E5E1E84-DDBC-40D6-B891-0D563A15A44A}
+		{AE0363D2-3630-4CDD-86A1-7D6A717361BD} = {0DF567E8-2A21-4A1C-90E8-025F1EC615F3}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8B0975FD-7050-48B0-88C5-48C33378E158}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,24 @@
+version: '3.7'
+
+services:
+    elsa-dashboard:
+        build: .
+        environment:
+            - Elsa:Smtp:Host=smtp4dev
+            - ConnectionStrings:MongoDb=mongodb://mongodb
+        ports:
+            - "22174:80"
+#        depends_on:
+#            - mongodb
+#            - smtp4dev
+
+    mongodb:
+        image: mongo
+        ports:
+            - "27017:27017"
+
+    smtp4dev:
+        image: opvolger/rnwoodsmtp4dev
+        ports:a
+            - "3000:80"
+            - "2525:25"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,9 +8,9 @@ services:
             - ConnectionStrings:MongoDb=mongodb://mongodb
         ports:
             - "22174:80"
-#        depends_on:
-#            - mongodb
-#            - smtp4dev
+        depends_on:
+            - mongodb
+            - smtp4dev
 
     mongodb:
         image: mongo
@@ -19,6 +19,6 @@ services:
 
     smtp4dev:
         image: opvolger/rnwoodsmtp4dev
-        ports:a
+        ports:
             - "3000:80"
             - "2525:25"

--- a/src/activities/Elsa.Activities.Dropbox/Elsa.Activities.Dropbox.csproj
+++ b/src/activities/Elsa.Activities.Dropbox/Elsa.Activities.Dropbox.csproj
@@ -23,7 +23,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Http" Version="3.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Http" Version="3.0.1" />
     </ItemGroup>
     
 </Project>

--- a/src/activities/Elsa.Activities.Http/Elsa.Activities.Http.csproj
+++ b/src/activities/Elsa.Activities.Http/Elsa.Activities.Http.csproj
@@ -31,7 +31,7 @@
         <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
         <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
-        <PackageReference Include="Microsoft.Extensions.Http" Version="3.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="3.0.1" />
     </ItemGroup>
 
 </Project>

--- a/src/activities/Elsa.Activities.Timers/Elsa.Activities.Timers.csproj
+++ b/src/activities/Elsa.Activities.Timers/Elsa.Activities.Timers.csproj
@@ -25,7 +25,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.0.1" />
         <PackageReference Include="NCrontab" Version="3.3.1" />
     </ItemGroup>
 

--- a/src/core/Elsa.Abstractions/Elsa.Abstractions.csproj
+++ b/src/core/Elsa.Abstractions/Elsa.Abstractions.csproj
@@ -18,10 +18,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="3.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Primitives" Version="3.0.0" />
-      <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.0.1" />
+      <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="3.0.1" />
+      <PackageReference Include="Microsoft.Extensions.Primitives" Version="3.0.1" />
+      <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
       <PackageReference Include="NodaTime" Version="3.0.0-beta01" />
       <PackageReference Include="NodaTime.Serialization.JsonNet" Version="2.2.0" />
       <PackageReference Include="System.ComponentModel.Annotations" Version="4.6.0" />

--- a/src/core/Elsa.Core/Elsa.Core.csproj
+++ b/src/core/Elsa.Core/Elsa.Core.csproj
@@ -25,14 +25,14 @@
         <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="7.0.0" />
         <PackageReference Include="Microsoft.AspNetCore.Hosting.Server.Abstractions" Version="2.2.0" />
         <PackageReference Include="Microsoft.CSharp" Version="4.6.0" />
-        <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="3.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.0.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Localization" Version="3.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="3.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.0.1" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Localization" Version="3.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.0.1" />
         <PackageReference Include="NodaTime.Serialization.JsonNet" Version="2.2.0" />
         <PackageReference Include="Elsa.Scrutor" Version="3.0.2.26" />
 

--- a/src/dashboard/Elsa.Dashboard.Web/Elsa.Dashboard.Web.csproj
+++ b/src/dashboard/Elsa.Dashboard.Web/Elsa.Dashboard.Web.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.0</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\core\Elsa\Elsa.csproj" />
+        <ProjectReference Include="..\..\dashboard\Elsa.Dashboard\Elsa.Dashboard.csproj" />
+        <ProjectReference Include="..\..\persistence\Elsa.Persistence.MongoDb\Elsa.Persistence.MongoDb.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/dashboard/Elsa.Dashboard.Web/Program.cs
+++ b/src/dashboard/Elsa.Dashboard.Web/Program.cs
@@ -1,15 +1,9 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 
 namespace Elsa.Dashboard.Web
 {
-    public class Program
+    public static class Program
     {
         public static void Main(string[] args)
         {

--- a/src/dashboard/Elsa.Dashboard.Web/Program.cs
+++ b/src/dashboard/Elsa.Dashboard.Web/Program.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Elsa.Dashboard.Web
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder => { webBuilder.UseStartup<Startup>(); });
+    }
+}

--- a/src/dashboard/Elsa.Dashboard.Web/Properties/launchSettings.json
+++ b/src/dashboard/Elsa.Dashboard.Web/Properties/launchSettings.json
@@ -1,0 +1,27 @@
+﻿{
+  "iisSettings": {
+    "windowsAuthentication": false, 
+    "anonymousAuthentication": true, 
+    "iisExpress": {
+      "applicationUrl": "http://localhost:22174",
+      "sslPort": 44332
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "Elsa.Dashboard.Web": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:22174",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/dashboard/Elsa.Dashboard.Web/README.md
+++ b/src/dashboard/Elsa.Dashboard.Web/README.md
@@ -1,0 +1,3 @@
+﻿# Elsa Dashboard
+
+This is a sample implementation of an ASP.NET Core application hosting both the Elsa Dashboard as well as Elsa services that trigger workflows.

--- a/src/dashboard/Elsa.Dashboard.Web/README.md
+++ b/src/dashboard/Elsa.Dashboard.Web/README.md
@@ -1,3 +1,6 @@
 ﻿# Elsa Dashboard
 
 This is a sample implementation of an ASP.NET Core application hosting both the Elsa Dashboard as well as Elsa services that trigger workflows.
+
+## Running the Project
+To run this project, make sure you have a MongoDB and SMTP host running. If not, then the easiest way is to run `docker compose up`.

--- a/src/dashboard/Elsa.Dashboard.Web/Startup.cs
+++ b/src/dashboard/Elsa.Dashboard.Web/Startup.cs
@@ -1,0 +1,53 @@
+using Elsa.Activities.Email.Extensions;
+using Elsa.Activities.Http.Extensions;
+using Elsa.Activities.Timers.Extensions;
+using Elsa.Dashboard.Extensions;
+using Elsa.Persistence.MongoDb.Extensions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Elsa.Dashboard.Web
+{
+    public class Startup
+    {
+        public Startup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        public void ConfigureServices(IServiceCollection services)
+        {
+            var elsaSection = Configuration.GetSection("Elsa");
+            
+            services
+                // Add workflow services.
+                .AddElsa(x => x.AddMongoDbStores(Configuration, "Elsa", "MongoDb"))
+                
+                // Add activities we'd like to use.
+                .AddHttpActivities(options => options.Bind(elsaSection.GetSection("Http")))
+                .AddEmailActivities(options => options.Bind(elsaSection.GetSection("Smtp")))
+                .AddTimerActivities(options => options.Bind(elsaSection.GetSection("BackgroundRunner")))
+                
+                // Add Dashboard services.
+                .AddElsaDashboard();
+        }
+
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            if (env.IsDevelopment()) 
+                app.UseDeveloperExceptionPage();
+
+            app
+                .UseStaticFiles()
+                .UseHttpActivities()
+                .UseRouting()
+                .UseEndpoints(endpoints => endpoints.MapControllers())
+                .UseWelcomePage();
+        }
+    }
+}

--- a/src/dashboard/Elsa.Dashboard.Web/Startup.cs
+++ b/src/dashboard/Elsa.Dashboard.Web/Startup.cs
@@ -29,6 +29,8 @@ namespace Elsa.Dashboard.Web
                 .AddElsa(x => x.AddMongoDbStores(Configuration, "Elsa", "MongoDb"))
                 
                 // Add activities we'd like to use.
+                // Configuring the activities as is done here is only required if we want to be able to actually run workflows form this application.
+                // Otherwise it's only necessary to register activities for the workflow designer to discover.
                 .AddHttpActivities(options => options.Bind(elsaSection.GetSection("Http")))
                 .AddEmailActivities(options => options.Bind(elsaSection.GetSection("Smtp")))
                 .AddTimerActivities(options => options.Bind(elsaSection.GetSection("BackgroundRunner")))
@@ -43,8 +45,10 @@ namespace Elsa.Dashboard.Web
                 app.UseDeveloperExceptionPage();
 
             app
-                .UseStaticFiles()
+                // This is only necessary if we want to be able to run workflows containing HTTP activities from this application. 
                 .UseHttpActivities()
+                
+                .UseStaticFiles()
                 .UseRouting()
                 .UseEndpoints(endpoints => endpoints.MapControllers())
                 .UseWelcomePage();

--- a/src/dashboard/Elsa.Dashboard.Web/appsettings.Development.json
+++ b/src/dashboard/Elsa.Dashboard.Web/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    }
+  }
+}

--- a/src/dashboard/Elsa.Dashboard.Web/appsettings.json
+++ b/src/dashboard/Elsa.Dashboard.Web/appsettings.json
@@ -1,0 +1,25 @@
+{
+    "Logging": {
+        "LogLevel": {
+            "Default": "Information",
+            "Microsoft": "Warning",
+            "Microsoft.Hosting.Lifetime": "Information"
+        }
+    },
+    "AllowedHosts": "*",
+    "ConnectionStrings": {
+        "MongoDb": "mongodb://localhost"
+    },
+    "Elsa": {
+        "Http": {
+            "BaseUrl": "http://localhost:22174"
+        },
+        "Smtp": {
+            "Host": "localhost",
+            "Port": "2525"
+        },
+        "Timers": {
+            "SweepInterval": "PT10S"
+        }
+    }
+}

--- a/src/dashboard/Elsa.Dashboard/Extensions/ActivityDefinitionListExtensions.cs
+++ b/src/dashboard/Elsa.Dashboard/Extensions/ActivityDefinitionListExtensions.cs
@@ -38,7 +38,7 @@ namespace Elsa.Dashboard.Extensions
             options.ActivityDefinitions
                 // Add all activities from all referenced assemblies.
                 .Discover(
-                    selector => selector.FromApplicationDependencies()
+                    selector => selector.FromApplicationDependencies(x => !x.FullName.StartsWith("Microsoft.AspNetCore")) // TODO: Prevents type load exception. Needs more investigation.
                         .AddClasses(x => x.AssignableTo<IActivity>()));
 
             return options;

--- a/src/dashboard/Elsa.WorkflowDesigner/Elsa.WorkflowDesigner.csproj
+++ b/src/dashboard/Elsa.WorkflowDesigner/Elsa.WorkflowDesigner.csproj
@@ -1,8 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFramework>netcoreapp3.0</TargetFramework>
+        <RazorLangVersion>3.0</RazorLangVersion>
         <LangVersion>8.0</LangVersion>
+        <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
         <Nullable>enable</Nullable>
         <PackageVersion>1.0.0</PackageVersion>
         <Authors>Elsa Contributors</Authors>
@@ -18,8 +20,11 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    </ItemGroup>
+
+    <ItemGroup>
         <PackageReference Include="Humanizer.Core" Version="2.7.9" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/persistence/Elsa.Persistence.DocumentDb/Elsa.Persistence.DocumentDb.csproj
+++ b/src/persistence/Elsa.Persistence.DocumentDb/Elsa.Persistence.DocumentDb.csproj
@@ -17,7 +17,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.8.1" />
+        <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.9.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/persistence/Elsa.Persistence.EntityFrameworkCore/Elsa.Persistence.EntityFrameworkCore.csproj
+++ b/src/persistence/Elsa.Persistence.EntityFrameworkCore/Elsa.Persistence.EntityFrameworkCore.csproj
@@ -19,10 +19,10 @@
 
     <ItemGroup>
         <PackageReference Include="FlexLabs.EntityFrameworkCore.Upsert" Version="3.0.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.0.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.0.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.0.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.0.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.0.1" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.0.1" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.0.1" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.0.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/persistence/Elsa.Persistence.MongoDb/Elsa.Persistence.MongoDb.csproj
+++ b/src/persistence/Elsa.Persistence.MongoDb/Elsa.Persistence.MongoDb.csproj
@@ -22,7 +22,7 @@
 
     <ItemGroup>
       <PackageReference Include="MongoDb.Bson.NodaTime" Version="2.0.0" />
-      <PackageReference Include="MongoDB.Driver" Version="2.9.2" />
+      <PackageReference Include="MongoDB.Driver" Version="2.9.3" />
     </ItemGroup>
 
 </Project>

--- a/src/persistence/Elsa.Persistence.YesSql/Elsa.Persistence.YesSql.csproj
+++ b/src/persistence/Elsa.Persistence.YesSql/Elsa.Persistence.YesSql.csproj
@@ -22,7 +22,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.0.1" />
         <PackageReference Include="YesSql.Core" Version="2.0.0-beta-1449" />
         <PackageReference Include="YesSql.Provider.MySql" Version="1.0.0-beta-1449" />
         <PackageReference Include="YesSql.Provider.PostgreSql" Version="1.0.0-beta-1449" />

--- a/src/samples/Sample05/Sample05.csproj
+++ b/src/samples/Sample05/Sample05.csproj
@@ -10,7 +10,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.0.1" />
     </ItemGroup>
 
 </Project>

--- a/src/samples/Sample14/Sample14.csproj
+++ b/src/samples/Sample14/Sample14.csproj
@@ -12,8 +12,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.0.0" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.0.0" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.0.1" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.0.1" />
     </ItemGroup>
 
 </Project>

--- a/src/samples/Sample18/Sample18.csproj
+++ b/src/samples/Sample18/Sample18.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.0.1" />
     </ItemGroup>
     
     <ItemGroup>

--- a/src/utils/Elsa.AutoMapper.Extensions/Elsa.AutoMapper.Extensions.csproj
+++ b/src/utils/Elsa.AutoMapper.Extensions/Elsa.AutoMapper.Extensions.csproj
@@ -18,7 +18,7 @@
     
     <ItemGroup>
         <PackageReference Include="AutoMapper" Version="9.0.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.0.1" />
         <PackageReference Include="NodaTime" Version="3.0.0-beta01" />
     </ItemGroup>
 


### PR DESCRIPTION
The Dockerfile builds a new project called Elsa.Dashboard.Web, which serves as both the dashboard and workflow server.

To build the Dockerfile:

`docker build --pull .`

To run the Dockerfile, make sure you have MongoDB and an SMTP host running.
If you don't have these installed, use the docker-compose file, which will run MongoDB and Smtp4Dev in containers.