### PR TITLE
Add Exception property to WorkflowFault

### DIFF
--- a/src/core/Elsa.Abstractions/Models/WorkflowFault.cs
+++ b/src/core/Elsa.Abstractions/Models/WorkflowFault.cs
@@ -1,8 +1,11 @@
-﻿namespace Elsa.Models
+using System;
+
+namespace Elsa.Models
 {
     public class WorkflowFault
     {
         public string FaultedActivityId { get; set; }
         public string Message { get; set; }
+        public Exception Exception { get; set; }
     }
 }

--- a/src/core/Elsa.Abstractions/Services/Models/WorkflowExecutionContext.cs
+++ b/src/core/Elsa.Abstractions/Services/Models/WorkflowExecutionContext.cs
@@ -89,14 +89,15 @@ namespace Elsa.Services.Models
             Workflow.Status = WorkflowStatus.Executing;
         }
 
-        public void Fault(IActivity activity, Exception exception) => Fault(activity, exception.Message);
+        public void Fault(IActivity activity, Exception exception) => Fault(activity, exception.Message, exception);
 
-        public void Fault(IActivity activity, string errorMessage)
+        public void Fault(IActivity activity, string errorMessage, Exception exception = null)
         {
             Workflow.FaultedAt = clock.GetCurrentInstant();
             Workflow.Fault = new WorkflowFault
             {
                 Message = errorMessage,
+                Exception = exception,
                 FaultedActivity = activity
             };
             Workflow.Status = WorkflowStatus.Faulted;

--- a/src/core/Elsa.Abstractions/Services/Models/WorkflowFault.cs
+++ b/src/core/Elsa.Abstractions/Services/Models/WorkflowFault.cs
@@ -1,16 +1,20 @@
-﻿namespace Elsa.Services.Models
+using System;
+
+namespace Elsa.Services.Models
 {
     public class WorkflowFault
     {
         public IActivity FaultedActivity { get; set; }
         public string Message { get; set; }
+        public Exception Exception { get; set; }
 
         public Elsa.Models.WorkflowFault ToInstance()
         {
             return new Elsa.Models.WorkflowFault
             {
                 FaultedActivityId = FaultedActivity?.Id,
-                Message = Message
+                Message = Message,
+                Exception = Exception
             };
         }
     }

--- a/src/core/Elsa.Core/Results/FaultWorkflowResult.cs
+++ b/src/core/Elsa.Core/Results/FaultWorkflowResult.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Elsa.Extensions;
@@ -12,9 +12,11 @@ namespace Elsa.Results
     public class FaultWorkflowResult : ActivityExecutionResult
     {
         private readonly string errorMessage;
+        private Exception exception;
 
         public FaultWorkflowResult(Exception exception) : this(exception.Message)
         {
+            this.exception = exception;
         }
 
         public FaultWorkflowResult(string errorMessage)
@@ -35,7 +37,7 @@ namespace Elsa.Results
                 x => x.ActivityFaultedAsync(workflowContext, currentActivity, errorMessage, cancellationToken),
                 logger);
 
-            workflowContext.Fault(workflowContext.CurrentActivity, errorMessage);
+            workflowContext.Fault(workflowContext.CurrentActivity, errorMessage, exception);
         }
     }
 }


### PR DESCRIPTION
Expose the underlying System.Exception that caused the Workflow to return a fault. This will allow callers to execute error handling based on the runtime Exception (if present) instead of error text.

Right now, Exception can be null. If Nullable Reference Types will be enabled in this project in the future, perhaps we can change this implementation a little and initialize the Exception object when only an errorMessage is specified.

