### PR TITLE
Fixed getter and setter for Name property

### DIFF
--- a/src/core/Elsa.Abstractions/Models/ActivityDefinition.cs
+++ b/src/core/Elsa.Abstractions/Models/ActivityDefinition.cs
@@ -29,9 +29,10 @@ namespace Elsa.Models
 
         public string Name
         {
-            get => State.ContainsKey(nameof(Name)) ? State[nameof(Name)].Value<string>() : default;
-            set => State[nameof(Name)] = value;
+            get => State.ContainsKey(nameof(Name).ToLower()) ? State[nameof(Name).ToLower()].Value<string>() : default;
+            set => State[nameof(Name).ToLower()] = value;
         }
+
 
         public string DisplayName { get; set; }
         public string Description { get; set; }


### PR DESCRIPTION
Since the State property is serialized JSON the getter and setter needs to look for the key lowercased. This allows the property to be set with the name and have the Name property persisted in the datastore (i.e. EF). This fixes the problem so the outputs of the activity may be retrieved by name