### PR TITLE
Variable fixes

### DIFF
--- a/src/core/Elsa.Abstractions/Models/Variables.cs
+++ b/src/core/Elsa.Abstractions/Models/Variables.cs
@@ -42,13 +42,18 @@ namespace Elsa.Models
             return this[name] = new Variable(value);
         }
 
+        public Variable SetVariable(string name, Variable variable)
+        {
+            return SetVariable(name, variable.Value);
+        }
+
         public void SetVariables(Variables variables) =>
             SetVariables((IEnumerable<KeyValuePair<string, Variable>>) variables);
 
         public void SetVariables(IEnumerable<KeyValuePair<string, Variable>> variables)
         {
             foreach (var variable in variables)
-                SetVariable(variable.Key, variable.Value.Value);
+                SetVariable(variable.Key, variable.Value);
         }
 
         public bool HasVariable(string name)

--- a/src/core/Elsa.Abstractions/Models/Variables.cs
+++ b/src/core/Elsa.Abstractions/Models/Variables.cs
@@ -33,8 +33,10 @@ namespace Elsa.Models
 
         public T GetVariable<T>(string name)
         {
-            object value = GetVariable(name) ?? default(T);
-            return (T)System.Convert.ChangeType(value, typeof(T));
+            object value = GetVariable(name);
+            return (value != default) 
+                ? (T)System.Convert.ChangeType(value, typeof(T))
+                : default(T);
         }
 
         public Variable SetVariable(string name, object value)

--- a/src/core/Elsa.Abstractions/Models/Variables.cs
+++ b/src/core/Elsa.Abstractions/Models/Variables.cs
@@ -31,7 +31,11 @@ namespace Elsa.Models
             return ContainsKey(name) ? this[name].Value : default;
         }
 
-        public T GetVariable<T>(string name) => (T) GetVariable(name);
+        public T GetVariable<T>(string name)
+        {
+            object value = GetVariable(name) ?? default(T);
+            return (T)System.Convert.ChangeType(value, typeof(T));
+        }
 
         public Variable SetVariable(string name, object value)
         {

--- a/src/core/Elsa.Abstractions/Models/Variables.cs
+++ b/src/core/Elsa.Abstractions/Models/Variables.cs
@@ -44,7 +44,7 @@ namespace Elsa.Models
         public void SetVariables(IEnumerable<KeyValuePair<string, Variable>> variables)
         {
             foreach (var variable in variables)
-                SetVariable(variable.Key, variable.Value);
+                SetVariable(variable.Key, variable.Value.Value);
         }
 
         public bool HasVariable(string name)


### PR DESCRIPTION
* SetVariables no longer re-wraps variable in another variable
* GetVariable<T> now uses Convert.ChangeType
Fixes issue where saving an Int32, serialising and deserialising, then accessing with GetVariable<int>(...) no longer causes type cast exception.
The saved value is a JValue which treats Int32 as Int64. Convert.ChangeType has a better chance of performing conversion without error.
Also returns default of T if the variable isn't found - **is this safe to do?**