### PR TITLE
YesSql instance storage fixes

### DIFF
--- a/src/persistence/Elsa.Persistence.YesSql/Extensions/StoreFactory.cs
+++ b/src/persistence/Elsa.Persistence.YesSql/Extensions/StoreFactory.cs
@@ -1,4 +1,5 @@
 using System;
+using Elsa.Persistence.YesSql.Serialization;
 using Microsoft.Extensions.DependencyInjection;
 using YesSql;
 using YesSql.Indexes;
@@ -10,6 +11,8 @@ namespace Elsa.Persistence.YesSql.Extensions
         internal static IStore CreateStore(IServiceProvider services, Action<IConfiguration> configure)
         {
             IConfiguration configuration = new Configuration();
+
+            configuration.ContentSerializer = new YesSqlJsonSerializer();
 
             configure(configuration);
             var store = global::YesSql.StoreFactory.CreateAsync(configuration).GetAwaiter().GetResult();

--- a/src/persistence/Elsa.Persistence.YesSql/Indexes/WorkflowInstanceIndex.cs
+++ b/src/persistence/Elsa.Persistence.YesSql/Indexes/WorkflowInstanceIndex.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using Elsa.Models;
+using Elsa.Persistence.YesSql.Documents;
 using YesSql.Indexes;
 
 namespace Elsa.Persistence.YesSql.Indexes
@@ -23,18 +24,19 @@ namespace Elsa.Persistence.YesSql.Indexes
         public DateTime CreatedAt { get; set; }
     }
 
-    public class WorkflowInstanceIndexProvider : IndexProvider<WorkflowInstance>
+    public class WorkflowInstanceIndexProvider : IndexProvider<WorkflowInstanceDocument>
     {
-        public override void Describe(DescribeContext<WorkflowInstance> context)
+        public override void Describe(DescribeContext<WorkflowInstanceDocument> context)
         {
             context.For<WorkflowInstanceIndex>()
                 .Map(
                     workflowInstance => new WorkflowInstanceIndex
                     {
-                        WorkflowDefinitionId = workflowInstance.Id,
+                        WorkflowInstanceId = workflowInstance.WorkflowInstanceId,
+                        WorkflowDefinitionId = workflowInstance.DefinitionId,
                         WorkflowStatus = workflowInstance.Status,
                         CorrelationId = workflowInstance.CorrelationId,
-                        CreatedAt = workflowInstance.CreatedAt.ToDateTimeUtc()
+                        CreatedAt = workflowInstance.CreatedAt
                     });
 
             context.For<WorkflowInstanceBlockingActivitiesIndex>()
@@ -47,7 +49,7 @@ namespace Elsa.Persistence.YesSql.Indexes
                                 ActivityType = activity.ActivityType,
                                 CorrelationId = workflowInstance.CorrelationId,
                                 WorkflowStatus = workflowInstance.Status,
-                                CreatedAt = workflowInstance.CreatedAt.ToDateTimeUtc()
+                                CreatedAt = workflowInstance.CreatedAt
                             }));
         }
     }

--- a/src/persistence/Elsa.Persistence.YesSql/Serialization/YesSqlJsonSerializer.cs
+++ b/src/persistence/Elsa.Persistence.YesSql/Serialization/YesSqlJsonSerializer.cs
@@ -1,0 +1,48 @@
+using System;
+using Newtonsoft.Json;
+using NodaTime;
+using NodaTime.Serialization.JsonNet;
+using YesSql;
+using YesSql.Serialization;
+
+namespace Elsa.Persistence.YesSql.Serialization
+{
+    /// <summary>
+    /// Copy of <see cref="JsonContentSerializer"/> from YesSql
+    /// including support for NodaTime types.
+    /// </summary>
+    public class YesSqlJsonSerializer : IContentSerializer
+    {
+        private static readonly JsonSerializerSettings jsonSettings;
+
+        static YesSqlJsonSerializer()
+        {
+            jsonSettings = CreateYesSqlSerializerSettings()
+                            .ConfigureForNodaTime(DateTimeZoneProviders.Tzdb);
+        }
+
+        public object Deserialize(string content, Type type)
+        {
+            return JsonConvert.DeserializeObject(content, type, jsonSettings);
+        }
+
+        public object DeserializeDynamic(string content)
+        {
+            return JsonConvert.DeserializeObject<object>(content, jsonSettings);
+        }
+
+        public string Serialize(object item)
+        {
+            return JsonConvert.SerializeObject(item, jsonSettings);
+        }
+
+        private static JsonSerializerSettings CreateYesSqlSerializerSettings()
+        {
+            return new JsonSerializerSettings
+            {
+                TypeNameHandling = TypeNameHandling.Auto,
+                DateTimeZoneHandling = DateTimeZoneHandling.Utc
+            };
+        }
+    }
+}

--- a/src/persistence/Elsa.Persistence.YesSql/Services/YesSqlWorkflowInstanceStore.cs
+++ b/src/persistence/Elsa.Persistence.YesSql/Services/YesSqlWorkflowInstanceStore.cs
@@ -25,8 +25,16 @@ namespace Elsa.Persistence.YesSql.Services
 
         public async Task<WorkflowInstance> SaveAsync(WorkflowInstance instance, CancellationToken cancellationToken)
         {
-            var document = mapper.Map<WorkflowInstanceDocument>(instance);
+            string instanceId = instance.Id;
+            
+            WorkflowInstanceDocument existingInstance = await session
+                                         .Query<WorkflowInstanceDocument, WorkflowInstanceIndex>(x => x.WorkflowInstanceId == instanceId)
+                                         .FirstOrDefaultAsync();
 
+            WorkflowInstanceDocument document = (existingInstance != null)
+                ? mapper.Map(instance, existingInstance)
+                : mapper.Map<WorkflowInstanceDocument>(instance);
+            
             session.Save(document);
             await session.CommitAsync();
             return mapper.Map<WorkflowInstance>(document);


### PR DESCRIPTION
* WorkflowInstanceIndex now stores records correctly
* Saving a workflow instance now updates existing instance rather than creating a new document
* Fixed serialisation exception when saving existing instance containing NodaTime types

I had to create a new YesSql `IContentSerializer` (`YesSqlJsonSerializer`) because the YesSql version (`YesSql.Serialization.JsonContentSerializer`) has private settings, so I couldn't derive and add NodaTime support.