### PR TITLE
Fix an issue with some DB Context factories

### DIFF
--- a/src/persistence/Elsa.Persistence.EntityFrameworkCore/DbContexts/DesignTimeDbContextFactoryBase.cs
+++ b/src/persistence/Elsa.Persistence.EntityFrameworkCore/DbContexts/DesignTimeDbContextFactoryBase.cs
@@ -1,0 +1,29 @@
+using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+
+namespace Elsa.Persistence.EntityFrameworkCore.DbContexts
+{
+    public abstract class DesignTimeDbContextFactoryBase<TDbContext> : IDesignTimeDbContextFactory<TDbContext> where TDbContext : DbContext
+    {
+        public TDbContext CreateDbContext(string[] args)
+        {
+            var optionsBuilder = new DbContextOptionsBuilder<TDbContext>();
+            var migrationAssembly = typeof(TDbContext).Assembly.FullName;
+            var connectionString = Environment.GetEnvironmentVariable("EF_CONNECTIONSTRING");
+
+            if(connectionString == null)
+            {
+                var providerName = typeof(TDbContext).Name.Replace("Context", "");
+                throw new InvalidOperationException($"Set the EF_CONNECTIONSTRING environment variable to a valid {providerName} connection string.");
+            }
+
+            optionsBuilder.UseSqlite(
+                connectionString,
+                x => x.MigrationsAssembly(migrationAssembly)
+            );
+
+            return (TDbContext)Activator.CreateInstance(typeof(TDbContext), optionsBuilder.Options);
+        }
+    }
+}

--- a/src/persistence/Elsa.Persistence.EntityFrameworkCore/DbContexts/MySqlContextFactory.cs
+++ b/src/persistence/Elsa.Persistence.EntityFrameworkCore/DbContexts/MySqlContextFactory.cs
@@ -1,26 +1,6 @@
-using System;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Design;
-
 namespace Elsa.Persistence.EntityFrameworkCore.DbContexts
 {
-    public class MySqlContextFactory : IDesignTimeDbContextFactory<MySqlContext>
+    public class MySqlContextFactory : DesignTimeDbContextFactoryBase<MySqlContext>
     {
-        public MySqlContext CreateDbContext(string[] args)
-        {
-            var optionsBuilder = new DbContextOptionsBuilder<MySqlContext>();
-            var migrationAssembly = typeof(MySqlContext).Assembly.FullName;
-            var connectionString = Environment.GetEnvironmentVariable("EF_CONNECTIONSTRING");
-
-            if(connectionString == null)
-                throw new InvalidOperationException("Set the EF_CONNECTIONSTRING environment variable to a valid MySQL connection string. E.g. SET EF_CONNECTIONSTRING=Server=localhost;Database=Elsa;User=sa;Password=Secret_password123!;");
-            
-            optionsBuilder.UseMySql(
-                connectionString,
-                x => x.MigrationsAssembly(migrationAssembly)
-            );
-
-            return new MySqlContext(optionsBuilder.Options);
-        }
     }
 }

--- a/src/persistence/Elsa.Persistence.EntityFrameworkCore/DbContexts/PostgreSqlContextFactory.cs
+++ b/src/persistence/Elsa.Persistence.EntityFrameworkCore/DbContexts/PostgreSqlContextFactory.cs
@@ -1,26 +1,6 @@
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Design;
-using System;
-
 namespace Elsa.Persistence.EntityFrameworkCore.DbContexts
 {
-    public class PostgreSqlContextFactory : IDesignTimeDbContextFactory<PostgreSqlContext>
+    public class PostgreSqlContextFactory : DesignTimeDbContextFactoryBase<PostgreSqlContext>
     {
-        public PostgreSqlContext CreateDbContext(string[] args)
-        {
-            var optionsBuilder = new DbContextOptionsBuilder<ElsaContext>();
-            var migrationAssembly = typeof(ElsaContext).Assembly.FullName;
-            var connectionString = Environment.GetEnvironmentVariable("EF_CONNECTIONSTRING");
-
-            if (connectionString == null)
-                throw new InvalidOperationException(@"Set the EF_CONNECTIONSTRING environment variable to a valid PostgreSql connection string. E.g. SET EF_CONNECTIONSTRING=Server=localhost;Database=Elsa;Port=5432;User Id=postgres;Password=Secret_password123!;");
-
-            optionsBuilder.UseNpgsql(
-                connectionString,
-                x => x.MigrationsAssembly(migrationAssembly)
-            );
-
-            return new PostgreSqlContext(optionsBuilder.Options);
-        }
     }
 }

--- a/src/persistence/Elsa.Persistence.EntityFrameworkCore/DbContexts/SqlServerContextFactory.cs
+++ b/src/persistence/Elsa.Persistence.EntityFrameworkCore/DbContexts/SqlServerContextFactory.cs
@@ -1,26 +1,6 @@
-using System;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Design;
-
 namespace Elsa.Persistence.EntityFrameworkCore.DbContexts
 {
-    public class SqlServerContextFactory : IDesignTimeDbContextFactory<SqlServerContext>
+    public class SqlServerContextFactory : DesignTimeDbContextFactoryBase<SqlServerContext>
     {
-        public SqlServerContext CreateDbContext(string[] args)
-        {
-            var optionsBuilder = new DbContextOptionsBuilder<ElsaContext>();
-            var migrationAssembly = typeof(ElsaContext).Assembly.FullName;
-            var connectionString = Environment.GetEnvironmentVariable("EF_CONNECTIONSTRING");
-
-            if(connectionString == null)
-                throw new InvalidOperationException("Set the EF_CONNECTIONSTRING environment variable to a valid SQL Server connection string. E.g. SET EF_CONNECTIONSTRING=Server=localhost;Database=Elsa;User=sa;Password=Secret_password123!;");
-            
-            optionsBuilder.UseSqlServer(
-                connectionString,
-                x => x.MigrationsAssembly(migrationAssembly)
-            );
-
-            return new SqlServerContext(optionsBuilder.Options);
-        }
     }
 }

--- a/src/persistence/Elsa.Persistence.EntityFrameworkCore/DbContexts/SqliteContext.cs
+++ b/src/persistence/Elsa.Persistence.EntityFrameworkCore/DbContexts/SqliteContext.cs
@@ -4,7 +4,7 @@ namespace Elsa.Persistence.EntityFrameworkCore.DbContexts
 {
     public class SqliteContext : ElsaContext
     {
-        public SqliteContext(DbContextOptions<ElsaContext> options) : base(options)
+        public SqliteContext(DbContextOptions<SqliteContext> options) : base(options)
         {
         }
     }

--- a/src/persistence/Elsa.Persistence.EntityFrameworkCore/DbContexts/SqliteContextFactory.cs
+++ b/src/persistence/Elsa.Persistence.EntityFrameworkCore/DbContexts/SqliteContextFactory.cs
@@ -1,26 +1,6 @@
-using System;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Design;
-
 namespace Elsa.Persistence.EntityFrameworkCore.DbContexts
 {
-    public class SqliteContextFactory : IDesignTimeDbContextFactory<SqliteContext>
+    public class SqliteContextFactory : DesignTimeDbContextFactoryBase<SqliteContext>
     {
-        public SqliteContext CreateDbContext(string[] args)
-        {
-            var optionsBuilder = new DbContextOptionsBuilder<ElsaContext>();
-            var migrationAssembly = typeof(ElsaContext).Assembly.FullName;
-            var connectionString = Environment.GetEnvironmentVariable("EF_CONNECTIONSTRING");
-
-            if(connectionString == null)
-                throw new InvalidOperationException(@"Set the EF_CONNECTIONSTRING environment variable to a valid SQLite connection string. E.g. SET EF_CONNECTIONSTRING=Data Source=c:\data\elsa.db;Cache=Shared;");
-
-            optionsBuilder.UseSqlite(
-                connectionString,
-                x => x.MigrationsAssembly(migrationAssembly)
-            );
-
-            return new SqliteContext(optionsBuilder.Options);
-        }
     }
 }

--- a/src/persistence/Elsa.Persistence.EntityFrameworkCore/Elsa.Persistence.EntityFrameworkCore.csproj
+++ b/src/persistence/Elsa.Persistence.EntityFrameworkCore/Elsa.Persistence.EntityFrameworkCore.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>

--- a/src/samples/Sample16/Sample16.csproj
+++ b/src/samples/Sample16/Sample16.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.0</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/samples/Sample19/Sample19.csproj
+++ b/src/samples/Sample19/Sample19.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.0</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/samples/Sample23/Sample23.csproj
+++ b/src/samples/Sample23/Sample23.csproj
@@ -6,12 +6,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.0">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fix an issue where some DB Context factories use the base ElsaContext type instead of the derived type, causing a "Unable to resolve service for type 'Microsoft.EntityFrameworkCore.DbContextOptions`1[]' while attempting to activate" error.