### PR TITLE
Minor cleanup of elsa 2.0

### DIFF
--- a/src/activities/Elsa.Activities.Console/Activities/ReadLine/ReadLine.cs
+++ b/src/activities/Elsa.Activities.Console/Activities/ReadLine/ReadLine.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Elsa.ActivityResults;
@@ -16,15 +16,13 @@ namespace Elsa.Activities.Console
         Category = "Console",
         Description = "Read text from standard in.",
         Icon = "fas fa-terminal",
-        RuntimeDescription =
-            "a => !!a.state.variableName ? `Read text from standard in and store into <strong>${ a.state.variableName }</strong>.` : 'Read text from standard in.'",
         Outcomes = new[] { OutcomeNames.Done }
     )]
     public class ReadLine : Activity
     {
         private readonly TextReader? _input;
 
-        public ReadLine()
+        public ReadLine() : this(System.Console.In)
         {
         }
 

--- a/src/activities/Elsa.Activities.Dropbox/Extensions/ServiceCollectionExtensions.cs
+++ b/src/activities/Elsa.Activities.Dropbox/Extensions/ServiceCollectionExtensions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Extensions.DependencyInjection
         public static IServiceCollection AddDropbox(this IServiceCollection services, Action<OptionsBuilder<DropboxOptions>>? options = null) =>
             services
                 .AddDropboxServices(options)
-                .AddActivity<SaveToDropbox>();
+                .AddDropboxActivities();
 
         public static IServiceCollection AddDropboxServices(this IServiceCollection services, Action<OptionsBuilder<DropboxOptions>>? options = null)
         {

--- a/src/activities/Elsa.Activities.Email/Activities/SendEmail/SendEmail.cs
+++ b/src/activities/Elsa.Activities.Email/Activities/SendEmail/SendEmail.cs
@@ -1,12 +1,10 @@
 using System.Threading;
 using System.Threading.Tasks;
-using Elsa.Activities.Email.Options;
 using Elsa.Activities.Email.Services;
 using Elsa.ActivityResults;
 using Elsa.Attributes;
 using Elsa.Services;
 using Elsa.Services.Models;
-using Microsoft.Extensions.Options;
 using MimeKit;
 using MimeKit.Text;
 
@@ -17,12 +15,10 @@ namespace Elsa.Activities.Email
     public class SendEmail : Activity
     {
         private readonly ISmtpService _smtpService;
-        private readonly IOptions<SmtpOptions> _options;
 
-        public SendEmail(ISmtpService smtpService, IOptions<SmtpOptions> options)
+        public SendEmail(ISmtpService smtpService)
         {
             _smtpService = smtpService;
-            _options = options;
         }
 
         [ActivityProperty(Hint = "The sender's email address.")]

--- a/src/activities/Elsa.Activities.Email/Activities/SendEmail/SendEmailBuilderExtensions.cs
+++ b/src/activities/Elsa.Activities.Email/Activities/SendEmail/SendEmailBuilderExtensions.cs
@@ -1,9 +1,8 @@
 using System;
-using Elsa.Activities.Email;
 using Elsa.Builders;
 
 // ReSharper disable once CheckNamespace
-namespace Elsa.Activities.Http
+namespace Elsa.Activities.Email
 {
     public static class SendEmailBuilderExtensions
     {

--- a/src/activities/Elsa.Activities.Email/Activities/SendEmail/SendEmailExtensions.cs
+++ b/src/activities/Elsa.Activities.Email/Activities/SendEmail/SendEmailExtensions.cs
@@ -1,10 +1,9 @@
 using System;
-using Elsa.Activities.Email;
 using Elsa.Builders;
 using Elsa.Services.Models;
 
 // ReSharper disable once CheckNamespace
-namespace Elsa.Activities.Http
+namespace Elsa.Activities.Email
 {
     public static class SendEmailExtensions
     {

--- a/src/activities/Elsa.Activities.Email/Extensions/ServiceCollectionExtensions.cs
+++ b/src/activities/Elsa.Activities.Email/Extensions/ServiceCollectionExtensions.cs
@@ -20,7 +20,6 @@ namespace Microsoft.Extensions.DependencyInjection
             options?.Invoke(optionsBuilder);
 
             return services
-                .AddOptions()
                 .AddSingleton<ISmtpService, SmtpService>();
         }
 

--- a/src/activities/Elsa.Activities.Http/Activities/Redirect/Redirect.cs
+++ b/src/activities/Elsa.Activities.Http/Activities/Redirect/Redirect.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Threading;
-using System.Threading.Tasks;
 using Elsa.Activities.Http.Results;
 using Elsa.ActivityResults;
 using Elsa.Attributes;
@@ -36,7 +34,7 @@ namespace Elsa.Activities.Http
         [ActivityProperty(Hint = "Whether or not the redirect is permanent (HTTP 301).")]
         public bool Permanent { get; set; }
 
-        protected override async ValueTask<IActivityExecutionResult> OnExecuteAsync(ActivityExecutionContext context, CancellationToken cancellationToken)
+        protected override IActivityExecutionResult OnExecute(ActivityExecutionContext context)
         {
             var response = _httpContextAccessor.HttpContext.Response;
 

--- a/src/activities/Elsa.Activities.Http/Activities/SendHttpRequest/SendHttpRequest.cs
+++ b/src/activities/Elsa.Activities.Http/Activities/SendHttpRequest/SendHttpRequest.cs
@@ -167,7 +167,7 @@ namespace Elsa.Activities.Http
 
         private static bool GetMethodSupportsBody(string method)
         {
-            var methods = new[] { "POST", "PUT", "PATCH" };
+            var methods = new[] { "POST", "PUT", "PATCH", "DELETE" };
             return methods.Contains(method, StringComparer.InvariantCultureIgnoreCase);
         }
     }

--- a/src/activities/Elsa.Activities.Http/Activities/WriteHttpResponse/WriteHttpResponse.cs
+++ b/src/activities/Elsa.Activities.Http/Activities/WriteHttpResponse/WriteHttpResponse.cs
@@ -31,7 +31,7 @@ namespace Elsa.Activities.Http
             _httpContextAccessor = httpContextAccessor;
         }
 
-        public IStringLocalizer T { get; }
+        private IStringLocalizer T { get; }
 
         /// <summary>
         /// The HTTP status code to return.

--- a/src/activities/Elsa.Activities.Http/Models/HttpResponseModel.cs
+++ b/src/activities/Elsa.Activities.Http/Models/HttpResponseModel.cs
@@ -5,10 +5,6 @@ namespace Elsa.Activities.Http.Models
 {
     public class HttpResponseModel
     {
-        public HttpResponseModel()
-        {
-        }
-
         public HttpStatusCode StatusCode { get; set; }
         public Dictionary<string, string[]> Headers { get; set; } = new Dictionary<string, string[]>();
         public object Content { get; set; }

--- a/src/activities/Elsa.Activities.MassTransit/Activities/MassTransitBusActivity.cs
+++ b/src/activities/Elsa.Activities.MassTransit/Activities/MassTransitBusActivity.cs
@@ -24,9 +24,7 @@ namespace Elsa.Activities.MassTransit
         /// the conversation and correlation id.
         /// </remarks>
         protected IPublishEndpoint PublishEndpoint =>
-            _consumeContext != null
-                ? (IPublishEndpoint)_consumeContext
-                : (IPublishEndpoint)_bus;
+            _consumeContext ?? (IPublishEndpoint)_bus;
 
         /// <summary>
         /// Gets the send endpoint provider to use.
@@ -36,9 +34,7 @@ namespace Elsa.Activities.MassTransit
         /// the conversation and correlation id.
         /// </remarks>
         protected ISendEndpointProvider SendEndpointProvider =>
-            _consumeContext != null
-                ? (ISendEndpointProvider)_consumeContext
-                : (ISendEndpointProvider)_bus;
+            _consumeContext ?? (ISendEndpointProvider)_bus;
 
     }
 }

--- a/src/activities/Elsa.Activities.Timers/Activities/CronEvent/CronEvent.cs
+++ b/src/activities/Elsa.Activities.Timers/Activities/CronEvent/CronEvent.cs
@@ -52,8 +52,7 @@ namespace Elsa.Activities.Timers
             var schedule = CrontabSchedule.Parse(CronExpression);
             var now = _clock.GetCurrentInstant();
 
-            if (StartTime == null)
-                StartTime = now;
+            StartTime ??= now;
 
             var nextOccurrence = schedule.GetNextOccurrence(StartTime.Value.ToDateTimeUtc());
 

--- a/src/activities/Elsa.Activities.Timers/Activities/CronEvent/CronEventBuilderExtensions.cs
+++ b/src/activities/Elsa.Activities.Timers/Activities/CronEvent/CronEventBuilderExtensions.cs
@@ -1,10 +1,9 @@
 using System;
-using Elsa.Activities.Timers;
 using Elsa.Builders;
 using Elsa.Services.Models;
 
 // ReSharper disable once CheckNamespace
-namespace Elsa.Activities.MassTransit
+namespace Elsa.Activities.Timers
 {
     public static class CronEventBuilderExtensions
     {

--- a/src/activities/Elsa.Activities.Timers/Activities/InstantEvent/InstantEventBuilderExtensions.cs
+++ b/src/activities/Elsa.Activities.Timers/Activities/InstantEvent/InstantEventBuilderExtensions.cs
@@ -1,11 +1,10 @@
 using System;
-using Elsa.Activities.Timers;
 using Elsa.Builders;
 using Elsa.Services.Models;
 using NodaTime;
 
 // ReSharper disable once CheckNamespace
-namespace Elsa.Activities.MassTransit
+namespace Elsa.Activities.Timers
 {
     public static class InstantEventBuilderExtensions
     {

--- a/src/activities/Elsa.Activities.Timers/Activities/TimerEvent/TimerEventBuilderExtensions.cs
+++ b/src/activities/Elsa.Activities.Timers/Activities/TimerEvent/TimerEventBuilderExtensions.cs
@@ -1,11 +1,10 @@
 using System;
-using Elsa.Activities.Timers;
 using Elsa.Builders;
 using Elsa.Services.Models;
 using NodaTime;
 
 // ReSharper disable once CheckNamespace
-namespace Elsa.Activities.MassTransit
+namespace Elsa.Activities.Timers
 {
     public static class TimerEventBuilderExtensions
     {

--- a/src/activities/Elsa.Activities.Timers/Extensions/ServiceCollectionExtensions.cs
+++ b/src/activities/Elsa.Activities.Timers/Extensions/ServiceCollectionExtensions.cs
@@ -15,7 +15,6 @@ namespace Microsoft.Extensions.DependencyInjection
             options?.Invoke(optionsBuilder);
             
             return services
-                .AddOptions()
                 .AddHostedService<TimersHostedService>()
                 .AddActivity<CronEvent>()
                 .AddActivity<TimerEvent>()

--- a/src/activities/Elsa.Activities.Timers/HostedServices/TimersHostedService.cs
+++ b/src/activities/Elsa.Activities.Timers/HostedServices/TimersHostedService.cs
@@ -29,11 +29,12 @@ namespace Elsa.Activities.Timers.HostedServices
             _options = options;
             _logger = logger;
         }
+
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
             while (!stoppingToken.IsCancellationRequested)
             {
-                if (await _distributedLockProvider.AcquireLockAsync(GetType().Name, stoppingToken))
+                if (await _distributedLockProvider.AcquireLockAsync(nameof(TimersHostedService), stoppingToken))
                 {
                     try
                     {

--- a/src/core/Elsa.YesSql.Provider.Sqlite.InMemory/SingletonDbConnectionFactory.cs
+++ b/src/core/Elsa.YesSql.Provider.Sqlite.InMemory/SingletonDbConnectionFactory.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Data.Common;
 using YesSql;
 
@@ -19,15 +19,10 @@ namespace Elsa.YesSql.Provider.Sqlite.InMemory
 
         public DbConnection CreateConnection()
         {
-            if (_connection == null)
+            return _connection ??= new TDbConnection
             {
-                _connection = new TDbConnection
-                {
-                    ConnectionString = _connectionString
-                };
-            }
-            
-            return _connection;
+                ConnectionString = _connectionString
+            };
         }
     }
 }

--- a/src/scripting/Elsa.Scripting.JavaScript/Converters/TruncatingNumberJsonConverter.cs
+++ b/src/scripting/Elsa.Scripting.JavaScript/Converters/TruncatingNumberJsonConverter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Newtonsoft.Json;
 
 namespace Elsa.Scripting.JavaScript.Converters
@@ -8,13 +8,9 @@ namespace Elsa.Scripting.JavaScript.Converters
     /// </summary>
     public class TruncatingNumberJsonConverter : JsonConverter
     {
-        public TruncatingNumberJsonConverter()
-        {
-        }
-
         public override bool CanRead => false;
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer) => throw new NotImplementedException("Unnecessary because CanRead is false. The type will skip the converter.");
-        public override bool CanConvert(Type objectType) => (objectType == typeof(decimal) || objectType == typeof(float) || objectType == typeof(double));
+        public override bool CanConvert(Type objectType) => objectType == typeof(decimal) || objectType == typeof(float) || objectType == typeof(double);
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer) => writer.WriteRawValue(IsWholeValue(value) ? JsonConvert.ToString(Convert.ToInt64(value)) : JsonConvert.ToString(value));
 
         private static bool IsWholeValue(object value)
@@ -27,7 +23,7 @@ namespace Elsa.Scripting.JavaScript.Converters
 
             if (value is float || value is double)
             {
-                var doubleValue = (double) value;
+                var doubleValue = Convert.ToDouble(value);
                 return doubleValue == Math.Truncate(doubleValue);
             }
 

--- a/src/scripting/Elsa.Scripting.Liquid/Services/LiquidExpressionHandler.cs
+++ b/src/scripting/Elsa.Scripting.Liquid/Services/LiquidExpressionHandler.cs
@@ -26,16 +26,16 @@ namespace Elsa.Scripting.Liquid.Services
 
         public async Task<object?> EvaluateAsync(string expression, Type returnType, ActivityExecutionContext context, CancellationToken cancellationToken)
         {
-            var templateContext = await CreateTemplateContextAsync(context);
+            var templateContext = await CreateTemplateContextAsync(context, cancellationToken);
             var result = await _liquidTemplateManager.RenderAsync(expression, templateContext);
             return string.IsNullOrWhiteSpace(result) ? default : Convert.ChangeType(result, returnType);
         }
 
-        private async Task<TemplateContext> CreateTemplateContextAsync(ActivityExecutionContext workflowContext)
+        private async Task<TemplateContext> CreateTemplateContextAsync(ActivityExecutionContext workflowContext, CancellationToken cancellationToken)
         {
             var context = new TemplateContext();
             context.SetValue("WorkflowExecutionContext", workflowContext);
-            await _mediator.Publish(new EvaluatingLiquidExpression(context, workflowContext));
+            await _mediator.Publish(new EvaluatingLiquidExpression(context, workflowContext), cancellationToken);
             context.Model = workflowContext;
             return context;
         }


### PR DESCRIPTION
I am opening this PR according to https://github.com/elsa-workflows/elsa-core/pull/413#pullrequestreview-513985910
It also does not contain changes for the projects in the `core` folder so as not to make this PR huge.

--------------------

Did you get rid of it Reflection Activity btw? I liked it and even had a plan to improve it.

--------------------

I also want to ask a question (probably it's not the best place, but anyway).
What is the benefit of taking `Action<OptionsBuilder<TOptions>>`?  like

```
public static IServiceCollection AddHttpServices(this IServiceCollection services, Action<OptionsBuilder<HttpActivityOptions>> options)
{
    options.Invoke(services.AddOptions<HttpActivityOptions>());
    // other stuff
}
```

and a caller should do
```
services.AddHttpActivities(options => options.Bind(elsaSection.GetSection("Http")))
```

Why is it better than

```
public static IServiceCollection AddHttpServices(this IServiceCollection services, Action<HttpActivityOptions> options)
{
    services.Configure(options);
    // other stuff
}
```

and 

```
services.AddHttpActivities(elsaSection.GetSection("Http").Bind)
```

?

I think `Action<OptionsBuilder<TOptions>>` adds extra complexity, but I don't see any value in it. Could you please share your opinion on this (I'm probably missing something important)?