### PR TITLE
Workflow instance delete API is not deleting the document

### DIFF
--- a/src/persistence/Elsa.Persistence.DocumentDb/Services/CosmosDbWorkflowInstanceStore.cs
+++ b/src/persistence/Elsa.Persistence.DocumentDb/Services/CosmosDbWorkflowInstanceStore.cs
@@ -31,7 +31,14 @@ namespace Elsa.Persistence.DocumentDb.Services
             CancellationToken cancellationToken = default)
         {
             var client = await GetDocumentClient();
-            await client.DeleteDocumentAsync(id, cancellationToken: cancellationToken);
+            var query = client.CreateDocumentQuery<WorkflowInstanceDocument>(GetCollectionUri())
+                .Where(c => c.Id == id);
+            var document = query.AsEnumerable().FirstOrDefault();
+            if (document != null)
+            {
+                var documentUri = new Uri(document.SelfLink, UriKind.Relative);
+                await client.DeleteDocumentAsync(documentUri, cancellationToken: cancellationToken);
+            }
         }
 
         public async Task<WorkflowInstance> GetByCorrelationIdAsync(


### PR DESCRIPTION
The delete API is not using the correct documentUri to delete the document. The fix uses the correct URI for the same.