### PR TITLE
Remove gravatar dependency

### DIFF
--- a/src/dashboard/Elsa.Dashboard/Areas/Elsa/Views/Shared/UserMenuItems.cshtml
+++ b/src/dashboard/Elsa.Dashboard/Areas/Elsa/Views/Shared/UserMenuItems.cshtml
@@ -7,7 +7,6 @@
     <a class="nav-link pr-0" href="#" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         <div class="media align-items-center">
             <span class="avatar avatar-sm rounded-circle">
-                @* <img gravatar-email="@email" gravatar-size="36" alt="My Gravatar" src=""/> *@
             </span>
             <div class="media-body ml-2 d-none d-lg-block">
                 <span class="mb-0 text-sm  font-weight-bold">@userName</span>

--- a/src/dashboard/Elsa.Dashboard/Areas/Elsa/Views/_ViewImports.cshtml
+++ b/src/dashboard/Elsa.Dashboard/Areas/Elsa/Views/_ViewImports.cshtml
@@ -1,5 +1,3 @@
-@using GravatarHelper.Common
 @using Elsa.Dashboard.Areas.Elsa.ViewModels
-@addTagHelper *, GravatarHelper.AspNetCore
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @addTagHelper *, Elsa.WorkflowDesigner

--- a/src/dashboard/Elsa.Dashboard/Elsa.Dashboard.csproj
+++ b/src/dashboard/Elsa.Dashboard/Elsa.Dashboard.csproj
@@ -31,10 +31,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="GravatarHelper.AspNetCore" Version="1.1.0" />
-    </ItemGroup>
-
-    <ItemGroup>
         <ProjectReference Include="..\..\core\Elsa.Abstractions\Elsa.Abstractions.csproj" />
         <ProjectReference Include="..\..\core\Elsa.Core\Elsa.Core.csproj" />
         <ProjectReference Include="..\Elsa.WorkflowDesigner\Elsa.WorkflowDesigner.csproj" />


### PR DESCRIPTION
There is a security Vulnerability with Microsoft.AspNetCore.Mvc version 1.0.0.

Since Gravatar does not appear to be used at all, remove the dependency to improve security.