### PR TITLE
fixed IOC and async/await related issues in CosmosDB persistence library (#311)

### DIFF
--- a/src/persistence/Elsa.Persistence.DocumentDb/DocumentDbStorage.cs
+++ b/src/persistence/Elsa.Persistence.DocumentDb/DocumentDbStorage.cs
@@ -1,28 +1,30 @@
 ﻿using Microsoft.Azure.Documents;
 using Microsoft.Azure.Documents.Client;
+using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using NodaTime;
+using NodaTime.Serialization.JsonNet;
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Elsa.Persistence.DocumentDb
 {
-    public class DocumentDbStorage
+    internal class DocumentDbStorage : IDocumentDbStorage
     {
-        private DocumentDbStorageOptions Options { get; }
-        internal DocumentClient Client { get; }
-        internal Uri CollectionUri { get; private set; }
+        private readonly SemaphoreSlim clientInstanceLock;
+        private readonly DocumentDbStorageOptions options;
+        private DocumentClient client;
+        private Dictionary<string, (string Name, Uri Uri)> collectionUris;
 
-        public DocumentDbStorage(
-            string url,
-            string authSecret,
-            string database,
-            string collection,
-            DocumentDbStorageOptions options = null)
+        public DocumentDbStorage(IOptions<DocumentDbStorageOptions> options)
         {
-            Options = options ?? new DocumentDbStorageOptions();
-            Options.DatabaseName = database;
-            Options.CollectionName = collection;
+            clientInstanceLock = new SemaphoreSlim(1, 1);
+
+            this.options = options.Value;
 
             var settings = new JsonSerializerSettings
             {
@@ -32,55 +34,68 @@ namespace Elsa.Persistence.DocumentDb
                 {
                     NamingStrategy = new CamelCaseNamingStrategy(false, false)
                 }
-            };
+            }.ConfigureForNodaTime(DateTimeZoneProviders.Tzdb);
 
             var connectionPolicy = ConnectionPolicy.Default;
-            connectionPolicy.ConnectionMode = Options.ConnectionMode;
-            connectionPolicy.ConnectionProtocol = Options.ConnectionProtocol;
-            connectionPolicy.RequestTimeout = Options.RequestTimeout;
+            connectionPolicy.ConnectionMode = this.options.ConnectionMode;
+            connectionPolicy.ConnectionProtocol = this.options.ConnectionProtocol;
+            connectionPolicy.RequestTimeout = this.options.RequestTimeout;
             connectionPolicy.RetryOptions = new RetryOptions
             {
                 MaxRetryWaitTimeInSeconds = 10,
                 MaxRetryAttemptsOnThrottledRequests = 5
             };
 
-            Client = new DocumentClient(new Uri(url), authSecret, settings, connectionPolicy);
-            var task = Client.OpenAsync();
-            var continueTask = task.ContinueWith(t => Initialize(), TaskContinuationOptions.OnlyOnRanToCompletion);
-            continueTask.Wait();
+            client = new DocumentClient(new Uri(this.options.Url), this.options.AuthSecret, settings, connectionPolicy);
         }
 
-        /// <summary>
-        /// Return the name of the database.
-        /// </summary>
-        public override string ToString() => $"DocumentDb Database: {Options.DatabaseName}";
+        public override string ToString() => $"DocumentDb Database: {options.DatabaseName}";
 
-        private void Initialize()
+        public async Task<DocumentClient> GetDocumentClient()
         {
-            var databaseTask = Client.CreateDatabaseIfNotExistsAsync(new Database { Id = Options.DatabaseName });
+            await clientInstanceLock.WaitAsync();
 
-            var collectionTask = databaseTask.ContinueWith(
-                    t =>
-                    {
-                        var databaseUri = UriFactory.CreateDatabaseUri(t.Result.Resource.Id);
-                        return Client.CreateDocumentCollectionIfNotExistsAsync(
-                            databaseUri,
-                            new DocumentCollection { Id = Options.CollectionName });
-                    },
-                    TaskContinuationOptions.OnlyOnRanToCompletion)
-                .Unwrap();
-
-            var continueTask = collectionTask.ContinueWith(
-                t =>
-                {
-                    CollectionUri = UriFactory.CreateDocumentCollectionUri(Options.DatabaseName, t.Result.Resource.Id);
-                },
-                TaskContinuationOptions.OnlyOnRanToCompletion);
-            continueTask.Wait();
-            if (continueTask.IsFaulted || continueTask.IsCanceled)
+            try
             {
-                throw new ApplicationException("Unable to setup the storage database", databaseTask.Exception);
+                if (collectionUris != null)
+                {
+                    return client;
+                }
+
+                await client.OpenAsync();
+
+                var database = await client.CreateDatabaseIfNotExistsAsync(new Database
+                {
+                    Id = options.DatabaseName
+                });
+
+
+
+                var tasks = options.CollectionNames.Select(async collectionName =>
+                {
+                    var databaseUri = UriFactory.CreateDatabaseUri(database.Resource.Id);
+                    var collection = await client.CreateDocumentCollectionIfNotExistsAsync(databaseUri, new DocumentCollection
+                    {
+                        Id = collectionName.Value
+                    });
+                    var uri = UriFactory.CreateDocumentCollectionUri(options.DatabaseName, collection.Resource.Id);
+
+                    return (collectionName.Key, Name: collectionName.Value, Uri: uri);
+                });
+
+                var results = await Task.WhenAll(tasks);
+
+                collectionUris = results.ToDictionary(x => x.Key, x => (x.Name, x.Uri));
+
+                return client;
+            }
+            finally
+            {
+                clientInstanceLock.Release();
             }
         }
+
+        public Uri GetWorkflowDefinitionCollectionUri() => collectionUris["WorkflowDefinition"].Uri;
+        public Uri GetWorkflowInstanceCollectionUri() => collectionUris["WorkflowInstance"].Uri;
     }
 }

--- a/src/persistence/Elsa.Persistence.DocumentDb/DocumentDbStorageOptions.cs
+++ b/src/persistence/Elsa.Persistence.DocumentDb/DocumentDbStorageOptions.cs
@@ -1,5 +1,6 @@
 using Microsoft.Azure.Documents.Client;
 using System;
+using System.Collections.Generic;
 
 namespace Elsa.Persistence.DocumentDb
 {
@@ -11,15 +12,31 @@ namespace Elsa.Persistence.DocumentDb
         /// <value>
         /// The name of the database.
         /// </value>
-        internal string DatabaseName { get; set; }
+        public string DatabaseName { get; set; }
 
         /// <summary>
-        /// Gets or sets the name of the collection.
+        /// Gets or sets the url of the DocumentDB.
         /// </summary>
         /// <value>
-        /// The name of the collection.
+        /// The url of the DocumentDB.
         /// </value>
-        internal string CollectionName { get; set; }
+        public string Url { get; set; }
+
+        /// <summary>
+        /// Gets or sets the secert to access DocumentDB.
+        /// </summary>
+        /// <value>
+        /// The secert to access DocumentDB.
+        /// </value>
+        public string AuthSecret { get; set; }
+
+        /// <summary>
+        /// Gets or sets the collection names under the DocumentDB.
+        /// </summary>
+        /// <value>
+        /// The collection names.
+        /// </value>
+        public IDictionary<string, string> CollectionNames { get; set; }
 
         /// <summary>
         /// Get or sets the request timeout for DocumentDB client. Default value set to 30 seconds

--- a/src/persistence/Elsa.Persistence.DocumentDb/DocumentDbStorageOptions.cs
+++ b/src/persistence/Elsa.Persistence.DocumentDb/DocumentDbStorageOptions.cs
@@ -23,10 +23,10 @@ namespace Elsa.Persistence.DocumentDb
         public string Url { get; set; }
 
         /// <summary>
-        /// Gets or sets the secert to access DocumentDB.
+        /// Gets or sets the secret to access DocumentDB.
         /// </summary>
         /// <value>
-        /// The secert to access DocumentDB.
+        /// The secret to access DocumentDB.
         /// </value>
         public string AuthSecret { get; set; }
 

--- a/src/persistence/Elsa.Persistence.DocumentDb/Documents/DocumentBase.cs
+++ b/src/persistence/Elsa.Persistence.DocumentDb/Documents/DocumentBase.cs
@@ -1,0 +1,12 @@
+﻿using Newtonsoft.Json;
+
+namespace Elsa.Persistence.DocumentDb.Documents
+{
+    public abstract class DocumentBase
+    {
+        [JsonProperty(PropertyName = "id")] public string Id { get; set; }
+        [JsonProperty(PropertyName = "_rid")] public string ResourceId { get; set; }
+        [JsonProperty(PropertyName = "_etag")] public string ETag { get; set; }
+        [JsonProperty(PropertyName = "_self")] public string SelfLink { get; set; }
+    }
+}

--- a/src/persistence/Elsa.Persistence.DocumentDb/Documents/WorkflowDefinitionVersionDocument.cs
+++ b/src/persistence/Elsa.Persistence.DocumentDb/Documents/WorkflowDefinitionVersionDocument.cs
@@ -4,9 +4,8 @@ using System.Collections.Generic;
 
 namespace Elsa.Persistence.DocumentDb.Documents
 {
-    public class WorkflowDefinitionVersionDocument
+    public class WorkflowDefinitionVersionDocument : DocumentBase
     {
-        [JsonProperty(PropertyName = "id")] public string Id { get; set; }
         [JsonProperty(PropertyName = "type")] public string Type { get; } = nameof(WorkflowDefinitionVersionDocument);
 
         [JsonProperty(PropertyName = "definitionId")]

--- a/src/persistence/Elsa.Persistence.DocumentDb/Documents/WorkflowInstanceDocument.cs
+++ b/src/persistence/Elsa.Persistence.DocumentDb/Documents/WorkflowInstanceDocument.cs
@@ -5,10 +5,8 @@ using System.Collections.Generic;
 
 namespace Elsa.Persistence.DocumentDb.Documents
 {
-    public class WorkflowInstanceDocument
+    public class WorkflowInstanceDocument : DocumentBase
     {
-        [JsonProperty(PropertyName = "id")] public string Id { get; set; }
-
         [JsonProperty(PropertyName = "definitionId")]
         public string DefinitionId { get; set; }
 

--- a/src/persistence/Elsa.Persistence.DocumentDb/Extensions/ServiceConfigurationExtensions.cs
+++ b/src/persistence/Elsa.Persistence.DocumentDb/Extensions/ServiceConfigurationExtensions.cs
@@ -4,6 +4,7 @@ using Elsa.Extensions;
 using Elsa.Mapping;
 using Elsa.Persistence.DocumentDb.Mapping;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace Elsa.Persistence.DocumentDb.Extensions
 {
@@ -11,35 +12,18 @@ namespace Elsa.Persistence.DocumentDb.Extensions
     {
         public static CosmosDbElsaBuilder AddCosmosDbProvider(
             this ElsaBuilder builder,
-            string url,
-            string authSecret,
-            string database,
-            string collection,
-            DocumentDbStorageOptions options = null)
+            Action<OptionsBuilder<DocumentDbStorageOptions>> options)
         {
-            if (string.IsNullOrEmpty(url)) throw new ArgumentNullException(nameof(url));
-            if (string.IsNullOrEmpty(authSecret)) throw new ArgumentNullException(nameof(authSecret));
-
-            var storage = new DocumentDbStorage(url, authSecret, database, collection, options);
+            options?.Invoke(builder.Services.AddOptions<DocumentDbStorageOptions>());
 
             builder.Services
-                .AddSingleton(storage)
+                .AddSingleton<IDocumentDbStorage, DocumentDbStorage>()
+                .AddSingleton<IWorkflowInstanceStore, CosmosDbWorkflowInstanceStore>()
+                .AddSingleton<IWorkflowDefinitionStore, CosmosDbWorkflowDefinitionStore>()
                 .AddMapperProfile<NodaTimeProfile>(ServiceLifetime.Singleton)
                 .AddMapperProfile<DocumentProfile>(ServiceLifetime.Singleton);
 
             return new CosmosDbElsaBuilder(builder.Services);
-        }
-
-        public static CosmosDbElsaBuilder AddWorkflowInstanceStore(this CosmosDbElsaBuilder configuration)
-        {
-            configuration.Services.AddSingleton<IWorkflowInstanceStore, CosmosDbWorkflowInstanceStore>();
-            return configuration;
-        }
-
-        public static CosmosDbElsaBuilder AddWorkflowDefinitionStore(this CosmosDbElsaBuilder configuration)
-        {
-            configuration.Services.AddSingleton<IWorkflowDefinitionStore, CosmosDbWorkflowDefinitionStore>();
-            return configuration;
         }
     }
 }

--- a/src/persistence/Elsa.Persistence.DocumentDb/Helpers/ClientHelper.cs
+++ b/src/persistence/Elsa.Persistence.DocumentDb/Helpers/ClientHelper.cs
@@ -19,7 +19,7 @@ namespace Elsa.Persistence.DocumentDb.Helpers
         /// <param name="disableAutomaticIdGeneration">Disables the automatic id generation, will throw an exception if id is missing.</param>
         /// <param name="cancellationToken">(Optional) <see cref="T:System.Threading.CancellationToken" /> representing request cancellation.</param>
         /// <returns></returns>
-        internal static Task<ResourceResponse<Document>> CreateDocumentWithRetriesAsync(
+        internal static async Task<ResourceResponse<Document>> CreateDocumentWithRetriesAsync(
             this DocumentClient client,
             Uri documentCollectionUri,
             object document,
@@ -27,15 +27,12 @@ namespace Elsa.Persistence.DocumentDb.Helpers
             bool disableAutomaticIdGeneration = false,
             CancellationToken cancellationToken = default)
         {
-            return Task.Run(
-                async () => await client.ExecuteWithRetries(
-                    () => client.CreateDocumentAsync(
-                        documentCollectionUri,
-                        document,
-                        options,
-                        disableAutomaticIdGeneration,
-                        cancellationToken)),
-                cancellationToken);
+            return await client.ExecuteWithRetries(async() => await client.CreateDocumentAsync(
+                    documentCollectionUri,
+                    document,
+                    options,
+                    disableAutomaticIdGeneration,
+                    cancellationToken));
         }
 
         /// <summary>
@@ -47,16 +44,16 @@ namespace Elsa.Persistence.DocumentDb.Helpers
         /// <param name="options">The request options for the request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="T:System.Threading.CancellationToken" /> representing request cancellation.</param>
         /// <returns></returns>
-        internal static Task<DocumentResponse<T>> ReadDocumentWithRetriesAsync<T>(
+        internal static async Task<DocumentResponse<T>> ReadDocumentWithRetriesAsync<T>(
             this DocumentClient client,
             Uri documentUri,
             RequestOptions options = null,
             CancellationToken cancellationToken = default)
         {
-            return Task.Run(
-                async () => await client.ExecuteWithRetries(
-                    () => client.ReadDocumentAsync<T>(documentUri, options, cancellationToken)),
-                cancellationToken);
+            return await client.ExecuteWithRetries(async() => await client.ReadDocumentAsync<T>(
+                documentUri, 
+                options, 
+                cancellationToken));
         }
 
         /// <summary>
@@ -68,7 +65,7 @@ namespace Elsa.Persistence.DocumentDb.Helpers
         /// <param name="options">The request options for the request.</param>
         /// <param name="disableAutomaticIdGeneration">Disables the automatic id generation, will throw an exception if id is missing.</param>
         /// <param name="cancellationToken">(Optional) <see cref="T:System.Threading.CancellationToken" /> representing request cancellation.</param>
-        internal static Task<ResourceResponse<Document>> UpsertDocumentWithRetriesAsync(
+        internal static async Task<ResourceResponse<Document>> UpsertDocumentWithRetriesAsync(
             this DocumentClient client,
             Uri documentCollectionUri,
             object document,
@@ -76,15 +73,12 @@ namespace Elsa.Persistence.DocumentDb.Helpers
             bool disableAutomaticIdGeneration = false,
             CancellationToken cancellationToken = default)
         {
-            return Task.Run(
-                async () => await client.ExecuteWithRetries(
-                    () => client.UpsertDocumentAsync(
-                        documentCollectionUri,
-                        document,
-                        options,
-                        disableAutomaticIdGeneration,
-                        cancellationToken)),
-                cancellationToken);
+            return await client.ExecuteWithRetries(async () => await client.UpsertDocumentAsync(
+                    documentCollectionUri,
+                    document,
+                    options,
+                    disableAutomaticIdGeneration,
+                    cancellationToken));
         }
 
         /// <summary>
@@ -94,16 +88,16 @@ namespace Elsa.Persistence.DocumentDb.Helpers
         /// <param name="documentUri">The URI of the document to delete.</param>
         /// <param name="options">The request options for the request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="T:System.Threading.CancellationToken" /> representing request cancellation.</param>
-        internal static Task<ResourceResponse<Document>> DeleteDocumentWithRetriesAsync(
+        internal static async Task<ResourceResponse<Document>> DeleteDocumentWithRetriesAsync(
             this DocumentClient client,
             Uri documentUri,
             RequestOptions options = null,
             CancellationToken cancellationToken = default)
         {
-            return Task.Run(
-                async () => await client.ExecuteWithRetries(
-                    () => client.DeleteDocumentAsync(documentUri, options, cancellationToken)),
-                cancellationToken);
+            return await client.ExecuteWithRetries(async () => await client.DeleteDocumentAsync(
+                documentUri, 
+                options, 
+                cancellationToken));
         }
 
         /// <summary>
@@ -115,17 +109,18 @@ namespace Elsa.Persistence.DocumentDb.Helpers
         /// <param name="options">The request options for the request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="T:System.Threading.CancellationToken" /> representing request cancellation.</param>
         /// <returns></returns>
-        internal static Task<ResourceResponse<Document>> ReplaceDocumentWithRetriesAsync(
+        internal static async Task<ResourceResponse<Document>> ReplaceDocumentWithRetriesAsync(
             this DocumentClient client,
             Uri documentUri,
             object document,
             RequestOptions options = null,
             CancellationToken cancellationToken = default)
         {
-            return Task.Run(
-                async () => await client.ExecuteWithRetries(
-                    () => client.ReplaceDocumentAsync(documentUri, document, options, cancellationToken)),
-                cancellationToken);
+            return await client.ExecuteWithRetries(async () => await client.ReplaceDocumentAsync(
+                documentUri,
+                document,
+                options,
+                cancellationToken));
         }
 
         /// <summary>
@@ -136,14 +131,14 @@ namespace Elsa.Persistence.DocumentDb.Helpers
         /// <param name="storedProcedureUri">The URI of the stored procedure to be executed.</param>
         /// <param name="procedureParams">The parameters for the stored procedure execution.</param>
         /// <returns></returns>
-        internal static Task<StoredProcedureResponse<T>> ExecuteStoredProcedureWithRetriesAsync<T>(
+        internal static async Task<StoredProcedureResponse<T>> ExecuteStoredProcedureWithRetriesAsync<T>(
             this DocumentClient client,
             Uri storedProcedureUri,
             params object[] procedureParams)
         {
-            return Task.Run(
-                async () => await client.ExecuteWithRetries(
-                    () => client.ExecuteStoredProcedureAsync<T>(storedProcedureUri, procedureParams)));
+            return await client.ExecuteWithRetries(async () => await client.ExecuteStoredProcedureAsync<T>(
+                storedProcedureUri, 
+                procedureParams));
         }
 
         /// <summary>

--- a/src/persistence/Elsa.Persistence.DocumentDb/Helpers/QueryHelper.cs
+++ b/src/persistence/Elsa.Persistence.DocumentDb/Helpers/QueryHelper.cs
@@ -14,7 +14,7 @@ namespace Elsa.Persistence.DocumentDb.Helpers
 
             while (query.HasMoreResults)
             {
-                var nextResults = await Task.Run(async () => await query.ExecuteNextWithRetriesAsync());
+                var nextResults = await query.ExecuteNextWithRetriesAsync();
                 results.AddRange(nextResults);
             }
 

--- a/src/persistence/Elsa.Persistence.DocumentDb/IDocumentDbStorage.cs
+++ b/src/persistence/Elsa.Persistence.DocumentDb/IDocumentDbStorage.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.Azure.Documents.Client;
+using System;
+using System.Threading.Tasks;
+
+namespace Elsa.Persistence.DocumentDb
+{
+    public interface IDocumentDbStorage
+    {
+        string ToString();
+        Task<DocumentClient> GetDocumentClient();
+        Uri GetWorkflowDefinitionCollectionUri();
+        Uri GetWorkflowInstanceCollectionUri();
+    }
+}

--- a/src/persistence/Elsa.Persistence.DocumentDb/Services/CosmosDbWorkflowDefinitionStore.cs
+++ b/src/persistence/Elsa.Persistence.DocumentDb/Services/CosmosDbWorkflowDefinitionStore.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -7,70 +8,74 @@ using Elsa.Persistence.DocumentDb.Documents;
 using Elsa.Persistence.DocumentDb.Extensions;
 using Elsa.Persistence.DocumentDb.Helpers;
 using Elsa.Services;
+using Microsoft.Azure.Documents.Client;
 
 namespace Elsa.Persistence.DocumentDb.Services
 {
     public class CosmosDbWorkflowDefinitionStore : IWorkflowDefinitionStore
     {
         private readonly IMapper mapper;
-        private readonly DocumentDbStorage storage;
+        private readonly IDocumentDbStorage storage;
 
-        public CosmosDbWorkflowDefinitionStore(DocumentDbStorage storage, IMapper mapper)
+        public CosmosDbWorkflowDefinitionStore(IDocumentDbStorage storage, IMapper mapper)
         {
             this.storage = storage;
             this.mapper = mapper;
         }
 
+        private async Task<DocumentClient> GetDocumentClient() => await storage.GetDocumentClient();
+        private Uri GetCollectionUri() => storage.GetWorkflowDefinitionCollectionUri();
+
         public async Task<WorkflowDefinitionVersion> AddAsync(WorkflowDefinitionVersion definition, CancellationToken cancellationToken = default)
         {
             var document = Map(definition);
-            var client = storage.Client;
-            await client.CreateDocumentWithRetriesAsync(storage.CollectionUri, document, cancellationToken: cancellationToken);
+            var client = await GetDocumentClient();
+            await client.CreateDocumentWithRetriesAsync(GetCollectionUri(), document, cancellationToken: cancellationToken);
             return Map(document);
         }
 
         public async Task<int> DeleteAsync(string id, CancellationToken cancellationToken = default)
         {
-            var client = storage.Client;
-            var records = await client.CreateDocumentQuery<WorkflowDefinitionVersionDocument>(storage.CollectionUri).Where(c => c.DefinitionId == id).ToQueryResultAsync();
+            var client = await GetDocumentClient();
+            var records = await client.CreateDocumentQuery<WorkflowDefinitionVersionDocument>(GetCollectionUri()).Where(c => c.DefinitionId == id).ToQueryResultAsync();
             foreach (var record in records)
             {
-                await client.DeleteDocumentAsync(record.Id, cancellationToken: cancellationToken);
+                await client.DeleteDocumentAsync(record.SelfLink, cancellationToken: cancellationToken);
             }
             return records.Count;
         }
 
-        public Task<WorkflowDefinitionVersion> GetByIdAsync(string id, VersionOptions version, CancellationToken cancellationToken = default)
+        public async Task<WorkflowDefinitionVersion> GetByIdAsync(string id, VersionOptions version, CancellationToken cancellationToken = default)
         {
-            var client = storage.Client;
-            var query = client.CreateDocumentQuery<WorkflowDefinitionVersionDocument>(storage.CollectionUri)
+            var client = await GetDocumentClient();
+            var query = client.CreateDocumentQuery<WorkflowDefinitionVersionDocument>(GetCollectionUri())
                 .Where(c => c.DefinitionId == id).WithVersion(version);
             var document = query.AsEnumerable().FirstOrDefault();
-            return Task.FromResult(Map(document));
+            return Map(document);
         }
 
-        public Task<IEnumerable<WorkflowDefinitionVersion>> ListAsync(VersionOptions version, CancellationToken cancellationToken = default)
+        public async Task<IEnumerable<WorkflowDefinitionVersion>> ListAsync(VersionOptions version, CancellationToken cancellationToken = default)
         {
-            var client = storage.Client;
-            var query = client.CreateDocumentQuery<WorkflowDefinitionVersionDocument>(storage.CollectionUri)
+            var client = await GetDocumentClient();
+            var query = client.CreateDocumentQuery<WorkflowDefinitionVersionDocument>(GetCollectionUri())
                 .WithVersion(version).ToList();
            
-            return Task.FromResult(mapper.Map<IEnumerable<WorkflowDefinitionVersion>>(query));
+            return mapper.Map<IEnumerable<WorkflowDefinitionVersion>>(query);
         }
 
         public async Task<WorkflowDefinitionVersion> SaveAsync(WorkflowDefinitionVersion definition, CancellationToken cancellationToken = default)
         {
             var document = Map(definition);
-            var client = storage.Client;
-            await client.UpsertDocumentWithRetriesAsync(storage.CollectionUri, document, cancellationToken: cancellationToken);
+            var client = await GetDocumentClient();
+            await client.UpsertDocumentWithRetriesAsync(GetCollectionUri(), document, cancellationToken: cancellationToken);
             return definition;
         }
 
         public async Task<WorkflowDefinitionVersion> UpdateAsync(WorkflowDefinitionVersion definition, CancellationToken cancellationToken = default)
         {
             var document = Map(definition);
-            var client = storage.Client;
-            await client.UpsertDocumentWithRetriesAsync(storage.CollectionUri, document, cancellationToken: cancellationToken);
+            var client = await GetDocumentClient();
+            await client.UpsertDocumentWithRetriesAsync(GetCollectionUri(), document, cancellationToken: cancellationToken);
             return Map(document);
         }
 

--- a/src/persistence/Elsa.Persistence.DocumentDb/Services/CosmosDbWorkflowInstanceStore.cs
+++ b/src/persistence/Elsa.Persistence.DocumentDb/Services/CosmosDbWorkflowInstanceStore.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -7,68 +8,72 @@ using Elsa.Models;
 using Elsa.Persistence.DocumentDb.Documents;
 using Elsa.Persistence.DocumentDb.Helpers;
 using Elsa.Services;
+using Microsoft.Azure.Documents.Client;
 
 namespace Elsa.Persistence.DocumentDb.Services
 {
     public class CosmosDbWorkflowInstanceStore : IWorkflowInstanceStore
     {
         private readonly IMapper mapper;
-        private readonly DocumentDbStorage storage;
+        private readonly IDocumentDbStorage storage;
 
-        public CosmosDbWorkflowInstanceStore(DocumentDbStorage storage, IMapper mapper)
+        public CosmosDbWorkflowInstanceStore(IDocumentDbStorage storage, IMapper mapper)
         {
             this.storage = storage;
             this.mapper = mapper;
         }
 
+        private async Task<DocumentClient> GetDocumentClient() => await storage.GetDocumentClient();
+        private Uri GetCollectionUri() => storage.GetWorkflowInstanceCollectionUri();
+
         public async Task DeleteAsync(
             string id,
             CancellationToken cancellationToken = default)
         {
-            var client = storage.Client;
+            var client = await GetDocumentClient();
             await client.DeleteDocumentAsync(id, cancellationToken: cancellationToken);
         }
 
-        public Task<WorkflowInstance> GetByCorrelationIdAsync(
+        public async Task<WorkflowInstance> GetByCorrelationIdAsync(
             string correlationId,
             CancellationToken cancellationToken = default)
         {
-            var client = storage.Client;
-            var query = client.CreateDocumentQuery<WorkflowInstanceDocument>(storage.CollectionUri)
+            var client = await GetDocumentClient();
+            var query = client.CreateDocumentQuery<WorkflowInstanceDocument>(GetCollectionUri())
                 .Where(c => c.CorrelationId == correlationId);
             var document = query.AsEnumerable().FirstOrDefault();
-            return Task.FromResult(Map(document));
+            return Map(document);
         }
 
-        public Task<WorkflowInstance> GetByIdAsync(
+        public async Task<WorkflowInstance> GetByIdAsync(
             string id,
             CancellationToken cancellationToken = default)
         {
-            var client = storage.Client;
-            var query = client.CreateDocumentQuery<WorkflowInstanceDocument>(storage.CollectionUri)
+            var client = await GetDocumentClient();
+            var query = client.CreateDocumentQuery<WorkflowInstanceDocument>(GetCollectionUri())
                 .Where(c => c.Id == id);
             var document = query.AsEnumerable().FirstOrDefault();
-            return Task.FromResult(Map(document));
+            return Map(document);
         }
 
-        public Task<IEnumerable<WorkflowInstance>> ListAllAsync(CancellationToken cancellationToken = default)
+        public async Task<IEnumerable<WorkflowInstance>> ListAllAsync(CancellationToken cancellationToken = default)
         {
-            var client = storage.Client;
+            var client = await GetDocumentClient();
             var query = client
-                .CreateDocumentQuery<WorkflowInstanceDocument>(storage.CollectionUri)
+                .CreateDocumentQuery<WorkflowInstanceDocument>(GetCollectionUri())
                 .OrderByDescending(x => x.CreatedAt);
-            return Task.FromResult(mapper.Map<IEnumerable<WorkflowInstance>>(query));
+            return mapper.Map<IEnumerable<WorkflowInstance>>(query);
         }
 
-        public Task<IEnumerable<(WorkflowInstance, ActivityInstance)>> ListByBlockingActivityAsync(
+        public async Task<IEnumerable<(WorkflowInstance, ActivityInstance)>> ListByBlockingActivityAsync(
             string activityType,
             string correlationId = null,
             CancellationToken cancellationToken = default)
         {
-            var client = storage.Client;
+            var client = await GetDocumentClient();
 
             var query = client
-                .CreateDocumentQuery<WorkflowInstanceDocument>(storage.CollectionUri)
+                .CreateDocumentQuery<WorkflowInstanceDocument>(GetCollectionUri())
                 .Where(x => x.Status == WorkflowStatus.Executing);
 
             if (!string.IsNullOrWhiteSpace(correlationId))
@@ -80,41 +85,41 @@ namespace Elsa.Persistence.DocumentDb.Services
             query = query.OrderByDescending(x => x.CreatedAt);
 
             var instances = Map(query.ToList());
-            return Task.FromResult(instances.GetBlockingActivities(activityType));
+            return instances.GetBlockingActivities(activityType);
         }
 
-        public Task<IEnumerable<WorkflowInstance>> ListByDefinitionAsync(
+        public async Task<IEnumerable<WorkflowInstance>> ListByDefinitionAsync(
             string definitionId,
             CancellationToken cancellationToken = default)
         {
-            var client = storage.Client;
-            var query = client.CreateDocumentQuery<WorkflowInstanceDocument>(storage.CollectionUri)
+            var client = await GetDocumentClient();
+            var query = client.CreateDocumentQuery<WorkflowInstanceDocument>(GetCollectionUri())
                 .Where(c => c.DefinitionId == definitionId)
                 .OrderByDescending(x => x.CreatedAt);
-            return Task.FromResult(Map(query.ToList()));
+            return Map(query.ToList());
         }
 
-        public Task<IEnumerable<WorkflowInstance>> ListByStatusAsync(
+        public async Task<IEnumerable<WorkflowInstance>> ListByStatusAsync(
             string definitionId,
             WorkflowStatus status,
             CancellationToken cancellationToken = default)
         {
-            var client = storage.Client;
-            var query = client.CreateDocumentQuery<WorkflowInstanceDocument>(storage.CollectionUri)
+            var client = await GetDocumentClient();
+            var query = client.CreateDocumentQuery<WorkflowInstanceDocument>(GetCollectionUri())
                 .Where(c => c.DefinitionId == definitionId && c.Status == status)
                 .OrderByDescending(x => x.CreatedAt);
-            return Task.FromResult(Map(query.ToList()));
+            return Map(query.ToList());
         }
 
-        public Task<IEnumerable<WorkflowInstance>> ListByStatusAsync(
+        public async Task<IEnumerable<WorkflowInstance>> ListByStatusAsync(
             WorkflowStatus status,
             CancellationToken cancellationToken = default)
         {
-            var client = storage.Client;
-            var query = client.CreateDocumentQuery<WorkflowInstanceDocument>(storage.CollectionUri)
+            var client = await GetDocumentClient();
+            var query = client.CreateDocumentQuery<WorkflowInstanceDocument>(GetCollectionUri())
                 .Where(c => c.Status == status)
                 .OrderByDescending(x => x.CreatedAt);
-            return Task.FromResult(Map(query.ToList()));
+            return Map(query.ToList());
         }
 
         public async Task<WorkflowInstance> SaveAsync(
@@ -122,9 +127,9 @@ namespace Elsa.Persistence.DocumentDb.Services
             CancellationToken cancellationToken = default)
         {
             var document = Map(instance);
-            var client = storage.Client;
+            var client = await GetDocumentClient();
             var response = await client.UpsertDocumentWithRetriesAsync(
-                storage.CollectionUri,
+                GetCollectionUri(),
                 document,
                 cancellationToken: cancellationToken);
 


### PR DESCRIPTION
Bug #311 : 
1. The class "DocumentDbStorage" has limitation in creating required collections for this application to run. 
2. The NodaTime serialization is not happening properly while sending/retrieving data to/from DB.  
3. The deletion of WorkflowDefinition throws exception
4. async/await is not used properly. Because of that application hanged while running in both IISExpress and IIS

Fixed all above issues. Also have done major refactoring in the following classes.
1. DocumentDbStorage.cs
3. ServiceConfigurationExtensions.cs
4. CosmosDbWorkflowInsanceStore.cs
5. CosmosDbWorkflowDefinitionStore.cs
6. ClientHelper.cs

