### PR TITLE
DocumentDB persistence layer unable to deserialize the Exception class instances

### DIFF
--- a/src/core/Elsa.Core/Serialization/Converters/ExceptionConverter.cs
+++ b/src/core/Elsa.Core/Serialization/Converters/ExceptionConverter.cs
@@ -1,14 +1,11 @@
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Elsa.Serialization.Converters
 {
     public class ExceptionConverter : JsonConverter<Exception>
     {
-
         public override void WriteJson(JsonWriter writer, Exception value, JsonSerializer serializer)
         {
             throw new NotImplementedException("Unnecessary because CanRead is false. The type will skip the converter.");
@@ -22,7 +19,6 @@ namespace Elsa.Serialization.Converters
             var jObject = JObject.Load(reader);
             var ex = System.Text.Json.JsonSerializer.Deserialize<Exception>(jObject.ToString());
             return ex;
-
         }
     }
 }

--- a/src/persistence/Elsa.Persistence.DocumentDb/DocumentDbStorage.cs
+++ b/src/persistence/Elsa.Persistence.DocumentDb/DocumentDbStorage.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Elsa.Serialization.Converters;
 
 namespace Elsa.Persistence.DocumentDb
 {
@@ -35,6 +36,8 @@ namespace Elsa.Persistence.DocumentDb
                     NamingStrategy = new CamelCaseNamingStrategy(false, false)
                 }
             }.ConfigureForNodaTime(DateTimeZoneProviders.Tzdb);
+
+            settings.Converters.Add(new ExceptionConverter());
 
             var connectionPolicy = ConnectionPolicy.Default;
             connectionPolicy.ConnectionMode = this.options.ConnectionMode;


### PR DESCRIPTION
The **JsonSerializerSettings** which is attached with **DocumentClient** do not have proper converters for **Exception** that leads to the JSON serialization error.

The changes to fix the issue available as part of the PR. Please have a look and approve the same. 