### PR TITLE
Fix bug in ForEach activity when the collection is empty

### DIFF
--- a/src/activities/Elsa.Activities.ControlFlow/Activities/ForEach.cs
+++ b/src/activities/Elsa.Activities.ControlFlow/Activities/ForEach.cs
@@ -48,6 +48,11 @@ namespace Elsa.Activities.ControlFlow.Activities
             var collection = await expressionEvaluator.EvaluateAsync(CollectionExpression, context, cancellationToken);
             var index = CurrentIndex;
 
+            if (collection.Count == 0)
+            {
+                return Done();
+            }
+
             if (index >= collection.Count)
             {
                 context.EndScope();


### PR DESCRIPTION
**Issue Summary**
The incorrect scope is ended (removed from the stack) when using the ForEach activity with an empty collection. This happens because the current scope is ended when the current index is equal to the count of items in the collection. In scenarios where the collection is empty, a new scope is **not** added, however, the previous scope is ended. This results in a faulted workflow when accessing variables from previous scopes and a 'System.InvalidOperationException' when accessing the default workflow scope.

**Steps to Reproduce**
Example workflow code
```csharp
public class ScopeTestWorkflow : IWorkflow
{
    public void Build(IWorkflowBuilder builder)
    {
        builder
            .StartWith<SetVariable>(x =>
            {
                x.VariableName = "scopeTest";
                x.ValueExpression = new LiteralExpression<string>("Variable is Correct");
            })
            .ForEach(x =>
            {
                x.IteratorName = "collection";
                x.CollectionExpression = new JavaScriptExpression<IList<object>>("[]");
            }, each =>
            {
                each
                .When(OutcomeNames.Iterate)
                .Then<WriteLine>(x => x.TextExpression = new JavaScriptExpression<string>("collection"))
                .Then(each);
            })
            .Then<WriteLine>(x => x.TextExpression = new JavaScriptExpression<string>("scopeTest"))
            .Then<WriteLine>(x => x.TextExpression = new LiteralExpression<string>("Done"));
    }
}
```

**Expected Console Output**
```
Variable is Correct
Done
```

**Actual Result**
1. No console output
2. Workflow is haulted with message 'Error while evaluating JavaScript expression "scopeTest". Message: scopeTest is not defined’
3. Workflow scope count is zero

**Resolution**
 Immediately return an outcome of done when the collection is empty