### PR TITLE
Multitenancy support

### DIFF
--- a/src/core/Elsa.Abstractions/Messaging/Domain/WorkflowDefinitionVersionStoreUpdated.cs
+++ b/src/core/Elsa.Abstractions/Messaging/Domain/WorkflowDefinitionVersionStoreUpdated.cs
@@ -1,11 +1,11 @@
-﻿using MediatR;
+using MediatR;
 
 namespace Elsa.Messaging.Domain
 {
     /// <summary>
     /// Published when the workflow definition store is updated. 
     /// </summary>
-    public class WorkflowDefinitionStoreUpdated : INotification
+    public class WorkflowDefinitionVersionStoreUpdated : INotification
     {
     }
 }

--- a/src/core/Elsa.Abstractions/Models/WorkflowDefinition.cs
+++ b/src/core/Elsa.Abstractions/Models/WorkflowDefinition.cs
@@ -1,0 +1,17 @@
+using NodaTime;
+using System.Collections.Generic;
+
+namespace Elsa.Models
+{
+    public class WorkflowDefinition
+    {
+        public WorkflowDefinition()
+        {
+            WorkflowDefinitionVersions = new List<WorkflowDefinitionVersion>();
+        }
+        public string Id { get; set; }
+        public string? TenantId { get; set; }
+        public Instant CreatedAt { get; set; }
+        public ICollection<WorkflowDefinitionVersion> WorkflowDefinitionVersions { get; set; }
+    }
+}

--- a/src/core/Elsa.Abstractions/Persistence/IWorkflowDefinitionStore.cs
+++ b/src/core/Elsa.Abstractions/Persistence/IWorkflowDefinitionStore.cs
@@ -1,18 +1,17 @@
+using Elsa.Models;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Elsa.Models;
 
 namespace Elsa.Persistence
 {
     public interface IWorkflowDefinitionStore
     {
-        Task<WorkflowDefinitionVersion> SaveAsync(WorkflowDefinitionVersion definition, CancellationToken cancellationToken = default);
-        Task<WorkflowDefinitionVersion> AddAsync(WorkflowDefinitionVersion definition, CancellationToken cancellationToken = default);
-        Task<WorkflowDefinitionVersion> GetByIdAsync(string id, CancellationToken cancellationToken = default);
-        Task<WorkflowDefinitionVersion> GetByIdAsync(string definitionId, VersionOptions version, CancellationToken cancellationToken = default);
-        Task<IEnumerable<WorkflowDefinitionVersion>> ListAsync(VersionOptions version, CancellationToken cancellationToken = default);
-        Task<WorkflowDefinitionVersion> UpdateAsync(WorkflowDefinitionVersion definition, CancellationToken cancellationToken = default);
+        Task<WorkflowDefinition> SaveAsync(WorkflowDefinition definition, CancellationToken cancellationToken = default);
+        Task<WorkflowDefinition> AddAsync(WorkflowDefinition definition, CancellationToken cancellationToken = default);
+        Task<WorkflowDefinition> GetByIdAsync(string id, CancellationToken cancellationToken = default);
+        Task<IEnumerable<WorkflowDefinition>> ListAsync(string tenantId = "", CancellationToken cancellationToken = default);
+        Task<WorkflowDefinition> UpdateAsync(WorkflowDefinition definition, CancellationToken cancellationToken = default);
         Task<int> DeleteAsync(string id, CancellationToken cancellationToken = default);
     }
 }

--- a/src/core/Elsa.Abstractions/Persistence/IWorkflowDefinitionStore.cs
+++ b/src/core/Elsa.Abstractions/Persistence/IWorkflowDefinitionStore.cs
@@ -9,9 +9,9 @@ namespace Elsa.Persistence
     {
         Task<WorkflowDefinition> SaveAsync(WorkflowDefinition definition, CancellationToken cancellationToken = default);
         Task<WorkflowDefinition> AddAsync(WorkflowDefinition definition, CancellationToken cancellationToken = default);
-        Task<WorkflowDefinition> GetByIdAsync(string id, CancellationToken cancellationToken = default);
-        Task<IEnumerable<WorkflowDefinition>> ListAsync(string tenantId = "", CancellationToken cancellationToken = default);
+        Task<WorkflowDefinition> GetByIdAsync(string tenantId, string id, CancellationToken cancellationToken = default);
+        Task<IEnumerable<WorkflowDefinition>> ListAsync(string tenantId, CancellationToken cancellationToken = default);
         Task<WorkflowDefinition> UpdateAsync(WorkflowDefinition definition, CancellationToken cancellationToken = default);
-        Task<int> DeleteAsync(string id, CancellationToken cancellationToken = default);
+        Task<int> DeleteAsync(string tenantId, string id, CancellationToken cancellationToken = default);
     }
 }

--- a/src/core/Elsa.Abstractions/Persistence/IWorkflowDefinitionVersionStore.cs
+++ b/src/core/Elsa.Abstractions/Persistence/IWorkflowDefinitionVersionStore.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Elsa.Models;
+
+namespace Elsa.Persistence
+{
+    public interface IWorkflowDefinitionVersionStore
+    {
+        Task<WorkflowDefinitionVersion> SaveAsync(WorkflowDefinitionVersion definitionVersion, CancellationToken cancellationToken = default);
+        Task<WorkflowDefinitionVersion> AddAsync(WorkflowDefinitionVersion definitionVersion, CancellationToken cancellationToken = default);
+        Task<WorkflowDefinitionVersion> GetByIdAsync(string id, CancellationToken cancellationToken = default);
+        Task<WorkflowDefinitionVersion> GetByIdAsync(string definitionId, VersionOptions version, CancellationToken cancellationToken = default);
+        Task<IEnumerable<WorkflowDefinitionVersion>> ListAsync(VersionOptions version, CancellationToken cancellationToken = default);
+        Task<WorkflowDefinitionVersion> UpdateAsync(WorkflowDefinitionVersion definitionVersion, CancellationToken cancellationToken = default);
+        Task<int> DeleteAsync(string id, CancellationToken cancellationToken = default);
+    }
+}

--- a/src/core/Elsa.Abstractions/Services/IWorkflowPublisher.cs
+++ b/src/core/Elsa.Abstractions/Services/IWorkflowPublisher.cs
@@ -7,17 +7,17 @@ namespace Elsa.Services
     public interface IWorkflowPublisher
     {
         WorkflowDefinitionVersion New();
-        
+
         Task<WorkflowDefinitionVersion> PublishAsync(string id, CancellationToken cancellationToken = default);
 
         Task<WorkflowDefinitionVersion> PublishAsync(
-            WorkflowDefinitionVersion workflowDefinition,
+            WorkflowDefinitionVersion workflowDefinitionVersion,
             CancellationToken cancellationToken = default);
 
-        Task<WorkflowDefinitionVersion> GetDraftAsync(string id, CancellationToken cancellationToken= default);
+        Task<WorkflowDefinitionVersion> GetDraftAsync(string id, CancellationToken cancellationToken = default);
 
         Task<WorkflowDefinitionVersion> SaveDraftAsync(
-            WorkflowDefinitionVersion workflowDefinition,
+            WorkflowDefinitionVersion workflowDefinitionVersion,
             CancellationToken cancellationToken = default);
     }
 }

--- a/src/core/Elsa.Core/ElsaOptions.cs
+++ b/src/core/Elsa.Core/ElsaOptions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Elsa.Caching;
 using Elsa.Persistence;
 using Elsa.Persistence.Memory;
@@ -17,29 +17,36 @@ namespace Elsa
         {
             Services = services;
 
-            WorkflowDefinitionStoreFactory = sp => sp.GetRequiredService<MemoryWorkflowDefinitionStore>();
+            WorkflowDefinitionVersionStoreFactory = sp => sp.GetRequiredService<MemoryWorkflowDefinitionVersionStore>();
             WorkflowInstanceStoreFactory = sp => sp.GetRequiredService<MemoryWorkflowInstanceStore>();
+            WorkflowDefinitionStoreFactory = sp => sp.GetRequiredService<MemoryWorkflowDefinitionStore>();
             DistributedLockProviderFactory = sp => new DefaultLockProvider();
             SignalFactory = sp => new Signal();
             ServiceBusConfigurer = ConfigureInMemoryServiceBus;
         }
 
         public IServiceCollection Services { get; }
-        internal Func<IServiceProvider, IWorkflowDefinitionStore> WorkflowDefinitionStoreFactory { get; private set; }
+        internal Func<IServiceProvider, IWorkflowDefinitionVersionStore> WorkflowDefinitionVersionStoreFactory { get; private set; }
         internal Func<IServiceProvider, IWorkflowInstanceStore> WorkflowInstanceStoreFactory { get; private set; }
+        internal Func<IServiceProvider, IWorkflowDefinitionStore> WorkflowDefinitionStoreFactory { get; private set; }
         internal Func<IServiceProvider, IDistributedLockProvider> DistributedLockProviderFactory { get; private set; }
         internal Func<IServiceProvider, ISignal> SignalFactory { get; private set; }
         internal Func<RebusConfigurer, IServiceProvider, RebusConfigurer> ServiceBusConfigurer { get; private set; }
 
-        public ElsaOptions UseWorkflowDefinitionStore(Func<IServiceProvider, IWorkflowDefinitionStore> factory)
+        public ElsaOptions UseWorkflowDefinitionVersionStore(Func<IServiceProvider, IWorkflowDefinitionVersionStore> factory)
         {
-            WorkflowDefinitionStoreFactory = factory;
+            WorkflowDefinitionVersionStoreFactory = factory;
             return this;
         }
 
         public ElsaOptions UseWorkflowInstanceStore(Func<IServiceProvider, IWorkflowInstanceStore> factory)
         {
             WorkflowInstanceStoreFactory = factory;
+            return this;
+        }
+        public ElsaOptions UseWorkflowDefinitionStore(Func<IServiceProvider, IWorkflowDefinitionStore> factory)
+        {
+            WorkflowDefinitionStoreFactory = factory;
             return this;
         }
 
@@ -60,8 +67,8 @@ namespace Elsa
             ServiceBusConfigurer = configure;
             return this;
         }
-        
-        public ElsaOptions ConfigureServiceBus(Func<RebusConfigurer, RebusConfigurer> configure) => 
+
+        public ElsaOptions ConfigureServiceBus(Func<RebusConfigurer, RebusConfigurer> configure) =>
             ConfigureServiceBus((bus, _) => configure(bus));
 
         private static RebusConfigurer ConfigureInMemoryServiceBus(RebusConfigurer rebus, IServiceProvider serviceProvider)

--- a/src/core/Elsa.Core/Extensions/ElsaServiceCollectionExtensions.cs
+++ b/src/core/Elsa.Core/Extensions/ElsaServiceCollectionExtensions.cs
@@ -41,6 +41,7 @@ namespace Microsoft.Extensions.DependencyInjection
             configure?.Invoke(options);
 
             services
+                .AddTransient(options.WorkflowDefinitionVersionStoreFactory)
                 .AddTransient(options.WorkflowDefinitionStoreFactory)
                 .AddTransient(options.WorkflowInstanceStoreFactory)
                 .AddSingleton(options.DistributedLockProviderFactory)
@@ -91,6 +92,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 .AddLocalization()
                 .AddMemoryCache()
                 .AddTransient<Func<IEnumerable<IActivity>>>(sp => sp.GetServices<IActivity>)
+                .AddSingleton<IActivityDescriber, ActivityDescriber>()
                 .AddSingleton<IIdGenerator, IdGenerator>()
                 .AddSingleton<ITokenSerializerProvider, TokenSerializerProvider>()
                 .AddSingleton<ITokenSerializer, TokenSerializer>()
@@ -110,7 +112,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 .AddSingleton<IWorkflowSchedulerQueue, WorkflowSchedulerQueue>()
                 .AddScoped<IWorkflowHost, WorkflowHost>()
                 .AddSingleton<IWorkflowActivator, WorkflowActivator>()
-                .AddSingleton<MemoryWorkflowDefinitionStore>()
+                .AddSingleton<MemoryWorkflowDefinitionVersionStore>()
                 .AddSingleton<MemoryWorkflowInstanceStore>()
                 .AddStartupRunner()
                 .AddTransient<IActivityResolver, ActivityResolver>()
@@ -120,7 +122,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 .AddTransient<Func<IWorkflowBuilder>>(sp => sp.GetRequiredService<IWorkflowBuilder>)
                 .AddStartupTask<StartServiceBusTask>()
                 .AddConsumer<RunWorkflow, RunWorkflowHandler>()
-                .AddAutoMapperProfile<WorkflowDefinitionProfile>(ServiceLifetime.Singleton)
+                .AddAutoMapperProfile<WorkflowDefinitionVersionProfile>(ServiceLifetime.Singleton)
                 .AddSerializationHandlers()
                 .AddMetadataHandlers()
                 .AddPrimitiveActivities();

--- a/src/core/Elsa.Core/Extensions/WorkflowDefinitionVersionExtensions.cs
+++ b/src/core/Elsa.Core/Extensions/WorkflowDefinitionVersionExtensions.cs
@@ -4,7 +4,7 @@ using Elsa.Models;
 
 namespace Elsa.Extensions
 {
-    public static class WorkflowDefinitionExtensions
+    public static class WorkflowDefinitionVersionExtensions
     {
         public static IEnumerable<WorkflowDefinitionVersion> WithVersion(
             this IEnumerable<WorkflowDefinitionVersion> query,
@@ -12,7 +12,7 @@ namespace Elsa.Extensions
         {
             return query.AsQueryable().WithVersion(version);
         }
-        
+
         public static IQueryable<WorkflowDefinitionVersion> WithVersion(
             this IQueryable<WorkflowDefinitionVersion> query,
             VersionOptions version)

--- a/src/core/Elsa.Core/Mapping/WorkflowDefinitionVersionProfile.cs
+++ b/src/core/Elsa.Core/Mapping/WorkflowDefinitionVersionProfile.cs
@@ -3,9 +3,9 @@ using Elsa.Models;
 
 namespace Elsa.Mapping
 {
-    public class WorkflowDefinitionProfile : Profile
+    public class WorkflowDefinitionVersionProfile : Profile
     {
-        public WorkflowDefinitionProfile()
+        public WorkflowDefinitionVersionProfile()
         {
             CreateMap<WorkflowDefinitionVersion, WorkflowDefinitionVersion>();
         }

--- a/src/core/Elsa.Core/Persistence/Memory/MemoryWorkflowDefinitionStore.cs
+++ b/src/core/Elsa.Core/Persistence/Memory/MemoryWorkflowDefinitionStore.cs
@@ -1,25 +1,22 @@
+using Elsa.Models;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Elsa.Extensions;
-using Elsa.Models;
 
 namespace Elsa.Persistence.Memory
 {
     public class MemoryWorkflowDefinitionStore : IWorkflowDefinitionStore
     {
-        private readonly List<WorkflowDefinitionVersion> definitions;
-
+        private readonly List<WorkflowDefinition> definitions;
         public MemoryWorkflowDefinitionStore()
         {
-            definitions = new List<WorkflowDefinitionVersion>();
+            definitions = new List<WorkflowDefinition>();
         }
-
-        public async Task<WorkflowDefinitionVersion> SaveAsync(WorkflowDefinitionVersion definition, CancellationToken cancellationToken = default)
+        public async Task<WorkflowDefinition> SaveAsync(WorkflowDefinition definition, CancellationToken cancellationToken = default)
         {
-            var existingDefinition = await GetByIdAsync(definition.Id, VersionOptions.SpecificVersion(definition.Version), cancellationToken);
+            var existingDefinition = await GetByIdAsync(definition.Id, cancellationToken);
 
             if (existingDefinition == null)
                 await AddAsync(definition, cancellationToken);
@@ -28,42 +25,32 @@ namespace Elsa.Persistence.Memory
 
             return definition;
         }
-
-        public async Task<WorkflowDefinitionVersion> AddAsync(WorkflowDefinitionVersion definition, CancellationToken cancellationToken = default)
+        public async Task<WorkflowDefinition> AddAsync(WorkflowDefinition definition, CancellationToken cancellationToken = default)
         {
-            var existingDefinition = await GetByIdAsync(definition.Id, VersionOptions.SpecificVersion(definition.Version), cancellationToken);
+            var existingDefinition = await GetByIdAsync(definition.Id, cancellationToken);
 
             if (existingDefinition != null)
             {
-                throw new ArgumentException($"A workflow definition with ID '{definition.Id}' and version '{definition.Version}' already exists.");
+                throw new ArgumentException($"A workflow definition with ID '{definition.Id}' already exists.");
             }
 
             definitions.Add(definition);
             return definition;
         }
-
-        public Task<WorkflowDefinitionVersion> GetByIdAsync(string id, CancellationToken cancellationToken = default)
+        public Task<WorkflowDefinition> GetByIdAsync(string id, CancellationToken cancellationToken = default)
         {
             var definition = definitions.FirstOrDefault(x => x.Id == id);
             return Task.FromResult(definition);
         }
-
-        public Task<WorkflowDefinitionVersion> GetByIdAsync(string definitionId, VersionOptions version, CancellationToken cancellationToken = default)
+        public Task<IEnumerable<WorkflowDefinition>> ListAsync(string tenantId = "", CancellationToken cancellationToken = default)
         {
-            var query = definitions.Where(x => x.DefinitionId == definitionId).AsQueryable().WithVersion(version);
-            var definition = query.FirstOrDefault();
-            return Task.FromResult(definition);
-        }
-
-        public Task<IEnumerable<WorkflowDefinitionVersion>> ListAsync(VersionOptions version, CancellationToken cancellationToken = default)
-        {
-            var query = definitions.AsQueryable().WithVersion(version);
+            var query = tenantId != "" ? definitions.Where(x => x.TenantId == tenantId).AsQueryable() : definitions.AsQueryable();
             return Task.FromResult(query.AsEnumerable());
         }
 
-        public async Task<WorkflowDefinitionVersion> UpdateAsync(WorkflowDefinitionVersion definition, CancellationToken cancellationToken)
+        public async Task<WorkflowDefinition> UpdateAsync(WorkflowDefinition definition, CancellationToken cancellationToken = default)
         {
-            var existingDefinition = await GetByIdAsync(definition.Id, VersionOptions.SpecificVersion(definition.Version), cancellationToken);
+            var existingDefinition = await GetByIdAsync(definition.Id, cancellationToken);
             var index = definitions.IndexOf(existingDefinition);
 
             definitions[index] = definition;
@@ -72,7 +59,7 @@ namespace Elsa.Persistence.Memory
 
         public Task<int> DeleteAsync(string id, CancellationToken cancellationToken = default)
         {
-            var count = definitions.RemoveAll(x => x.DefinitionId == id);
+            var count = definitions.RemoveAll(x => x.Id == id);
             return Task.FromResult(count);
         }
     }

--- a/src/core/Elsa.Core/Persistence/Memory/MemoryWorkflowDefinitionStore.cs
+++ b/src/core/Elsa.Core/Persistence/Memory/MemoryWorkflowDefinitionStore.cs
@@ -16,7 +16,7 @@ namespace Elsa.Persistence.Memory
         }
         public async Task<WorkflowDefinition> SaveAsync(WorkflowDefinition definition, CancellationToken cancellationToken = default)
         {
-            var existingDefinition = await GetByIdAsync(definition.Id, cancellationToken);
+            var existingDefinition = await GetByIdAsync(definition.TenantId, definition.Id, cancellationToken);
 
             if (existingDefinition == null)
                 await AddAsync(definition, cancellationToken);
@@ -27,7 +27,7 @@ namespace Elsa.Persistence.Memory
         }
         public async Task<WorkflowDefinition> AddAsync(WorkflowDefinition definition, CancellationToken cancellationToken = default)
         {
-            var existingDefinition = await GetByIdAsync(definition.Id, cancellationToken);
+            var existingDefinition = await GetByIdAsync(definition.TenantId, definition.Id, cancellationToken);
 
             if (existingDefinition != null)
             {
@@ -37,29 +37,29 @@ namespace Elsa.Persistence.Memory
             definitions.Add(definition);
             return definition;
         }
-        public Task<WorkflowDefinition> GetByIdAsync(string id, CancellationToken cancellationToken = default)
+        public Task<WorkflowDefinition> GetByIdAsync(string tenantId, string id, CancellationToken cancellationToken = default)
         {
-            var definition = definitions.FirstOrDefault(x => x.Id == id);
+            var definition = definitions.FirstOrDefault(x => x.TenantId == tenantId && x.Id == id);
             return Task.FromResult(definition);
         }
-        public Task<IEnumerable<WorkflowDefinition>> ListAsync(string tenantId = "", CancellationToken cancellationToken = default)
+        public Task<IEnumerable<WorkflowDefinition>> ListAsync(string tenantId, CancellationToken cancellationToken = default)
         {
-            var query = tenantId != "" ? definitions.Where(x => x.TenantId == tenantId).AsQueryable() : definitions.AsQueryable();
+            var query = definitions.Where(x => x.TenantId == tenantId).AsQueryable();
             return Task.FromResult(query.AsEnumerable());
         }
 
         public async Task<WorkflowDefinition> UpdateAsync(WorkflowDefinition definition, CancellationToken cancellationToken = default)
         {
-            var existingDefinition = await GetByIdAsync(definition.Id, cancellationToken);
+            var existingDefinition = await GetByIdAsync(definition.TenantId, definition.Id, cancellationToken);
             var index = definitions.IndexOf(existingDefinition);
 
             definitions[index] = definition;
             return definition;
         }
 
-        public Task<int> DeleteAsync(string id, CancellationToken cancellationToken = default)
+        public Task<int> DeleteAsync(string tenantId, string id, CancellationToken cancellationToken = default)
         {
-            var count = definitions.RemoveAll(x => x.Id == id);
+            var count = definitions.RemoveAll(x => x.TenantId == tenantId && x.Id == id);
             return Task.FromResult(count);
         }
     }

--- a/src/core/Elsa.Core/Persistence/Memory/MemoryWorkflowDefinitionVersionStore.cs
+++ b/src/core/Elsa.Core/Persistence/Memory/MemoryWorkflowDefinitionVersionStore.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Elsa.Extensions;
+using Elsa.Models;
+
+namespace Elsa.Persistence.Memory
+{
+    public class MemoryWorkflowDefinitionVersionStore : IWorkflowDefinitionVersionStore
+    {
+        private readonly List<WorkflowDefinitionVersion> definitionVersions;
+
+        public MemoryWorkflowDefinitionVersionStore()
+        {
+            definitionVersions = new List<WorkflowDefinitionVersion>();
+        }
+
+        public async Task<WorkflowDefinitionVersion> SaveAsync(WorkflowDefinitionVersion definitionVersion, CancellationToken cancellationToken = default)
+        {
+            var existingDefinitionVersion = await GetByIdAsync(definitionVersion.Id, VersionOptions.SpecificVersion(definitionVersion.Version), cancellationToken);
+
+            if (existingDefinitionVersion == null)
+                await AddAsync(definitionVersion, cancellationToken);
+            else
+                await UpdateAsync(definitionVersion, cancellationToken);
+
+            return definitionVersion;
+        }
+
+        public async Task<WorkflowDefinitionVersion> AddAsync(WorkflowDefinitionVersion definitionVersion, CancellationToken cancellationToken = default)
+        {
+            var existingDefinitionVersion = await GetByIdAsync(definitionVersion.Id, VersionOptions.SpecificVersion(definitionVersion.Version), cancellationToken);
+
+            if (existingDefinitionVersion != null)
+            {
+                throw new ArgumentException($"A workflow definition with ID '{definitionVersion.Id}' and version '{definitionVersion.Version}' already exists.");
+            }
+
+            definitionVersions.Add(definitionVersion);
+            return definitionVersion;
+        }
+
+        public Task<WorkflowDefinitionVersion> GetByIdAsync(string id, CancellationToken cancellationToken = default)
+        {
+            var definitionVersion = definitionVersions.FirstOrDefault(x => x.Id == id);
+            return Task.FromResult(definitionVersion);
+        }
+
+        public Task<WorkflowDefinitionVersion> GetByIdAsync(string definitionId, VersionOptions version, CancellationToken cancellationToken = default)
+        {
+            var query = definitionVersions.Where(x => x.DefinitionId == definitionId).AsQueryable().WithVersion(version);
+            var definitionVersion = query.FirstOrDefault();
+            return Task.FromResult(definitionVersion);
+        }
+
+        public Task<IEnumerable<WorkflowDefinitionVersion>> ListAsync(VersionOptions version, CancellationToken cancellationToken = default)
+        {
+            var query = definitionVersions.AsQueryable().WithVersion(version);
+            return Task.FromResult(query.AsEnumerable());
+        }
+
+        public async Task<WorkflowDefinitionVersion> UpdateAsync(WorkflowDefinitionVersion definitionVersion, CancellationToken cancellationToken)
+        {
+            var existingDefinitionVersion = await GetByIdAsync(definitionVersion.Id, VersionOptions.SpecificVersion(definitionVersion.Version), cancellationToken);
+            var index = definitionVersions.IndexOf(existingDefinitionVersion);
+
+            definitionVersions[index] = definitionVersion;
+            return definitionVersion;
+        }
+
+        public Task<int> DeleteAsync(string id, CancellationToken cancellationToken = default)
+        {
+            var count = definitionVersions.RemoveAll(x => x.DefinitionId == id);
+            return Task.FromResult(count);
+        }
+    }
+}

--- a/src/core/Elsa.Core/Persistence/PublishingWorkflowDefinitionVersionStore.cs
+++ b/src/core/Elsa.Core/Persistence/PublishingWorkflowDefinitionVersionStore.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Elsa.Messaging.Domain;
@@ -7,27 +7,27 @@ using MediatR;
 
 namespace Elsa.Persistence
 {
-    public class PublishingWorkflowDefinitionStore : IWorkflowDefinitionStore
+    public class PublishingWorkflowDefinitionVersionStore : IWorkflowDefinitionVersionStore
     {
-        private readonly IWorkflowDefinitionStore decoratedStore;
+        private readonly IWorkflowDefinitionVersionStore decoratedStore;
         private readonly IMediator mediator;
 
-        public PublishingWorkflowDefinitionStore(IWorkflowDefinitionStore decoratedStore, IMediator mediator)
+        public PublishingWorkflowDefinitionVersionStore(IWorkflowDefinitionVersionStore decoratedStore, IMediator mediator)
         {
             this.decoratedStore = decoratedStore;
             this.mediator = mediator;
         }
         
-        public async Task<WorkflowDefinitionVersion> SaveAsync(WorkflowDefinitionVersion definition, CancellationToken cancellationToken = default)
+        public async Task<WorkflowDefinitionVersion> SaveAsync(WorkflowDefinitionVersion definitionVersion, CancellationToken cancellationToken = default)
         {
-            var savedDefinition = await decoratedStore.SaveAsync(definition, cancellationToken);
+            var savedDefinitionVersion = await decoratedStore.SaveAsync(definitionVersion, cancellationToken);
             await PublishUpdateEventAsync(cancellationToken);
-            return savedDefinition;
+            return savedDefinitionVersion;
         }
 
-        public async Task<WorkflowDefinitionVersion> AddAsync(WorkflowDefinitionVersion definition, CancellationToken cancellationToken = default)
+        public async Task<WorkflowDefinitionVersion> AddAsync(WorkflowDefinitionVersion definitionVersion, CancellationToken cancellationToken = default)
         {
-            var result = await decoratedStore.AddAsync(definition, cancellationToken);
+            var result = await decoratedStore.AddAsync(definitionVersion, cancellationToken);
             await PublishUpdateEventAsync(cancellationToken);
             return result;
         }
@@ -47,11 +47,11 @@ namespace Elsa.Persistence
             return decoratedStore.ListAsync(version, cancellationToken);
         }
 
-        public async Task<WorkflowDefinitionVersion> UpdateAsync(WorkflowDefinitionVersion definition, CancellationToken cancellationToken = default)
+        public async Task<WorkflowDefinitionVersion> UpdateAsync(WorkflowDefinitionVersion definitionVersion, CancellationToken cancellationToken = default)
         {
-            var updatedDefinition = await decoratedStore.UpdateAsync(definition, cancellationToken);
+            var updatedDefinitionVersion = await decoratedStore.UpdateAsync(definitionVersion, cancellationToken);
             await PublishUpdateEventAsync(cancellationToken);
-            return updatedDefinition;
+            return updatedDefinitionVersion;
         }
 
         public async Task<int> DeleteAsync(string id, CancellationToken cancellationToken = default)
@@ -63,7 +63,7 @@ namespace Elsa.Persistence
 
         private Task PublishUpdateEventAsync(CancellationToken cancellationToken)
         {
-            return mediator.Publish(new WorkflowDefinitionStoreUpdated(), cancellationToken);
+            return mediator.Publish(new WorkflowDefinitionVersionStoreUpdated(), cancellationToken);
         }
     }
 }

--- a/src/core/Elsa.Core/Services/WorkflowPublisher.cs
+++ b/src/core/Elsa.Core/Services/WorkflowPublisher.cs
@@ -157,7 +157,6 @@ namespace Elsa.Services
             {
                 WorkflowDefinition newDefinition = new WorkflowDefinition();
                 newDefinition.Id = idGenerator.Generate();
-                newDefinition.TenantId = "Milan";
                 newDefinition.CreatedAt = clock.GetCurrentInstant();
                 await definitionStore.AddAsync(newDefinition);
                 workflowDefinitionVersion.DefinitionId = newDefinition.Id;

--- a/src/core/Elsa.Core/Services/WorkflowPublisher.cs
+++ b/src/core/Elsa.Core/Services/WorkflowPublisher.cs
@@ -3,28 +3,36 @@ using System.Threading.Tasks;
 using AutoMapper;
 using Elsa.Models;
 using Elsa.Persistence;
+using NodaTime;
 
 namespace Elsa.Services
 {
     public class WorkflowPublisher : IWorkflowPublisher
     {
-        private readonly IWorkflowDefinitionStore store;
+        private readonly IWorkflowDefinitionStore definitionStore;
+        private readonly IWorkflowDefinitionVersionStore store;
         private readonly IIdGenerator idGenerator;
         private readonly IMapper mapper;
+        private readonly IClock clock;
+
 
         public WorkflowPublisher(
-            IWorkflowDefinitionStore store,
+            IWorkflowDefinitionStore definitionStore,
+            IWorkflowDefinitionVersionStore store,
             IIdGenerator idGenerator,
-            IMapper mapper)
+            IMapper mapper,
+            IClock clock)
         {
+            this.definitionStore = definitionStore;
             this.store = store;
             this.idGenerator = idGenerator;
             this.mapper = mapper;
+            this.clock = clock;
         }
 
         public WorkflowDefinitionVersion New()
         {
-            var definition = new WorkflowDefinitionVersion
+            var definitionVersion = new WorkflowDefinitionVersion
             {
                 Id = idGenerator.Generate(),
                 DefinitionId = idGenerator.Generate(),
@@ -36,70 +44,70 @@ namespace Elsa.Services
                 IsDisabled = false
             };
 
-            return definition;
+            return definitionVersion;
         }
 
         public async Task<WorkflowDefinitionVersion> PublishAsync(
             string id,
             CancellationToken cancellationToken)
         {
-            var definition = await store.GetByIdAsync(id, VersionOptions.Latest, cancellationToken);
+            var definitionVersion = await store.GetByIdAsync(id, VersionOptions.Latest, cancellationToken);
 
-            if (definition == null)
+            if (definitionVersion == null)
                 return null;
 
-            return await PublishAsync(definition, cancellationToken);
+            return await PublishAsync(definitionVersion, cancellationToken);
         }
 
         public async Task<WorkflowDefinitionVersion> PublishAsync(
-            WorkflowDefinitionVersion workflowDefinition,
+            WorkflowDefinitionVersion workflowDefinitionVersion,
             CancellationToken cancellationToken)
         {
-            var definition = mapper.Map<WorkflowDefinitionVersion>(workflowDefinition);
+            var definitionVersion = mapper.Map<WorkflowDefinitionVersion>(workflowDefinitionVersion);
 
-            var publishedDefinition = await store.GetByIdAsync(
-                definition.DefinitionId,
+            var publishedDefinitionVersion = await store.GetByIdAsync(
+                definitionVersion.DefinitionId,
                 VersionOptions.Published,
                 cancellationToken);
 
-            if (publishedDefinition != null)
+            if (publishedDefinitionVersion != null)
             {
-                publishedDefinition.IsPublished = false;
-                publishedDefinition.IsLatest = false;
-                await store.UpdateAsync(publishedDefinition, cancellationToken);
+                publishedDefinitionVersion.IsPublished = false;
+                publishedDefinitionVersion.IsLatest = false;
+                await store.UpdateAsync(publishedDefinitionVersion, cancellationToken);
             }
 
-            if (definition.IsPublished)
+            if (definitionVersion.IsPublished)
             {
-                definition.Id = idGenerator.Generate();
-                definition.Version++;
+                definitionVersion.Id = idGenerator.Generate();
+                definitionVersion.Version++;
             }
             else
             {
-                definition.IsPublished = true;   
+                definitionVersion.IsPublished = true;
             }
 
-            definition.IsLatest = true;
-            definition = Initialize(definition);
-            
-            await store.SaveAsync(definition, cancellationToken);
+            definitionVersion.IsLatest = true;
+            definitionVersion = await InitializeAsync(definitionVersion);
 
-            return definition;
+            await store.SaveAsync(definitionVersion, cancellationToken);
+
+            return definitionVersion;
         }
 
         public async Task<WorkflowDefinitionVersion> GetDraftAsync(
             string id,
             CancellationToken cancellationToken)
         {
-            var definition = await store.GetByIdAsync(id, VersionOptions.Latest, cancellationToken);
+            var definitionVersion = await store.GetByIdAsync(id, VersionOptions.Latest, cancellationToken);
 
-            if (definition == null)
+            if (definitionVersion == null)
                 return null;
 
-            if (!definition.IsPublished)
-                return definition;
+            if (!definitionVersion.IsPublished)
+                return definitionVersion;
 
-            var draft = mapper.Map<WorkflowDefinitionVersion>(definition);
+            var draft = mapper.Map<WorkflowDefinitionVersion>(definitionVersion);
             draft.Id = idGenerator.Generate();
             draft.IsPublished = false;
             draft.IsLatest = true;
@@ -109,13 +117,13 @@ namespace Elsa.Services
         }
 
         public async Task<WorkflowDefinitionVersion> SaveDraftAsync(
-            WorkflowDefinitionVersion workflowDefinition,
+            WorkflowDefinitionVersion workflowDefinitionVersion,
             CancellationToken cancellationToken)
         {
-            var draft = mapper.Map<WorkflowDefinitionVersion>(workflowDefinition);
-            
+            var draft = mapper.Map<WorkflowDefinitionVersion>(workflowDefinitionVersion);
+
             var latestVersion = await store.GetByIdAsync(
-                workflowDefinition.DefinitionId,
+                workflowDefinitionVersion.DefinitionId,
                 VersionOptions.Latest,
                 cancellationToken);
 
@@ -124,31 +132,38 @@ namespace Elsa.Services
                 latestVersion.IsLatest = false;
                 draft.Id = idGenerator.Generate();
                 draft.Version++;
-                
+
                 await store.UpdateAsync(latestVersion, cancellationToken);
             }
-   
+
             draft.IsLatest = true;
             draft.IsPublished = false;
-            draft = Initialize(draft);
-            
+            draft = await InitializeAsync(draft);
+
             await store.SaveAsync(draft, cancellationToken);
 
             return draft;
         }
 
-        private WorkflowDefinitionVersion Initialize(WorkflowDefinitionVersion workflowDefinition)
+        private async Task<WorkflowDefinitionVersion> InitializeAsync(WorkflowDefinitionVersion workflowDefinitionVersion)
         {
-            if (workflowDefinition.Id == null)
-                workflowDefinition.Id = idGenerator.Generate();
+            if (workflowDefinitionVersion.Id == null)
+                workflowDefinitionVersion.Id = idGenerator.Generate();
 
-            if (workflowDefinition.Version == 0)
-                workflowDefinition.Version = 1;
+            if (workflowDefinitionVersion.Version == 0)
+                workflowDefinitionVersion.Version = 1;
 
-            if (workflowDefinition.DefinitionId == null)
-                workflowDefinition.DefinitionId = idGenerator.Generate();
+            if (workflowDefinitionVersion.DefinitionId == null)
+            {
+                WorkflowDefinition newDefinition = new WorkflowDefinition();
+                newDefinition.Id = idGenerator.Generate();
+                newDefinition.TenantId = "Milan";
+                newDefinition.CreatedAt = clock.GetCurrentInstant();
+                await definitionStore.AddAsync(newDefinition);
+                workflowDefinitionVersion.DefinitionId = newDefinition.Id;
+            }
 
-            return workflowDefinition;
+            return workflowDefinitionVersion;
         }
     }
 }

--- a/src/core/Elsa.Core/WorkflowProviders/StoreWorkflowProvider.cs
+++ b/src/core/Elsa.Core/WorkflowProviders/StoreWorkflowProvider.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -15,10 +15,10 @@ namespace Elsa.WorkflowProviders
     /// </summary>
     public class StoreWorkflowProvider : IWorkflowProvider
     {
-        private readonly IWorkflowDefinitionStore store;
+        private readonly IWorkflowDefinitionVersionStore store;
         private readonly IActivityResolver activityResolver;
 
-        public StoreWorkflowProvider(IWorkflowDefinitionStore store, IActivityResolver activityResolver)
+        public StoreWorkflowProvider(IWorkflowDefinitionVersionStore store, IActivityResolver activityResolver)
         {
             this.store = store;
             this.activityResolver = activityResolver;
@@ -26,28 +26,28 @@ namespace Elsa.WorkflowProviders
 
         public async Task<IEnumerable<Workflow>> GetWorkflowsAsync(CancellationToken cancellationToken)
         {
-            var workflowDefinitions = await store.ListAsync(VersionOptions.All, cancellationToken);
-            return workflowDefinitions.Select(CreateWorkflow);
+            var workflowDefinitionVersions = await store.ListAsync(VersionOptions.All, cancellationToken);
+            return workflowDefinitionVersions.Select(CreateWorkflow);
         }
 
-        private Workflow CreateWorkflow(WorkflowDefinitionVersion definition)
+        private Workflow CreateWorkflow(WorkflowDefinitionVersion definitionVersion)
         {
-            var resolvedActivities = definition.Activities.Select(ResolveActivity).ToDictionary(x => x.Id);
+            var resolvedActivities = definitionVersion.Activities.Select(ResolveActivity).ToDictionary(x => x.Id);
 
             var workflow = new Workflow
             {
-                DefinitionId = definition.DefinitionId,
-                Description = definition.Description,
-                Name = definition.Name,
-                Version = definition.Version,
-                IsLatest = definition.IsLatest,
-                IsPublished = definition.IsPublished,
-                IsDisabled = definition.IsDisabled,
-                IsSingleton = definition.IsSingleton,
-                PersistenceBehavior = definition.PersistenceBehavior,
-                DeleteCompletedInstances = definition.DeleteCompletedInstances,
+                DefinitionId = definitionVersion.DefinitionId,
+                Description = definitionVersion.Description,
+                Name = definitionVersion.Name,
+                Version = definitionVersion.Version,
+                IsLatest = definitionVersion.IsLatest,
+                IsPublished = definitionVersion.IsPublished,
+                IsDisabled = definitionVersion.IsDisabled,
+                IsSingleton = definitionVersion.IsSingleton,
+                PersistenceBehavior = definitionVersion.PersistenceBehavior,
+                DeleteCompletedInstances = definitionVersion.DeleteCompletedInstances,
                 Activities = resolvedActivities.Values,
-                Connections = definition.Connections.Select(x => ResolveConnection(x, resolvedActivities)).ToList()
+                Connections = definitionVersion.Connections.Select(x => ResolveConnection(x, resolvedActivities)).ToList()
             };
 
             return workflow;

--- a/src/providers/Elsa.Persistence.DocumentDb/Documents/WorkflowDefinitionDocument.cs
+++ b/src/providers/Elsa.Persistence.DocumentDb/Documents/WorkflowDefinitionDocument.cs
@@ -1,0 +1,16 @@
+using Newtonsoft.Json;
+using System;
+
+namespace Elsa.Persistence.DocumentDb.Documents
+{
+    public class WorkflowDefinitionDocument
+    {
+        [JsonProperty(PropertyName = "id")] public string Id { get; set; }
+
+        [JsonProperty(PropertyName = "tenantId")]
+        public string TenantId { get; set; }
+
+        [JsonProperty(PropertyName = "createdAt")]
+        public DateTime CreatedAt { get; set; }
+    }
+}

--- a/src/providers/Elsa.Persistence.DocumentDb/Extensions/ElsaOptionsExtensions.cs
+++ b/src/providers/Elsa.Persistence.DocumentDb/Extensions/ElsaOptionsExtensions.cs
@@ -13,17 +13,26 @@ namespace Elsa.Persistence.DocumentDb.Extensions
             options
                 .AddCosmosDbProvider(dbOptions)
                 .UseWorkflowDefinitionStore(sp => sp.GetRequiredService<CosmosDbWorkflowDefinitionStore>());
-            
+
             options.Services.AddSingleton<CosmosDbWorkflowDefinitionStore>();
             return options;
         }
-        
+        public static ElsaOptions UseCosmosDbWorkflowDefinitionVersionStore(this ElsaOptions options, DocumentDbStorageOptions dbOptions)
+        {
+            options
+                .AddCosmosDbProvider(dbOptions)
+                .UseWorkflowDefinitionVersionStore(sp => sp.GetRequiredService<CosmosDbWorkflowDefinitionVersionStore>());
+
+            options.Services.AddSingleton<CosmosDbWorkflowDefinitionVersionStore>();
+            return options;
+        }
+
         public static ElsaOptions UseCosmosDbWorkflowInstanceStore(this ElsaOptions options, DocumentDbStorageOptions dbOptions)
         {
             options
                 .AddCosmosDbProvider(dbOptions)
                 .UseWorkflowInstanceStore(sp => sp.GetRequiredService<CosmosDbWorkflowInstanceStore>());
-            
+
             options.Services.AddSingleton<IWorkflowInstanceStore, CosmosDbWorkflowInstanceStore>();
             return options;
         }
@@ -34,7 +43,7 @@ namespace Elsa.Persistence.DocumentDb.Extensions
         {
             if (options.HasService<DocumentDbStorage>())
                 return options;
-            
+
             var storage = new DocumentDbStorage(documentDbOptions);
 
             options.Services

--- a/src/providers/Elsa.Persistence.DocumentDb/Services/CosmosDbWorkflowDefinitionStore.cs
+++ b/src/providers/Elsa.Persistence.DocumentDb/Services/CosmosDbWorkflowDefinitionStore.cs
@@ -1,13 +1,12 @@
+using AutoMapper;
+using Elsa.Models;
+using Elsa.Persistence.DocumentDb.Documents;
+using Elsa.Persistence.DocumentDb.Helpers;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using AutoMapper;
-using Elsa.Models;
-using Elsa.Persistence.DocumentDb.Documents;
-using Elsa.Persistence.DocumentDb.Extensions;
-using Elsa.Persistence.DocumentDb.Helpers;
 
 namespace Elsa.Persistence.DocumentDb.Services
 {
@@ -16,66 +15,13 @@ namespace Elsa.Persistence.DocumentDb.Services
         private readonly IMapper mapper;
         private readonly DocumentDbStorage storage;
         private Uri? collectionUrl;
-
         public CosmosDbWorkflowDefinitionStore(DocumentDbStorage storage, IMapper mapper)
         {
             this.storage = storage;
             this.mapper = mapper;
             collectionUrl = default;
         }
-
-        public async Task<WorkflowDefinitionVersion> AddAsync(WorkflowDefinitionVersion definition, CancellationToken cancellationToken = default)
-        {
-            var document = Map(definition);
-            var client = storage.Client;
-            var collectionUrl = await GetCollectionUriAsync(cancellationToken);
-            await client.CreateDocumentWithRetriesAsync(collectionUrl, document, cancellationToken: cancellationToken);
-            return Map(document);
-        }
-
-        public async Task<WorkflowDefinitionVersion> GetByIdAsync(string id, CancellationToken cancellationToken = default)
-        {
-            var client = storage.Client;
-            var collectionUrl = await GetCollectionUriAsync(cancellationToken);
-            var query = client.CreateDocumentQuery<WorkflowDefinitionVersionDocument>(collectionUrl).Where(c => c.Id == id);
-            var document = query.FirstOrDefault();
-            return Map(document);
-        }
-
-        public async Task<WorkflowDefinitionVersion> GetByIdAsync(string definitionId, VersionOptions version, CancellationToken cancellationToken = default)
-        {
-            var client = storage.Client;
-            var collectionUrl = await GetCollectionUriAsync(cancellationToken);
-            var query = client.CreateDocumentQuery<WorkflowDefinitionVersionDocument>(collectionUrl)
-                .Where(c => c.DefinitionId == definitionId).WithVersion(version);
-            var document = query.AsEnumerable().FirstOrDefault();
-            return Map(document);
-        }
-        
-        public async Task<int> DeleteAsync(string id, CancellationToken cancellationToken = default)
-        {
-            var client = storage.Client;
-            var collectionUrl = await GetCollectionUriAsync(cancellationToken);
-            var workflowDefinitionDocuments = await client.CreateDocumentQuery<WorkflowDefinitionVersionDocument>(collectionUrl).Where(c => c.DefinitionId == id).ToQueryResultAsync();
-            foreach (var record in workflowDefinitionDocuments)
-            {
-                await client.DeleteDocumentAsync(record.Id, cancellationToken: cancellationToken);
-            }
-            return workflowDefinitionDocuments.Count;
-        }
-
-        public async Task<IEnumerable<WorkflowDefinitionVersion>> ListAsync(VersionOptions version, CancellationToken cancellationToken = default)
-        {
-            var client = storage.Client;
-            var collectionUrl = await GetCollectionUriAsync(cancellationToken);
-            var query = client
-                .CreateDocumentQuery<WorkflowDefinitionVersionDocument>(collectionUrl)
-                .WithVersion(version).ToList();
-           
-            return mapper.Map<IEnumerable<WorkflowDefinitionVersion>>(query);
-        }
-
-        public async Task<WorkflowDefinitionVersion> SaveAsync(WorkflowDefinitionVersion definition, CancellationToken cancellationToken = default)
+        public async Task<WorkflowDefinition> SaveAsync(WorkflowDefinition definition, CancellationToken cancellationToken = default)
         {
             var document = Map(definition);
             var client = storage.Client;
@@ -83,8 +29,34 @@ namespace Elsa.Persistence.DocumentDb.Services
             await client.UpsertDocumentWithRetriesAsync(collectionUrl, document, cancellationToken: cancellationToken);
             return definition;
         }
+        public async Task<WorkflowDefinition> AddAsync(WorkflowDefinition definition, CancellationToken cancellationToken = default)
+        {
+            var document = Map(definition);
+            var client = storage.Client;
+            var collectionUrl = await GetCollectionUriAsync(cancellationToken);
+            await client.CreateDocumentWithRetriesAsync(collectionUrl, document, cancellationToken: cancellationToken);
+            return Map(document);
+        }
+        public async Task<WorkflowDefinition> GetByIdAsync(string id, CancellationToken cancellationToken = default)
+        {
+            var client = storage.Client;
+            var collectionUrl = await GetCollectionUriAsync(cancellationToken);
+            var query = client.CreateDocumentQuery<WorkflowDefinitionDocument>(collectionUrl).Where(c => c.Id == id);
+            var document = query.FirstOrDefault();
+            return Map(document);
+        }
 
-        public async Task<WorkflowDefinitionVersion> UpdateAsync(WorkflowDefinitionVersion definition, CancellationToken cancellationToken = default)
+        public async Task<IEnumerable<WorkflowDefinition>> ListAsync(string tenantId = "", CancellationToken cancellationToken = default)
+        {
+            var client = storage.Client;
+            var collectionUrl = await GetCollectionUriAsync(cancellationToken);
+            var query = tenantId != "" ?
+                client.CreateDocumentQuery<WorkflowDefinitionDocument>(collectionUrl).Where(x => x.TenantId == tenantId).ToList() :
+                client.CreateDocumentQuery<WorkflowDefinitionDocument>(collectionUrl).ToList();
+
+            return mapper.Map<IEnumerable<WorkflowDefinition>>(query);
+        }
+        public async Task<WorkflowDefinition> UpdateAsync(WorkflowDefinition definition, CancellationToken cancellationToken = default)
         {
             var document = Map(definition);
             var client = storage.Client;
@@ -92,23 +64,36 @@ namespace Elsa.Persistence.DocumentDb.Services
             await client.UpsertDocumentWithRetriesAsync(collectionUrl, document, cancellationToken: cancellationToken);
             return Map(document);
         }
-        
+
+        public async Task<int> DeleteAsync(string id, CancellationToken cancellationToken = default)
+        {
+            var client = storage.Client;
+            var collectionUrl = await GetCollectionUriAsync(cancellationToken);
+            var workflowDefinitionDocuments = await client.CreateDocumentQuery<WorkflowDefinitionDocument>(collectionUrl).Where(c => c.Id == id).ToQueryResultAsync();
+
+            foreach (var record in workflowDefinitionDocuments)
+            {
+                await client.DeleteDocumentAsync(record.Id, cancellationToken: cancellationToken);
+            }
+            return workflowDefinitionDocuments.Count;
+        }
         private async Task<Uri> GetCollectionUriAsync(CancellationToken cancellationToken)
         {
-            if (collectionUrl == null) 
+            if (collectionUrl == null)
                 collectionUrl = await storage.GetCollectionAsync("WorkflowDefinitions", cancellationToken);
 
             return collectionUrl;
         }
 
-        private WorkflowDefinitionVersionDocument Map(WorkflowDefinitionVersion source)
+        private WorkflowDefinitionDocument Map(WorkflowDefinition source)
         {
-            return mapper.Map<WorkflowDefinitionVersionDocument>(source);
+            return mapper.Map<WorkflowDefinitionDocument>(source);
         }
 
-        private WorkflowDefinitionVersion Map(WorkflowDefinitionVersionDocument source)
+        private WorkflowDefinition Map(WorkflowDefinitionDocument source)
         {
-            return mapper.Map<WorkflowDefinitionVersion>(source);
+            return mapper.Map<WorkflowDefinition>(source);
         }
+
     }
 }

--- a/src/providers/Elsa.Persistence.DocumentDb/Services/CosmosDbWorkflowDefinitionStore.cs
+++ b/src/providers/Elsa.Persistence.DocumentDb/Services/CosmosDbWorkflowDefinitionStore.cs
@@ -37,22 +37,20 @@ namespace Elsa.Persistence.DocumentDb.Services
             await client.CreateDocumentWithRetriesAsync(collectionUrl, document, cancellationToken: cancellationToken);
             return Map(document);
         }
-        public async Task<WorkflowDefinition> GetByIdAsync(string id, CancellationToken cancellationToken = default)
+        public async Task<WorkflowDefinition> GetByIdAsync(string tenantId, string id, CancellationToken cancellationToken = default)
         {
             var client = storage.Client;
             var collectionUrl = await GetCollectionUriAsync(cancellationToken);
-            var query = client.CreateDocumentQuery<WorkflowDefinitionDocument>(collectionUrl).Where(c => c.Id == id);
+            var query = client.CreateDocumentQuery<WorkflowDefinitionDocument>(collectionUrl).Where(c => c.TenantId == tenantId && c.Id == id);
             var document = query.FirstOrDefault();
             return Map(document);
         }
 
-        public async Task<IEnumerable<WorkflowDefinition>> ListAsync(string tenantId = "", CancellationToken cancellationToken = default)
+        public async Task<IEnumerable<WorkflowDefinition>> ListAsync(string tenantId, CancellationToken cancellationToken = default)
         {
             var client = storage.Client;
             var collectionUrl = await GetCollectionUriAsync(cancellationToken);
-            var query = tenantId != "" ?
-                client.CreateDocumentQuery<WorkflowDefinitionDocument>(collectionUrl).Where(x => x.TenantId == tenantId).ToList() :
-                client.CreateDocumentQuery<WorkflowDefinitionDocument>(collectionUrl).ToList();
+            var query = client.CreateDocumentQuery<WorkflowDefinitionDocument>(collectionUrl).Where(x => x.TenantId == tenantId).ToList();
 
             return mapper.Map<IEnumerable<WorkflowDefinition>>(query);
         }
@@ -65,11 +63,11 @@ namespace Elsa.Persistence.DocumentDb.Services
             return Map(document);
         }
 
-        public async Task<int> DeleteAsync(string id, CancellationToken cancellationToken = default)
+        public async Task<int> DeleteAsync(string tenantId, string id, CancellationToken cancellationToken = default)
         {
             var client = storage.Client;
             var collectionUrl = await GetCollectionUriAsync(cancellationToken);
-            var workflowDefinitionDocuments = await client.CreateDocumentQuery<WorkflowDefinitionDocument>(collectionUrl).Where(c => c.Id == id).ToQueryResultAsync();
+            var workflowDefinitionDocuments = await client.CreateDocumentQuery<WorkflowDefinitionDocument>(collectionUrl).Where(c => c.TenantId == tenantId && c.Id == id).ToQueryResultAsync();
 
             foreach (var record in workflowDefinitionDocuments)
             {

--- a/src/providers/Elsa.Persistence.DocumentDb/Services/CosmosDbWorkflowDefinitionVersionStore.cs
+++ b/src/providers/Elsa.Persistence.DocumentDb/Services/CosmosDbWorkflowDefinitionVersionStore.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using AutoMapper;
+using Elsa.Models;
+using Elsa.Persistence.DocumentDb.Documents;
+using Elsa.Persistence.DocumentDb.Extensions;
+using Elsa.Persistence.DocumentDb.Helpers;
+
+namespace Elsa.Persistence.DocumentDb.Services
+{
+    public class CosmosDbWorkflowDefinitionVersionStore : IWorkflowDefinitionVersionStore
+    {
+        private readonly IMapper mapper;
+        private readonly DocumentDbStorage storage;
+        private Uri? collectionUrl;
+
+        public CosmosDbWorkflowDefinitionVersionStore(DocumentDbStorage storage, IMapper mapper)
+        {
+            this.storage = storage;
+            this.mapper = mapper;
+            collectionUrl = default;
+        }
+
+        public async Task<WorkflowDefinitionVersion> AddAsync(WorkflowDefinitionVersion definitionVersion, CancellationToken cancellationToken = default)
+        {
+            var document = Map(definitionVersion);
+            var client = storage.Client;
+            var collectionUrl = await GetCollectionUriAsync(cancellationToken);
+            await client.CreateDocumentWithRetriesAsync(collectionUrl, document, cancellationToken: cancellationToken);
+            return Map(document);
+        }
+
+        public async Task<WorkflowDefinitionVersion> GetByIdAsync(string id, CancellationToken cancellationToken = default)
+        {
+            var client = storage.Client;
+            var collectionUrl = await GetCollectionUriAsync(cancellationToken);
+            var query = client.CreateDocumentQuery<WorkflowDefinitionVersionDocument>(collectionUrl).Where(c => c.Id == id);
+            var document = query.FirstOrDefault();
+            return Map(document);
+        }
+
+        public async Task<WorkflowDefinitionVersion> GetByIdAsync(string definitionId, VersionOptions version, CancellationToken cancellationToken = default)
+        {
+            var client = storage.Client;
+            var collectionUrl = await GetCollectionUriAsync(cancellationToken);
+            var query = client.CreateDocumentQuery<WorkflowDefinitionVersionDocument>(collectionUrl)
+                .Where(c => c.DefinitionId == definitionId).WithVersion(version);
+            var document = query.AsEnumerable().FirstOrDefault();
+            return Map(document);
+        }
+
+        public async Task<int> DeleteAsync(string id, CancellationToken cancellationToken = default)
+        {
+            var client = storage.Client;
+            var collectionUrl = await GetCollectionUriAsync(cancellationToken);
+            var workflowDefinitionVersionDocuments = await client.CreateDocumentQuery<WorkflowDefinitionVersionDocument>(collectionUrl).Where(c => c.DefinitionId == id).ToQueryResultAsync();
+            foreach (var record in workflowDefinitionVersionDocuments)
+            {
+                await client.DeleteDocumentAsync(record.Id, cancellationToken: cancellationToken);
+            }
+            return workflowDefinitionVersionDocuments.Count;
+        }
+
+        public async Task<IEnumerable<WorkflowDefinitionVersion>> ListAsync(VersionOptions version, CancellationToken cancellationToken = default)
+        {
+            var client = storage.Client;
+            var collectionUrl = await GetCollectionUriAsync(cancellationToken);
+            var query = client
+                .CreateDocumentQuery<WorkflowDefinitionVersionDocument>(collectionUrl)
+                .WithVersion(version).ToList();
+
+            return mapper.Map<IEnumerable<WorkflowDefinitionVersion>>(query);
+        }
+
+        public async Task<WorkflowDefinitionVersion> SaveAsync(WorkflowDefinitionVersion definitionVersion, CancellationToken cancellationToken = default)
+        {
+            var document = Map(definitionVersion);
+            var client = storage.Client;
+            var collectionUrl = await GetCollectionUriAsync(cancellationToken);
+            await client.UpsertDocumentWithRetriesAsync(collectionUrl, document, cancellationToken: cancellationToken);
+            return definitionVersion;
+        }
+
+        public async Task<WorkflowDefinitionVersion> UpdateAsync(WorkflowDefinitionVersion definitionVersion, CancellationToken cancellationToken = default)
+        {
+            var document = Map(definitionVersion);
+            var client = storage.Client;
+            var collectionUrl = await GetCollectionUriAsync(cancellationToken);
+            await client.UpsertDocumentWithRetriesAsync(collectionUrl, document, cancellationToken: cancellationToken);
+            return Map(document);
+        }
+
+        private async Task<Uri> GetCollectionUriAsync(CancellationToken cancellationToken)
+        {
+            if (collectionUrl == null)
+                collectionUrl = await storage.GetCollectionAsync("WorkflowDefinitionVersions", cancellationToken);
+
+            return collectionUrl;
+        }
+
+        private WorkflowDefinitionVersionDocument Map(WorkflowDefinitionVersion source)
+        {
+            return mapper.Map<WorkflowDefinitionVersionDocument>(source);
+        }
+
+        private WorkflowDefinitionVersion Map(WorkflowDefinitionVersionDocument source)
+        {
+            return mapper.Map<WorkflowDefinitionVersion>(source);
+        }
+    }
+}

--- a/src/providers/Elsa.Persistence.EntityFrameworkCore/Entities/WorkflowDefinitionEntity.cs
+++ b/src/providers/Elsa.Persistence.EntityFrameworkCore/Entities/WorkflowDefinitionEntity.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+
+namespace Elsa.Persistence.EntityFrameworkCore.Entities
+{
+    public class WorkflowDefinitionEntity
+    {
+        public string Id { get; set; }
+        public string? TenantId { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public ICollection<WorkflowDefinitionVersionEntity> WorkflowDefinitionVersions { get; set; }
+    }
+}

--- a/src/providers/Elsa.Persistence.EntityFrameworkCore/Entities/WorkflowDefinitionVersionEntity.cs
+++ b/src/providers/Elsa.Persistence.EntityFrameworkCore/Entities/WorkflowDefinitionVersionEntity.cs
@@ -10,7 +10,7 @@ namespace Elsa.Persistence.EntityFrameworkCore.Entities
         public string DefinitionId { get; set; }
         public int Version { get; set; }
         public string Name { get; set; }
-        public string? Description { get; set; }
+        public string Description { get; set; }
         public Variables Variables { get; set; }
         public bool IsSingleton { get; set; }
         public bool IsDisabled { get; set; }

--- a/src/providers/Elsa.Persistence.EntityFrameworkCore/Entities/WorkflowDefinitionVersionEntity.cs
+++ b/src/providers/Elsa.Persistence.EntityFrameworkCore/Entities/WorkflowDefinitionVersionEntity.cs
@@ -10,12 +10,13 @@ namespace Elsa.Persistence.EntityFrameworkCore.Entities
         public string DefinitionId { get; set; }
         public int Version { get; set; }
         public string Name { get; set; }
-        public string Description { get; set; }
+        public string? Description { get; set; }
         public Variables Variables { get; set; }
         public bool IsSingleton { get; set; }
         public bool IsDisabled { get; set; }
         public bool IsPublished { get; set; }
         public bool IsLatest { get; set; }
+        public WorkflowDefinitionEntity WorkflowDefinition { get; set; }
         public ICollection<ActivityDefinitionEntity> Activities { get; set; }
         public ICollection<ConnectionDefinitionEntity> Connections { get; set; }
     }

--- a/src/providers/Elsa.Persistence.EntityFrameworkCore/Mapping/EntitiesProfile.cs
+++ b/src/providers/Elsa.Persistence.EntityFrameworkCore/Mapping/EntitiesProfile.cs
@@ -8,6 +8,9 @@ namespace Elsa.Persistence.EntityFrameworkCore.Mapping
     {
         public EntitiesProfile()
         {
+            CreateMap<WorkflowDefinition, WorkflowDefinitionEntity>();
+            CreateMap<WorkflowDefinitionEntity, WorkflowDefinition>();
+
             CreateMap<WorkflowDefinitionVersion, WorkflowDefinitionVersionEntity>()
                 .ForMember(d => d.VersionId, d => d.MapFrom(s => s.Id))
                 .ForMember(d => d.Id, d => d.Ignore());

--- a/src/providers/Elsa.Persistence.EntityFrameworkCore/Services/EntityFrameworkCoreWorkflowDefinitionStore.cs
+++ b/src/providers/Elsa.Persistence.EntityFrameworkCore/Services/EntityFrameworkCoreWorkflowDefinitionStore.cs
@@ -26,7 +26,7 @@ namespace Elsa.Persistence.EntityFrameworkCore.Services
             var existingEntity =
                 await dbContext
                     .WorkflowDefinitions
-                    .FirstOrDefaultAsync(x => x.Id == definition.Id, cancellationToken);
+                    .FirstOrDefaultAsync(x => x.TenantId == definition.TenantId && x.Id == definition.Id, cancellationToken);
 
             if (existingEntity == null)
                 return await AddAsync(definition, cancellationToken);
@@ -41,22 +41,20 @@ namespace Elsa.Persistence.EntityFrameworkCore.Services
             return Map(entity);
         }
 
-        public async Task<WorkflowDefinition> GetByIdAsync(string id, CancellationToken cancellationToken = default)
+        public async Task<WorkflowDefinition> GetByIdAsync(string tenantId, string id, CancellationToken cancellationToken = default)
         {
             var query = dbContext
                 .WorkflowDefinitions
                 .Include(x => x.WorkflowDefinitionVersions)
-                .Where(x => x.Id == id);
+                .Where(x => x.TenantId == tenantId && x.Id == id);
 
             var entity = await query.FirstOrDefaultAsync(cancellationToken);
 
             return Map(entity);
         }
-        public async Task<IEnumerable<WorkflowDefinition>> ListAsync(string tenantId = "", CancellationToken cancellationToken = default)
+        public async Task<IEnumerable<WorkflowDefinition>> ListAsync(string tenantId, CancellationToken cancellationToken = default)
         {
-            var query = tenantId != "" ?
-                dbContext.WorkflowDefinitions.Where(x => x.TenantId == tenantId).Include(x => x.WorkflowDefinitionVersions).AsQueryable() :
-                dbContext.WorkflowDefinitions.Include(x => x.WorkflowDefinitionVersions).AsQueryable();
+            var query = dbContext.WorkflowDefinitions.Where(x => x.TenantId == tenantId).Include(x => x.WorkflowDefinitionVersions).AsQueryable();
 
             var entities = await query.ToListAsync(cancellationToken);
 
@@ -66,7 +64,7 @@ namespace Elsa.Persistence.EntityFrameworkCore.Services
         {
             var entity = await dbContext
                 .WorkflowDefinitions
-                .FirstOrDefaultAsync(x => x.Id == definition.Id, cancellationToken);
+                .FirstOrDefaultAsync(x => x.TenantId == definition.TenantId && x.Id == definition.Id, cancellationToken);
 
             entity = mapper.Map(definition, entity);
 
@@ -76,10 +74,10 @@ namespace Elsa.Persistence.EntityFrameworkCore.Services
 
             return Map(entity);
         }
-        public async Task<int> DeleteAsync(string id, CancellationToken cancellationToken = default)
+        public async Task<int> DeleteAsync(string tenantId, string id, CancellationToken cancellationToken = default)
         {
             var definitions = await dbContext.WorkflowDefinitions
-                .Where(x => x.Id == id)
+                .Where(x => x.TenantId == tenantId && x.Id == id)
                 .Include(x => x.WorkflowDefinitionVersions)
                 .ToListAsync(cancellationToken);
 

--- a/src/providers/Elsa.Persistence.EntityFrameworkCore/Services/EntityFrameworkCoreWorkflowDefinitionVersionStore.cs
+++ b/src/providers/Elsa.Persistence.EntityFrameworkCore/Services/EntityFrameworkCoreWorkflowDefinitionVersionStore.cs
@@ -1,0 +1,170 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using AutoMapper;
+using Elsa.Models;
+using Elsa.Persistence.EntityFrameworkCore.DbContexts;
+using Elsa.Persistence.EntityFrameworkCore.Entities;
+using Elsa.Persistence.EntityFrameworkCore.Extensions;
+using Microsoft.EntityFrameworkCore;
+
+namespace Elsa.Persistence.EntityFrameworkCore.Services
+{
+    public class EntityFrameworkCoreWorkflowDefinitionVersionStore : IWorkflowDefinitionVersionStore
+    {
+        private readonly ElsaContext dbContext;
+        private readonly IMapper mapper;
+
+        public EntityFrameworkCoreWorkflowDefinitionVersionStore(ElsaContext dbContext, IMapper mapper)
+        {
+            this.dbContext = dbContext;
+            this.mapper = mapper;
+        }
+
+        public async Task<WorkflowDefinitionVersion> SaveAsync(WorkflowDefinitionVersion definitionVersion, CancellationToken cancellationToken = default)
+        {
+            var existingEntity =
+                await dbContext
+                    .WorkflowDefinitionVersions
+                    .Include(x => x.WorkflowDefinition)
+                    .Include(x => x.Activities)
+                    .Include(x => x.Connections)
+                    .FirstOrDefaultAsync(x => x.VersionId == definitionVersion.Id, cancellationToken);
+
+            if (existingEntity == null)
+                return await AddAsync(definitionVersion, cancellationToken);
+
+            return await UpdateAsync(definitionVersion, cancellationToken);
+        }
+
+        public async Task<WorkflowDefinitionVersion> AddAsync(WorkflowDefinitionVersion definitionVersion, CancellationToken cancellationToken = default)
+        {
+            var entity = Map(definitionVersion);
+            await dbContext.WorkflowDefinitionVersions.AddAsync(entity, cancellationToken);
+            await dbContext.SaveChangesAsync(cancellationToken);
+            return Map(entity);
+        }
+
+        public async Task<WorkflowDefinitionVersion> GetByIdAsync(string id, CancellationToken cancellationToken = default)
+        {
+            var query = dbContext
+                .WorkflowDefinitionVersions
+                .Include(x => x.WorkflowDefinition)
+                .Include(x => x.Activities)
+                .Include(x => x.Connections)
+                .Where(x => x.VersionId == id);
+
+            var entity = await query.FirstOrDefaultAsync(cancellationToken);
+
+            return Map(entity);
+        }
+
+        public async Task<WorkflowDefinitionVersion> GetByIdAsync(
+            string definitionId,
+            VersionOptions version,
+            CancellationToken cancellationToken = default)
+        {
+            var query = dbContext
+                .WorkflowDefinitionVersions
+                .Include(x => x.WorkflowDefinition)
+                .Include(x => x.Activities)
+                .Include(x => x.Connections)
+                .AsQueryable()
+                .Where(x => x.DefinitionId == definitionId)
+                .WithVersion(version);
+
+            var entity = await query.FirstOrDefaultAsync(cancellationToken);
+
+            return Map(entity);
+        }
+
+        public async Task<WorkflowDefinitionVersion> UpdateAsync(WorkflowDefinitionVersion definitionVersion, CancellationToken cancellationToken)
+        {
+            var entity = await dbContext
+                .WorkflowDefinitionVersions
+                .Include(x => x.Activities)
+                .Include(x => x.Connections)
+                .FirstOrDefaultAsync(x => x.VersionId == definitionVersion.Id, cancellationToken);
+
+            DeleteActivities(entity);
+            DeleteConnections(entity);
+
+            entity = mapper.Map(definitionVersion, entity);
+
+            dbContext.WorkflowDefinitionVersions.Update(entity);
+
+            await dbContext.SaveChangesAsync(cancellationToken);
+            return Map(entity);
+        }
+
+        public async Task<IEnumerable<WorkflowDefinitionVersion>> ListAsync(
+            VersionOptions version,
+            CancellationToken cancellationToken = default)
+        {
+            var query = dbContext
+                .WorkflowDefinitionVersions
+                .Include(x => x.Activities)
+                .Include(x => x.Connections)
+                .AsQueryable()
+                .WithVersion(version);
+
+            var entities = await query.ToListAsync(cancellationToken);
+
+            return mapper.Map<IEnumerable<WorkflowDefinitionVersion>>(entities);
+        }
+
+        public async Task<int> DeleteAsync(string id, CancellationToken cancellationToken = default)
+        {
+            var definitionVersionRecords = await dbContext.WorkflowDefinitionVersions
+                .Where(x => x.DefinitionId == id)
+                .ToListAsync(cancellationToken);
+
+            var instanceRecords = await dbContext
+                .WorkflowInstances.Where(x => x.DefinitionId == id)
+                .ToListAsync(cancellationToken);
+
+            var activityDefinitionRecords = await dbContext.ActivityDefinitions
+                .Where(x => x.WorkflowDefinitionVersion.DefinitionId == id)
+                .ToListAsync(cancellationToken);
+
+            var connectionRecords = await dbContext.ConnectionDefinitions
+                .Where(x => x.WorkflowDefinitionVersion.DefinitionId == id)
+                .ToListAsync(cancellationToken);
+
+            var activityInstanceRecords = await dbContext.ActivityInstances
+                .Where(x => x.WorkflowInstance.DefinitionId == id)
+                .ToListAsync(cancellationToken);
+
+            var blockingActivityRecords = await dbContext.BlockingActivities
+                .Where(x => x.WorkflowInstance.DefinitionId == id)
+                .ToListAsync(cancellationToken);
+
+            dbContext.WorkflowInstances.RemoveRange(instanceRecords);
+            dbContext.WorkflowDefinitionVersions.RemoveRange(definitionVersionRecords);
+            dbContext.ActivityDefinitions.RemoveRange(activityDefinitionRecords);
+            dbContext.ConnectionDefinitions.RemoveRange(connectionRecords);
+            dbContext.ActivityInstances.RemoveRange(activityInstanceRecords);
+            dbContext.BlockingActivities.RemoveRange(blockingActivityRecords);
+
+            await dbContext.SaveChangesAsync(cancellationToken);
+
+            return definitionVersionRecords.Count;
+        }
+
+        private void DeleteActivities(WorkflowDefinitionVersionEntity entity)
+        {
+            dbContext.ActivityDefinitions.RemoveRange(entity.Activities);
+            entity.Activities.Clear();
+        }
+
+        private void DeleteConnections(WorkflowDefinitionVersionEntity entity)
+        {
+            dbContext.ConnectionDefinitions.RemoveRange(entity.Connections);
+            entity.Connections.Clear();
+        }
+
+        private WorkflowDefinitionVersionEntity Map(WorkflowDefinitionVersion source) => mapper.Map<WorkflowDefinitionVersionEntity>(source);
+        private WorkflowDefinitionVersion Map(WorkflowDefinitionVersionEntity source) => mapper.Map<WorkflowDefinitionVersion>(source);
+    }
+}

--- a/src/providers/Elsa.Persistence.EntityFrameworkCore/Services/EntityFrameworkCoreWorkflowDefinitionVersionStore.cs
+++ b/src/providers/Elsa.Persistence.EntityFrameworkCore/Services/EntityFrameworkCoreWorkflowDefinitionVersionStore.cs
@@ -116,6 +116,10 @@ namespace Elsa.Persistence.EntityFrameworkCore.Services
 
         public async Task<int> DeleteAsync(string id, CancellationToken cancellationToken = default)
         {
+            var definitionRecords = await dbContext.WorkflowDefinitions
+                .Where(x => x.Id == id)
+                .ToListAsync(cancellationToken);
+
             var definitionVersionRecords = await dbContext.WorkflowDefinitionVersions
                 .Where(x => x.DefinitionId == id)
                 .ToListAsync(cancellationToken);
@@ -140,8 +144,11 @@ namespace Elsa.Persistence.EntityFrameworkCore.Services
                 .Where(x => x.WorkflowInstance.DefinitionId == id)
                 .ToListAsync(cancellationToken);
 
+
+
             dbContext.WorkflowInstances.RemoveRange(instanceRecords);
             dbContext.WorkflowDefinitionVersions.RemoveRange(definitionVersionRecords);
+            dbContext.WorkflowDefinitions.RemoveRange(definitionRecords);
             dbContext.ActivityDefinitions.RemoveRange(activityDefinitionRecords);
             dbContext.ConnectionDefinitions.RemoveRange(connectionRecords);
             dbContext.ActivityInstances.RemoveRange(activityInstanceRecords);

--- a/src/providers/Elsa.Persistence.MongoDb/Extensions/ServiceCollectionExtensions.cs
+++ b/src/providers/Elsa.Persistence.MongoDb/Extensions/ServiceCollectionExtensions.cs
@@ -11,7 +11,7 @@ using MongoDB.Driver;
 using Microsoft.Extensions.DependencyInjection;
 
 // ReSharper disable once CheckNamespace
-namespace Elsa.Persistence.MongoDb.Extensions
+namespace Microsoft.Extensions.DependencyInjection
 {
     public static class ServiceCollectionExtensions
     {

--- a/src/providers/Elsa.Persistence.MongoDb/Services/MongoWorkflowDefinitionVersionStore.cs
+++ b/src/providers/Elsa.Persistence.MongoDb/Services/MongoWorkflowDefinitionVersionStore.cs
@@ -1,0 +1,91 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Elsa.Extensions;
+using Elsa.Models;
+using MongoDB.Driver;
+using MongoDB.Driver.Linq;
+
+namespace Elsa.Persistence.MongoDb.Services
+{
+    public class MongoWorkflowDefinitionVersionStore : IWorkflowDefinitionVersionStore
+    {
+        private readonly IMongoCollection<WorkflowDefinitionVersion> workflowDefinitionVersionCollection;
+        private readonly IMongoCollection<WorkflowInstance> workflowInstanceCollection;
+
+        public MongoWorkflowDefinitionVersionStore(
+            IMongoCollection<WorkflowDefinitionVersion> workflowDefinitionVersionCollection,
+            IMongoCollection<WorkflowInstance> workflowInstanceCollection)
+        {
+            this.workflowDefinitionVersionCollection = workflowDefinitionVersionCollection;
+            this.workflowInstanceCollection = workflowInstanceCollection;
+        }
+
+        public async Task<WorkflowDefinitionVersion> SaveAsync(
+            WorkflowDefinitionVersion definitionVersion,
+            CancellationToken cancellationToken = default)
+        {
+            await workflowDefinitionVersionCollection.ReplaceOneAsync(
+                x => x.Id == definitionVersion.Id && x.Version == definitionVersion.Version,
+                definitionVersion,
+                new ReplaceOptions { IsUpsert = true },
+                cancellationToken
+            );
+
+            return definitionVersion;
+        }
+
+        public async Task<WorkflowDefinitionVersion> AddAsync(WorkflowDefinitionVersion definitionVersion, CancellationToken cancellationToken = default)
+        {
+            await workflowDefinitionVersionCollection.InsertOneAsync(definitionVersion, new InsertOneOptions(), cancellationToken);
+            return definitionVersion;
+        }
+
+        public Task<WorkflowDefinitionVersion> GetByIdAsync(string id, CancellationToken cancellationToken = default)
+        {
+            return workflowDefinitionVersionCollection.AsQueryable().FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+        }
+
+        public async Task<WorkflowDefinitionVersion> GetByIdAsync(
+            string definitionId,
+            VersionOptions version,
+            CancellationToken cancellationToken = default)
+        {
+            var query = (IMongoQueryable<WorkflowDefinitionVersion>)workflowDefinitionVersionCollection.AsQueryable()
+                .Where(x => x.DefinitionId == definitionId)
+                .WithVersion(version);
+
+            return await query.FirstOrDefaultAsync(cancellationToken);
+        }
+
+        public async Task<IEnumerable<WorkflowDefinitionVersion>> ListAsync(
+            VersionOptions version,
+            CancellationToken cancellationToken = default)
+        {
+            var query = workflowDefinitionVersionCollection.AsQueryable();
+            var results = await query.ToListAsync(cancellationToken);
+            return results.WithVersion(version);
+        }
+
+        public async Task<WorkflowDefinitionVersion> UpdateAsync(WorkflowDefinitionVersion definitionVersion,
+            CancellationToken cancellationToken)
+        {
+            await workflowDefinitionVersionCollection.ReplaceOneAsync(
+                x => x.Id == definitionVersion.Id && x.Version == definitionVersion.Version,
+                definitionVersion,
+                new ReplaceOptions { IsUpsert = false },
+                cancellationToken
+            );
+
+            return definitionVersion;
+        }
+
+        public async Task<int> DeleteAsync(string id, CancellationToken cancellationToken = default)
+        {
+            await workflowInstanceCollection.DeleteManyAsync(x => x.DefinitionId == id, cancellationToken);
+            var result = await workflowDefinitionVersionCollection.DeleteManyAsync(x => x.DefinitionId == id, cancellationToken);
+
+            return (int)result.DeletedCount;
+        }
+    }
+}

--- a/src/providers/Elsa.Persistence.YesSql/Documents/WorkflowDefinitionDocument.cs
+++ b/src/providers/Elsa.Persistence.YesSql/Documents/WorkflowDefinitionDocument.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Elsa.Persistence.YesSql.Documents
+{
+    public class WorkflowDefinitionDocument : YesSqlDocument
+    {
+        public string Id { get; set; }
+        public string TenantId { get; set; }
+        public DateTime CreatedAt { get; set; }
+    }
+}

--- a/src/providers/Elsa.Persistence.YesSql/Documents/WorkflowDefinitionVersionDocument.cs
+++ b/src/providers/Elsa.Persistence.YesSql/Documents/WorkflowDefinitionVersionDocument.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using Elsa.Models;
 
 namespace Elsa.Persistence.YesSql.Documents
@@ -10,6 +10,7 @@ namespace Elsa.Persistence.YesSql.Documents
         public int Version { get; set; }
         public string Name { get; set; }
         public string Description { get; set; }
+        public WorkflowDefinition WorkflowDefinition { get; set; }
         public ICollection<ActivityDefinition> Activities { get; set; }
         public IList<ConnectionDefinition> Connections { get; set; }
         public Variables Variables { get; set; }

--- a/src/providers/Elsa.Persistence.YesSql/Extensions/WorkflowDefinitionExtensions.cs
+++ b/src/providers/Elsa.Persistence.YesSql/Extensions/WorkflowDefinitionExtensions.cs
@@ -7,8 +7,8 @@ namespace Elsa.Persistence.YesSql.Extensions
 {
     public static class WorkflowDefinitionExtensions
     {
-        public static IQuery<WorkflowDefinitionVersionDocument, WorkflowDefinitionIndex> WithVersion(
-            this IQuery<WorkflowDefinitionVersionDocument, WorkflowDefinitionIndex> query, 
+        public static IQuery<WorkflowDefinitionVersionDocument, WorkflowDefinitionVersionIndex> WithVersion(
+            this IQuery<WorkflowDefinitionVersionDocument, WorkflowDefinitionVersionIndex> query,
             VersionOptions version)
         {
             if (version.IsDraft)

--- a/src/providers/Elsa.Persistence.YesSql/Extensions/YesSqlServiceCollectionExtensions.cs
+++ b/src/providers/Elsa.Persistence.YesSql/Extensions/YesSqlServiceCollectionExtensions.cs
@@ -21,6 +21,7 @@ namespace Elsa.Persistence.YesSql.Extensions
         {
             return options
                 .UseYesSqlWorkflowDefinitionStore(configure)
+                .UseYesSqlWorkflowDefinitionVersionStore(configure)
                 .UseYesSqlWorkflowInstanceStore(configure);
         }
 
@@ -37,6 +38,18 @@ namespace Elsa.Persistence.YesSql.Extensions
             return options;
         }
 
+        public static ElsaOptions UseYesSqlWorkflowDefinitionVersionStore(
+            this ElsaOptions options,
+            Action<IConfiguration> configure)
+        {
+            options
+                .AddYesSqlProvider(configure)
+                .UseWorkflowDefinitionVersionStore(sp => sp.GetRequiredService<YesSqlWorkflowDefinitionVersionStore>())
+                .Services
+                .AddScoped<YesSqlWorkflowDefinitionVersionStore>();
+
+            return options;
+        }
         public static ElsaOptions UseYesSqlWorkflowDefinitionStore(
             this ElsaOptions options,
             Action<IConfiguration> configure)
@@ -59,7 +72,7 @@ namespace Elsa.Persistence.YesSql.Extensions
 
             options.Services
                 .AddSingleton(sp => StoreFactory.CreateStore(sp, configure))
-                .AddSingleton<IIndexProvider, WorkflowDefinitionIndexProvider>()
+                .AddSingleton<IIndexProvider, WorkflowDefinitionVersionIndexProvider>()
                 .AddSingleton<IIndexProvider, WorkflowInstanceIndexProvider>()
                 .AddTransient<ISchemaVersionStore, SchemaVersionStore>()
                 .AddScoped(CreateSession)

--- a/src/providers/Elsa.Persistence.YesSql/Indexes/WorkflowDefinitionIndex.cs
+++ b/src/providers/Elsa.Persistence.YesSql/Indexes/WorkflowDefinitionIndex.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Elsa.Models;
@@ -8,62 +9,25 @@ namespace Elsa.Persistence.YesSql.Indexes
 {
     public class WorkflowDefinitionIndex : MapIndex
     {
-        public string VersionId { get; set; }
-        public string WorkflowDefinitionId { get; set; }
-        public int Version { get; set; }
-        public bool IsLatest { get; set; }
-        public bool IsPublished { get; set; }
-        public bool IsDisabled { get; set; }
+        public string Id { get; set; }
+        public string TenantId { get; set; }
+        public DateTime CreatedAt { get; set; }
     }
 
-    public class WorkflowDefinitionStartActivitiesIndex : MapIndex
+    public class WorkflowDefinitionIndexProvider : IndexProvider<WorkflowDefinitionDocument>
     {
-        public string StartActivityId { get; set; }
-        public string StartActivityType { get; set; }
-        public bool IsDisabled { get; set; }
-    }
-
-    public class WorkflowDefinitionIndexProvider : IndexProvider<WorkflowDefinitionVersionDocument>
-    {
-        public override void Describe(DescribeContext<WorkflowDefinitionVersionDocument> context)
+        public override void Describe(DescribeContext<WorkflowDefinitionDocument> context)
         {
             context.For<WorkflowDefinitionIndex>()
                 .Map(
                     document => new WorkflowDefinitionIndex
                     {
-                        VersionId =  document.VersionId,
-                        WorkflowDefinitionId = document.WorkflowDefinitionId,
-                        Version = document.Version,
-                        IsPublished = document.IsPublished,
-                        IsLatest = document.IsLatest,
-                        IsDisabled = document.IsDisabled
+                        Id = document.Id,
+                        TenantId = document.TenantId,
+                        CreatedAt = document.CreatedAt
                     }
                 );
 
-            context.For<WorkflowDefinitionStartActivitiesIndex>()
-                .Map(
-                    document => GetStartActivities(document)
-                        .Select(
-                            activity => new WorkflowDefinitionStartActivitiesIndex
-                            {
-                                StartActivityId = activity.Id,
-                                StartActivityType = activity.Type,
-                                IsDisabled = document.IsDisabled
-                            }
-                        )
-                );
-        }
-        
-        private static IEnumerable<ActivityDefinition> GetStartActivities(WorkflowDefinitionVersionDocument workflow)
-        {
-            var targetActivityIds = workflow.Connections.Select(x => x.TargetActivityId).Distinct().ToLookup(x => x);
-            
-            var query =
-                from activity in workflow.Activities
-                where !targetActivityIds.Contains(activity.Id)
-                select activity;
-
-            return query;
         }
     }
 }

--- a/src/providers/Elsa.Persistence.YesSql/Indexes/WorkflowDefinitionVersionIndex.cs
+++ b/src/providers/Elsa.Persistence.YesSql/Indexes/WorkflowDefinitionVersionIndex.cs
@@ -1,0 +1,69 @@
+using System.Collections.Generic;
+using System.Linq;
+using Elsa.Models;
+using Elsa.Persistence.YesSql.Documents;
+using YesSql.Indexes;
+
+namespace Elsa.Persistence.YesSql.Indexes
+{
+    public class WorkflowDefinitionVersionIndex : MapIndex
+    {
+        public string VersionId { get; set; }
+        public string WorkflowDefinitionId { get; set; }
+        public int Version { get; set; }
+        public bool IsLatest { get; set; }
+        public bool IsPublished { get; set; }
+        public bool IsDisabled { get; set; }
+    }
+
+    public class WorkflowDefinitionVersionStartActivitiesIndex : MapIndex
+    {
+        public string StartActivityId { get; set; }
+        public string StartActivityType { get; set; }
+        public bool IsDisabled { get; set; }
+    }
+
+    public class WorkflowDefinitionVersionIndexProvider : IndexProvider<WorkflowDefinitionVersionDocument>
+    {
+        public override void Describe(DescribeContext<WorkflowDefinitionVersionDocument> context)
+        {
+            context.For<WorkflowDefinitionVersionIndex>()
+                .Map(
+                    document => new WorkflowDefinitionVersionIndex
+                    {
+                        VersionId = document.VersionId,
+                        WorkflowDefinitionId = document.WorkflowDefinitionId,
+                        Version = document.Version,
+                        IsPublished = document.IsPublished,
+                        IsLatest = document.IsLatest,
+                        IsDisabled = document.IsDisabled
+                    }
+                );
+
+            context.For<WorkflowDefinitionVersionStartActivitiesIndex>()
+                .Map(
+                    document => GetStartActivities(document)
+                        .Select(
+                            activity => new WorkflowDefinitionVersionStartActivitiesIndex
+                            {
+                                StartActivityId = activity.Id,
+                                StartActivityType = activity.Type,
+                                IsDisabled = document.IsDisabled
+                            }
+                        )
+                );
+        }
+
+        private static IEnumerable<ActivityDefinition> GetStartActivities(WorkflowDefinitionVersionDocument workflow)
+        {
+            var targetActivityIds = workflow.Connections.Select(x => x.TargetActivityId).Distinct().ToLookup(x => x);
+
+            var query =
+                from activity in workflow.Activities
+                where !targetActivityIds.Contains(activity.Id)
+                select activity;
+
+            return query;
+        }
+    }
+}

--- a/src/providers/Elsa.Persistence.YesSql/Services/YesSqlWorkflowDefinitionStore.cs
+++ b/src/providers/Elsa.Persistence.YesSql/Services/YesSqlWorkflowDefinitionStore.cs
@@ -36,23 +36,20 @@ namespace Elsa.Persistence.YesSql.Services
             return mapper.Map<WorkflowDefinition>(document);
         }
 
-        public async Task<WorkflowDefinition> GetByIdAsync(string id, CancellationToken cancellationToken = default)
+        public async Task<WorkflowDefinition> GetByIdAsync(string tenantId, string id, CancellationToken cancellationToken = default)
         {
             var query = session
                 .Query<WorkflowDefinitionDocument, WorkflowDefinitionIndex>()
-                .Where(x => x.Id == id);
+                .Where(x => x.TenantId == tenantId && x.Id == id);
 
             var document = await query.FirstOrDefaultAsync();
 
             return mapper.Map<WorkflowDefinition>(document);
         }
 
-        public async Task<IEnumerable<WorkflowDefinition>> ListAsync(string tenantId = "", CancellationToken cancellationToken = default)
+        public async Task<IEnumerable<WorkflowDefinition>> ListAsync(string tenantId, CancellationToken cancellationToken = default)
         {
-            var query = tenantId != "" ?
-                session.Query<WorkflowDefinitionDocument, WorkflowDefinitionIndex>().Where(x => x.TenantId == tenantId) :
-                session.Query<WorkflowDefinitionDocument, WorkflowDefinitionIndex>();
-
+            var query = session.Query<WorkflowDefinitionDocument, WorkflowDefinitionIndex>().Where(x => x.TenantId == tenantId);
             var documents = await query.ListAsync();
 
             return mapper.Map<IEnumerable<WorkflowDefinition>>(documents);
@@ -61,7 +58,7 @@ namespace Elsa.Persistence.YesSql.Services
         {
             var query = session
                 .Query<WorkflowDefinitionDocument, WorkflowDefinitionIndex>()
-                .Where(x => x.Id == definition.Id);
+                .Where(x => x.TenantId == definition.TenantId && x.Id == definition.Id);
 
             var document = await query.FirstOrDefaultAsync();
 
@@ -71,10 +68,10 @@ namespace Elsa.Persistence.YesSql.Services
 
             return mapper.Map<WorkflowDefinition>(document);
         }
-        public async Task<int> DeleteAsync(string id, CancellationToken cancellationToken = default)
+        public async Task<int> DeleteAsync(string tenantId, string id, CancellationToken cancellationToken = default)
         {
             var definitionDocuments = (await session.Query<WorkflowDefinitionDocument, WorkflowDefinitionIndex>()
-                    .Where(x => x.Id == id)
+                    .Where(x => x.TenantId == tenantId && x.Id == id)
                     .ListAsync())
                 .ToList();
 

--- a/src/providers/Elsa.Persistence.YesSql/Services/YesSqlWorkflowDefinitionVersionStore.cs
+++ b/src/providers/Elsa.Persistence.YesSql/Services/YesSqlWorkflowDefinitionVersionStore.cs
@@ -1,0 +1,126 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using AutoMapper;
+using Elsa.Models;
+using Elsa.Persistence.YesSql.Documents;
+using Elsa.Persistence.YesSql.Extensions;
+using Elsa.Persistence.YesSql.Indexes;
+using YesSql;
+
+namespace Elsa.Persistence.YesSql.Services
+{
+    public class YesSqlWorkflowDefinitionVersionStore : IWorkflowDefinitionVersionStore
+    {
+        private readonly ISession session;
+        private readonly IMapper mapper;
+
+        public YesSqlWorkflowDefinitionVersionStore(ISession session, IMapper mapper)
+        {
+            this.session = session;
+            this.mapper = mapper;
+        }
+
+        public async Task<WorkflowDefinitionVersion> SaveAsync(
+            WorkflowDefinitionVersion definitionVersion,
+            CancellationToken cancellationToken = default)
+        {
+            var document = mapper.Map<WorkflowDefinitionVersionDocument>(definitionVersion);
+            session.Save(document);
+            await session.CommitAsync();
+            return mapper.Map<WorkflowDefinitionVersion>(document);
+        }
+
+        public async Task<WorkflowDefinitionVersion> AddAsync(WorkflowDefinitionVersion definitionVersion, CancellationToken cancellationToken = default)
+        {
+            var document = mapper.Map<WorkflowDefinitionVersionDocument>(definitionVersion);
+
+            session.Save(document);
+            await session.CommitAsync();
+            return mapper.Map<WorkflowDefinitionVersion>(document);
+        }
+
+        public async Task<WorkflowDefinitionVersion> GetByIdAsync(string id, CancellationToken cancellationToken = default)
+        {
+            var query = session
+                .Query<WorkflowDefinitionVersionDocument, WorkflowDefinitionVersionIndex>()
+                .Where(x => x.VersionId == id);
+
+            var document = await query.FirstOrDefaultAsync();
+
+            return mapper.Map<WorkflowDefinitionVersion>(document);
+        }
+
+        public async Task<WorkflowDefinitionVersion> GetByIdAsync(
+            string definitionId,
+            VersionOptions version,
+            CancellationToken cancellationToken = default)
+        {
+            var query = session
+                .Query<WorkflowDefinitionVersionDocument, WorkflowDefinitionVersionIndex>()
+                .Where(x => x.WorkflowDefinitionId == definitionId)
+                .WithVersion(version);
+
+            var document = await query.FirstOrDefaultAsync();
+
+            return mapper.Map<WorkflowDefinitionVersion>(document);
+        }
+
+        public async Task<IEnumerable<WorkflowDefinitionVersion>> ListAsync(
+            VersionOptions version,
+            CancellationToken cancellationToken = default)
+        {
+            var query = session.Query<WorkflowDefinitionVersionDocument, WorkflowDefinitionVersionIndex>()
+                .WithVersion(version);
+            var documents = await query.ListAsync();
+
+            return mapper.Map<IEnumerable<WorkflowDefinitionVersion>>(documents);
+        }
+
+        public async Task<WorkflowDefinitionVersion> UpdateAsync(
+            WorkflowDefinitionVersion definitionVersion,
+            CancellationToken cancellationToken)
+        {
+            var query = session
+                .Query<WorkflowDefinitionVersionDocument, WorkflowDefinitionVersionIndex>()
+                .Where(x => x.WorkflowDefinitionId == definitionVersion.DefinitionId)
+                .WithVersion(VersionOptions.SpecificVersion(definitionVersion.Version));
+
+            var document = await query.FirstOrDefaultAsync();
+
+            document = mapper.Map(definitionVersion, document);
+            session.Save(document);
+            await session.CommitAsync();
+
+            return mapper.Map<WorkflowDefinitionVersion>(document);
+        }
+
+        public async Task<int> DeleteAsync(string id, CancellationToken cancellationToken = default)
+        {
+            var instanceDocuments = (await session.Query<WorkflowInstanceDocument, WorkflowInstanceIndex>()
+                    .Where(x => x.WorkflowDefinitionId == id)
+                    .ListAsync())
+                .ToList();
+
+            var definitionVersionDocuments = (await session
+                    .Query<WorkflowDefinitionVersionDocument, WorkflowDefinitionVersionIndex>()
+                    .Where(x => x.WorkflowDefinitionId == id)
+                    .ListAsync())
+                .ToList();
+
+            foreach (var document in instanceDocuments)
+            {
+                session.Delete(document);
+            }
+
+            foreach (var document in definitionVersionDocuments)
+            {
+                session.Delete(document);
+            }
+
+            await session.CommitAsync();
+            return definitionVersionDocuments.Count;
+        }
+    }
+}

--- a/src/providers/Elsa.Persistence.YesSql/StartupTasks/InitializeStoreTask.cs
+++ b/src/providers/Elsa.Persistence.YesSql/StartupTasks/InitializeStoreTask.cs
@@ -44,7 +44,12 @@ namespace Elsa.Persistence.YesSql.StartupTasks
             PerformUpdates(builder =>
             {
                 builder
-                    .CreateMapIndexTable(nameof(WorkflowDefinitionIndex), table => table
+                .CreateMapIndexTable(nameof(WorkflowDefinitionIndex), table => table
+                        .Column<string>("Id")
+                        .Column<string>("TenantId")
+                        .Column<DateTime>("CreatedAt")
+                    )
+                    .CreateMapIndexTable(nameof(WorkflowDefinitionVersionIndex), table => table
                         .Column<string>("VersionId")
                         .Column<string>("WorkflowDefinitionId")
                         .Column<int>("Version")
@@ -52,7 +57,7 @@ namespace Elsa.Persistence.YesSql.StartupTasks
                         .Column<bool>("IsLatest")
                         .Column<bool>("IsDisabled")
                     )
-                    .CreateMapIndexTable(nameof(WorkflowDefinitionStartActivitiesIndex), table => table
+                    .CreateMapIndexTable(nameof(WorkflowDefinitionVersionStartActivitiesIndex), table => table
                         .Column<string>("StartActivityId")
                         .Column<string>("StartActivityType")
                         .Column<bool>("IsDisabled")

--- a/src/samples/Elsa.Samples.CustomActivities/Properties/launchSettings.json
+++ b/src/samples/Elsa.Samples.CustomActivities/Properties/launchSettings.json
@@ -1,0 +1,27 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:56946/",
+      "sslPort": 44318
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "Elsa.Samples.CustomActivities": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:5001;http://localhost:5000"
+    }
+  }
+}

--- a/src/samples/Elsa.Samples.HelloWorldHttp/Properties/launchSettings.json
+++ b/src/samples/Elsa.Samples.HelloWorldHttp/Properties/launchSettings.json
@@ -1,0 +1,27 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:56945/",
+      "sslPort": 44384
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "Elsa.Samples.HelloWorldHttp": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:5001;http://localhost:5000"
+    }
+  }
+}

--- a/src/samples/Elsa.Samples.Serialization/Program.cs
+++ b/src/samples/Elsa.Samples.Serialization/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Elsa.Activities.Console;
 using Elsa.Expressions;
@@ -18,20 +18,20 @@ namespace Elsa.Samples.Serialization
                 .AddElsa()
                 .AddConsoleActivities()
                 .BuildServiceProvider();
-            
+
             var activityResolver = services.GetRequiredService<IActivityResolver>();
             var writeLine = activityResolver.ResolveActivity<WriteLine>().WithText(new LiteralExpression<string>("Foo"));
-            
-            var workflowDefinition = new WorkflowDefinitionVersion
+
+            var workflowDefinitionVersion = new WorkflowDefinitionVersion
             {
                 Activities = new List<ActivityDefinition> { ActivityDefinition.FromActivity(writeLine) }
             };
 
             var serializer = services.GetRequiredService<IWorkflowSerializer>();
-            var json = serializer.Serialize(workflowDefinition, JsonTokenFormatter.FormatName);
-            
+            var json = serializer.Serialize(workflowDefinitionVersion, JsonTokenFormatter.FormatName);
+
             Console.WriteLine(json);
-            
+
         }
     }
 }

--- a/src/server/Elsa.Server.GraphQL/Mutation.cs
+++ b/src/server/Elsa.Server.GraphQL/Mutation.cs
@@ -20,22 +20,22 @@ namespace Elsa.Server.GraphQL
         {
             this.mapper = mapper;
         }
-        
-        public async Task<WorkflowDefinitionVersion> SaveWorkflowDefinition(
+
+        public async Task<WorkflowDefinitionVersion> SaveWorkflowDefinitionVersion(
             string? id,
             WorkflowSaveAction saveAction,
             WorkflowInput workflowInput,
-            [Service] IWorkflowDefinitionStore store,
+            [Service] IWorkflowDefinitionVersionStore store,
             [Service] IIdGenerator idGenerator,
             [Service] ITokenSerializer serializer,
             [Service] IWorkflowPublisher publisher,
             CancellationToken cancellationToken)
         {
-            var workflowDefinition = id != null ? await store.GetByIdAsync(id, cancellationToken) : default;
+            var workflowDefinitionVersion = id != null ? await store.GetByIdAsync(id, cancellationToken) : default;
 
-            if (workflowDefinition == null)
+            if (workflowDefinitionVersion == null)
             {
-                workflowDefinition = new WorkflowDefinitionVersion
+                workflowDefinitionVersion = new WorkflowDefinitionVersion
                 {
                     Id = idGenerator.Generate(),
                     DefinitionId = idGenerator.Generate(),
@@ -45,43 +45,43 @@ namespace Elsa.Server.GraphQL
             }
 
             if (workflowInput.Activities != null)
-                workflowDefinition.Activities = workflowInput.Activities.Select(ToActivityDefinition).ToList();
+                workflowDefinitionVersion.Activities = workflowInput.Activities.Select(ToActivityDefinition).ToList();
 
             if (workflowInput.Connections != null)
-                workflowDefinition.Connections = workflowInput.Connections;
+                workflowDefinitionVersion.Connections = workflowInput.Connections;
 
             if (workflowInput.Description != null)
-                workflowDefinition.Description = workflowInput.Description.Trim();
+                workflowDefinitionVersion.Description = workflowInput.Description.Trim();
 
             if (workflowInput.Name != null)
-                workflowDefinition.Name = workflowInput.Name.Trim();
+                workflowDefinitionVersion.Name = workflowInput.Name.Trim();
 
             if (workflowInput.IsDisabled != null)
-                workflowDefinition.IsDisabled = workflowInput.IsDisabled.Value;
+                workflowDefinitionVersion.IsDisabled = workflowInput.IsDisabled.Value;
 
             if (workflowInput.IsSingleton != null)
-                workflowDefinition.IsSingleton = workflowInput.IsSingleton.Value;
+                workflowDefinitionVersion.IsSingleton = workflowInput.IsSingleton.Value;
 
             if (workflowInput.DeleteCompletedInstances != null)
-                workflowDefinition.DeleteCompletedInstances = workflowInput.DeleteCompletedInstances.Value;
+                workflowDefinitionVersion.DeleteCompletedInstances = workflowInput.DeleteCompletedInstances.Value;
 
             if (workflowInput.Variables != null)
-                workflowDefinition.Variables = serializer.Deserialize<Variables>(workflowInput.Variables);
+                workflowDefinitionVersion.Variables = serializer.Deserialize<Variables>(workflowInput.Variables);
 
             if (workflowInput.PersistenceBehavior != null)
-                workflowDefinition.PersistenceBehavior = workflowInput.PersistenceBehavior.Value;
+                workflowDefinitionVersion.PersistenceBehavior = workflowInput.PersistenceBehavior.Value;
 
             if (saveAction == WorkflowSaveAction.Publish)
-                workflowDefinition = await publisher.PublishAsync(workflowDefinition, cancellationToken);
+                workflowDefinitionVersion = await publisher.PublishAsync(workflowDefinitionVersion, cancellationToken);
             else
-                workflowDefinition = await publisher.SaveDraftAsync(workflowDefinition, cancellationToken);
+                workflowDefinitionVersion = await publisher.SaveDraftAsync(workflowDefinitionVersion, cancellationToken);
 
-            return workflowDefinition;
+            return workflowDefinitionVersion;
         }
 
-        public async Task<int> DeleteWorkflowDefinition(
+        public async Task<int> DeleteWorkflowDefinitionVersion(
             string id,
-            [Service] IWorkflowDefinitionStore store,
+            [Service] IWorkflowDefinitionVersionStore store,
             CancellationToken cancellationToken)
         {
             return await store.DeleteAsync(id, cancellationToken);

--- a/src/server/Elsa.Server.GraphQL/Query.cs
+++ b/src/server/Elsa.Server.GraphQL/Query.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -29,43 +29,43 @@ namespace Elsa.Server.GraphQL
             return type == null ? default : describer.Describe(type);
         }
 
-        public async Task<IEnumerable<WorkflowDefinitionVersion>> GetWorkflowDefinitions(
+        public async Task<IEnumerable<WorkflowDefinitionVersion>> GetWorkflowDefinitionVersions(
             VersionOptionsInput? version,
-            [Service] IWorkflowDefinitionStore store,
+            [Service] IWorkflowDefinitionVersionStore store,
             [Service] IMapper mapper,
             CancellationToken cancellationToken)
         {
             var mappedVersion = mapper.Map<VersionOptions?>(version);
             return await store.ListAsync(mappedVersion ?? VersionOptions.Latest, cancellationToken);
         }
-        
-        public async Task<WorkflowDefinitionVersion> GetWorkflowDefinition(
+
+        public async Task<WorkflowDefinitionVersion> GetWorkflowDefinitionVersion(
             string? id,
             string? definitionId,
             VersionOptionsInput? version,
-            [Service] IWorkflowDefinitionStore store,
+            [Service] IWorkflowDefinitionVersionStore store,
             [Service] IMapper mapper,
             CancellationToken cancellationToken)
         {
             if (id != null)
                 return await store.GetByIdAsync(id, cancellationToken);
-            
+
             var mappedVersion = mapper.Map<VersionOptions?>(version);
             return await store.GetByIdAsync(definitionId, mappedVersion ?? VersionOptions.Latest, cancellationToken);
         }
 
         public async Task<IEnumerable<WorkflowInstance>> GetWorkflowInstances(
-            string definitionId, 
+            string definitionId,
             WorkflowStatus? status,
             [Service] IWorkflowInstanceStore store,
             CancellationToken cancellationToken)
         {
-            if(status == null)
+            if (status == null)
                 return await store.ListByDefinitionAsync(definitionId, cancellationToken);
 
             return await store.ListByStatusAsync(definitionId, status.Value, cancellationToken);
         }
-        
+
         public async Task<WorkflowInstance> GetWorkflowInstance(
             string id,
             [Service] IWorkflowInstanceStore store,

--- a/src/server/Elsa.Server.GraphQL/Types/MutationType.cs
+++ b/src/server/Elsa.Server.GraphQL/Types/MutationType.cs
@@ -7,11 +7,11 @@ namespace Elsa.Server.GraphQL.Types
         protected override void Configure(IObjectTypeDescriptor<Mutation> descriptor)
         {
             descriptor
-                .Field(x => x.SaveWorkflowDefinition(default, default, default, default, default, default, default, default))
+                .Field(x => x.SaveWorkflowDefinitionVersion(default, default, default, default, default, default, default, default))
                 .Argument("id", x => x.Type<IdType>());
 
             descriptor
-                .Field(x => x.DeleteWorkflowDefinition(default, default, default))
+                .Field(x => x.DeleteWorkflowDefinitionVersion(default, default, default))
                 .Argument("id", x => x.Type<IdType>());
         }
     }

--- a/src/server/Elsa.Server.GraphQL/Types/QueryType.cs
+++ b/src/server/Elsa.Server.GraphQL/Types/QueryType.cs
@@ -9,13 +9,13 @@ namespace Elsa.Server.GraphQL.Types
             descriptor
                 .Field(x => x.GetActivityDescriptor(default, default, default))
                 .Argument("typeName", x => x.Type<IdType>());
-            
+
             descriptor
-                .Field(x => x.GetWorkflowDefinitions(default, default, default, default))
+                .Field(x => x.GetWorkflowDefinitionVersions(default, default, default, default))
                 .Argument("version", x => x.Type<VersionOptionsInputType>());
-            
+
             descriptor
-                .Field(x => x.GetWorkflowDefinition(default, default, default, default, default, default))
+                .Field(x => x.GetWorkflowDefinitionVersion(default, default, default, default, default, default))
                 .Argument("id", x => x.Type<IdType>())
                 .Argument("definitionId", x => x.Type<IdType>())
                 .Argument("version", x => x.Type<VersionOptionsInputType>());
@@ -23,7 +23,7 @@ namespace Elsa.Server.GraphQL.Types
             descriptor
                 .Field(x => x.GetWorkflowInstances(default, default, default, default))
                 .Argument("definitionId", x => x.Type<IdType>());
-            
+
             descriptor
                 .Field(x => x.GetWorkflowInstance(default, default, default))
                 .Argument("id", x => x.Type<IdType>());


### PR DESCRIPTION
Pull request related to Multitenancy support issue. Here is a brief description on what was changed/implemented:

1) created WorkflowDefinition model in Elsa.Abstractions and WorkflowDefinitionEntity in entities;
2) updated ElsaContext with new entities and ConfigureWOrkflowDefinition method;
3) renamed IWorkflowDefinitionStore to IWorkflowDefinitionVersionStore;
4) renamed all occurences (arguments, parameters, etc.) of WorkflowDefinitionVersion type to improve consistency in code. 

This means that lines like:

`Task<WorkflowDefinitionVersion> SaveAsync(WorkflowDefinitionVersion definition, CancellationToken cancellationToken = default);` 

now become:

`Task<WorkfowDefinitionVersion> SaveASync(WorkflowDefintionVersion definitionVersion, CancellationToken cancellationToken = default);` where we can see that the "definition" has now become "definitionVersion".

5) implemented IWorkflowDefinitionStore in all database providers (also created necessary documents, indexes and classes);
6) updated WorkflowPublisher.cs to create a WorkflowDefinition when creating a WorkflowDefinitionVersion with DefinitionId == null;
7) set up services and dependency injection for new stores;


If anything in this pull request doesn't satisfy the multitenancy support requirements, or if something is unnecessary - I'll gladly accept any suggestions on what could be improved, modified or changed. :)