### PR TITLE
Moved JavaScript DI extension method namespace (#179)

### DIFF
--- a/src/scripting/Elsa.Scripting.JavaScript/Extensions/JavaScriptServiceCollectionExtensions.cs
+++ b/src/scripting/Elsa.Scripting.JavaScript/Extensions/JavaScriptServiceCollectionExtensions.cs
@@ -2,11 +2,11 @@ using Elsa.Extensions;
 using Elsa.Scripting.JavaScript.Options;
 using Elsa.Scripting.JavaScript.Services;
 using Elsa.Services;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using System;
 
-namespace Elsa.Scripting.JavaScript.Extensions
+// ReSharper disable once CheckNamespace
+namespace Microsoft.Extensions.DependencyInjection
 {
     public static class JavaScriptServiceCollectionExtensions
     {


### PR DESCRIPTION
Moved `WithJavaScriptOptions` into `Microsoft.Extensions.DependencyInjection` namespace so easier to discover. Existing AddJavaScriptExpressionEvaluator method also moved in. This should be safe as it shouldn't be called anyone directly, as it's called as part of AddElsa().