### PR TITLE
CurrentScope is incorrect

### DIFF
--- a/src/activities/Elsa.Activities.ControlFlow/Activities/ForEach.cs
+++ b/src/activities/Elsa.Activities.ControlFlow/Activities/ForEach.cs
@@ -68,8 +68,8 @@ namespace Elsa.Activities.ControlFlow.Activities
                 context.BeginScope();
             }
 
-            context.CurrentScope.SetVariable(IteratorName, value);
-
+            var scope =context. Workflow.Scopes.FirstOrDefault(x => x.Variables.ContainsKey(IteratorName)) ?? context.CurrentScope;
+            scope.SetVariable(IteratorName, value);
             return Outcome(OutcomeNames.Iterate);
         }
     }


### PR DESCRIPTION
In the first iteration, a new scope will be created and pushed onto the top of the stack. CurrentScope is now a scope at the top of the stack, but in the second iteration, the newly added scope will change to the bottom. CurrentScope becomes the original Scope at the bottom of the stack.
My code only solved my problem, I didn't find the reason for stack inversion.