### PR TITLE
Switch activity now sets "Result" output variable with the expression…

### DIFF
--- a/src/activities/Elsa.Activities.ControlFlow/Activities/Switch.cs
+++ b/src/activities/Elsa.Activities.ControlFlow/Activities/Switch.cs
@@ -56,6 +56,8 @@ namespace Elsa.Activities.ControlFlow.Activities
             if (ContainsCase(result) || !ContainsCase("default"))
                 return Outcome(result);
 
+            Output.SetVariable("Result", result);
+
             return Outcome("default");
         }
 


### PR DESCRIPTION
… result

As discussed in #181 

The Switch activity now sets a `Result` output variable, meaning it's then available later in the workflow if the Switch is named. 

e.g. if Switch activity named `MySwitch`, the JavaScript expression `MySwitch.Result` will retrieve the result of the expression used in the Switch.