### PR TITLE
Reverse WorkflowInstanceEntity.Scopes on deserialization

### DIFF
--- a/src/persistence/Elsa.Persistence.EntityFrameworkCore/DbContexts/ElsaContext.cs
+++ b/src/persistence/Elsa.Persistence.EntityFrameworkCore/DbContexts/ElsaContext.cs
@@ -94,7 +94,7 @@ namespace Elsa.Persistence.EntityFrameworkCore.DbContexts
                 .Property(x => x.Scopes)
                 .HasConversion(
                     x => Serialize(x),
-                    x => Deserialize<Stack<WorkflowExecutionScope>>(x)
+                    x => DeserializeScopes(x)
                 );
             
             entity
@@ -175,6 +175,12 @@ namespace Elsa.Persistence.EntityFrameworkCore.DbContexts
         private T Deserialize<T>(string json)
         {
             return JsonConvert.DeserializeObject<T>(json, serializerSettings);
+        }
+
+        private Stack<WorkflowExecutionScope> DeserializeScopes(string json)
+        {
+            var reversedScopes = JsonConvert.DeserializeObject<Stack<WorkflowExecutionScope>>(json, serializerSettings);
+            return reversedScopes is { } ? new Stack<WorkflowExecutionScope>(reversedScopes) : null;
         }
     }
 }


### PR DESCRIPTION
There is a known issue in Newtonsoft.Json that it reverse the stack on deserialization and we have to manually reverse it. To resolve #334 
Reference: https://github.com/JamesNK/Newtonsoft.Json/issues/1596