### PR TITLE
Introduce Workflow Instance Name

### DIFF
--- a/src/activities/Elsa.Activities.Http/Middleware/HttpRequestMiddleware.cs
+++ b/src/activities/Elsa.Activities.Http/Middleware/HttpRequestMiddleware.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
@@ -28,7 +29,7 @@ namespace Elsa.Activities.Http.Middleware
             httpContext.Request.TryGetCorrelationId(out var correlationId);
 
             var results = await workflowSelector.SelectWorkflowsAsync<ReceiveHttpRequestTrigger>(
-                    x => (x.Path == path) && (x.Method == null || x.Method == method) && (x.CorrelationId == null || x.CorrelationId == correlationId),
+                    x => AreSame(x.Path, path) && (x.Method == null || AreSame(x.Method, method)) && (x.CorrelationId == null && correlationId == null || x.CorrelationId == correlationId),
                     cancellationToken)
                 .ToList();
 
@@ -64,5 +65,7 @@ namespace Elsa.Activities.Http.Middleware
                 await workflowRunner.RunWorkflowAsync(result.WorkflowBlueprint, workflowInstance, result.ActivityId, cancellationToken: cancellationToken);
             }
         }
+
+        private static bool AreSame(string a, string b) => string.Equals(a, b, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/activities/Elsa.Activities.Timers.Quartz/Extensions/TimersOptionsExtensions.cs
+++ b/src/activities/Elsa.Activities.Timers.Quartz/Extensions/TimersOptionsExtensions.cs
@@ -13,10 +13,6 @@ namespace Elsa.Activities.Timers
 {
     public static class TimersOptionsExtensions
     {
-        /// <summary>
-        /// Add Quartz for background processing
-        /// </summary>
-        /// <param name="timersOptions"></param>
         public static void UseQuartzProvider(this TimersOptions timersOptions, Action<QuartzOptions>? configureOptions = default, Action<IServiceCollectionQuartzConfigurator>? configureQuartz = default)
         {
             if (configureOptions != null)

--- a/src/activities/Elsa.Activities.Timers.Quartz/Jobs/RunQuartzWorkflowJob.cs
+++ b/src/activities/Elsa.Activities.Timers.Quartz/Jobs/RunQuartzWorkflowJob.cs
@@ -49,7 +49,7 @@ namespace Elsa.Activities.Timers.Quartz.Jobs
             }
             else
             {
-                var workflowInstance = await _workflowInstanceStore.FindByIdAsync(workflowInstanceId, cancellationToken);
+                var workflowInstance = await GetWorkflowInstanceAsync(workflowInstanceId, cancellationToken);
 
                 if (workflowInstance == null)
                 {
@@ -69,10 +69,8 @@ namespace Elsa.Activities.Timers.Quartz.Jobs
             {
                 workflowInstance = await _workflowInstanceStore.FindByIdAsync(workflowInstanceId, cancellationToken);
 
-                if (workflowInstance == null)
-                {
-                    System.Threading.Thread.Sleep(10000);
-                }
+                if (workflowInstance == null) 
+                    Thread.Sleep(10000);
             }
 
             return workflowInstance;

--- a/src/activities/Elsa.Activities.Timers/Extensions/ServiceCollectionExtensions.cs
+++ b/src/activities/Elsa.Activities.Timers/Extensions/ServiceCollectionExtensions.cs
@@ -1,5 +1,4 @@
 using System;
-
 using Elsa.Activities.Timers;
 using Elsa.Activities.Timers.HostedServices;
 using Elsa.Activities.Timers.Options;
@@ -10,18 +9,17 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     public static class ServiceCollectionExtensions
     {
-        public static IServiceCollection AddTimerActivities(this IServiceCollection services,
-            Action<TimersOptions>? configure = default)
+        public static IServiceCollection AddTimerActivities(this IServiceCollection services, Action<TimersOptions>? configure = default)
         {
             var options = new TimersOptions(services);
             configure?.Invoke(options);
 
-            return services                
+            return services
                 .AddHostedService<StartJobs>()
                 .AddActivity<Cron>()
                 .AddActivity<Timer>()
                 .AddActivity<StartAt>()
-                 .AddActivity<ClearTimer>()
+                .AddActivity<ClearTimer>()
                 .AddTriggerProvider<TimerTriggerProvider>()
                 .AddTriggerProvider<CronTriggerProvider>()
                 .AddTriggerProvider<StartAtTriggerProvider>();

--- a/src/clients/Elsa.Client/Models/WorkflowInstance.cs
+++ b/src/clients/Elsa.Client/Models/WorkflowInstance.cs
@@ -14,33 +14,32 @@ namespace Elsa.Client.Models
         {
             Variables = new Variables();
             Activities = new List<ActivityInstance>();
-            ExecutionLog = new List<ExecutionLogEntry>();
             ScheduledActivities = new Stack<ScheduledActivity>();
             PostScheduledActivities = new Stack<ScheduledActivity>();
         }
 
-        [DataMember(Order = 1)] public string EntityId { get; set; } = default!;
+        [DataMember(Order = 1)] public string Id { get; set; } = default!;
         [DataMember(Order = 2)] public string DefinitionId { get; set; } = default!;
         [DataMember(Order = 3)] public int Version { get; set; }
         [DataMember(Order = 4)] public WorkflowStatus WorkflowStatus { get; set; }
         [DataMember(Order = 5)] public string? CorrelationId { get; set; }
         [DataMember(Order = 6)] public string? ContextId { get; set; }
-        [DataMember(Order = 7)] public Instant CreatedAt { get; set; }
-        [DataMember(Order = 8)] public Instant? LastExecutedAt { get; set; }
-        [DataMember(Order = 9)] public Instant? LastBurstAt { get; set; }
-        [DataMember(Order = 10)] public Instant? FinishedAt { get; set; }
-        [DataMember(Order = 11)] public Variables Variables { get; set; }
-        [DataMember(Order = 12)] public object? Output { get; set; }
-        [DataMember(Order = 13)] public ICollection<ActivityInstance> Activities { get; set; }
+        [DataMember(Order = 7)] public string? Name { get; set; }
+        [DataMember(Order = 8)] public Instant CreatedAt { get; set; }
+        [DataMember(Order = 9)] public Instant? LastExecutedAt { get; set; }
+        [DataMember(Order = 10)] public Instant? LastBurstAt { get; set; }
+        [DataMember(Order = 11)] public Instant? FinishedAt { get; set; }
+        [DataMember(Order = 12)] public Variables Variables { get; set; }
+        [DataMember(Order = 13)] public object? Output { get; set; }
+        [DataMember(Order = 14)] public ICollection<ActivityInstance> Activities { get; set; }
 
-        [DataMember(Order = 14)]
+        [DataMember(Order = 15)]
         public HashSet<BlockingActivity> BlockingActivities
         {
             get => _blockingActivities;
             set => _blockingActivities = new HashSet<BlockingActivity>(value, BlockingActivityEqualityComparer.Instance);
         }
-
-        [DataMember(Order = 15)] public ICollection<ExecutionLogEntry> ExecutionLog { get; set; }
+        
         [DataMember(Order = 16)] public WorkflowFault? Fault { get; set; }
         [DataMember(Order = 17)] public Stack<ScheduledActivity> ScheduledActivities { get; set; }
         [DataMember(Order = 18)] public Stack<ScheduledActivity> PostScheduledActivities { get; set; }

--- a/src/clients/Elsa.Client/Services/IWorkflowInstancesApi.cs
+++ b/src/clients/Elsa.Client/Services/IWorkflowInstancesApi.cs
@@ -17,6 +17,7 @@ namespace Elsa.Client.Services
             [AliasAs("workflow")] string? workflowDefinitionId = default,
             [AliasAs("status")] WorkflowStatus? workflowStatus = default,
             OrderBy? orderBy = default,
+            string? searchTerm = default,
             CancellationToken cancellationToken = default);
 
         [Delete("/v1/workflow-instances/{id}")]

--- a/src/core/Elsa.Abstractions/Models/WorkflowInstance.cs
+++ b/src/core/Elsa.Abstractions/Models/WorkflowInstance.cs
@@ -12,7 +12,6 @@ namespace Elsa.Models
         {
             Variables = new Variables();
             Activities = new List<ActivityInstance>();
-            //ExecutionLog = new List<ExecutionLogEntry>();
             ScheduledActivities = new Stack<ScheduledActivity>();
             PostScheduledActivities = new Stack<ScheduledActivity>();
             ParentActivities = new Stack<string>();
@@ -24,6 +23,7 @@ namespace Elsa.Models
         public WorkflowStatus WorkflowStatus { get; set; }
         public string? CorrelationId { get; set; }
         public string? ContextId { get; set; }
+        public string? Name { get; set; }
         public Instant CreatedAt { get; set; }
         public Instant? LastExecutedAt { get; set; }
         public Instant? FinishedAt { get; set; }
@@ -38,8 +38,7 @@ namespace Elsa.Models
             get => _blockingActivities;
             set => _blockingActivities = new HashSet<BlockingActivity>(value, BlockingActivityEqualityComparer.Instance);
         }
-
-        //public ICollection<ExecutionLogEntry> ExecutionLog { get; set; }
+        
         public WorkflowFault? Fault { get; set; }
         public Stack<ScheduledActivity> ScheduledActivities { get; set; }
         public Stack<ScheduledActivity> PostScheduledActivities { get; set; }

--- a/src/core/Elsa.Abstractions/Persistence/Specifications/Specification.cs
+++ b/src/core/Elsa.Abstractions/Persistence/Specifications/Specification.cs
@@ -15,7 +15,7 @@ namespace Elsa.Persistence.Specifications
         public static readonly ISpecification<T> None = All.Not();
         private Func<T, bool>? _predicate;
 
-        public bool IsSatisfiedBy(T entity)
+        public virtual bool IsSatisfiedBy(T entity)
         {
             _predicate ??= ToExpression().Compile();
             return _predicate(entity);

--- a/src/core/Elsa.Core/Activities/Primitives/SetName/SetName.cs
+++ b/src/core/Elsa.Core/Activities/Primitives/SetName/SetName.cs
@@ -1,0 +1,26 @@
+using Elsa.ActivityResults;
+using Elsa.Attributes;
+using Elsa.Services;
+using Elsa.Services.Models;
+
+// ReSharper disable once CheckNamespace
+namespace Elsa.Activities.Primitives
+{
+    [Activity(
+        DisplayName = "Set Name",
+        Description = "Set the name of the workflow instance.",
+        Category = "Primitives",
+        Outcomes = new[] { OutcomeNames.Done }
+    )]
+    public class SetName : Activity
+    {
+        [ActivityProperty(Hint = "The value to set as the workflow instance's name.")]
+        public string? Value { get; set; }
+
+        protected override IActivityExecutionResult OnExecute(ActivityExecutionContext context)
+        {
+            context.WorkflowExecutionContext.WorkflowInstance.Name = Value;
+            return Done();
+        }
+    }
+}

--- a/src/core/Elsa.Core/Activities/Primitives/SetName/SetNameBuilderExtensions.cs
+++ b/src/core/Elsa.Core/Activities/Primitives/SetName/SetNameBuilderExtensions.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Threading.Tasks;
+using Elsa.Activities.Primitives;
+using Elsa.Builders;
+using Elsa.Services.Models;
+
+// ReSharper disable once CheckNamespace
+namespace Elsa.Activities.Primitives
+{
+    public static class SetNameBuilderExtensions
+    {
+        public static IOutcomeBuilder SetName(this IBuilder builder, Action<ISetupActivity<SetName>> setup) => builder.Then(setup).When(OutcomeNames.Done);
+        public static IOutcomeBuilder SetName(this IBuilder builder, Func<ActivityExecutionContext, ValueTask<string?>> value) => builder.SetName(activity => activity.WithValue(value));
+        public static IOutcomeBuilder SetName(this IBuilder builder, Func<ActivityExecutionContext, string?> value) => builder.SetName(activity => activity.WithValue(value));
+        public static IOutcomeBuilder SetName(this IBuilder builder, Func<ValueTask<string?>> value) => builder.SetName(activity => activity.WithValue(value));
+        public static IOutcomeBuilder SetName(this IBuilder builder, Func<string?> value) => builder.SetName(activity => activity.WithValue(value));
+        public static IOutcomeBuilder SetName(this IBuilder builder, string? value) => builder.SetName(activity => activity.WithValue(value));
+    }
+}

--- a/src/core/Elsa.Core/Activities/Primitives/SetName/SetNameExtensions.cs
+++ b/src/core/Elsa.Core/Activities/Primitives/SetName/SetNameExtensions.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Threading.Tasks;
+using Elsa.Builders;
+using Elsa.Services.Models;
+
+namespace Elsa.Activities.Primitives
+{
+    public static class SetNameExtensions
+    {
+        public static ISetupActivity<SetName> WithValue(this ISetupActivity<SetName> activity, Func<ActivityExecutionContext, ValueTask<string?>> value) => activity.Set(x => x.Value, value);
+        public static ISetupActivity<SetName> WithValue(this ISetupActivity<SetName> activity, Func<ValueTask<string?>> value) => activity.Set(x => x.Value, value);
+        public static ISetupActivity<SetName> WithValue(this ISetupActivity<SetName> activity, Func<ActivityExecutionContext, string?> value) => activity.Set(x => x.Value, value);
+        public static ISetupActivity<SetName> WithValue(this ISetupActivity<SetName> activity, Func<string?> value) => activity.Set(x => x.Value, value);
+        public static ISetupActivity<SetName> WithValue(this ISetupActivity<SetName> activity, string? value) => activity.Set(x => x.Value, value);
+    }
+}

--- a/src/core/Elsa.Core/Activities/Primitives/SetVariable/SetVariableBuilderExtensions.cs
+++ b/src/core/Elsa.Core/Activities/Primitives/SetVariable/SetVariableBuilderExtensions.cs
@@ -1,11 +1,10 @@
 using System;
 using System.Threading.Tasks;
-using Elsa.Activities.Primitives;
 using Elsa.Builders;
 using Elsa.Services.Models;
 
 // ReSharper disable once CheckNamespace
-namespace Elsa.Activities.ControlFlow
+namespace Elsa.Activities.Primitives
 {
     public static class SetVariableBuilderExtensions
     {

--- a/src/core/Elsa.Core/Elsa.Core.csproj.DotSettings
+++ b/src/core/Elsa.Core/Elsa.Core.csproj.DotSettings
@@ -1,5 +1,6 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=activities_005Ccontrolflow_005Cfor/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=activities_005Cprimitives_005Csetname/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=activities_005Csignaling_005Cactivities_005Creceivesignal/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=activities_005Csignaling_005Creceivesignal/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=activities_005Csignaling_005Csignaled/@EntryIndexedValue">True</s:Boolean>

--- a/src/core/Elsa.Core/Extensions/ElsaServiceCollectionExtensions.cs
+++ b/src/core/Elsa.Core/Extensions/ElsaServiceCollectionExtensions.cs
@@ -137,6 +137,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services
                 .AddActivity<CompositeActivity>()
                 .AddActivity<Inline>()
+                .AddActivity<SetName>()
                 .AddActivity<Finish>()
                 .AddActivity<For>()
                 .AddActivity<ForEach>()

--- a/src/core/Elsa.Core/Persistence/InMemory/InMemorySpecificationExtensions.cs
+++ b/src/core/Elsa.Core/Persistence/InMemory/InMemorySpecificationExtensions.cs
@@ -5,7 +5,7 @@ namespace Elsa.Persistence.InMemory
 {
     public static class InMemorySpecificationExtensions
     {
-        public static IQueryable<T> Apply<T>(this IQueryable<T> queryable, ISpecification<T> specification) => queryable.Where(specification.ToExpression());
+        public static IQueryable<T> Apply<T>(this IQueryable<T> queryable, ISpecification<T> specification) => queryable.Where(x => specification.IsSatisfiedBy(x));
 
         public static IQueryable<T> Apply<T>(this IQueryable<T> queryable, IOrderBy<T>? specification)
         {

--- a/src/core/Elsa.Core/Persistence/Specifications/SpecificationExtensions.cs
+++ b/src/core/Elsa.Core/Persistence/Specifications/SpecificationExtensions.cs
@@ -5,10 +5,8 @@ namespace Elsa.Persistence.Specifications
     public static class SpecificationExtensions
     {
         public static ISpecification<T> WithTenant<T>(this ISpecification<T> specification, string? tenantId) where T : ITenantScope => specification.And(new TenantSpecification<T>(tenantId));
-
-        public static ISpecification<WorkflowInstance> WithWorkflowDefinition(this ISpecification<WorkflowInstance> specification, string workflowDefinitionId) =>
-            specification.And(new WorkflowInstanceDefinitionIdSpecification(workflowDefinitionId));
-
+        public static ISpecification<WorkflowInstance> WithWorkflowDefinition(this ISpecification<WorkflowInstance> specification, string workflowDefinitionId) => specification.And(new WorkflowInstanceDefinitionIdSpecification(workflowDefinitionId));
+        public static ISpecification<WorkflowInstance> WithWorkflowName(this ISpecification<WorkflowInstance> specification, string name) => specification.And(new WorkflowInstanceNameMatchSpecification(name));
         public static ISpecification<WorkflowInstance> WithStatus(this ISpecification<WorkflowInstance> specification, WorkflowStatus status) => specification.And(new WorkflowStatusSpecification(status));
         public static ISpecification<WorkflowDefinition> WithVersionOptions(this ISpecification<WorkflowDefinition> specification, VersionOptions versionOptions) => specification.And(new VersionOptionsSpecification(versionOptions));
     }

--- a/src/core/Elsa.Core/Persistence/Specifications/WorkflowInstanceNameMatchSpecification.cs
+++ b/src/core/Elsa.Core/Persistence/Specifications/WorkflowInstanceNameMatchSpecification.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Linq.Expressions;
+using Elsa.Models;
+
+namespace Elsa.Persistence.Specifications
+{
+    public class WorkflowInstanceNameMatchSpecification : Specification<WorkflowInstance>
+    {
+        public string Name { get; set; }
+        public WorkflowInstanceNameMatchSpecification(string name) => Name = name;
+        public override Expression<Func<WorkflowInstance, bool>> ToExpression() => x => x.Name!.Contains(Name);
+        public override bool IsSatisfiedBy(WorkflowInstance entity) => entity.Name != null && entity.Name.IndexOf(Name, StringComparison.OrdinalIgnoreCase) >= 0;
+    }
+}

--- a/src/dashboards/blazor/ElsaDashboard.Application/ClientApp/public/modal.html
+++ b/src/dashboards/blazor/ElsaDashboard.Application/ClientApp/public/modal.html
@@ -1,0 +1,61 @@
+﻿<!-- This example requires Tailwind CSS v2.0+ -->
+<div class="fixed z-10 inset-0 overflow-y-auto">
+    <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
+        <!--
+          Background overlay, show/hide based on modal state.
+    
+          Entering: "ease-out duration-300"
+            From: "opacity-0"
+            To: "opacity-100"
+          Leaving: "ease-in duration-200"
+            From: "opacity-100"
+            To: "opacity-0"
+        -->
+        <div class="fixed inset-0 transition-opacity" aria-hidden="true">
+            <div class="absolute inset-0 bg-gray-500 opacity-75"></div>
+        </div>
+
+        <!-- This element is to trick the browser into centering the modal contents. -->
+        <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
+        <!--
+          Modal panel, show/hide based on modal state.
+    
+          Entering: "ease-out duration-300"
+            From: "opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+            To: "opacity-100 translate-y-0 sm:scale-100"
+          Leaving: "ease-in duration-200"
+            From: "opacity-100 translate-y-0 sm:scale-100"
+            To: "opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+        -->
+        <div class="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full" role="dialog" aria-modal="true" aria-labelledby="modal-headline">
+            <div class="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+                <div class="sm:flex sm:items-start">
+                    <div class="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-red-100 sm:mx-0 sm:h-10 sm:w-10">
+                        <!-- Heroicon name: exclamation -->
+                        <svg class="h-6 w-6 text-red-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path>
+                        </svg>
+                    </div>
+                    <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
+                        <h3 class="text-lg leading-6 font-medium text-gray-900" id="modal-headline">
+                            Deactivate account
+                        </h3>
+                        <div class="mt-2">
+                            <p class="text-sm text-gray-500">
+                                Are you sure you want to deactivate your account? All of your data will be permanently removed. This action cannot be undone.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="bg-gray-50 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
+                <button type="button" class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-red-600 text-base font-medium text-white hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 sm:ml-3 sm:w-auto sm:text-sm">
+                    Deactivate
+                </button>
+                <button type="button" class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm">
+                    Cancel
+                </button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/dashboards/blazor/ElsaDashboard.Application/ClientApp/src/modal.html
+++ b/src/dashboards/blazor/ElsaDashboard.Application/ClientApp/src/modal.html
@@ -1,0 +1,61 @@
+﻿<!-- This example requires Tailwind CSS v2.0+ -->
+<div class="fixed z-10 inset-0 overflow-y-auto">
+    <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
+        <!--
+          Background overlay, show/hide based on modal state.
+    
+          Entering: "ease-out duration-300"
+            From: "opacity-0"
+            To: "opacity-100"
+          Leaving: "ease-in duration-200"
+            From: "opacity-100"
+            To: "opacity-0"
+        -->
+        <div class="fixed inset-0 transition-opacity" aria-hidden="true">
+            <div class="absolute inset-0 bg-gray-500 opacity-75"></div>
+        </div>
+
+        <!-- This element is to trick the browser into centering the modal contents. -->
+        <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
+        <!--
+          Modal panel, show/hide based on modal state.
+    
+          Entering: "ease-out duration-300"
+            From: "opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+            To: "opacity-100 translate-y-0 sm:scale-100"
+          Leaving: "ease-in duration-200"
+            From: "opacity-100 translate-y-0 sm:scale-100"
+            To: "opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+        -->
+        <div class="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full" role="dialog" aria-modal="true" aria-labelledby="modal-headline">
+            <div class="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+                <div class="sm:flex sm:items-start">
+                    <div class="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-red-100 sm:mx-0 sm:h-10 sm:w-10">
+                        <!-- Heroicon name: exclamation -->
+                        <svg class="h-6 w-6 text-red-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                        </svg>
+                    </div>
+                    <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
+                        <h3 class="text-lg leading-6 font-medium text-gray-900" id="modal-headline">
+                            Deactivate account
+                        </h3>
+                        <div class="mt-2">
+                            <p class="text-sm text-gray-500">
+                                Are you sure you want to deactivate your account? All of your data will be permanently removed. This action cannot be undone.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="bg-gray-50 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
+                <button type="button" class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-red-600 text-base font-medium text-white hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 sm:ml-3 sm:w-auto sm:text-sm">
+                    Deactivate
+                </button>
+                <button type="button" class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm">
+                    Cancel
+                </button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/dashboards/blazor/ElsaDashboard.Application/Pages/WorkflowInstances/List.razor
+++ b/src/dashboards/blazor/ElsaDashboard.Application/Pages/WorkflowInstances/List.razor
@@ -73,6 +73,9 @@
                     Version
                 </th>
                 <th class="px-6 py-3 border-b border-gray-200 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
+                    Instance Name
+                </th>
+                <th class="px-6 py-3 border-b border-gray-200 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
                     Status
                 </th>
                 <th class="px-6 py-3 border-b border-gray-200 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
@@ -88,14 +91,15 @@
             @foreach (var workflowInstance in WorkflowInstances.Items)
             {
                 var workflowKey = (workflowInstance.DefinitionId, workflowInstance.Version);
-                var workflowBlueprint = WorkflowBlueprints.ContainsKey(workflowKey) ? WorkflowBlueprints[workflowKey] : new WorkflowBlueprint { DisplayName = "(Blueprint Not Found)" };
+                var workflowBlueprint = WorkflowBlueprints.ContainsKey(workflowKey) ? WorkflowBlueprints[workflowKey] : new WorkflowBlueprint {DisplayName = "(Blueprint Not Found)"};
+                var instanceName = string.IsNullOrWhiteSpace(workflowInstance.Name) ? "" : workflowInstance.Name;
                 var displayName = workflowBlueprint.DisplayName!;
                 var statusColor = GetStatusColor(workflowInstance.WorkflowStatus);
-                var viewUrl = $"workflow-instances/{workflowInstance.EntityId}/viewer";
+                var viewUrl = $"workflow-instances/{workflowInstance.Id}/viewer";
                 <tr>
                     <td class="px-6 py-3 whitespace-no-wrap text-sm leading-5 font-medium text-gray-900">
-                        <a href="@($"workflow-instances/{workflowInstance.EntityId}/viewer")" class="truncate hover:text-gray-600">
-                            @workflowInstance.EntityId
+                        <a href="@($"workflow-instances/{workflowInstance.Id}/viewer")" class="truncate hover:text-gray-600">
+                            @workflowInstance.Id
                         </a>
                     </td>
                     <td class="px-6 py-3 whitespace-no-wrap text-sm leading-5 font-medium text-gray-900 text-left">
@@ -105,6 +109,11 @@
                     </td>
                     <td class="hidden md:table-cell px-6 py-3 whitespace-no-wrap text-sm leading-5 text-gray-500 text-right">
                         @workflowInstance.Version
+                    </td>
+                    <td class="px-6 py-3 whitespace-no-wrap text-sm leading-5 font-medium text-gray-900 text-left">
+                        <a href="@($"workflow-registry/{workflowInstance.DefinitionId}/viewer")" class="truncate hover:text-gray-600">
+                            @instanceName
+                        </a>
                     </td>
                     <td class="hidden md:table-cell px-6 py-3 whitespace-no-wrap text-sm leading-5 text-gray-500 text-right">
                         <div class="flex items-center space-x-3 lg:pl-2">

--- a/src/dashboards/blazor/ElsaDashboard.Application/Pages/WorkflowInstances/List.razor
+++ b/src/dashboards/blazor/ElsaDashboard.Application/Pages/WorkflowInstances/List.razor
@@ -13,7 +13,7 @@
     <!-- Search bar -->
     <div class="flex-1 px-4 flex justify-between sm:px-6 lg:max-w-6xl lg:px-8">
         <div class="flex-1 flex">
-            <form class="w-full flex md:ml-0" action="#" method="GET">
+            <EditForm EditContext="EditContext" OnValidSubmit="OnSearchSubmit" class="w-full flex md:ml-0" >
                 <label for="search_field" class="sr-only">Search</label>
                 <div class="relative w-full text-cool-gray-400 focus-within:text-cool-gray-600">
                     <div class="absolute inset-y-0 left-0 flex items-center pointer-events-none">
@@ -21,9 +21,9 @@
                             <path fill-rule="evenodd" clip-rule="evenodd" d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z"></path>
                         </svg>
                     </div>
-                    <input id="search_field" class="block w-full h-full pl-8 pr-3 py-2 rounded-md text-cool-gray-900 placeholder-cool-gray-500 focus:outline-none focus:placeholder-cool-gray-400 sm:text-sm" placeholder="Search" type="search">
+                    <InputText @bind-Value="@SearchModel.SearchTerm" id="search_field" class="block w-full h-full pl-8 pr-3 py-2 rounded-md text-cool-gray-900 placeholder-cool-gray-500 focus:outline-none focus:placeholder-cool-gray-400 sm:text-sm" placeholder="Search" type="search"/>
                 </div>
-            </form>
+            </EditForm>
         </div>
     </div>
 </div>

--- a/src/dashboards/blazor/ElsaDashboard.Application/Pages/WorkflowInstances/List.razor.cs
+++ b/src/dashboards/blazor/ElsaDashboard.Application/Pages/WorkflowInstances/List.razor.cs
@@ -105,7 +105,7 @@ namespace ElsaDashboard.Application.Pages.WorkflowInstances
             if (result.Cancelled)
                 return;
 
-            await WorkflowInstanceService.DeleteAsync(workflowInstance.EntityId);
+            await WorkflowInstanceService.DeleteAsync(workflowInstance.Id);
             await LoadWorkflowInstancesAsync();
         }
 

--- a/src/dashboards/blazor/ElsaDashboard.Application/Pages/WorkflowInstances/SearchModel.cs
+++ b/src/dashboards/blazor/ElsaDashboard.Application/Pages/WorkflowInstances/SearchModel.cs
@@ -1,0 +1,7 @@
+﻿namespace ElsaDashboard.Application.Pages.WorkflowInstances
+{
+    internal class SearchModel
+    {
+        public string? SearchTerm { get; set; }
+    }
+}

--- a/src/dashboards/blazor/ElsaDashboard.Backend/Rpc/WorkflowInstanceService.cs
+++ b/src/dashboards/blazor/ElsaDashboard.Backend/Rpc/WorkflowInstanceService.cs
@@ -10,10 +10,7 @@ namespace ElsaDashboard.Backend.Rpc
     {
         private readonly IElsaClient _elsaClient;
         public WorkflowInstanceService(IElsaClient elsaClient) => _elsaClient = elsaClient;
-
-        public Task<PagedList<WorkflowInstance>> ListAsync(ListWorkflowInstancesRequest request, CallContext context = default) =>
-            _elsaClient.WorkflowInstances.ListAsync(request.Page, request.PageSize, request.WorkflowDefinitionId, request.WorkflowStatus, request.OrderBy, context.CancellationToken);
-
+        public Task<PagedList<WorkflowInstance>> ListAsync(ListWorkflowInstancesRequest request, CallContext context = default) => _elsaClient.WorkflowInstances.ListAsync(request.Page, request.PageSize, request.WorkflowDefinitionId, request.WorkflowStatus, request.OrderBy, request.SearchTerm, context.CancellationToken);
         public Task<WorkflowInstance?> GetByIdAsync(GetWorkflowInstanceByIdRequest request, CallContext context = default) => _elsaClient.WorkflowInstances.GetByIdAsync(request.WorkflowInstanceId, context.CancellationToken);
         public Task DeleteAsync(DeleteWorkflowInstanceRequest request, CallContext context = default) => _elsaClient.WorkflowInstances.DeleteAsync(request.WorkflowInstanceId, context.CancellationToken);
     }

--- a/src/dashboards/blazor/ElsaDashboard.Shared/Rpc/WorkflowInstance/Extensions/WorkflowInstanceServiceExtensions.cs
+++ b/src/dashboards/blazor/ElsaDashboard.Shared/Rpc/WorkflowInstance/Extensions/WorkflowInstanceServiceExtensions.cs
@@ -12,8 +12,9 @@ namespace ElsaDashboard.Shared.Rpc
             int pageSize = 50,
             string? workflowDefinitionId = default,
             WorkflowStatus? workflowStatus = default,
-            OrderBy? orderBy = default) =>
-            service.ListAsync(new ListWorkflowInstancesRequest(page, pageSize, workflowDefinitionId, workflowStatus, orderBy));
+            OrderBy? orderBy = default,
+            string? searchTerm = default) =>
+            service.ListAsync(new ListWorkflowInstancesRequest(page, pageSize, workflowDefinitionId, workflowStatus, orderBy, searchTerm));
 
         public static Task<WorkflowInstance?> GetByIdAsync(this IWorkflowInstanceService service, string workflowInstanceId) => service.GetByIdAsync(new GetWorkflowInstanceByIdRequest(workflowInstanceId));
         public static Task DeleteAsync(this IWorkflowInstanceService service, string workflowInstanceId) => service.DeleteAsync(new DeleteWorkflowInstanceRequest(workflowInstanceId));

--- a/src/dashboards/blazor/ElsaDashboard.Shared/Rpc/WorkflowInstance/Models/ListWorkflowInstancesRequest.cs
+++ b/src/dashboards/blazor/ElsaDashboard.Shared/Rpc/WorkflowInstance/Models/ListWorkflowInstancesRequest.cs
@@ -11,13 +11,14 @@ namespace ElsaDashboard.Shared.Rpc
         {
         }
 
-        public ListWorkflowInstancesRequest(int page, int pageSize = 50, string? workflowDefinitionId = default, WorkflowStatus? workflowStatus = default, OrderBy? orderBy = default)
+        public ListWorkflowInstancesRequest(int page, int pageSize = 50, string? workflowDefinitionId = default, WorkflowStatus? workflowStatus = default, OrderBy? orderBy = default, string? searchTerm = default)
         {
             Page = page;
             PageSize = pageSize;
             WorkflowDefinitionId = workflowDefinitionId;
             WorkflowStatus = workflowStatus;
             OrderBy = orderBy;
+            SearchTerm = searchTerm;
         }
 
         [ProtoMember(1)] public int Page { get; set; }
@@ -25,5 +26,6 @@ namespace ElsaDashboard.Shared.Rpc
         [ProtoMember(3)] public string? WorkflowDefinitionId { get; set; }
         [ProtoMember(4)] public WorkflowStatus? WorkflowStatus { get; set; }
         [ProtoMember(5)] public OrderBy? OrderBy { get; set; }
+        [ProtoMember(6)] public string? SearchTerm { get; set; }
     }
 }

--- a/src/persistence/Elsa.Persistence.YesSql/Documents/WorkflowInstanceDocument.cs
+++ b/src/persistence/Elsa.Persistence.YesSql/Documents/WorkflowInstanceDocument.cs
@@ -17,6 +17,7 @@ namespace Elsa.Persistence.YesSql.Documents
         public WorkflowStatus WorkflowStatus { get; set; }
         public string? CorrelationId { get; set; }
         public string? ContextId { get; set; }
+        public string? Name { get; set; }
         public Instant CreatedAt { get; set; }
         public Instant? LastExecutedAt { get; set; }
         public Instant? FinishedAt { get; set; }
@@ -31,8 +32,7 @@ namespace Elsa.Persistence.YesSql.Documents
             get => _blockingActivities;
             set => _blockingActivities = new HashSet<BlockingActivity>(value, BlockingActivityEqualityComparer.Instance);
         }
-
-        public ICollection<WorkflowExecutionLogRecord> ExecutionLog { get; set; } = new List<WorkflowExecutionLogRecord>();
+        
         public WorkflowFault? Fault { get; set; }
         public Stack<ScheduledActivity> ScheduledActivities { get; set; } = new();
         public Stack<ScheduledActivity> PostScheduledActivities { get; set; } = new();

--- a/src/persistence/Elsa.Persistence.YesSql/Indexes/WorkflowInstanceIndex.cs
+++ b/src/persistence/Elsa.Persistence.YesSql/Indexes/WorkflowInstanceIndex.cs
@@ -15,6 +15,7 @@ namespace Elsa.Persistence.YesSql.Indexes
         public int Version { get; set; }
         public string? CorrelationId { get; set; }
         public string? ContextId { get; set; }
+        public string? Name { get; set; }
         public WorkflowStatus WorkflowStatus { get; set; }
         public DateTimeOffset CreatedAt { get; set; }
         public DateTimeOffset? LastExecutedAt { get; set; }
@@ -50,6 +51,7 @@ namespace Elsa.Persistence.YesSql.Indexes
                         WorkflowStatus = workflowInstance.WorkflowStatus,
                         CorrelationId = workflowInstance.CorrelationId,
                         ContextId = workflowInstance.ContextId,
+                        Name = workflowInstance.Name,
                         CreatedAt = workflowInstance.CreatedAt.ToDateTimeOffset(),
                         CancelledAt = workflowInstance.CancelledAt?.ToDateTimeOffset(),
                         FinishedAt = workflowInstance.FinishedAt?.ToDateTimeOffset(),

--- a/src/persistence/Elsa.Persistence.YesSql/Migrations.cs
+++ b/src/persistence/Elsa.Persistence.YesSql/Migrations.cs
@@ -29,6 +29,7 @@ namespace Elsa.Persistence.YesSql
                     .Column<int>(nameof(WorkflowInstanceIndex.Version))
                     .Column<string?>(nameof(WorkflowInstanceIndex.CorrelationId))
                     .Column<string?>(nameof(WorkflowInstanceIndex.ContextId))
+                    .Column<string?>(nameof(WorkflowInstanceIndex.Name))
                     .Column(nameof(WorkflowInstanceIndex.WorkflowStatus), DbType.String)
                     .Column(nameof(WorkflowInstanceIndex.CreatedAt), DbType.DateTimeOffset)
                     .Column(nameof(WorkflowInstanceIndex.LastExecutedAt), DbType.DateTimeOffset)

--- a/src/samples/aspnet/Elsa.Samples.CorrelationHttp/Workflows/RegistrationWorkflow.cs
+++ b/src/samples/aspnet/Elsa.Samples.CorrelationHttp/Workflows/RegistrationWorkflow.cs
@@ -2,6 +2,7 @@
 using Elsa.Activities.ControlFlow;
 using Elsa.Activities.Http;
 using Elsa.Activities.Http.Models;
+using Elsa.Activities.Primitives;
 using Elsa.Builders;
 using Elsa.Samples.CorrelationHttp.Models;
 using Microsoft.AspNetCore.Http;

--- a/src/samples/aspnet/Elsa.Samples.ForkJoinTimerAndSignalHttp/Workflows/DemoWorkflow.cs
+++ b/src/samples/aspnet/Elsa.Samples.ForkJoinTimerAndSignalHttp/Workflows/DemoWorkflow.cs
@@ -1,5 +1,6 @@
 ﻿using Elsa.Activities.Console;
 using Elsa.Activities.ControlFlow;
+using Elsa.Activities.Primitives;
 using Elsa.Activities.Timers;
 using Elsa.Builders;
 using Elsa.Services.Models;

--- a/src/samples/console/Elsa.Samples.ForLoopConsole/LoopingWorkflow.cs
+++ b/src/samples/console/Elsa.Samples.ForLoopConsole/LoopingWorkflow.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Elsa.Activities.Console;
 using Elsa.Activities.ControlFlow;
+using Elsa.Activities.Primitives;
 using Elsa.Builders;
 
 namespace Elsa.Samples.ForLoopConsole

--- a/src/samples/worker/Elsa.Samples.CustomAttributesChildWorker/Workflows/GenerateOrdersWorkflow.cs
+++ b/src/samples/worker/Elsa.Samples.CustomAttributesChildWorker/Workflows/GenerateOrdersWorkflow.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Elsa.Activities.Console;
 using Elsa.Activities.ControlFlow;
+using Elsa.Activities.Primitives;
 using Elsa.Activities.Rebus;
 using Elsa.Activities.Timers;
 using Elsa.Builders;

--- a/src/samples/worker/Elsa.Samples.CustomAttributesChildWorker/Workflows/OrderReceivedWorkflow.cs
+++ b/src/samples/worker/Elsa.Samples.CustomAttributesChildWorker/Workflows/OrderReceivedWorkflow.cs
@@ -1,5 +1,6 @@
 ﻿using Elsa.Activities.Console;
 using Elsa.Activities.ControlFlow;
+using Elsa.Activities.Primitives;
 using Elsa.Activities.Rebus;
 using Elsa.Activities.Workflows;
 using Elsa.Builders;

--- a/src/samples/worker/Elsa.Samples.MultiTenantChildWorker/Workflows/GenerateOrdersWorkflow.cs
+++ b/src/samples/worker/Elsa.Samples.MultiTenantChildWorker/Workflows/GenerateOrdersWorkflow.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Elsa.Activities.Console;
 using Elsa.Activities.ControlFlow;
+using Elsa.Activities.Primitives;
 using Elsa.Activities.Rebus;
 using Elsa.Activities.Timers;
 using Elsa.Builders;

--- a/src/samples/worker/Elsa.Samples.MultiTenantChildWorker/Workflows/OrderReceivedWorkflow.cs
+++ b/src/samples/worker/Elsa.Samples.MultiTenantChildWorker/Workflows/OrderReceivedWorkflow.cs
@@ -1,5 +1,6 @@
 ﻿using Elsa.Activities.Console;
 using Elsa.Activities.ControlFlow;
+using Elsa.Activities.Primitives;
 using Elsa.Activities.Rebus;
 using Elsa.Activities.Workflows;
 using Elsa.Builders;

--- a/src/samples/worker/Elsa.Samples.RunChildWorkflowWorker/Workflows/ChildWorkflow.cs
+++ b/src/samples/worker/Elsa.Samples.RunChildWorkflowWorker/Workflows/ChildWorkflow.cs
@@ -1,5 +1,6 @@
 ﻿using Elsa.Activities.Console;
 using Elsa.Activities.ControlFlow;
+using Elsa.Activities.Primitives;
 using Elsa.Builders;
 
 namespace Elsa.Samples.RunChildWorkflowWorker.Workflows

--- a/src/server/Elsa.Server.Api/Endpoints/WorkflowInstances/List.cs
+++ b/src/server/Elsa.Server.Api/Endpoints/WorkflowInstances/List.cs
@@ -36,8 +36,9 @@ namespace Elsa.Server.Api.Endpoints.WorkflowInstances
             [FromQuery(Name = "workflow")] string? workflowDefinitionId = default,
             [FromQuery(Name = "status")] WorkflowStatus? workflowStatus = default,
             [FromQuery] OrderBy? orderBy = default,
+            [FromQuery] string? searchTerm = default,
             int page = 0,
-            int pageSize = 50,
+            int pageSize = 25,
             CancellationToken cancellationToken = default)
         {
             var specification = Specification<WorkflowInstance>.All;
@@ -47,6 +48,9 @@ namespace Elsa.Server.Api.Endpoints.WorkflowInstances
 
             if (workflowStatus != null)
                 specification = specification.WithStatus(workflowStatus.Value);
+            
+            if (!string.IsNullOrWhiteSpace(searchTerm))
+                specification = specification.WithWorkflowName(searchTerm);
 
             var orderBySpecification = default(OrderBy<WorkflowInstance>);
             

--- a/src/server/Elsa.Server.Api/Models/WorkflowInstance.cs
+++ b/src/server/Elsa.Server.Api/Models/WorkflowInstance.cs
@@ -1,50 +1,48 @@
-﻿using System.Collections.Generic;
-using System.Runtime.Serialization;
-using Elsa.Comparers;
-using Elsa.Models;
-using Newtonsoft.Json.Linq;
-using NodaTime;
-
-namespace Elsa.Server.Api.Models
-{
-    [DataContract]
-    public class WorkflowInstanceModel
-    {
-        private HashSet<BlockingActivity> _blockingActivities = new(BlockingActivityEqualityComparer.Instance);
-
-        public WorkflowInstanceModel()
-        {
-            Variables = new Variables();
-            Activities = new List<ActivityInstance>();
-            ExecutionLog = new List<WorkflowExecutionLogRecord>();
-            ScheduledActivities = new Stack<ScheduledActivity>();
-            PostScheduledActivities = new Stack<ScheduledActivity>();
-        }
-
-        [DataMember(Order = 1)] public int Id { get; set; }
-        [DataMember(Order = 2)] public string WorkflowInstanceId { get; set; } = default!;
-        [DataMember(Order = 3)] public string WorkflowDefinitionId { get; set; } = default!;
-        [DataMember(Order = 4)] public int Version { get; set; }
-        [DataMember(Order = 5)] public WorkflowStatus Status { get; set; }
-        [DataMember(Order = 6)] public string? CorrelationId { get; set; }
-        [DataMember(Order = 7)] public string? ContextId { get; set; }
-        [DataMember(Order = 8)] public Instant CreatedAt { get; set; }
-        [DataMember(Order = 9)] public Instant? LastExecutedAt { get; set; }
-        [DataMember(Order = 10)] public Instant? LastBurstAt { get; set; }
-        [DataMember(Order = 11)] public Instant? CompletedAt { get; set; }
-        [DataMember(Order = 12)] public Variables Variables { get; set; }
-        [DataMember(Order = 13)] public JObject? Output { get; set; }
-        [DataMember(Order = 14)] public ICollection<ActivityInstance> Activities { get; set; }
-
-        [DataMember(Order = 15)] public HashSet<BlockingActivity> BlockingActivities
-        {
-            get => _blockingActivities;
-            set => _blockingActivities = new HashSet<BlockingActivity>(value, BlockingActivityEqualityComparer.Instance);
-        }
-
-        [DataMember(Order = 16)] public ICollection<WorkflowExecutionLogRecord> ExecutionLog { get; set; }
-        [DataMember(Order = 17)] public WorkflowFault? Fault { get; set; }
-        [DataMember(Order = 18)] public Stack<ScheduledActivity> ScheduledActivities { get; set; }
-        [DataMember(Order = 19)] public Stack<ScheduledActivity> PostScheduledActivities { get; set; }
-    }
-}
+﻿// using System.Collections.Generic;
+// using System.Runtime.Serialization;
+// using Elsa.Comparers;
+// using Elsa.Models;
+// using Newtonsoft.Json.Linq;
+// using NodaTime;
+//
+// namespace Elsa.Server.Api.Models
+// {
+//     [DataContract]
+//     public class WorkflowInstanceModel
+//     {
+//         private HashSet<BlockingActivity> _blockingActivities = new(BlockingActivityEqualityComparer.Instance);
+//
+//         public WorkflowInstanceModel()
+//         {
+//             Variables = new Variables();
+//             Activities = new List<ActivityInstance>();
+//             ScheduledActivities = new Stack<ScheduledActivity>();
+//             PostScheduledActivities = new Stack<ScheduledActivity>();
+//         }
+//         
+//         [DataMember(Order = 1)] public string WorkflowInstanceId { get; set; } = default!;
+//         [DataMember(Order = 2)] public string WorkflowDefinitionId { get; set; } = default!;
+//         [DataMember(Order = 3)] public int Version { get; set; }
+//         [DataMember(Order = 4)] public WorkflowStatus Status { get; set; }
+//         [DataMember(Order = 5)] public string? CorrelationId { get; set; }
+//         [DataMember(Order = 6)] public string? ContextId { get; set; }
+//         [DataMember(Order = 7)] public string? Name { get; set; }
+//         [DataMember(Order = 8)] public Instant CreatedAt { get; set; }
+//         [DataMember(Order = 9)] public Instant? LastExecutedAt { get; set; }
+//         [DataMember(Order = 10)] public Instant? LastBurstAt { get; set; }
+//         [DataMember(Order = 11)] public Instant? CompletedAt { get; set; }
+//         [DataMember(Order = 12)] public Variables Variables { get; set; }
+//         [DataMember(Order = 13)] public JObject? Output { get; set; }
+//         [DataMember(Order = 14)] public ICollection<ActivityInstance> Activities { get; set; }
+//
+//         [DataMember(Order = 15)] public HashSet<BlockingActivity> BlockingActivities
+//         {
+//             get => _blockingActivities;
+//             set => _blockingActivities = new HashSet<BlockingActivity>(value, BlockingActivityEqualityComparer.Instance);
+//         }
+//         
+//         [DataMember(Order = 16)] public WorkflowFault? Fault { get; set; }
+//         [DataMember(Order = 17)] public Stack<ScheduledActivity> ScheduledActivities { get; set; }
+//         [DataMember(Order = 18)] public Stack<ScheduledActivity> PostScheduledActivities { get; set; }
+//     }
+// }

--- a/src/server/Elsa.Server.Host/Elsa.Server.Host.csproj
+++ b/src/server/Elsa.Server.Host/Elsa.Server.Host.csproj
@@ -12,6 +12,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\..\activities\Elsa.Activities.Timers.Quartz\Elsa.Activities.Timers.Quartz.csproj" />
         <ProjectReference Include="..\..\persistence\Elsa.Persistence.YesSql\Elsa.Persistence.YesSql.csproj" />
         <ProjectReference Include="..\Elsa.Server.Api\Elsa.Server.Api.csproj" />
     </ItemGroup>

--- a/src/server/Elsa.Server.Host/Startup.cs
+++ b/src/server/Elsa.Server.Host/Startup.cs
@@ -43,6 +43,7 @@ namespace Elsa.Server.Host
                 .AddWorkflow<HelloWorld>()
                 .AddWorkflow<HelloWorldV2>()
                 .AddWorkflow<GoodbyeWorld>()
+                .AddWorkflow<NamingWorkflow>()
                 ;
         }
 

--- a/src/server/Elsa.Server.Host/Startup.cs
+++ b/src/server/Elsa.Server.Host/Startup.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Hosting;
 using Elsa.Persistence.YesSql;
 using YesSql.Provider.Sqlite;
 using System.Data;
+using Elsa.Activities.Timers;
 using Elsa.Persistence.YesSql.Extensions;
 
 namespace Elsa.Server.Host
@@ -37,7 +38,7 @@ namespace Elsa.Server.Host
                 .AddConsoleActivities()
                 .AddHttpActivities(elsaSection.GetSection("Http").Bind)
                 .AddEmailActivities(elsaSection.GetSection("Smtp").Bind)
-                .AddTimerActivities(elsaSection.GetSection("BackgroundRunner").Bind)
+                .AddTimerActivities(options => options.UseQuartzProvider())
                 .AddStartupTask<ResumeRunningWorkflowsTask>()
                 .AddWorkflow<HelloWorld>()
                 .AddWorkflow<HelloWorldV2>()

--- a/src/server/Elsa.Server.Host/Workflows/NamingWorkflow.cs
+++ b/src/server/Elsa.Server.Host/Workflows/NamingWorkflow.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Net;
+using Elsa.Activities.ControlFlow;
+using Elsa.Activities.Http;
+using Elsa.Activities.Http.Models;
+using Elsa.Activities.Primitives;
+using Elsa.Builders;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
+
+namespace Elsa.Server.Host.Workflows
+{
+    public class NamingWorkflow : IWorkflow
+    {
+        public void Build(IWorkflowBuilder workflow)
+        {
+            workflow
+                .WithDisplayName("Onboarding")
+                .HttpRequestReceived("/signup")
+                .Correlate(() => Guid.NewGuid().ToString("N"))
+                .WriteHttpResponse(x => x.WithStatusCode(HttpStatusCode.OK).WithContent(context => $"Tell me your name please. Use correlation ID {context.WorkflowExecutionContext.CorrelationId}").WithContentType("text/plain"))
+                .HttpRequestReceived(x => x.WithPath("/signup").WithMethod(HttpMethod.Post.ToString()).WithReadContent())
+                .SetVariable("Name", context => (string) context.GetInput<HttpRequestModel>().Body)
+                .SetName(context => context.GetVariable<string>("Name"))
+                
+                .WriteHttpResponse(x => x
+                    .WithStatusCode(HttpStatusCode.OK)
+                    .WithContent(context => $"Welcome aboard, {context.GetVariable<string>("Name")}!")
+                    .WithContentType("text/plain"));
+        }
+    }
+}

--- a/test/integration/Elsa.Core.IntegrationTests/Workflows/IfElseWorkflow.cs
+++ b/test/integration/Elsa.Core.IntegrationTests/Workflows/IfElseWorkflow.cs
@@ -1,5 +1,6 @@
 ﻿using Elsa.Activities.Console;
 using Elsa.Activities.ControlFlow;
+using Elsa.Activities.Primitives;
 using Elsa.Builders;
 
 namespace Elsa.Core.IntegrationTests.Workflows

--- a/test/integration/Elsa.Core.IntegrationTests/Workflows/WhileWorkflow.cs
+++ b/test/integration/Elsa.Core.IntegrationTests/Workflows/WhileWorkflow.cs
@@ -1,5 +1,6 @@
 ﻿using Elsa.Activities.Console;
 using Elsa.Activities.ControlFlow;
+using Elsa.Activities.Primitives;
 using Elsa.Builders;
 using Elsa.Services.Models;
 


### PR DESCRIPTION
This PR adds the ability for workflows to specify a name for the workflow instance and then search on workflows by name. This is useful for scenarios such as customer-oriented workflows where a workflow revolves around a customer. The workflow can set the workflow instance name to be that of the customer's, making it easily identifiable from the dashboard.