### PR TITLE
Fix#325:Elsa 2#RunWorkflowDefinitionAsync getting object reference null

### DIFF
--- a/Samples.sln
+++ b/Samples.sln
@@ -54,43 +54,45 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Elsa.Activities.Reflection"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "server", "server", "{468E498C-59DB-4541-8D8A-0D89DE9083AB}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Server.Core", "src\server\Elsa.Server.Core\Elsa.Server.Core.csproj", "{D91E2F7B-D5B7-4D1C-A3F0-B0475C33F539}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Elsa.Server.Core", "src\server\Elsa.Server.Core\Elsa.Server.Core.csproj", "{D91E2F7B-D5B7-4D1C-A3F0-B0475C33F539}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Server.Host", "src\server\Elsa.Server.Host\Elsa.Server.Host.csproj", "{FC54EDBA-71FB-4A87-8FD5-54759DF77CCE}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Elsa.Server.Host", "src\server\Elsa.Server.Host\Elsa.Server.Host.csproj", "{FC54EDBA-71FB-4A87-8FD5-54759DF77CCE}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{AB1AE008-6FD6-414C-8E88-D735F42E1FA6}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "unit", "unit", "{0A3C36AB-2ACF-4175-A512-66B4C3DB9371}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Core.UnitTests", "test\unit\Elsa.Core.UnitTests\Elsa.Core.UnitTests.csproj", "{475EEB95-ED27-4366-88EA-97C5000AC8E8}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Elsa.Core.UnitTests", "test\unit\Elsa.Core.UnitTests\Elsa.Core.UnitTests.csproj", "{475EEB95-ED27-4366-88EA-97C5000AC8E8}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "shared", "shared", "{0A6747EA-7AC6-4B6F-BC0C-C40C8A80C44D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Testing.Shared", "test\shared\Elsa.Testing.Shared\Elsa.Testing.Shared.csproj", "{E7C689EB-5AD6-4E91-A007-6116EEA702FC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Elsa.Testing.Shared", "test\shared\Elsa.Testing.Shared\Elsa.Testing.Shared.csproj", "{E7C689EB-5AD6-4E91-A007-6116EEA702FC}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Persistence.DocumentDb", "src\providers\Elsa.Persistence.DocumentDb\Elsa.Persistence.DocumentDb.csproj", "{C042677F-973C-4672-AFA1-31B389962FE5}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Elsa.Persistence.DocumentDb", "src\providers\Elsa.Persistence.DocumentDb\Elsa.Persistence.DocumentDb.csproj", "{C042677F-973C-4672-AFA1-31B389962FE5}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Persistence.EntityFrameworkCore", "src\providers\Elsa.Persistence.EntityFrameworkCore\Elsa.Persistence.EntityFrameworkCore.csproj", "{3F43514A-927E-4C62-B153-AFCAD7B1A7FC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Elsa.Persistence.EntityFrameworkCore", "src\providers\Elsa.Persistence.EntityFrameworkCore\Elsa.Persistence.EntityFrameworkCore.csproj", "{3F43514A-927E-4C62-B153-AFCAD7B1A7FC}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Persistence.MongoDb", "src\providers\Elsa.Persistence.MongoDb\Elsa.Persistence.MongoDb.csproj", "{36A6F881-1B40-438D-9B6D-80F01CE76D51}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Elsa.Persistence.MongoDb", "src\providers\Elsa.Persistence.MongoDb\Elsa.Persistence.MongoDb.csproj", "{36A6F881-1B40-438D-9B6D-80F01CE76D51}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Persistence.YesSql", "src\providers\Elsa.Persistence.YesSql\Elsa.Persistence.YesSql.csproj", "{DA825F41-EE97-47B3-801E-C694A6C53AEC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Elsa.Persistence.YesSql", "src\providers\Elsa.Persistence.YesSql\Elsa.Persistence.YesSql.csproj", "{DA825F41-EE97-47B3-801E-C694A6C53AEC}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Samples.Timers", "src\samples\Elsa.Samples.Timers\Elsa.Samples.Timers.csproj", "{071DD6EC-D00C-4513-82B6-3FE8438061E3}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Elsa.Samples.Timers", "src\samples\Elsa.Samples.Timers\Elsa.Samples.Timers.csproj", "{071DD6EC-D00C-4513-82B6-3FE8438061E3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.DistributedLocking.SqlServer", "src\providers\Elsa.DistributedLocking.SqlServer\Elsa.DistributedLocking.SqlServer.csproj", "{150EF356-E8BC-4922-91C2-362017479409}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Elsa.DistributedLocking.SqlServer", "src\providers\Elsa.DistributedLocking.SqlServer\Elsa.DistributedLocking.SqlServer.csproj", "{150EF356-E8BC-4922-91C2-362017479409}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Server.GraphQL", "src\server\Elsa.Server.GraphQL\Elsa.Server.GraphQL.csproj", "{12D29DDC-A885-4CAA-908C-106D845B10C0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Elsa.Server.GraphQL", "src\server\Elsa.Server.GraphQL\Elsa.Server.GraphQL.csproj", "{12D29DDC-A885-4CAA-908C-106D845B10C0}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Samples.Serialization", "src\samples\Elsa.Samples.Serialization\Elsa.Samples.Serialization.csproj", "{DF47517F-9029-44DF-A29F-F2DE15041473}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Elsa.Samples.Serialization", "src\samples\Elsa.Samples.Serialization\Elsa.Samples.Serialization.csproj", "{DF47517F-9029-44DF-A29F-F2DE15041473}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Samples.HelloWorldConsole", "src\samples\Elsa.Samples.HelloWorldConsole\Elsa.Samples.HelloWorldConsole.csproj", "{E224F8CF-F9F5-4E99-B405-758F3C02C47A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Elsa.Samples.HelloWorldConsole", "src\samples\Elsa.Samples.HelloWorldConsole\Elsa.Samples.HelloWorldConsole.csproj", "{E224F8CF-F9F5-4E99-B405-758F3C02C47A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Samples.HelloWorldHttp", "src\samples\Elsa.Samples.HelloWorldHttp\Elsa.Samples.HelloWorldHttp.csproj", "{A11D79AE-F4C9-4595-9B73-0E0AB221B90D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Elsa.Samples.HelloWorldHttp", "src\samples\Elsa.Samples.HelloWorldHttp\Elsa.Samples.HelloWorldHttp.csproj", "{A11D79AE-F4C9-4595-9B73-0E0AB221B90D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Samples.CustomActivities", "src\samples\Elsa.Samples.CustomActivities\Elsa.Samples.CustomActivities.csproj", "{554C21D7-10BE-48E6-B0EF-9FCA43B32A0F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Elsa.Samples.CustomActivities", "src\samples\Elsa.Samples.CustomActivities\Elsa.Samples.CustomActivities.csproj", "{554C21D7-10BE-48E6-B0EF-9FCA43B32A0F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Samples.TimesheetApproval", "src\samples\Elsa.Samples.TimesheetApproval\Elsa.Samples.TimesheetApproval.csproj", "{1678743A-9095-4683-8DCD-5763F41924E2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Elsa.Samples.TimesheetApproval", "src\samples\Elsa.Samples.TimesheetApproval\Elsa.Samples.TimesheetApproval.csproj", "{1678743A-9095-4683-8DCD-5763F41924E2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Samples.WorkflowDefinition", "src\samples\Elsa.Samples.WorkflowDefinition\Elsa.Samples.WorkflowDefinition.csproj", "{7AC91435-7D10-4353-9064-598A6F8EAED6}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -146,10 +148,6 @@ Global
 		{01DC21DD-C6E2-4B21-864E-97D29448F777}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{01DC21DD-C6E2-4B21-864E-97D29448F777}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{01DC21DD-C6E2-4B21-864E-97D29448F777}.Release|Any CPU.Build.0 = Release|Any CPU
-		{2AEA0028-96D6-4823-A88F-24294E4BA4E8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{2AEA0028-96D6-4823-A88F-24294E4BA4E8}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{2AEA0028-96D6-4823-A88F-24294E4BA4E8}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{2AEA0028-96D6-4823-A88F-24294E4BA4E8}.Release|Any CPU.Build.0 = Release|Any CPU
 		{258F624E-98D7-4498-AE2E-F612D8ECA763}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{258F624E-98D7-4498-AE2E-F612D8ECA763}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{258F624E-98D7-4498-AE2E-F612D8ECA763}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -218,6 +216,10 @@ Global
 		{1678743A-9095-4683-8DCD-5763F41924E2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1678743A-9095-4683-8DCD-5763F41924E2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1678743A-9095-4683-8DCD-5763F41924E2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7AC91435-7D10-4353-9064-598A6F8EAED6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7AC91435-7D10-4353-9064-598A6F8EAED6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7AC91435-7D10-4353-9064-598A6F8EAED6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7AC91435-7D10-4353-9064-598A6F8EAED6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -240,7 +242,6 @@ Global
 		{6BB5EB72-AD9A-41ED-A6AA-0FF1093EA41B} = {35F44BE9-13D0-417C-A01A-F0787BEE6DC3}
 		{18BE8F72-E528-4617-B1B1-07BD35337DFC} = {9C3C685E-3D7D-4638-A031-24F71CF74B52}
 		{01DC21DD-C6E2-4B21-864E-97D29448F777} = {9C3C685E-3D7D-4638-A031-24F71CF74B52}
-		{2AEA0028-96D6-4823-A88F-24294E4BA4E8} = {5E5E1E84-DDBC-40D6-B891-0D563A15A44A}
 		{258F624E-98D7-4498-AE2E-F612D8ECA763} = {B43B546E-23F3-46E8-ACB7-D04F05CDA180}
 		{468E498C-59DB-4541-8D8A-0D89DE9083AB} = {DA71CDAA-8DD3-4D5F-9FBD-8E4B37A2D925}
 		{D91E2F7B-D5B7-4D1C-A3F0-B0475C33F539} = {468E498C-59DB-4541-8D8A-0D89DE9083AB}
@@ -261,6 +262,7 @@ Global
 		{A11D79AE-F4C9-4595-9B73-0E0AB221B90D} = {5E5E1E84-DDBC-40D6-B891-0D563A15A44A}
 		{554C21D7-10BE-48E6-B0EF-9FCA43B32A0F} = {5E5E1E84-DDBC-40D6-B891-0D563A15A44A}
 		{1678743A-9095-4683-8DCD-5763F41924E2} = {5E5E1E84-DDBC-40D6-B891-0D563A15A44A}
+		{7AC91435-7D10-4353-9064-598A6F8EAED6} = {5E5E1E84-DDBC-40D6-B891-0D563A15A44A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8B0975FD-7050-48B0-88C5-48C33378E158}

--- a/src/core/Elsa.Abstractions/Services/IWorkflowHost.cs
+++ b/src/core/Elsa.Abstractions/Services/IWorkflowHost.cs
@@ -8,15 +8,16 @@ namespace Elsa.Services
     public interface IWorkflowHost
     {
         Task<WorkflowExecutionContext> RunWorkflowAsync(Workflow workflow, string? activityId = default, object? input = default, string? correlationId = default, CancellationToken cancellationToken = default);
-        
+
         Task<WorkflowExecutionContext?> RunWorkflowInstanceAsync(string workflowInstanceId, string? activityId = default, object? input = default, CancellationToken cancellationToken = default);
+
         Task<WorkflowExecutionContext?> RunWorkflowInstanceAsync(WorkflowInstance workflowInstance, string? activityId = default, object? input = default, CancellationToken cancellationToken = default);
-        
+
         /// <summary>
         /// Run a registered workflow by its ID.
         /// </summary>
-        Task<WorkflowExecutionContext> RunWorkflowDefinitionAsync(string workflowDefinitionId, string? activityId, object? input = default, string? correlationId = default, CancellationToken cancellationToken = default);
-        
+        Task<WorkflowExecutionContext> RunWorkflowDefinitionAsync(string workflowDefinitionId, string? activityId = default, object? input = default, string? correlationId = default, CancellationToken cancellationToken = default);
+
         // /// <summary>
         // /// Resume a workflow instance.
         // /// </summary>

--- a/src/core/Elsa.Core/Services/WorkflowHost.cs
+++ b/src/core/Elsa.Core/Services/WorkflowHost.cs
@@ -79,7 +79,7 @@ namespace Elsa.Services
             if (workflow == null)
             {
                 logger.LogError("Workflow definition {WorkflowInstanceId} either not registered or not published.", workflowDefinitionId);
-                throw new WorkflowException("The triggered workflow definition either not registered or not published.");
+                throw new WorkflowException("The specified workflow definition is either not registered or not published.");
             }
             var workflowInstance = await workflowActivator.ActivateAsync(workflow, correlationId, cancellationToken);
             return await RunAsync(workflow, workflowInstance, activityId, input, cancellationToken);

--- a/src/core/Elsa.Core/Services/WorkflowHost.cs
+++ b/src/core/Elsa.Core/Services/WorkflowHost.cs
@@ -73,7 +73,7 @@ namespace Elsa.Services
             return await RunAsync(workflow, workflowInstance, activityId, input, cancellationToken);
         }
 
-        public async Task<WorkflowExecutionContext> RunWorkflowDefinitionAsync(string workflowDefinitionId, string? activityId, object? input = default, string? correlationId = default, CancellationToken cancellationToken = default)
+        public async Task<WorkflowExecutionContext> RunWorkflowDefinitionAsync(string workflowDefinitionId, string? activityId = default, object? input = default, string? correlationId = default, CancellationToken cancellationToken = default)
         {
             var workflow = await workflowRegistry.GetWorkflowAsync(workflowDefinitionId, VersionOptions.Published, cancellationToken);
             if (workflow == null)

--- a/src/samples/Elsa.Samples.WorkflowDefinition/Elsa.Samples.WorkflowDefinition.csproj
+++ b/src/samples/Elsa.Samples.WorkflowDefinition/Elsa.Samples.WorkflowDefinition.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\activities\Elsa.Activities.Console\Elsa.Activities.Console.csproj" />
+    <ProjectReference Include="..\..\core\Elsa.Abstractions\Elsa.Abstractions.csproj" />
+    <ProjectReference Include="..\..\core\Elsa.Core\Elsa.Core.csproj" />
+    <ProjectReference Include="..\..\core\Elsa\Elsa.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/samples/Elsa.Samples.WorkflowDefinition/Program.cs
+++ b/src/samples/Elsa.Samples.WorkflowDefinition/Program.cs
@@ -55,7 +55,7 @@ namespace Elsa.Samples.WorkflowDefinition
 
             //Run it
             var invoker = services.GetService<IWorkflowHost>();
-            await invoker.RunWorkflowDefinitionAsync("definition-001", "activity-1");
+            await invoker.RunWorkflowDefinitionAsync("definition-001");
 
             Console.ReadLine();
         }

--- a/src/samples/Elsa.Samples.WorkflowDefinition/Program.cs
+++ b/src/samples/Elsa.Samples.WorkflowDefinition/Program.cs
@@ -1,0 +1,63 @@
+using Elsa.Activities.Console;
+using Elsa.Expressions;
+using Elsa.Models;
+using Elsa.Persistence;
+using Elsa.Services;
+using Elsa.Builders;
+
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Elsa.Samples.WorkflowDefinition
+{
+    internal class Program
+    {
+        private static async Task Main(string[] args)
+        {
+            var services = new ServiceCollection()
+                               .AddElsa()
+                               .AddLogging(log => log.AddConsole())
+                               .AddConsoleActivities()
+                               .AddSingleton(Console.In)
+                               .BuildServiceProvider();
+
+            var activityResolver = services.GetRequiredService<IActivityResolver>();
+            var activity1 = activityResolver.ResolveActivity<WriteLine>()
+                                            .WithId("activity-1")
+                                            .WithText(new LiteralExpression<string>("Hello world!"));
+
+            var activity2 = activityResolver.ResolveActivity<WriteLine>()
+                                            .WithId("activity-2")
+                                            .WithText(new LiteralExpression<string>("Goodbye cruel world...!"));
+
+            //Create Workflow Definition
+            var workflowDefinition = new WorkflowDefinitionVersion
+            {
+                DefinitionId = "definition-001",
+                IsPublished = true,
+                Activities = new List<ActivityDefinition>
+                {
+                    ActivityDefinition.FromActivity(activity1),
+                    ActivityDefinition.FromActivity(activity2)
+                },
+                Connections = new[]
+                {
+                    new ConnectionDefinition("activity-1", "activity-2", OutcomeNames.Done),
+                }
+            };
+
+            //Register it
+            var workflowDefination = services.GetService<IWorkflowDefinitionStore>();
+            await workflowDefination.AddAsync(workflowDefinition);
+
+            //Run it
+            var invoker = services.GetService<IWorkflowHost>();
+            await invoker.RunWorkflowDefinitionAsync("definition-001", "activity-1");
+
+            Console.ReadLine();
+        }
+    }
+}


### PR DESCRIPTION
This PR will fix _Object reference not set to an instance of an object._ if user tries to run workflow definition without publish it.

**How To Test?**
To test this fix, I have added new sample project named `Elsa.Samples.WorkflowDefinition`. While creating WorkflowDefinition I have mentioned `IsPublished = true`, if you change it to `false`, it will log the error using Microsoft.Logging framework as fatal error and also it will throw Workflow exception as below - 

![image](https://user-images.githubusercontent.com/5505886/84502665-6c68ae80-acd6-11ea-9f41-ba6e6ce02f4b.png)
