### PR TITLE
Fix link on Orchard Core doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Although there's an effort being made to [port WF to .NET Standard](https://gith
 
 ### What about Orchard Workflows?
 
-Both [Orchard](http://docs.orchardproject.net/en/latest/Documentation/Workflows/) and [Orchard Core](https://orchardcore.readthedocs.io/en/dev/OrchardCore.Modules/OrchardCore.Workflows/) ship with a powerful workflows module, and both are awesome.
+Both [Orchard](http://docs.orchardproject.net/en/latest/Documentation/Workflows/) and [Orchard Core](https://orchardcore.readthedocs.io/en/dev/docs/reference/modules/Workflows/) ship with a powerful workflows module, and both are awesome.
 In fact, Elsa Workflows is taken & adapted from Orchard Core's Workflows module. Elsa uses a similar model, but there are some differences:  
 
 - Elsa Workflows is completely decoupled from web, whereas Orchard Core Workflows is coupled to not only the web, but also the Orchard Core Framework itself.


### PR DESCRIPTION
The new url is https://orchardcore.readthedocs.io/en/dev/docs/reference/modules/Workflows/