### PR TITLE
Add script options configuration (#179)

### DIFF
--- a/src/core/Elsa/ElsaServiceCollectionExtensions.cs
+++ b/src/core/Elsa/ElsaServiceCollectionExtensions.cs
@@ -4,9 +4,7 @@ using Elsa.Activities.ControlFlow.Extensions;
 using Elsa.Activities.UserTask.Extensions;
 using Elsa.Activities.Workflows.Extensions;
 using Elsa.Scripting.JavaScript.Extensions;
-using Elsa.Scripting.JavaScript.Options;
 using Elsa.Scripting.Liquid.Extensions;
-using Microsoft.Extensions.Options;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection
@@ -24,14 +22,6 @@ namespace Microsoft.Extensions.DependencyInjection
                 .AddControlFlowActivities()
                 .AddWorkflowActivities()
                 .AddUserTaskActivities();
-        }
-
-        public static IServiceCollection WithJavaScriptOptions(this IServiceCollection services, Action<OptionsBuilder<ScriptOptions>> options)
-        {
-            var scriptOptions = services.AddOptions<ScriptOptions>();
-            options(scriptOptions);
-
-            return services;
         }
     }
 }

--- a/src/core/Elsa/ElsaServiceCollectionExtensions.cs
+++ b/src/core/Elsa/ElsaServiceCollectionExtensions.cs
@@ -1,10 +1,12 @@
-﻿using System;
+using System;
 using Elsa;
 using Elsa.Activities.ControlFlow.Extensions;
 using Elsa.Activities.UserTask.Extensions;
 using Elsa.Activities.Workflows.Extensions;
 using Elsa.Scripting.JavaScript.Extensions;
+using Elsa.Scripting.JavaScript.Options;
 using Elsa.Scripting.Liquid.Extensions;
+using Microsoft.Extensions.Options;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection
@@ -22,6 +24,14 @@ namespace Microsoft.Extensions.DependencyInjection
                 .AddControlFlowActivities()
                 .AddWorkflowActivities()
                 .AddUserTaskActivities();
+        }
+
+        public static IServiceCollection WithJavaScriptOptions(this IServiceCollection services, Action<OptionsBuilder<ScriptOptions>> options)
+        {
+            var scriptOptions = services.AddOptions<ScriptOptions>();
+            options(scriptOptions);
+
+            return services;
         }
     }
 }

--- a/src/scripting/Elsa.Scripting.JavaScript/Extensions/JavaScriptServiceCollectionExtensions.cs
+++ b/src/scripting/Elsa.Scripting.JavaScript/Extensions/JavaScriptServiceCollectionExtensions.cs
@@ -17,11 +17,11 @@ namespace Elsa.Scripting.JavaScript.Extensions
                 .AddNotificationHandlers(typeof(JavaScriptServiceCollectionExtensions));
         }
 
-        public static IServiceCollection ConfigureJavaScriptOptions(this IServiceCollection services, Action<OptionsBuilder<ScriptOptions>> options)
+        public static IServiceCollection WithJavaScriptOptions(this IServiceCollection services, Action<OptionsBuilder<ScriptOptions>> options)
         {
             var scriptOptions = services.AddOptions<ScriptOptions>();
             options(scriptOptions);
-            
+
             return services;
         }
     }

--- a/src/scripting/Elsa.Scripting.JavaScript/Extensions/JavaScriptServiceCollectionExtensions.cs
+++ b/src/scripting/Elsa.Scripting.JavaScript/Extensions/JavaScriptServiceCollectionExtensions.cs
@@ -1,7 +1,10 @@
 using Elsa.Extensions;
+using Elsa.Scripting.JavaScript.Options;
 using Elsa.Scripting.JavaScript.Services;
 using Elsa.Services;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using System;
 
 namespace Elsa.Scripting.JavaScript.Extensions
 {
@@ -12,6 +15,14 @@ namespace Elsa.Scripting.JavaScript.Extensions
             return services
                 .TryAddProvider<IExpressionEvaluator, JavaScriptExpressionEvaluator>(ServiceLifetime.Scoped)
                 .AddNotificationHandlers(typeof(JavaScriptServiceCollectionExtensions));
+        }
+
+        public static IServiceCollection ConfigureJavaScriptOptions(this IServiceCollection services, Action<OptionsBuilder<ScriptOptions>> options)
+        {
+            var scriptOptions = services.AddOptions<ScriptOptions>();
+            options(scriptOptions);
+            
+            return services;
         }
     }
 }

--- a/src/scripting/Elsa.Scripting.JavaScript/Options/ScriptOptions.cs
+++ b/src/scripting/Elsa.Scripting.JavaScript/Options/ScriptOptions.cs
@@ -1,0 +1,12 @@
+namespace Elsa.Scripting.JavaScript.Options
+{
+    public class ScriptOptions
+    {
+        public ScriptOptions()
+        {
+            AllowClr = true;
+        }
+
+        public bool AllowClr { get; set; }
+    }
+}


### PR DESCRIPTION
I've given this a crack using the options builder pattern, but I'm interested to know if you think there's a better/tidier way of doing it.

I tried adding another optional parameter to `AddElsa` extension method, but that didn't look great, as I then needed to provided the param name with both the existing param and the new one being optional:

`services.AddElsa(scriptOptions: options => options.Configure(x => x.AllowClr = false)`

What I've commited is a separate extension method. 

```
.AddElsa()
.WithJavaScriptOptions(x => x.Configure(o => o.AllowClr = false))
```

If it's not called, it will default to allowing CLR use as per the existing version.