### PR TITLE
Fixed Serialization for Objects

### DIFF
--- a/src/core/Elsa.Abstractions/Converters/TypeNameHandlingConverter.cs
+++ b/src/core/Elsa.Abstractions/Converters/TypeNameHandlingConverter.cs
@@ -28,6 +28,7 @@ namespace Elsa.Converters
 
         static TypeNameHandlingConverter()
         {
+            RegisterTypeHandler<ObjectHandler>();
             RegisterTypeHandler<DateTimeHandler>();
             RegisterTypeHandler<InstantHandler>();
             RegisterTypeHandler<AnnualDateHandler>();
@@ -51,7 +52,7 @@ namespace Elsa.Converters
             var token = JToken.FromObject(value);
             var handler = GetHandler(x => x.CanSerialize(token, valueType));
 
-            handler.Serialize(writer, serializer, token);
+            handler.Serialize(writer, serializer, valueType, token);
         }
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)

--- a/src/core/Elsa.Abstractions/Serialization/Handlers/DefaultValueHandler.cs
+++ b/src/core/Elsa.Abstractions/Serialization/Handlers/DefaultValueHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -10,6 +10,6 @@ namespace Elsa.Serialization.Handlers
         public bool CanSerialize(JToken value, Type type) => true;
         public bool CanDeserialize(JToken value, Type type) => true;
         public object Deserialize(JsonReader reader, JsonSerializer serializer, Type type, JToken value) => serializer.Deserialize(value.CreateReader(), type);
-        public void Serialize(JsonWriter writer, JsonSerializer serializer, JToken value) => serializer.Serialize(writer, value);
+        public void Serialize(JsonWriter writer, JsonSerializer serializer, Type type, JToken value) => serializer.Serialize(writer, value);
     }
 }

--- a/src/core/Elsa.Abstractions/Serialization/Handlers/IValueHandler.cs
+++ b/src/core/Elsa.Abstractions/Serialization/Handlers/IValueHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -10,6 +10,6 @@ namespace Elsa.Serialization.Handlers
         bool CanSerialize(JToken value, Type type);
         bool CanDeserialize(JToken value, Type type);
         object Deserialize(JsonReader reader, JsonSerializer serializer, Type type, JToken value);
-        void Serialize(JsonWriter writer, JsonSerializer serializer, JToken value);
+        void Serialize(JsonWriter writer, JsonSerializer serializer, Type type, JToken value);
     }
 }

--- a/src/core/Elsa.Abstractions/Serialization/Handlers/ObjectHandler.cs
+++ b/src/core/Elsa.Abstractions/Serialization/Handlers/ObjectHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -19,9 +19,9 @@ namespace Elsa.Serialization.Handlers
             return value.ToObject(objectType, serializer);
         }
 
-        public void Serialize(JsonWriter writer, JsonSerializer serializer, JToken value)
+        public void Serialize(JsonWriter writer, JsonSerializer serializer, Type type, JToken value)
         {
-            value[TypeFieldName] = GetAssemblyQualifiedTypeName(value.GetType());
+            value[TypeFieldName] = GetAssemblyQualifiedTypeName(type);
             value.WriteTo(writer, serializer.Converters.ToArray());
         }
         

--- a/src/core/Elsa.Abstractions/Serialization/Handlers/PrimitiveValueHandler.cs
+++ b/src/core/Elsa.Abstractions/Serialization/Handlers/PrimitiveValueHandler.cs
@@ -18,7 +18,7 @@ namespace Elsa.Serialization.Handlers
             return ParseValue(valueToken);
         }
 
-        public virtual void Serialize(JsonWriter writer, JsonSerializer serializer, JToken value)
+        public virtual void Serialize(JsonWriter writer, JsonSerializer serializer, Type type, JToken value)
         {
             var token = new JObject
             {


### PR DESCRIPTION
After commit: 80ad408 (Fix broken date/time/nodatime serialization (#214)), custom object type names weren't being serialised in the TypeName attribute.

I've registered `ObjectHandler` which was already in there. 

Also had to add `Type` param to `IValueHandler.Serialize` as was unable to get the underlying object type from `JObject`.