### PR TITLE
Redesign activities and workflows management

### DIFF
--- a/Elsa.sln
+++ b/Elsa.sln
@@ -185,6 +185,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.DistributedLocking.Sql
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Activities.Timers", "src\activities\Elsa.Activities.Timers\Elsa.Activities.Timers.csproj", "{74E83393-50AF-41E3-A1C8-97202673CD85}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Activities.Rebus", "src\activities\Elsa.Activities.Rebus\Elsa.Activities.Rebus.csproj", "{A9843C3F-74F7-4282-A7B7-841F6B8EB12D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -443,6 +445,10 @@ Global
 		{74E83393-50AF-41E3-A1C8-97202673CD85}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{74E83393-50AF-41E3-A1C8-97202673CD85}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{74E83393-50AF-41E3-A1C8-97202673CD85}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A9843C3F-74F7-4282-A7B7-841F6B8EB12D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A9843C3F-74F7-4282-A7B7-841F6B8EB12D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A9843C3F-74F7-4282-A7B7-841F6B8EB12D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A9843C3F-74F7-4282-A7B7-841F6B8EB12D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -529,6 +535,7 @@ Global
 		{C90CD39C-8CDD-4BCB-AB6A-CF981D468DD2} = {7CD5C8D5-EC78-4A99-A514-F01CA7197AC8}
 		{78F2A9DC-3092-4371-ABFE-87C5DA4DE351} = {7CD5C8D5-EC78-4A99-A514-F01CA7197AC8}
 		{74E83393-50AF-41E3-A1C8-97202673CD85} = {37D2E628-5CC1-4C8E-8C02-3B0A29E2ACAA}
+		{A9843C3F-74F7-4282-A7B7-841F6B8EB12D} = {B43B546E-23F3-46E8-ACB7-D04F05CDA180}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8B0975FD-7050-48B0-88C5-48C33378E158}

--- a/src/activities/Elsa.Activities.Rebus/Triggers/MessageReceivedTrigger.cs
+++ b/src/activities/Elsa.Activities.Rebus/Triggers/MessageReceivedTrigger.cs
@@ -15,7 +15,7 @@ namespace Elsa.Activities.Rebus.Triggers
         public override async ValueTask<ITrigger> GetTriggerAsync(TriggerProviderContext<RebusMessageReceived> context, CancellationToken cancellationToken) =>
             new MessageReceivedTrigger
             {
-                MessageType = (await context.Activity.GetPropertyValueAsync(x => x.MessageType, cancellationToken)).Name,
+                MessageType = (await context.Activity.GetPropertyValueAsync(x => x.MessageType, cancellationToken))!.Name,
                 CorrelationId = context.ActivityExecutionContext.WorkflowExecutionContext.CorrelationId
             };
     }

--- a/src/core/Elsa.Abstractions/ElsaOptions.cs
+++ b/src/core/Elsa.Abstractions/ElsaOptions.cs
@@ -1,0 +1,53 @@
+using Elsa.Models;
+using Elsa.Services;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Elsa
+{
+    public class ElsaOptions
+    {
+        /// <summary>
+        /// The set of activities available to workflows.
+        /// </summary>
+        private TypeList _activities { get; } = new TypeList();
+
+        public IEnumerable<Type> Activities => _activities.ToList().AsReadOnly();
+
+        public ElsaOptions RegisterActivity<T>() where T : IActivity, new()
+        {
+            return RegisterActivity(typeof(T));
+
+        }
+        public ElsaOptions RegisterActivity(Type activityType)
+        {
+            if(IsActivityRegistered(activityType) == false)
+            {
+                _activities.Add(activityType);
+            }
+
+            return this;
+        }
+
+        public ElsaOptions UnregisterActivityType<T>() where T : IActivity, new()
+        {
+            return UnregisterActivityType(typeof(T));
+        }
+
+        public ElsaOptions UnregisterActivityType(Type activityType)
+        {
+            if (IsActivityRegistered(activityType) == false)
+            {
+                _activities.RemoveWhere(type => type.FullName == activityType.FullName);
+            }
+            
+            return this;
+        }
+
+        public bool IsActivityRegistered(Type activityType)
+        {
+            return _activities.Contains(activityType);
+        }
+    }
+}

--- a/src/core/Elsa.Abstractions/ElsaOptions.cs
+++ b/src/core/Elsa.Abstractions/ElsaOptions.cs
@@ -12,12 +12,12 @@ namespace Elsa
         /// <summary>
         /// The set of activities available to workflows.
         /// </summary>
-        private readonly TypeList _activities = new TypeList();
+        private readonly TypeList _activities = new();
 
         /// <summary>
         /// The available programmed workflows
         /// </summary>
-        private readonly TypeList _workflows = new TypeList();
+        private readonly TypeList _workflows = new();
 
         public IEnumerable<Type> Activities => _activities.ToList().AsReadOnly();
 

--- a/src/core/Elsa.Abstractions/ElsaOptions.cs
+++ b/src/core/Elsa.Abstractions/ElsaOptions.cs
@@ -11,7 +11,7 @@ namespace Elsa
         /// <summary>
         /// The set of activities available to workflows.
         /// </summary>
-        private TypeList _activities { get; } = new TypeList();
+        private readonly TypeList _activities = new TypeList();
 
         public IEnumerable<Type> Activities => _activities.ToList().AsReadOnly();
 
@@ -20,6 +20,7 @@ namespace Elsa
             return RegisterActivity(typeof(T));
 
         }
+
         public ElsaOptions RegisterActivity(Type activityType)
         {
             if(IsActivityRegistered(activityType) == false)

--- a/src/core/Elsa.Abstractions/ElsaOptions.cs
+++ b/src/core/Elsa.Abstractions/ElsaOptions.cs
@@ -1,3 +1,4 @@
+using Elsa.Builders;
 using Elsa.Models;
 using Elsa.Services;
 using System;
@@ -13,12 +14,22 @@ namespace Elsa
         /// </summary>
         private readonly TypeList _activities = new TypeList();
 
+        /// <summary>
+        /// The available programmed workflows
+        /// </summary>
+        private readonly TypeList _workflows = new TypeList();
+
         public IEnumerable<Type> Activities => _activities.ToList().AsReadOnly();
+
+        public IEnumerable<Type> Workflows => _workflows.ToList().AsReadOnly();
+
+        public int NumberOfRegisteredActivities => _activities.Count;
+
+        public int NumberOfRegisteredWorkflows => _workflows.Count;
 
         public ElsaOptions RegisterActivity<T>() where T : IActivity, new()
         {
             return RegisterActivity(typeof(T));
-
         }
 
         public ElsaOptions RegisterActivity(Type activityType)
@@ -49,6 +60,41 @@ namespace Elsa
         public bool IsActivityRegistered(Type activityType)
         {
             return _activities.Contains(activityType);
+        }
+
+        public ElsaOptions RegisterWorkflow<T>() where T : IWorkflow, new()
+        {
+            return RegisterWorkflow(typeof(T));
+        }
+
+        public ElsaOptions RegisterWorkflow(Type workflowType)
+        {
+            if (IsWorkflowRegistered(workflowType) == false)
+            {
+                _workflows.Add(workflowType);
+            }
+
+            return this;
+        }
+
+        public ElsaOptions UnregisterWorkflowType<T>() where T : IWorkflow, new()
+        {
+            return UnregisterWorkflowType(typeof(T));
+        }
+
+        public ElsaOptions UnregisterWorkflowType(Type workflowType)
+        {
+            if (IsWorkflowRegistered(workflowType) == false)
+            {
+                _workflows.RemoveWhere(type => type.FullName == workflowType.FullName);
+            }
+
+            return this;
+        }
+
+        public bool IsWorkflowRegistered(Type workflowType)
+        {
+            return _workflows.Contains(workflowType);
         }
     }
 }

--- a/src/core/Elsa.Abstractions/Extensions/AssemblyExtensions.cs
+++ b/src/core/Elsa.Abstractions/Extensions/AssemblyExtensions.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+// The System.Reflection namespace is not used here because of the likelihood that another library will use identical functions. This can cause conflicts.
+namespace Elsa.Extensions
+{
+    public static class AssemblyExtensions
+    {
+        public static IEnumerable<Type> GetAllWithInterface(this Assembly assembly, Type @interface) => assembly.GetTypes().Where(t => t.IsClass && t.IsAbstract == false && t.GetInterfaces().Contains(@interface));
+        public static IEnumerable<Type> GetAllWithInterface<TType>(this Assembly assembly) => assembly.GetAllWithInterface(typeof(TType));
+    }
+}

--- a/src/core/Elsa.Abstractions/Extensions/ServiceCollectionExtensions.cs
+++ b/src/core/Elsa.Abstractions/Extensions/ServiceCollectionExtensions.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Extensions.DependencyInjection
         public static IServiceCollection AddWorkflowProvider<T>(this IServiceCollection services) where T : class, IWorkflowProvider => services.AddTransient<IWorkflowProvider, T>();
 
         public static IServiceCollection AddWorkflowContextProvider<T>(this IServiceCollection services) where T : class, IWorkflowContextProvider => services.AddTransient<IWorkflowContextProvider, T>();
+       
         public static IServiceCollection AddWorkflowContextProvider(this IServiceCollection services, Assembly assembly)
         {
             var workflowContextProviderType = typeof(IWorkflowContextProvider);

--- a/src/core/Elsa.Abstractions/Extensions/ServiceCollectionExtensions.cs
+++ b/src/core/Elsa.Abstractions/Extensions/ServiceCollectionExtensions.cs
@@ -1,5 +1,7 @@
 using Elsa.Services;
 using Elsa.Triggers;
+using Elsa.Extensions;
+using System.Reflection;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection
@@ -7,7 +9,34 @@ namespace Microsoft.Extensions.DependencyInjection
     public static class ServiceCollectionExtensions
     {    
         public static IServiceCollection AddWorkflowProvider<T>(this IServiceCollection services) where T : class, IWorkflowProvider => services.AddTransient<IWorkflowProvider, T>();
-        public static IServiceCollection AddTriggerProvider<T>(this IServiceCollection services) where T : class, ITriggerProvider => services.AddTransient<ITriggerProvider, T>();
+
         public static IServiceCollection AddWorkflowContextProvider<T>(this IServiceCollection services) where T : class, IWorkflowContextProvider => services.AddTransient<IWorkflowContextProvider, T>();
+        public static IServiceCollection AddWorkflowContextProvider(this IServiceCollection services, Assembly assembly)
+        {
+            var workflowContextProviderType = typeof(IWorkflowContextProvider);
+            var types = assembly.GetAllWithInterface(workflowContextProviderType);
+
+            foreach (var type in types)
+            {
+                services.AddTransient(workflowContextProviderType, type);
+            }
+
+            return services;
+        }
+
+        public static IServiceCollection AddTriggerProvider<T>(this IServiceCollection services) where T : class, ITriggerProvider => services.AddTransient<ITriggerProvider, T>();
+       
+        public static IServiceCollection AddTriggerProvider(this IServiceCollection services, Assembly assembly)
+        {         
+            var triggerProviderType = typeof(ITriggerProvider);
+            var types = assembly.GetAllWithInterface(triggerProviderType);
+
+            foreach (var type in types)
+            {
+                services.AddTransient(triggerProviderType, type);
+            }
+
+            return services;
+        }
     }
 }

--- a/src/core/Elsa.Abstractions/Models/TypeList.cs
+++ b/src/core/Elsa.Abstractions/Models/TypeList.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Elsa.Models
+{
+    public class TypeList : HashSet<Type>
+    {
+    }
+}

--- a/src/core/Elsa.Core/ActivityTypeProviders/TypeBasedActivityProvider.cs
+++ b/src/core/Elsa.Core/ActivityTypeProviders/TypeBasedActivityProvider.cs
@@ -15,7 +15,7 @@ namespace Elsa.ActivityTypeProviders
     {
         private readonly IActivityDescriber _activityDescriber;
         private readonly IActivityActivator _activityActivator;
-        private readonly IEnumerable<Type> _activityTypeLookup;
+        private readonly IEnumerable<Type> _activityTypes;
 
         public TypeBasedActivityProvider(IOptions<ElsaOptions> options,
             IActivityDescriber activityDescriber, 
@@ -24,7 +24,7 @@ namespace Elsa.ActivityTypeProviders
             _activityDescriber = activityDescriber;
             _activityActivator = activityActivator;
 
-            _activityTypeLookup = options.Value.Activities;
+            _activityTypes = options.Value.Activities;
         }
         
         public ValueTask<IEnumerable<ActivityType>> GetActivityTypesAsync(CancellationToken cancellationToken) => new(GetActivityTypesInternal());
@@ -57,7 +57,7 @@ namespace Elsa.ActivityTypeProviders
             };
         }
 
-        private IEnumerable<Type> GetActivityTypes() => _activityTypeLookup;
+        private IEnumerable<Type> GetActivityTypes() => _activityTypes;
 
         private Task<IActivity> ActivateActivity(ActivityExecutionContext context, Type type) => _activityActivator.ActivateActivityAsync(context, type);
     }

--- a/src/core/Elsa.Core/ActivityTypeProviders/TypeBasedActivityProvider.cs
+++ b/src/core/Elsa.Core/ActivityTypeProviders/TypeBasedActivityProvider.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -7,7 +7,7 @@ using Elsa.ActivityProviders;
 using Elsa.Metadata;
 using Elsa.Services;
 using Elsa.Services.Models;
-using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace Elsa.ActivityTypeProviders
 {
@@ -15,16 +15,16 @@ namespace Elsa.ActivityTypeProviders
     {
         private readonly IActivityDescriber _activityDescriber;
         private readonly IActivityActivator _activityActivator;
-        private readonly IDictionary<string, Type> _activityTypeLookup;
+        private readonly IEnumerable<Type> _activityTypeLookup;
 
-        public TypeBasedActivityProvider(IServiceProvider serviceProvider, IActivityDescriber activityDescriber, IActivityActivator activityActivator)
+        public TypeBasedActivityProvider(IOptions<ElsaOptions> options,
+            IActivityDescriber activityDescriber, 
+            IActivityActivator activityActivator)
         {
             _activityDescriber = activityDescriber;
             _activityActivator = activityActivator;
 
-            using var scope = serviceProvider.CreateScope();
-            var activities = scope.ServiceProvider.GetServices<IActivity>();
-            _activityTypeLookup = activities.Select(x => x.GetType()).Distinct().ToDictionary(x => x.Name);
+            _activityTypeLookup = options.Value.Activities;
         }
         
         public ValueTask<IEnumerable<ActivityType>> GetActivityTypesAsync(CancellationToken cancellationToken) => new(GetActivityTypesInternal());
@@ -57,7 +57,7 @@ namespace Elsa.ActivityTypeProviders
             };
         }
 
-        private IEnumerable<Type> GetActivityTypes() => _activityTypeLookup.Values.ToList();
+        private IEnumerable<Type> GetActivityTypes() => _activityTypeLookup;
 
         private Task<IActivity> ActivateActivity(ActivityExecutionContext context, Type type) => _activityActivator.ActivateActivityAsync(context, type);
     }

--- a/src/core/Elsa.Core/ActivityTypeProviders/TypeBasedActivityProvider.cs
+++ b/src/core/Elsa.Core/ActivityTypeProviders/TypeBasedActivityProvider.cs
@@ -15,7 +15,7 @@ namespace Elsa.ActivityTypeProviders
     {
         private readonly IActivityDescriber _activityDescriber;
         private readonly IActivityActivator _activityActivator;
-        private readonly IEnumerable<Type> _activityTypes;
+        private readonly ElsaOptions _elsaOptions;
 
         public TypeBasedActivityProvider(IOptions<ElsaOptions> options,
             IActivityDescriber activityDescriber, 
@@ -24,12 +24,13 @@ namespace Elsa.ActivityTypeProviders
             _activityDescriber = activityDescriber;
             _activityActivator = activityActivator;
 
-            _activityTypes = options.Value.Activities;
+            _elsaOptions = options.Value;
         }
         
         public ValueTask<IEnumerable<ActivityType>> GetActivityTypesAsync(CancellationToken cancellationToken) => new(GetActivityTypesInternal());
+       
         private IEnumerable<ActivityType> GetActivityTypesInternal() => GetActivityTypes().Select(CreateActivityType);
-
+       
         private ActivityType CreateActivityType(Type activityType)
         {
             var info = _activityDescriber.Describe(activityType)!;
@@ -57,7 +58,7 @@ namespace Elsa.ActivityTypeProviders
             };
         }
 
-        private IEnumerable<Type> GetActivityTypes() => _activityTypes;
+        private IEnumerable<Type> GetActivityTypes() => _elsaOptions.Activities;
 
         private Task<IActivity> ActivateActivity(ActivityExecutionContext context, Type type) => _activityActivator.ActivateActivityAsync(context, type);
     }

--- a/src/core/Elsa.Core/ElsaConfiguration.cs
+++ b/src/core/Elsa.Core/ElsaConfiguration.cs
@@ -17,9 +17,9 @@ using Storage.Net.Blobs;
 
 namespace Elsa
 {
-    public class ElsaConfigurationsOptions
+    public class ElsaConfiguration
     {
-        public ElsaConfigurationsOptions(IServiceCollection services)
+        public ElsaConfiguration(IServiceCollection services)
         {
             Services = services;
 
@@ -63,63 +63,63 @@ namespace Elsa
         internal Action AddAutoMapper { get; private set; }
         internal Action<ServiceBusEndpointConfigurationContext> ConfigureServiceBusEndpoint { get; private set; }
 
-        public ElsaConfigurationsOptions UseDistributedLockProvider(Func<IServiceProvider, IDistributedLockProvider> factory)
+        public ElsaConfiguration UseDistributedLockProvider(Func<IServiceProvider, IDistributedLockProvider> factory)
         {
             DistributedLockProviderFactory = factory;
             return this;
         }
 
-        public ElsaConfigurationsOptions UseSignal(Func<IServiceProvider, ISignal> factory)
+        public ElsaConfiguration UseSignal(Func<IServiceProvider, ISignal> factory)
         {
             SignalFactory = factory;
             return this;
         }
 
-        public ElsaConfigurationsOptions UseStorage(Func<IBlobStorage> factory) => UseStorage(_ => factory());
+        public ElsaConfiguration UseStorage(Func<IBlobStorage> factory) => UseStorage(_ => factory());
 
-        public ElsaConfigurationsOptions UseStorage(Func<IServiceProvider, IBlobStorage> factory)
+        public ElsaConfiguration UseStorage(Func<IServiceProvider, IBlobStorage> factory)
         {
             StorageFactory = factory;
             return this;
         }
         
-        public ElsaConfigurationsOptions UseWorkflowDefinitionStore(Func<IServiceProvider, IWorkflowDefinitionStore> factory)
+        public ElsaConfiguration UseWorkflowDefinitionStore(Func<IServiceProvider, IWorkflowDefinitionStore> factory)
         {
             WorkflowDefinitionStoreFactory = factory;
             return this;
         }
         
-        public ElsaConfigurationsOptions UseWorkflowInstanceStore(Func<IServiceProvider, IWorkflowInstanceStore> factory)
+        public ElsaConfiguration UseWorkflowInstanceStore(Func<IServiceProvider, IWorkflowInstanceStore> factory)
         {
             WorkflowInstanceStoreFactory = factory;
             return this;
         }
         
-        public ElsaConfigurationsOptions UseWorkflowExecutionLogStore(Func<IServiceProvider, IWorkflowExecutionLogStore> factory)
+        public ElsaConfiguration UseWorkflowExecutionLogStore(Func<IServiceProvider, IWorkflowExecutionLogStore> factory)
         {
             WorkflowExecutionLogStoreFactory = factory;
             return this;
         }
 
-        public ElsaConfigurationsOptions UseAutoMapper(Action addAutoMapper)
+        public ElsaConfiguration UseAutoMapper(Action addAutoMapper)
         {
             AddAutoMapper = addAutoMapper;
             return this;
         }
 
-        public ElsaConfigurationsOptions UseJsonSerializer(Func<IServiceProvider, JsonSerializer> factory)
+        public ElsaConfiguration UseJsonSerializer(Func<IServiceProvider, JsonSerializer> factory)
         {
             CreateJsonSerializer = factory;
             return this;
         }
 
-        public ElsaConfigurationsOptions ConfigureJsonSerializer(Action<IServiceProvider, JsonSerializer> configure)
+        public ElsaConfiguration ConfigureJsonSerializer(Action<IServiceProvider, JsonSerializer> configure)
         {
             JsonSerializerConfigurer = configure;
             return this;
         }
 
-        public ElsaConfigurationsOptions UseServiceBus(Action<ServiceBusEndpointConfigurationContext> setup)
+        public ElsaConfiguration UseServiceBus(Action<ServiceBusEndpointConfigurationContext> setup)
         {
             ConfigureServiceBusEndpoint = setup;
             return this;

--- a/src/core/Elsa.Core/ElsaConfigurationsOptions.cs
+++ b/src/core/Elsa.Core/ElsaConfigurationsOptions.cs
@@ -17,9 +17,9 @@ using Storage.Net.Blobs;
 
 namespace Elsa
 {
-    public class ElsaOptions
+    public class ElsaConfigurationsOptions
     {
-        public ElsaOptions(IServiceCollection services)
+        public ElsaConfigurationsOptions(IServiceCollection services)
         {
             Services = services;
 
@@ -63,63 +63,63 @@ namespace Elsa
         internal Action AddAutoMapper { get; private set; }
         internal Action<ServiceBusEndpointConfigurationContext> ConfigureServiceBusEndpoint { get; private set; }
 
-        public ElsaOptions UseDistributedLockProvider(Func<IServiceProvider, IDistributedLockProvider> factory)
+        public ElsaConfigurationsOptions UseDistributedLockProvider(Func<IServiceProvider, IDistributedLockProvider> factory)
         {
             DistributedLockProviderFactory = factory;
             return this;
         }
 
-        public ElsaOptions UseSignal(Func<IServiceProvider, ISignal> factory)
+        public ElsaConfigurationsOptions UseSignal(Func<IServiceProvider, ISignal> factory)
         {
             SignalFactory = factory;
             return this;
         }
 
-        public ElsaOptions UseStorage(Func<IBlobStorage> factory) => UseStorage(_ => factory());
+        public ElsaConfigurationsOptions UseStorage(Func<IBlobStorage> factory) => UseStorage(_ => factory());
 
-        public ElsaOptions UseStorage(Func<IServiceProvider, IBlobStorage> factory)
+        public ElsaConfigurationsOptions UseStorage(Func<IServiceProvider, IBlobStorage> factory)
         {
             StorageFactory = factory;
             return this;
         }
         
-        public ElsaOptions UseWorkflowDefinitionStore(Func<IServiceProvider, IWorkflowDefinitionStore> factory)
+        public ElsaConfigurationsOptions UseWorkflowDefinitionStore(Func<IServiceProvider, IWorkflowDefinitionStore> factory)
         {
             WorkflowDefinitionStoreFactory = factory;
             return this;
         }
         
-        public ElsaOptions UseWorkflowInstanceStore(Func<IServiceProvider, IWorkflowInstanceStore> factory)
+        public ElsaConfigurationsOptions UseWorkflowInstanceStore(Func<IServiceProvider, IWorkflowInstanceStore> factory)
         {
             WorkflowInstanceStoreFactory = factory;
             return this;
         }
         
-        public ElsaOptions UseWorkflowExecutionLogStore(Func<IServiceProvider, IWorkflowExecutionLogStore> factory)
+        public ElsaConfigurationsOptions UseWorkflowExecutionLogStore(Func<IServiceProvider, IWorkflowExecutionLogStore> factory)
         {
             WorkflowExecutionLogStoreFactory = factory;
             return this;
         }
 
-        public ElsaOptions UseAutoMapper(Action addAutoMapper)
+        public ElsaConfigurationsOptions UseAutoMapper(Action addAutoMapper)
         {
             AddAutoMapper = addAutoMapper;
             return this;
         }
 
-        public ElsaOptions UseJsonSerializer(Func<IServiceProvider, JsonSerializer> factory)
+        public ElsaConfigurationsOptions UseJsonSerializer(Func<IServiceProvider, JsonSerializer> factory)
         {
             CreateJsonSerializer = factory;
             return this;
         }
 
-        public ElsaOptions ConfigureJsonSerializer(Action<IServiceProvider, JsonSerializer> configure)
+        public ElsaConfigurationsOptions ConfigureJsonSerializer(Action<IServiceProvider, JsonSerializer> configure)
         {
             JsonSerializerConfigurer = configure;
             return this;
         }
 
-        public ElsaOptions UseServiceBus(Action<ServiceBusEndpointConfigurationContext> setup)
+        public ElsaConfigurationsOptions UseServiceBus(Action<ServiceBusEndpointConfigurationContext> setup)
         {
             ConfigureServiceBusEndpoint = setup;
             return this;

--- a/src/core/Elsa.Core/Extensions/ElsaServiceCollectionExtensions.cs
+++ b/src/core/Elsa.Core/Extensions/ElsaServiceCollectionExtensions.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             var type = workflow.GetType();
             return services
-              .AddSingleton(type)
+              .AddSingleton(type, workflow)
               .AddWorkflow(type);
         }
 

--- a/src/core/Elsa.Core/Extensions/ElsaServiceCollectionExtensions.cs
+++ b/src/core/Elsa.Core/Extensions/ElsaServiceCollectionExtensions.cs
@@ -82,15 +82,11 @@ namespace Microsoft.Extensions.DependencyInjection
             return services;
         }
 
-        public static IServiceCollection AddWorkflow<T>(this IServiceCollection services) where T : class, IWorkflow =>
-            services
-                .AddSingleton<T>()
-                .AddSingleton<IWorkflow>(sp => sp.GetRequiredService<T>());
+        public static IServiceCollection AddWorkflow<T>(this IServiceCollection services) where T : IWorkflow, new() =>
+            services.AddWorkflow(typeof(T));
 
-        public static IServiceCollection AddWorkflow(this IServiceCollection services, IWorkflow workflow) =>
-            services
-                .AddSingleton(workflow.GetType(), workflow)
-                .AddTransient(sp => workflow);
+        public static IServiceCollection AddWorkflow(this IServiceCollection services, Type workflow) =>
+            services.Configure<ElsaOptions>(options => options.RegisterWorkflow(workflow));
 
         public static IServiceCollection StartWorkflow<T>(this IServiceCollection services) where T : class, IWorkflow => services.AddHostedService<StartWorkflow<T>>();
 
@@ -103,9 +99,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             foreach (var type in types)
             {
-                services
-                   .AddSingleton(type)
-                   .AddSingleton(sp => (IWorkflow)sp.GetRequiredService(type));
+                services.AddWorkflow(type);
             }
 
             return services;

--- a/src/core/Elsa.Core/Extensions/ElsaServiceCollectionExtensions.cs
+++ b/src/core/Elsa.Core/Extensions/ElsaServiceCollectionExtensions.cs
@@ -37,9 +37,9 @@ namespace Microsoft.Extensions.DependencyInjection
     {
         public static IServiceCollection AddElsaCore(
             this IServiceCollection services,
-            Action<ElsaConfigurationsOptions>? configure = default)
+            Action<ElsaConfiguration>? configure = default)
         {
-            var options = new ElsaConfigurationsOptions(services);
+            var options = new ElsaConfiguration(services);
             configure?.Invoke(options);
 
             services
@@ -111,9 +111,9 @@ namespace Microsoft.Extensions.DependencyInjection
             return services;
         }
 
-        private static IServiceCollection AddMediatR(this ElsaConfigurationsOptions options) => options.Services.AddMediatR(mediatr => mediatr.AsScoped(), typeof(IActivity));
+        private static IServiceCollection AddMediatR(this ElsaConfiguration options) => options.Services.AddMediatR(mediatr => mediatr.AsScoped(), typeof(IActivity));
 
-        private static ElsaConfigurationsOptions AddWorkflowsCore(this ElsaConfigurationsOptions configuration)
+        private static ElsaConfiguration AddWorkflowsCore(this ElsaConfiguration configuration)
         {
             var services = configuration.Services;
             services.TryAddSingleton<IClock>(SystemClock.Instance);
@@ -123,7 +123,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 .AddLocalization()
                 .AddMemoryCache()
                 .AddSingleton<IIdGenerator, IdGenerator>()
-                .AddSingleton(sp => sp.GetRequiredService<ElsaConfigurationsOptions>().CreateJsonSerializer(sp))
+                .AddSingleton(sp => sp.GetRequiredService<ElsaConfiguration>().CreateJsonSerializer(sp))
                 .AddSingleton<IContentSerializer, DefaultContentSerializer>()
                 .AddSingleton<TypeJsonConverter>()
                 .TryAddProvider<IExpressionHandler, LiteralHandler>(ServiceLifetime.Singleton)

--- a/src/core/Elsa.Core/Extensions/ElsaServiceCollectionExtensions.cs
+++ b/src/core/Elsa.Core/Extensions/ElsaServiceCollectionExtensions.cs
@@ -70,9 +70,6 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <summary>
         /// Add all activities (<see cref="IActivity"/>) that are in the assembly
         /// </summary>
-        /// <param name="services"></param>
-        /// <param name="assembly"></param>
-        /// <returns></returns>
         public static IServiceCollection AddActivity(this IServiceCollection services, Assembly assembly)
         {
             var types = assembly.GetAllWithInterface<IActivity>();
@@ -100,9 +97,6 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <summary>
         /// Add all workflows (<see cref="IWorkflow"/>) that are in the assembly and have no constructor with parameters
         /// </summary>
-        /// <param name="services"></param>
-        /// <param name="assembly"></param>
-        /// <returns></returns>
         public static IServiceCollection AddWorkflow(this IServiceCollection services, Assembly assembly)
         {
             var types = assembly.GetAllWithInterface<IWorkflow>().Where(x => x.GetConstructors().Any(ctor => ctor.GetParameters().Length > 0) == false);

--- a/src/core/Elsa.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/core/Elsa.Core/Extensions/ServiceCollectionExtensions.cs
@@ -42,6 +42,6 @@ namespace Microsoft.Extensions.DependencyInjection
 
         public static IServiceCollection Replace<TService, TImplementation>(this IServiceCollection services, ServiceLifetime lifetime) => services.Replace(new ServiceDescriptor(typeof(TService), typeof(TImplementation), lifetime));
         public static bool HasService<T>(this IServiceCollection services) => services.Any(x => x.ServiceType == typeof(T));
-        public static bool HasService<T>(this ElsaOptions configuration) => configuration.Services.HasService<T>();
+        public static bool HasService<T>(this ElsaConfigurationsOptions configuration) => configuration.Services.HasService<T>();
     }
 }

--- a/src/core/Elsa.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/core/Elsa.Core/Extensions/ServiceCollectionExtensions.cs
@@ -42,6 +42,6 @@ namespace Microsoft.Extensions.DependencyInjection
 
         public static IServiceCollection Replace<TService, TImplementation>(this IServiceCollection services, ServiceLifetime lifetime) => services.Replace(new ServiceDescriptor(typeof(TService), typeof(TImplementation), lifetime));
         public static bool HasService<T>(this IServiceCollection services) => services.Any(x => x.ServiceType == typeof(T));
-        public static bool HasService<T>(this ElsaConfigurationsOptions configuration) => configuration.Services.HasService<T>();
+        public static bool HasService<T>(this ElsaConfiguration configuration) => configuration.Services.HasService<T>();
     }
 }

--- a/src/core/Elsa.Core/Services/ServiceBusFactory.cs
+++ b/src/core/Elsa.Core/Services/ServiceBusFactory.cs
@@ -8,12 +8,12 @@ namespace Elsa.Services
 {
     public class ServiceBusFactory : IServiceBusFactory
     {
-        private readonly ElsaOptions _elsaOptions;
+        private readonly ElsaConfigurationsOptions _elsaOptions;
         private readonly IServiceProvider _serviceProvider;
         private readonly IDictionary<string, IBus> _serviceBuses = new Dictionary<string, IBus>();
         private readonly DependencyInjectionHandlerActivator _handlerActivator;
 
-        public ServiceBusFactory(ElsaOptions elsaOptions, IServiceProvider serviceProvider)
+        public ServiceBusFactory(ElsaConfigurationsOptions elsaOptions, IServiceProvider serviceProvider)
         {
             _elsaOptions = elsaOptions;
             _serviceProvider = serviceProvider;

--- a/src/core/Elsa.Core/Services/ServiceBusFactory.cs
+++ b/src/core/Elsa.Core/Services/ServiceBusFactory.cs
@@ -8,12 +8,12 @@ namespace Elsa.Services
 {
     public class ServiceBusFactory : IServiceBusFactory
     {
-        private readonly ElsaConfigurationsOptions _elsaOptions;
+        private readonly ElsaConfiguration _elsaOptions;
         private readonly IServiceProvider _serviceProvider;
         private readonly IDictionary<string, IBus> _serviceBuses = new Dictionary<string, IBus>();
         private readonly DependencyInjectionHandlerActivator _handlerActivator;
 
-        public ServiceBusFactory(ElsaConfigurationsOptions elsaOptions, IServiceProvider serviceProvider)
+        public ServiceBusFactory(ElsaConfiguration elsaOptions, IServiceProvider serviceProvider)
         {
             _elsaOptions = elsaOptions;
             _serviceProvider = serviceProvider;

--- a/src/core/Elsa.Core/WorkflowProviders/ProgrammaticWorkflowProvider.cs
+++ b/src/core/Elsa.Core/WorkflowProviders/ProgrammaticWorkflowProvider.cs
@@ -6,6 +6,8 @@ using System.Threading.Tasks;
 using Elsa.Builders;
 using Elsa.Services;
 using Elsa.Services.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace Elsa.WorkflowProviders
 {
@@ -17,8 +19,17 @@ namespace Elsa.WorkflowProviders
         private readonly IEnumerable<IWorkflow> _workflows;
         private readonly Func<IWorkflowBuilder> _workflowBuilder;
 
-        public ProgrammaticWorkflowProvider(IEnumerable<IWorkflow> workflows, Func<IWorkflowBuilder> workflowBuilder)
-        {
+        public ProgrammaticWorkflowProvider(IOptions<ElsaOptions> elsaOptions, 
+            IServiceProvider serviceProvider,
+            Func<IWorkflowBuilder> workflowBuilder)
+        {         
+            var workflows = new List<IWorkflow>(elsaOptions.Value.NumberOfRegisteredWorkflows);
+
+            foreach(var workflow in elsaOptions.Value.Workflows)
+            {
+                workflows.Add((IWorkflow)ActivatorUtilities.CreateInstance(serviceProvider, workflow));
+            }
+
             _workflows = workflows;
             _workflowBuilder = workflowBuilder;
         }

--- a/src/core/Elsa/ElsaServiceCollectionExtensions.cs
+++ b/src/core/Elsa/ElsaServiceCollectionExtensions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Extensions.DependencyInjection
     {
         public static IServiceCollection AddElsa(
             this IServiceCollection services,
-            Action<ElsaOptions>? configure = default)
+            Action<ElsaConfigurationsOptions>? configure = default)
         {
             return services
                 .AddElsaCore(configure)

--- a/src/core/Elsa/ElsaServiceCollectionExtensions.cs
+++ b/src/core/Elsa/ElsaServiceCollectionExtensions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Extensions.DependencyInjection
     {
         public static IServiceCollection AddElsa(
             this IServiceCollection services,
-            Action<ElsaConfigurationsOptions>? configure = default)
+            Action<ElsaConfiguration>? configure = default)
         {
             return services
                 .AddElsaCore(configure)

--- a/src/locking/Elsa.DistributedLocking.AzureBlob/ElsaOptionsExtensions.cs
+++ b/src/locking/Elsa.DistributedLocking.AzureBlob/ElsaOptionsExtensions.cs
@@ -6,7 +6,7 @@ namespace Elsa
 {
     public static class ElsaOptionsExtensions
     {
-        public static ElsaConfigurationsOptions UseAzureBlobLockProvider(this ElsaConfigurationsOptions options, string connectionString, TimeSpan? leaseTime = null, TimeSpan? renewInterval = null)
+        public static ElsaConfiguration UseAzureBlobLockProvider(this ElsaConfiguration options, string connectionString, TimeSpan? leaseTime = null, TimeSpan? renewInterval = null)
         {
             options
                 .UseDistributedLockProvider(sp =>

--- a/src/locking/Elsa.DistributedLocking.AzureBlob/ElsaOptionsExtensions.cs
+++ b/src/locking/Elsa.DistributedLocking.AzureBlob/ElsaOptionsExtensions.cs
@@ -6,7 +6,7 @@ namespace Elsa
 {
     public static class ElsaOptionsExtensions
     {
-        public static ElsaOptions UseAzureBlobLockProvider(this ElsaOptions options, string connectionString, TimeSpan? leaseTime = null, TimeSpan? renewInterval = null)
+        public static ElsaConfigurationsOptions UseAzureBlobLockProvider(this ElsaConfigurationsOptions options, string connectionString, TimeSpan? leaseTime = null, TimeSpan? renewInterval = null)
         {
             options
                 .UseDistributedLockProvider(sp =>

--- a/src/locking/Elsa.DistributedLocking.Redis/ElsaOptionsExtensions.cs
+++ b/src/locking/Elsa.DistributedLocking.Redis/ElsaOptionsExtensions.cs
@@ -11,7 +11,7 @@ namespace Elsa
 {
     public static class ElsaOptionsExtensions
     {
-        public static ElsaOptions UseRedisLockProvider(this ElsaOptions options, string connectionString, TimeSpan? lockTimeout = null)
+        public static ElsaConfigurationsOptions UseRedisLockProvider(this ElsaConfigurationsOptions options, string connectionString, TimeSpan? lockTimeout = null)
         {
             options.UseStackExchangeConnectionMultiplexer(connectionString)
                 .UseRedLockFactory()
@@ -24,7 +24,7 @@ namespace Elsa
             return options;
         }
 
-        private static ElsaOptions UseStackExchangeConnectionMultiplexer(this ElsaOptions options, string connectionString)
+        private static ElsaConfigurationsOptions UseStackExchangeConnectionMultiplexer(this ElsaConfigurationsOptions options, string connectionString)
         {
             if (string.IsNullOrWhiteSpace(connectionString))
             {
@@ -36,7 +36,7 @@ namespace Elsa
             return options;
         }
 
-        private static ElsaOptions UseRedLockFactory(this ElsaOptions options)
+        private static ElsaConfigurationsOptions UseRedLockFactory(this ElsaConfigurationsOptions options)
         {
             options.Services.AddSingleton<IDistributedLockFactory, RedLockFactory>(
                 sp => RedLockFactory.Create(

--- a/src/locking/Elsa.DistributedLocking.Redis/ElsaOptionsExtensions.cs
+++ b/src/locking/Elsa.DistributedLocking.Redis/ElsaOptionsExtensions.cs
@@ -11,7 +11,7 @@ namespace Elsa
 {
     public static class ElsaOptionsExtensions
     {
-        public static ElsaConfigurationsOptions UseRedisLockProvider(this ElsaConfigurationsOptions options, string connectionString, TimeSpan? lockTimeout = null)
+        public static ElsaConfiguration UseRedisLockProvider(this ElsaConfiguration options, string connectionString, TimeSpan? lockTimeout = null)
         {
             options.UseStackExchangeConnectionMultiplexer(connectionString)
                 .UseRedLockFactory()
@@ -24,7 +24,7 @@ namespace Elsa
             return options;
         }
 
-        private static ElsaConfigurationsOptions UseStackExchangeConnectionMultiplexer(this ElsaConfigurationsOptions options, string connectionString)
+        private static ElsaConfiguration UseStackExchangeConnectionMultiplexer(this ElsaConfiguration options, string connectionString)
         {
             if (string.IsNullOrWhiteSpace(connectionString))
             {
@@ -36,7 +36,7 @@ namespace Elsa
             return options;
         }
 
-        private static ElsaConfigurationsOptions UseRedLockFactory(this ElsaConfigurationsOptions options)
+        private static ElsaConfiguration UseRedLockFactory(this ElsaConfiguration options)
         {
             options.Services.AddSingleton<IDistributedLockFactory, RedLockFactory>(
                 sp => RedLockFactory.Create(

--- a/src/locking/Elsa.DistributedLocking.SqlServer/ElsaOptionsExtensions.cs
+++ b/src/locking/Elsa.DistributedLocking.SqlServer/ElsaOptionsExtensions.cs
@@ -5,7 +5,7 @@ namespace Elsa
 {
     public static class ElsaOptionsExtensions
     {
-        public static ElsaConfigurationsOptions UseSqlServerLockProvider(this ElsaConfigurationsOptions options, string connectionString)
+        public static ElsaConfiguration UseSqlServerLockProvider(this ElsaConfiguration options, string connectionString)
         {
             return options.UseDistributedLockProvider(sp => new SqlLockProvider(connectionString, sp.GetRequiredService<ILogger<SqlLockProvider>>()));
         }

--- a/src/locking/Elsa.DistributedLocking.SqlServer/ElsaOptionsExtensions.cs
+++ b/src/locking/Elsa.DistributedLocking.SqlServer/ElsaOptionsExtensions.cs
@@ -5,7 +5,7 @@ namespace Elsa
 {
     public static class ElsaOptionsExtensions
     {
-        public static ElsaOptions UseSqlServerLockProvider(this ElsaOptions options, string connectionString)
+        public static ElsaConfigurationsOptions UseSqlServerLockProvider(this ElsaConfigurationsOptions options, string connectionString)
         {
             return options.UseDistributedLockProvider(sp => new SqlLockProvider(connectionString, sp.GetRequiredService<ILogger<SqlLockProvider>>()));
         }

--- a/src/persistence/Elsa.Persistence.MongoDb/Extensions/ServiceCollectionExtensions.cs
+++ b/src/persistence/Elsa.Persistence.MongoDb/Extensions/ServiceCollectionExtensions.cs
@@ -12,7 +12,7 @@ namespace Elsa.Persistence.MongoDb.Extensions
 {
     public static class ServiceCollectionExtensions
     {
-        public static ElsaConfigurationsOptions UseMongoDbPersistence(this ElsaConfigurationsOptions elsa, Action<ElsaMongoDbOptions> configureOptions)
+        public static ElsaConfiguration UseMongoDbPersistence(this ElsaConfiguration elsa, Action<ElsaMongoDbOptions> configureOptions)
         {
             AddCore(elsa);
             elsa.Services.Configure(configureOptions);
@@ -20,14 +20,14 @@ namespace Elsa.Persistence.MongoDb.Extensions
             return elsa;
         }
 
-        public static ElsaConfigurationsOptions UseMongoDbPersistence(this ElsaConfigurationsOptions elsa, IConfiguration options)
+        public static ElsaConfiguration UseMongoDbPersistence(this ElsaConfiguration elsa, IConfiguration options)
         {
             AddCore(elsa);
             elsa.Services.Configure<ElsaMongoDbOptions>(options);
             return elsa;
         }
 
-        private static void AddCore(ElsaConfigurationsOptions elsa)
+        private static void AddCore(ElsaConfiguration elsa)
         {
             elsa.Services
                 .AddSingleton<MongoDbWorkflowDefinitionStore>()

--- a/src/persistence/Elsa.Persistence.MongoDb/Extensions/ServiceCollectionExtensions.cs
+++ b/src/persistence/Elsa.Persistence.MongoDb/Extensions/ServiceCollectionExtensions.cs
@@ -12,7 +12,7 @@ namespace Elsa.Persistence.MongoDb.Extensions
 {
     public static class ServiceCollectionExtensions
     {
-        public static ElsaOptions UseMongoDbPersistence(this ElsaOptions elsa, Action<ElsaMongoDbOptions> configureOptions)
+        public static ElsaConfigurationsOptions UseMongoDbPersistence(this ElsaConfigurationsOptions elsa, Action<ElsaMongoDbOptions> configureOptions)
         {
             AddCore(elsa);
             elsa.Services.Configure(configureOptions);
@@ -20,14 +20,14 @@ namespace Elsa.Persistence.MongoDb.Extensions
             return elsa;
         }
 
-        public static ElsaOptions UseMongoDbPersistence(this ElsaOptions elsa, IConfiguration options)
+        public static ElsaConfigurationsOptions UseMongoDbPersistence(this ElsaConfigurationsOptions elsa, IConfiguration options)
         {
             AddCore(elsa);
             elsa.Services.Configure<ElsaMongoDbOptions>(options);
             return elsa;
         }
 
-        private static void AddCore(ElsaOptions elsa)
+        private static void AddCore(ElsaConfigurationsOptions elsa)
         {
             elsa.Services
                 .AddSingleton<MongoDbWorkflowDefinitionStore>()

--- a/src/persistence/Elsa.Persistence.YesSql/Extensions/ServiceCollectionExtensions.cs
+++ b/src/persistence/Elsa.Persistence.YesSql/Extensions/ServiceCollectionExtensions.cs
@@ -17,10 +17,10 @@ namespace Elsa.Persistence.YesSql.Extensions
 {
     public static class ServiceCollectionExtensions
     {
-        public static ElsaConfigurationsOptions UseYesSqlPersistence(this ElsaConfigurationsOptions elsa) => elsa.UseYesSqlPersistence(config => config.UseSqLite("Data Source=elsa.db;Cache=Shared", IsolationLevel.ReadUncommitted));
-        public static ElsaConfigurationsOptions UseYesSqlPersistence(this ElsaConfigurationsOptions elsa, Action<IConfiguration> configure) => elsa.UseYesSqlPersistence((_, config) => configure(config));
+        public static ElsaConfiguration UseYesSqlPersistence(this ElsaConfiguration elsa) => elsa.UseYesSqlPersistence(config => config.UseSqLite("Data Source=elsa.db;Cache=Shared", IsolationLevel.ReadUncommitted));
+        public static ElsaConfiguration UseYesSqlPersistence(this ElsaConfiguration elsa, Action<IConfiguration> configure) => elsa.UseYesSqlPersistence((_, config) => configure(config));
 
-        public static ElsaConfigurationsOptions UseYesSqlPersistence(this ElsaConfigurationsOptions elsa, Action<IServiceProvider, IConfiguration> configure)
+        public static ElsaConfiguration UseYesSqlPersistence(this ElsaConfiguration elsa, Action<IServiceProvider, IConfiguration> configure)
         {
             elsa.Services
                 .AddScoped<YesSqlWorkflowDefinitionStore>()

--- a/src/persistence/Elsa.Persistence.YesSql/Extensions/ServiceCollectionExtensions.cs
+++ b/src/persistence/Elsa.Persistence.YesSql/Extensions/ServiceCollectionExtensions.cs
@@ -17,10 +17,10 @@ namespace Elsa.Persistence.YesSql.Extensions
 {
     public static class ServiceCollectionExtensions
     {
-        public static ElsaOptions UseYesSqlPersistence(this ElsaOptions elsa) => elsa.UseYesSqlPersistence(config => config.UseSqLite("Data Source=elsa.db;Cache=Shared", IsolationLevel.ReadUncommitted));
-        public static ElsaOptions UseYesSqlPersistence(this ElsaOptions elsa, Action<IConfiguration> configure) => elsa.UseYesSqlPersistence((_, config) => configure(config));
+        public static ElsaConfigurationsOptions UseYesSqlPersistence(this ElsaConfigurationsOptions elsa) => elsa.UseYesSqlPersistence(config => config.UseSqLite("Data Source=elsa.db;Cache=Shared", IsolationLevel.ReadUncommitted));
+        public static ElsaConfigurationsOptions UseYesSqlPersistence(this ElsaConfigurationsOptions elsa, Action<IConfiguration> configure) => elsa.UseYesSqlPersistence((_, config) => configure(config));
 
-        public static ElsaOptions UseYesSqlPersistence(this ElsaOptions elsa, Action<IServiceProvider, IConfiguration> configure)
+        public static ElsaConfigurationsOptions UseYesSqlPersistence(this ElsaConfigurationsOptions elsa, Action<IServiceProvider, IConfiguration> configure)
         {
             elsa.Services
                 .AddScoped<YesSqlWorkflowDefinitionStore>()

--- a/src/servicebus/Elsa.Rebus.AzureServiceBus/Extensions/ElsaOptionsExtensions.cs
+++ b/src/servicebus/Elsa.Rebus.AzureServiceBus/Extensions/ElsaOptionsExtensions.cs
@@ -8,7 +8,7 @@ namespace Elsa.Rebus.AzureServiceBus
 {
     public static class ElsaOptionsExtensions
     {
-        public static ElsaConfigurationsOptions UseAzureServiceBus(this ElsaConfigurationsOptions elsaOptions, string connectionString, LogLevel logLevel = LogLevel.Info, ITokenProvider? tokenProvider = default)
+        public static ElsaConfiguration UseAzureServiceBus(this ElsaConfiguration elsaOptions, string connectionString, LogLevel logLevel = LogLevel.Info, ITokenProvider? tokenProvider = default)
         {
             return elsaOptions.UseServiceBus(context => ConfigureAzureServiceBusEndpoint(context, connectionString, logLevel, tokenProvider));
         } 

--- a/src/servicebus/Elsa.Rebus.AzureServiceBus/Extensions/ElsaOptionsExtensions.cs
+++ b/src/servicebus/Elsa.Rebus.AzureServiceBus/Extensions/ElsaOptionsExtensions.cs
@@ -8,7 +8,7 @@ namespace Elsa.Rebus.AzureServiceBus
 {
     public static class ElsaOptionsExtensions
     {
-        public static ElsaOptions UseAzureServiceBus(this ElsaOptions elsaOptions, string connectionString, LogLevel logLevel = LogLevel.Info, ITokenProvider? tokenProvider = default)
+        public static ElsaConfigurationsOptions UseAzureServiceBus(this ElsaConfigurationsOptions elsaOptions, string connectionString, LogLevel logLevel = LogLevel.Info, ITokenProvider? tokenProvider = default)
         {
             return elsaOptions.UseServiceBus(context => ConfigureAzureServiceBusEndpoint(context, connectionString, logLevel, tokenProvider));
         } 

--- a/src/servicebus/Elsa.Rebus.RabbitMq/Extensions/ElsaOptionsExtensions.cs
+++ b/src/servicebus/Elsa.Rebus.RabbitMq/Extensions/ElsaOptionsExtensions.cs
@@ -7,7 +7,7 @@ namespace Elsa.Rebus.RabbitMq.Extensions
 {
     public static class ElsaOptionsExtensions
     {
-        public static ElsaOptions UseRabbitMq(this ElsaOptions elsaOptions, string connectionString, LogLevel logLevel = LogLevel.Info)
+        public static ElsaConfigurationsOptions UseRabbitMq(this ElsaConfigurationsOptions elsaOptions, string connectionString, LogLevel logLevel = LogLevel.Info)
         {
             return elsaOptions.UseServiceBus(context => ConfigureAzureServiceBusEndpoint(context, connectionString, logLevel));
         } 

--- a/src/servicebus/Elsa.Rebus.RabbitMq/Extensions/ElsaOptionsExtensions.cs
+++ b/src/servicebus/Elsa.Rebus.RabbitMq/Extensions/ElsaOptionsExtensions.cs
@@ -7,7 +7,7 @@ namespace Elsa.Rebus.RabbitMq.Extensions
 {
     public static class ElsaOptionsExtensions
     {
-        public static ElsaConfigurationsOptions UseRabbitMq(this ElsaConfigurationsOptions elsaOptions, string connectionString, LogLevel logLevel = LogLevel.Info)
+        public static ElsaConfiguration UseRabbitMq(this ElsaConfiguration elsaOptions, string connectionString, LogLevel logLevel = LogLevel.Info)
         {
             return elsaOptions.UseServiceBus(context => ConfigureAzureServiceBusEndpoint(context, connectionString, logLevel));
         } 


### PR DESCRIPTION
I took a point from the list #468.

Activities are now stored in `ElsaOptions`. I renamed the old class `ElsaOptions` to `ElsaConfigurationsOptions`. Among other things because `public IServiceCollection Services { get; }` is not needed at runtime.

Also, activities and workflows can be added via Assembly. It is no longer necessary to add each activity and workflow individually.