### PR TITLE
fix for bug #341 and fix designer toolbar alignment

### DIFF
--- a/src/core/Elsa.Abstractions/Models/ActivityDefinition.cs
+++ b/src/core/Elsa.Abstractions/Models/ActivityDefinition.cs
@@ -29,8 +29,8 @@ namespace Elsa.Models
 
         public string Name
         {
-            get => State.ContainsKey(nameof(Name)) ? State[nameof(Name)].Value<string>() : default;
-            set => State[nameof(Name)] = value;
+            get => State.ContainsKey(nameof(Name).ToLower()) ? State[nameof(Name).ToLower()].Value<string>() : default;
+            set => State[nameof(Name).ToLower()] = value;
         }
 
         public string DisplayName { get; set; }

--- a/src/dashboard/Elsa.Dashboard/Areas/Elsa/Views/Shared/WorkflowDefinitionEditor.cshtml
+++ b/src/dashboard/Elsa.Dashboard/Areas/Elsa/Views/Shared/WorkflowDefinitionEditor.cshtml
@@ -8,11 +8,11 @@
             <div class="card bg-secondary shadow">
                 <div class="card-header bg-white border-0">
                     <div class="row align-items-center">
-                        <div class="col-8">
+                        <div class="col">
                             <h3 id="editorCaption" class="mb-0">@Model.Name</h3>
                             <small id="editorDescription" class="text-muted">@Model.Description</small>
                         </div>
-                        <div class="col-4 text-right">
+                        <div class="col text-right">
                             <a href="#!" class="btn btn-primary" onclick="addActivity()">Add Activity</a>
                             <a href="#!" class="btn btn-secondary" onclick="exportWorkflow()">Download</a>
                             <a href="#!" class="btn btn-secondary" onclick="importWorkflow()">Import</a>


### PR DESCRIPTION
Bug #341: the issue is generated by the ContainsKey() that adds the Name propery (uppercase) even if there is already name (lowercase) added by the activity definition. Fixed with a "ToLower()" on get and set methods of ActivityDefinition

Layout problem: the "Import" and "Settings gear" goes to a new line. Fixed by setting the style of Title+Descrition and toolbar as col instead of col-8 and col-4 to allow the browser to autosize the column