### PR TITLE
Fix : ListByBlockingActivityAsync() in documentDB persistence layer is not retrieving the blocked activities

### DIFF
--- a/src/core/Elsa.Abstractions/Models/BlockingActivity.cs
+++ b/src/core/Elsa.Abstractions/Models/BlockingActivity.cs
@@ -1,3 +1,5 @@
+using Newtonsoft.Json;
+
 namespace Elsa.Models
 {
     public class BlockingActivity
@@ -11,8 +13,11 @@ namespace Elsa.Models
             ActivityId = activityId;
             ActivityType = activityType;
         }
-        
+
+        [JsonProperty(PropertyName = "activityId")]
         public string ActivityId { get; set; }
+
+        [JsonProperty(PropertyName = "activityType")]
         public string ActivityType { get; set; }
     }
 }


### PR DESCRIPTION
ListByBlockingActivityAsync() builds following query to retrieve blocked activities. 

SELECT VALUE root FROM root JOIN (SELECT VALUE EXISTS(SELECT VALUE y0 FROM root JOIN y0 IN root["blockingActivities"] WHERE (y0["**ActivityType**"] = "ReceiveMassTransitMessage") ) ) AS v0 WHERE (((root["status"] = 1) AND (root["correlationId"] = "c02bc6fe-3730-4805-82f0-85741172aef7")) AND v0) ORDER BY root["createdAt"] DESC "}}

Due to the serialization issue, **ActivityType** is not serialized into **activityType** in the query. The fix helps to correct the same. After the fix, the query will be built like below

SELECT VALUE root FROM root JOIN (SELECT VALUE EXISTS(SELECT VALUE y0 FROM root JOIN y0 IN root["blockingActivities"] WHERE (y0["**activityType**"] = "ReceiveMassTransitMessage") ) ) AS v0 WHERE (((root["status"] = 1) AND (root["correlationId"] = "c02bc6fe-3730-4805-82f0-85741172aef7")) AND v0) ORDER BY root["createdAt"] DESC "}}

  