### PR TITLE
Add the ability to publish events via MassTransit

### DIFF
--- a/src/activities/Elsa.Activities.MassTransit/Activities/PublishMassTransitMessage.cs
+++ b/src/activities/Elsa.Activities.MassTransit/Activities/PublishMassTransitMessage.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Elsa.Attributes;
+using Elsa.Expressions;
+using Elsa.Results;
+using Elsa.Services;
+using Elsa.Services.Models;
+using MassTransit;
+
+namespace Elsa.Activities.MassTransit.Activities
+{
+    [ActivityDefinition(
+        Category = "MassTransit",
+        DisplayName = "Publish MassTransit Message",
+        Description = "Publish an event via MassTransit."
+    )]
+    public class PublishMassTransitMessage : Activity
+    {
+        private readonly ConsumeContext consumeContext;
+        private readonly IBus bus;
+        private readonly IWorkflowExpressionEvaluator evaluator;
+
+        public PublishMassTransitMessage(ConsumeContext consumeContext, IBus bus, IWorkflowExpressionEvaluator evaluator)
+        {
+            this.consumeContext = consumeContext;
+            this.bus = bus;
+            this.evaluator = evaluator;
+        }
+
+        [ActivityProperty(Hint = "The assembly-qualified type name of the event to publish.")]
+        public Type MessageType
+        {
+            get
+            {
+                var typeName = GetState<string>();
+                return string.IsNullOrWhiteSpace(typeName) ? null : System.Type.GetType(typeName);
+            }
+            set => SetState(value.AssemblyQualifiedName);
+        }
+
+        [ActivityProperty(Hint = "An expression that evaluates to the event to publish.")]
+        public WorkflowExpression Message
+        {
+            get => GetState<WorkflowExpression>();
+            set => SetState(value);
+        }
+
+        protected override bool OnCanExecute(WorkflowExecutionContext context)
+        {
+            return MessageType != null;
+        }
+
+        /// <summary>
+        /// Gets the publish endpoint to use.
+        /// </summary>
+        /// <remarks>
+        /// Will use the current scopes consume context if one exists to maintain
+        /// the conversation and correlation id.
+        /// </remarks>
+        private IPublishEndpoint PublishEndpoint =>
+            consumeContext != null
+                ? (IPublishEndpoint)consumeContext
+                : (IPublishEndpoint)bus;
+
+        protected override async Task<ActivityExecutionResult> OnExecuteAsync(WorkflowExecutionContext context,
+            CancellationToken cancellationToken)
+        {
+            var message = await evaluator.EvaluateAsync(Message, MessageType, context, cancellationToken);
+
+            await PublishEndpoint.Publish(message, cancellationToken);
+
+            return Done();
+        }
+    }
+}

--- a/src/activities/Elsa.Activities.MassTransit/Extensions/ServiceCollectionExtensions.cs
+++ b/src/activities/Elsa.Activities.MassTransit/Extensions/ServiceCollectionExtensions.cs
@@ -22,6 +22,7 @@ namespace Elsa.Activities.MassTransit.Extensions
 
             services
                 .AddActivity<SendMassTransitMessage>()
+                .AddActivity<PublishMassTransitMessage>()
                 .AddActivity<ReceiveMassTransitMessage>();
 
             services.AddSingleton<SimplifiedBusHealthCheck>();

--- a/src/samples/Sample08/Workflows/HandleOrderWorkflow.cs
+++ b/src/samples/Sample08/Workflows/HandleOrderWorkflow.cs
@@ -24,7 +24,7 @@ namespace Sample08.Workflows
                     }
                 )
                 .Then<TimerEvent>(activity => activity.TimeoutExpression = new LiteralExpression<TimeSpan>("00:00:05"))
-                .Then<SendMassTransitMessage>(activity =>
+                .Then<PublishMassTransitMessage>(activity =>
                     {
                         activity.Message = new JavaScriptExpression<OrderShipped>("return { correlationId: correlationId(), order: order}");
                         activity.MessageType = typeof(OrderShipped);


### PR DESCRIPTION
I have also made a small change to try and maintain using the consume context which is available in the current scope when consuming a message from the bus. 

If this consume context is not available in the current scope, then the bus is used.

This allows for maintaining a continuous conversation ID if available.