### PR TITLE
Cosmos DB persistence layer refactoring

### DIFF
--- a/src/persistence/Elsa.Persistence.DocumentDb/Documents/DocumentBase.cs
+++ b/src/persistence/Elsa.Persistence.DocumentDb/Documents/DocumentBase.cs
@@ -1,12 +1,26 @@
-﻿using Newtonsoft.Json;
+﻿using Elsa.Persistence.DocumentDb.Extensions;
+using Newtonsoft.Json;
 
 namespace Elsa.Persistence.DocumentDb.Documents
 {
     public abstract class DocumentBase
     {
-        [JsonProperty(PropertyName = "id")] public string Id { get; set; }
-        [JsonProperty(PropertyName = "_rid")] public string ResourceId { get; set; }
-        [JsonProperty(PropertyName = "_etag")] public string ETag { get; set; }
-        [JsonProperty(PropertyName = "_self")] public string SelfLink { get; set; }
+        [JsonProperty(PropertyName = "id")] 
+        public string Id { get; set; }
+        
+        [JsonProperty(PropertyName = "_rid")] 
+        public string ResourceId { get; set; }
+        
+        [JsonProperty(PropertyName = "_etag")] 
+        public string ETag { get; set; }
+
+        [JsonProperty(PropertyName = "_self")] 
+        public string SelfLink { get; set; }
+
+        [JsonProperty(PropertyName = "tenantId")]
+        public string TenantId { get; set; }
+
+        public static K GetCollectionName<T,K>() where T : DocumentBase where K : class => 
+            typeof(T).GetConstantValue<K>("COLLECTION_NAME");
     }
 }

--- a/src/persistence/Elsa.Persistence.DocumentDb/Documents/WorkflowDefinitionVersionDocument.cs
+++ b/src/persistence/Elsa.Persistence.DocumentDb/Documents/WorkflowDefinitionVersionDocument.cs
@@ -6,6 +6,8 @@ namespace Elsa.Persistence.DocumentDb.Documents
 {
     public class WorkflowDefinitionVersionDocument : DocumentBase
     {
+        internal const string COLLECTION_NAME = "WorkflowDefinition";
+
         [JsonProperty(PropertyName = "type")] 
         public string Type { get; } = nameof(WorkflowDefinitionVersionDocument);
 
@@ -15,7 +17,8 @@ namespace Elsa.Persistence.DocumentDb.Documents
         [JsonProperty(PropertyName = "version")]
         public int Version { get; set; }
 
-        [JsonProperty(PropertyName = "name")] public string Name { get; set; }
+        [JsonProperty(PropertyName = "name")] 
+        public string Name { get; set; }
 
         [JsonProperty(PropertyName = "description")]
         public string Description { get; set; }
@@ -40,8 +43,5 @@ namespace Elsa.Persistence.DocumentDb.Documents
 
         [JsonProperty(PropertyName = "isLatest")]
         public bool IsLatest { get; set; }
-
-        [JsonProperty(PropertyName = "tenantId")]
-        public string TenantId { get; set; }
     }
 }

--- a/src/persistence/Elsa.Persistence.DocumentDb/Documents/WorkflowInstanceDocument.cs
+++ b/src/persistence/Elsa.Persistence.DocumentDb/Documents/WorkflowInstanceDocument.cs
@@ -7,6 +7,8 @@ namespace Elsa.Persistence.DocumentDb.Documents
 {
     public class WorkflowInstanceDocument : DocumentBase
     {
+        internal const string COLLECTION_NAME = "WorkflowInstance";
+
         [JsonProperty(PropertyName = "definitionId")]
         public string DefinitionId { get; set; }
 
@@ -55,8 +57,5 @@ namespace Elsa.Persistence.DocumentDb.Documents
 
         [JsonProperty(PropertyName = "fault")] 
         public WorkflowFault Fault { get; set; }
-
-        [JsonProperty(PropertyName = "tenantId")]
-        public string TenantId { get; set; }
     }
 }

--- a/src/persistence/Elsa.Persistence.DocumentDb/Elsa.Persistence.DocumentDb.csproj
+++ b/src/persistence/Elsa.Persistence.DocumentDb/Elsa.Persistence.DocumentDb.csproj
@@ -25,7 +25,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.12.0" />
+        <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.13.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/persistence/Elsa.Persistence.DocumentDb/Extensions/DateTimeExtensions.cs
+++ b/src/persistence/Elsa.Persistence.DocumentDb/Extensions/DateTimeExtensions.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Globalization;
 
-namespace Elsa.Persistence.DocumentDb.Helpers
+namespace Elsa.Persistence.DocumentDb.Extensions
 {
-    internal static class TimeHelper
+    internal static class DateTimeExtensions
     {
         private static readonly DateTime EpochDateTime = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
 
@@ -18,9 +18,8 @@ namespace Elsa.Persistence.DocumentDb.Helpers
 
         internal static string TryParseToEpoch(this string s)
         {
-            return DateTime.TryParse(s, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var date)
-                ? date.ToEpoch().ToString(CultureInfo.InvariantCulture)
-                : s;
+            return DateTime.TryParse(s, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var date) ? 
+                date.ToEpoch().ToString(CultureInfo.InvariantCulture) : s;
         }
     }
 }

--- a/src/persistence/Elsa.Persistence.DocumentDb/Extensions/DocumentClientExtensions.cs
+++ b/src/persistence/Elsa.Persistence.DocumentDb/Extensions/DocumentClientExtensions.cs
@@ -1,13 +1,12 @@
-using Microsoft.Azure.Documents;
-using Microsoft.Azure.Documents.Client;
-using Microsoft.Azure.Documents.Linq;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Azure.Documents;
+using Microsoft.Azure.Documents.Client;
 
-namespace Elsa.Persistence.DocumentDb.Helpers
+namespace Elsa.Persistence.DocumentDb.Extensions
 {
-    internal static class ClientHelper
+    internal static class DocumentClientExtensions
     {
         /// <summary>
         /// Creates a document as an asynchronous operation in the Azure Cosmos DB service.
@@ -140,34 +139,6 @@ namespace Elsa.Persistence.DocumentDb.Helpers
             return await ExecuteWithRetries(async () => await client.ExecuteStoredProcedureAsync<T>(
                 storedProcedureUri, 
                 procedureParams), cancellationToken);
-        }
-
-        /// <summary>
-        /// Execute the function with retries on throttle
-        /// </summary>
-        internal static async Task<FeedResponse<T>> ExecuteNextWithRetriesAsync<T>(this IDocumentQuery<T> query,
-            CancellationToken cancellationToken = default)
-        {
-            while (true)
-            {
-                TimeSpan timeSpan;
-
-                try
-                {
-                    return await query.ExecuteNextAsync<T>(cancellationToken);
-                }
-                catch (DocumentClientException ex) when (ex.StatusCode != null && (int) ex.StatusCode == 429)
-                {
-                    timeSpan = ex.RetryAfter;
-                }
-                catch (AggregateException ex) when (ex.InnerException is DocumentClientException de &&
-                                                    de.StatusCode != null && (int) de.StatusCode == 429)
-                {
-                    timeSpan = de.RetryAfter;
-                }
-
-                await Task.Delay(timeSpan, cancellationToken);
-            }
         }
 
         /// <summary>

--- a/src/persistence/Elsa.Persistence.DocumentDb/Extensions/DocumentQueryExtensions.cs
+++ b/src/persistence/Elsa.Persistence.DocumentDb/Extensions/DocumentQueryExtensions.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Documents;
+using Microsoft.Azure.Documents.Client;
+using Microsoft.Azure.Documents.Linq;
+
+namespace Elsa.Persistence.DocumentDb.Extensions
+{
+    internal static class DocumentQueryExtensions
+    {
+        /// <summary>
+        /// Execute the function with retries on throttle
+        /// </summary>
+        internal static async Task<FeedResponse<T>> ExecuteNextWithRetriesAsync<T>(this IDocumentQuery<T> query,
+            CancellationToken cancellationToken = default)
+        {
+            while (true)
+            {
+                TimeSpan timeSpan;
+
+                try
+                {
+                    return await query.ExecuteNextAsync<T>(cancellationToken);
+                }
+                catch (DocumentClientException ex) when (ex.StatusCode != null && (int)ex.StatusCode == 429)
+                {
+                    timeSpan = ex.RetryAfter;
+                }
+                catch (AggregateException ex) when (ex.InnerException is DocumentClientException de &&
+                                                    de.StatusCode != null && (int)de.StatusCode == 429)
+                {
+                    timeSpan = de.RetryAfter;
+                }
+
+                await Task.Delay(timeSpan, cancellationToken);
+            }
+        }
+    }
+}

--- a/src/persistence/Elsa.Persistence.DocumentDb/Extensions/QueryableExtensions.cs
+++ b/src/persistence/Elsa.Persistence.DocumentDb/Extensions/QueryableExtensions.cs
@@ -1,12 +1,12 @@
-using Microsoft.Azure.Documents.Linq;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Azure.Documents.Linq;
 
-namespace Elsa.Persistence.DocumentDb.Helpers
+namespace Elsa.Persistence.DocumentDb.Extensions
 {
-    internal static class QueryHelper
+    internal static class QueryableExtensions
     {
         internal static async Task<IList<T>> ToQueryResultAsync<T>(this IQueryable<T> source, CancellationToken cancellationToken = default)
         {

--- a/src/persistence/Elsa.Persistence.DocumentDb/Extensions/ServiceConfigurationExtensions.cs
+++ b/src/persistence/Elsa.Persistence.DocumentDb/Extensions/ServiceConfigurationExtensions.cs
@@ -2,6 +2,7 @@ using System;
 using Elsa.Persistence.DocumentDb.Services;
 using Elsa.Extensions;
 using Elsa.Mapping;
+using Elsa.Persistence.DocumentDb.Helpers;
 using Elsa.Persistence.DocumentDb.Mapping;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -10,9 +11,8 @@ namespace Elsa.Persistence.DocumentDb.Extensions
 {
     public static class ServiceConfigurationExtensions
     {
-        public static CosmosDbElsaBuilder AddCosmosDbProvider(
-            this ElsaBuilder builder,
-            Action<OptionsBuilder<DocumentDbStorageOptions>> options)
+        public static CosmosDbElsaBuilder AddCosmosDbProvider<T>(this ElsaBuilder builder, Type cosmosDBStoreHelperType,
+            Action<OptionsBuilder<DocumentDbStorageOptions>> options) where T : class, ITenantProvider
         {
             options?.Invoke(builder.Services.AddOptions<DocumentDbStorageOptions>());
 
@@ -21,9 +21,23 @@ namespace Elsa.Persistence.DocumentDb.Extensions
                 .AddSingleton<IWorkflowInstanceStore, CosmosDbWorkflowInstanceStore>()
                 .AddSingleton<IWorkflowDefinitionStore, CosmosDbWorkflowDefinitionStore>()
                 .AddMapperProfile<NodaTimeProfile>(ServiceLifetime.Singleton)
-                .AddMapperProfile<DocumentProfile>(ServiceLifetime.Singleton);
+                .AddMapperProfile<DocumentProfile>(ServiceLifetime.Singleton)
+                .AddTransient<ITenantProvider, T>()
+                .AddTransient(typeof(ICosmosDbStoreHelper<>), cosmosDBStoreHelperType);
 
             return new CosmosDbElsaBuilder(builder.Services);
+        }
+
+        public static CosmosDbElsaBuilder AddCosmosDbProvider<T>(this ElsaBuilder builder,
+            Action<OptionsBuilder<DocumentDbStorageOptions>> options) where T : class, ITenantProvider
+        {
+            return builder.AddCosmosDbProvider<T>(typeof(CosmosDbStoreHelper<>), options);
+        }
+
+        public static CosmosDbElsaBuilder AddCosmosDbProvider(this ElsaBuilder builder,
+            Action<OptionsBuilder<DocumentDbStorageOptions>> options)
+        {
+            return builder.AddCosmosDbProvider<TenantProvider>(options);
         }
     }
 }

--- a/src/persistence/Elsa.Persistence.DocumentDb/Extensions/TypeExtensions.cs
+++ b/src/persistence/Elsa.Persistence.DocumentDb/Extensions/TypeExtensions.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+
+namespace Elsa.Persistence.DocumentDb.Extensions
+{
+    internal static class TypeExtension
+    {
+        internal static T GetConstantValue<T>(this Type type, string fieldName) where T : class
+        {
+            var fieldInfo = type
+                .GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.FlattenHierarchy)
+                .FirstOrDefault(fi => fi.IsLiteral && !fi.IsInitOnly && fi.Name == fieldName);
+            return fieldInfo != null && fieldInfo.GetRawConstantValue() is T constantValue ? constantValue : default;
+        }
+    }
+}

--- a/src/persistence/Elsa.Persistence.DocumentDb/Helpers/CosmosDbStoreHelper.cs
+++ b/src/persistence/Elsa.Persistence.DocumentDb/Helpers/CosmosDbStoreHelper.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Elsa.Persistence.DocumentDb.Documents;
+using Elsa.Persistence.DocumentDb.Extensions;
+using Microsoft.Azure.Documents;
+using Microsoft.Azure.Documents.Client;
+
+namespace Elsa.Persistence.DocumentDb.Helpers
+{
+    internal class CosmosDbStoreHelper<T> : ICosmosDbStoreHelper<T> where T : DocumentBase
+    {
+        private readonly IDocumentDbStorage storage;
+        private readonly ITenantProvider tenantProvider;
+
+        public CosmosDbStoreHelper(IDocumentDbStorage storage, ITenantProvider tenantProvider)
+        {
+            this.storage = storage;
+            this.tenantProvider = tenantProvider;
+        }
+
+        private async Task<DocumentClient> GetDocumentClient() => await storage.GetDocumentClient();
+        private async Task<Uri> GetCollectionUriAsync() => await storage.GetCollectionUriAsync<T>();
+        private string GetTenantId() => tenantProvider.GetTenantId<T>();
+
+        public async Task<T> FirstOrDefaultAsync(Func<IQueryable<T>, IQueryable<T>> predicate)
+        {
+            var query = await BuildQueryAsync(predicate);
+            return query.AsEnumerable().FirstOrDefault();
+        }
+
+        public async Task<IList<T>> ListAsync(Func<IQueryable<T>, IQueryable<T>> predicate, CancellationToken cancellationToken)
+        {
+            var query = await BuildQueryAsync(predicate);
+            return await query.ToQueryResultAsync(cancellationToken);
+        }
+
+        public async Task<T> AddAsync(T document, CancellationToken cancellationToken)
+        {
+            var client = await GetDocumentClient();
+            var uri = await GetCollectionUriAsync();
+            var tenantId = GetTenantId();
+            var requestOptions = new RequestOptions
+            {
+                PartitionKey = new PartitionKey(tenantId)
+            };
+            var response = await client.CreateDocumentWithRetriesAsync(uri, document, requestOptions, cancellationToken: cancellationToken);
+            return (dynamic)response.Resource;
+        }
+
+        public async Task<T> SaveAsync(T document, CancellationToken cancellationToken)
+        {
+            var client = await GetDocumentClient();
+            var uri = await GetCollectionUriAsync();
+            var tenantId = GetTenantId();
+            var requestOptions = new RequestOptions
+            {
+                PartitionKey = new PartitionKey(tenantId)
+            };
+            var response = await client.UpsertDocumentWithRetriesAsync(uri, document, requestOptions, cancellationToken: cancellationToken);
+
+            return (dynamic)response.Resource;
+        }
+
+        public async Task DeleteAsync(T document, CancellationToken cancellationToken)
+        {
+            var client = await GetDocumentClient();
+            var requestOptions = new RequestOptions
+            {
+                PartitionKey = new PartitionKey(document.TenantId)
+            };
+            var documentUri = new Uri(document.SelfLink, UriKind.Relative);
+            await client.DeleteDocumentWithRetriesAsync(documentUri, requestOptions, cancellationToken);
+        }
+
+        private async Task<IQueryable<T>> BuildQueryAsync(Func<IQueryable<T>, IQueryable<T>> predicate)
+        {
+            var client = await GetDocumentClient();
+            var uri = await GetCollectionUriAsync();
+            var tenantId = GetTenantId();
+            var feedOptions = new FeedOptions
+            {
+                PartitionKey = new PartitionKey(tenantId)
+            };
+            var query = client
+                .CreateDocumentQuery<T>(uri, feedOptions)
+                .Where(c => c.TenantId == tenantId);
+
+            return predicate(query);
+        }
+    }
+}

--- a/src/persistence/Elsa.Persistence.DocumentDb/Helpers/ICosmosDbStoreHelper.cs
+++ b/src/persistence/Elsa.Persistence.DocumentDb/Helpers/ICosmosDbStoreHelper.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Elsa.Persistence.DocumentDb.Documents;
+
+namespace Elsa.Persistence.DocumentDb.Helpers
+{
+    public interface ICosmosDbStoreHelper<T> where T : DocumentBase
+    {
+        Task<T> FirstOrDefaultAsync(Func<IQueryable<T>, IQueryable<T>> predicate);
+        Task<IList<T>> ListAsync(Func<IQueryable<T>, IQueryable<T>> predicate, CancellationToken cancellationToken);
+        Task<T> AddAsync(T document, CancellationToken cancellationToken);
+        Task<T> SaveAsync(T document, CancellationToken cancellationToken);
+        Task DeleteAsync(T document, CancellationToken cancellationToken);
+    }
+}

--- a/src/persistence/Elsa.Persistence.DocumentDb/IDocumentDbStorage.cs
+++ b/src/persistence/Elsa.Persistence.DocumentDb/IDocumentDbStorage.cs
@@ -1,6 +1,7 @@
 using Microsoft.Azure.Documents.Client;
 using System;
 using System.Threading.Tasks;
+using Elsa.Persistence.DocumentDb.Documents;
 
 namespace Elsa.Persistence.DocumentDb
 {
@@ -8,7 +9,6 @@ namespace Elsa.Persistence.DocumentDb
     {
         string ToString();
         Task<DocumentClient> GetDocumentClient();
-        Task<(string Name, Uri Uri, string TenantId)> GetWorkflowDefinitionCollectionInfoAsync();
-        Task<(string Name, Uri Uri, string TenantId)> GetWorkflowInstanceCollectionInfoAsync();
+        Task<Uri> GetCollectionUriAsync<T>() where T : DocumentBase;
     }
 }

--- a/src/persistence/Elsa.Persistence.DocumentDb/ITenantProvider.cs
+++ b/src/persistence/Elsa.Persistence.DocumentDb/ITenantProvider.cs
@@ -1,0 +1,9 @@
+using Elsa.Persistence.DocumentDb.Documents;
+
+namespace Elsa.Persistence.DocumentDb
+{
+    public interface ITenantProvider
+    {
+        string GetTenantId<T>() where T : DocumentBase;
+    }
+}

--- a/src/persistence/Elsa.Persistence.DocumentDb/Mapping/DocumentProfile.cs
+++ b/src/persistence/Elsa.Persistence.DocumentDb/Mapping/DocumentProfile.cs
@@ -6,10 +6,18 @@ namespace Elsa.Persistence.DocumentDb.Mapping
 {
     public sealed class DocumentProfile : MappingProfile
     {
-        public DocumentProfile()
+        private readonly ITenantProvider tenantProvider;
+
+        public DocumentProfile(ITenantProvider tenantProvider)
         {
-            CreateMap<WorkflowDefinitionVersion, WorkflowDefinitionVersionDocument>().ReverseMap();
-            CreateMap<WorkflowInstance, WorkflowInstanceDocument>().ReverseMap();
+            this.tenantProvider = tenantProvider;
+
+            CreateMap<WorkflowDefinitionVersion, WorkflowDefinitionVersionDocument>()
+                .ForMember(d => d.TenantId, opt => opt.MapFrom(s => this.tenantProvider.GetTenantId<WorkflowDefinitionVersionDocument>()))
+                .ReverseMap();
+            CreateMap<WorkflowInstance, WorkflowInstanceDocument>()
+                .ForMember(d => d.TenantId, opt => opt.MapFrom(s => this.tenantProvider.GetTenantId<WorkflowInstanceDocument>()))
+                .ReverseMap();
         }
     }
 }

--- a/src/persistence/Elsa.Persistence.DocumentDb/Services/CosmosDbWorkflowDefinitionStore.cs
+++ b/src/persistence/Elsa.Persistence.DocumentDb/Services/CosmosDbWorkflowDefinitionStore.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -8,67 +7,25 @@ using Elsa.Persistence.DocumentDb.Documents;
 using Elsa.Persistence.DocumentDb.Extensions;
 using Elsa.Persistence.DocumentDb.Helpers;
 using Elsa.Services;
-using Microsoft.Azure.Documents;
-using Microsoft.Azure.Documents.Client;
 
 namespace Elsa.Persistence.DocumentDb.Services
 {
-    public class CosmosDbWorkflowDefinitionStore : IWorkflowDefinitionStore
+    public class CosmosDbWorkflowDefinitionStore : CosmosDbWorkflowStoreBase<WorkflowDefinitionVersion, WorkflowDefinitionVersionDocument>, IWorkflowDefinitionStore
     {
-        private readonly IMapper mapper;
-        private readonly IDocumentDbStorage storage;
-
-        public CosmosDbWorkflowDefinitionStore(IDocumentDbStorage storage, IMapper mapper)
-        {
-            this.storage = storage;
-            this.mapper = mapper;
-        }
-
-        private async Task<DocumentClient> GetDocumentClient() => await storage.GetDocumentClient();
-        private async Task<(string Name, Uri Uri, string TenantId)> GetCollectionInfoAsync() => 
-            await storage.GetWorkflowDefinitionCollectionInfoAsync();
+        public CosmosDbWorkflowDefinitionStore(IMapper mapper, ICosmosDbStoreHelper<WorkflowDefinitionVersionDocument> cosmosDbStoreHelper) 
+            : base(mapper, cosmosDbStoreHelper) { }
 
         public async Task<WorkflowDefinitionVersion> AddAsync(WorkflowDefinitionVersion definition, CancellationToken cancellationToken = default)
         {
             var document = Map(definition);
-            var client = await GetDocumentClient();
-            var (_, uri, tenantId) = await GetCollectionInfoAsync();
-            var requestOptions = new RequestOptions
-            {
-                PartitionKey = new PartitionKey(tenantId)
-            };
-            document.TenantId = tenantId;
-            var response = await client.CreateDocumentWithRetriesAsync(uri, document, requestOptions, cancellationToken: cancellationToken);
-            document = (dynamic)response.Resource;
-
+            document = await cosmosDbStoreHelper.AddAsync(document, cancellationToken);
             return Map(document);
         }
 
         public async Task<int> DeleteAsync(string id, CancellationToken cancellationToken = default)
         {
-            var client = await GetDocumentClient();
-            var (_, uri, tenantId) = await GetCollectionInfoAsync();
-            var feedOptions = new FeedOptions
-            {
-                PartitionKey = new PartitionKey(tenantId)
-            };
-            var requestOptions = new RequestOptions
-            {
-                PartitionKey = new PartitionKey(tenantId)
-            };
-            var query = client
-                .CreateDocumentQuery<WorkflowDefinitionVersionDocument>(uri, feedOptions)
-                .Where(c => c.TenantId == tenantId)
-                .Where(c => c.DefinitionId == id);
-            var documents = await query.ToQueryResultAsync(cancellationToken);
-            var tasks = documents.Select(d =>
-            {
-                var documentUri = new Uri(d.SelfLink, UriKind.Relative);
-                return client.DeleteDocumentWithRetriesAsync(documentUri,
-                    requestOptions,
-                    cancellationToken);
-            }).ToArray();
-
+            var documents = await cosmosDbStoreHelper.ListAsync(q => q.Where(c => c.DefinitionId == id), cancellationToken);
+            var tasks = documents.Select(d => cosmosDbStoreHelper.DeleteAsync(d, cancellationToken)).ToArray();
             await Task.WhenAll(tasks);
 
             return documents.Count;
@@ -76,62 +33,27 @@ namespace Elsa.Persistence.DocumentDb.Services
 
         public async Task<WorkflowDefinitionVersion> GetByIdAsync(string id, VersionOptions version, CancellationToken cancellationToken = default)
         {
-            var client = await GetDocumentClient();
-            var (_, uri, tenantId) = await GetCollectionInfoAsync();
-            var feedOptions = new FeedOptions
+            var document = await cosmosDbStoreHelper.FirstOrDefaultAsync(q =>
             {
-                PartitionKey = new PartitionKey(tenantId)
-            };
-            var query = client
-                .CreateDocumentQuery<WorkflowDefinitionVersionDocument>(uri, feedOptions)
-                .Where(c => c.TenantId == tenantId)
-                .Where(c => c.DefinitionId == id)
-                .WithVersion(version);
-            var document = query.AsEnumerable().FirstOrDefault();
-
+                return q.Where(c => c.DefinitionId == id)
+                    .WithVersion(version);
+            });
             return Map(document);
         }
         public async Task<IEnumerable<WorkflowDefinitionVersion>> ListAsync(VersionOptions version, CancellationToken cancellationToken = default)
         {
-            var client = await GetDocumentClient();
-            var (_, uri, tenantId) = await GetCollectionInfoAsync();
-            var feedOptions = new FeedOptions
-            {
-                PartitionKey = new PartitionKey(tenantId)
-            };
-            var query = client
-                .CreateDocumentQuery<WorkflowDefinitionVersionDocument>(uri, feedOptions)
-                .Where(c => c.TenantId == tenantId)
-                .WithVersion(version);
-            var documents = await query.ToQueryResultAsync(cancellationToken);
-
+            var documents = await cosmosDbStoreHelper.ListAsync(q => q.WithVersion(version), cancellationToken);
             return Map(documents);
         }
 
         public async Task<WorkflowDefinitionVersion> SaveAsync(WorkflowDefinitionVersion definition, CancellationToken cancellationToken = default)
         {
             var document = Map(definition);
-            var client = await GetDocumentClient();
-            var (_, uri, tenantId) = await GetCollectionInfoAsync();
-            var requestOptions = new RequestOptions
-            {
-                PartitionKey = new PartitionKey(tenantId)
-            };
-            document.TenantId = tenantId;
-            var response = await client.UpsertDocumentWithRetriesAsync(uri, document, requestOptions, cancellationToken: cancellationToken);
-
-            document = (dynamic)response.Resource;
+            document = await cosmosDbStoreHelper.SaveAsync(document, cancellationToken);
             return Map(document);
         }
 
-        public async Task<WorkflowDefinitionVersion> UpdateAsync(WorkflowDefinitionVersion definition, CancellationToken cancellationToken = default)
-        {
-            return await SaveAsync(definition, cancellationToken);
-        }
-
-        private WorkflowDefinitionVersionDocument Map(WorkflowDefinitionVersion source) => mapper.Map<WorkflowDefinitionVersionDocument>(source);
-        private WorkflowDefinitionVersion Map(WorkflowDefinitionVersionDocument source) => mapper.Map<WorkflowDefinitionVersion>(source);
-        private IEnumerable<WorkflowDefinitionVersion> Map(IEnumerable<WorkflowDefinitionVersionDocument> source) => 
-            mapper.Map<IEnumerable<WorkflowDefinitionVersion>>(source);
+        public async Task<WorkflowDefinitionVersion> UpdateAsync(WorkflowDefinitionVersion definition, CancellationToken cancellationToken = default) => 
+            await SaveAsync(definition, cancellationToken);
     }
 }

--- a/src/persistence/Elsa.Persistence.DocumentDb/Services/CosmosDbWorkflowInstanceStore.cs
+++ b/src/persistence/Elsa.Persistence.DocumentDb/Services/CosmosDbWorkflowInstanceStore.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -8,220 +7,99 @@ using Elsa.Models;
 using Elsa.Persistence.DocumentDb.Documents;
 using Elsa.Persistence.DocumentDb.Helpers;
 using Elsa.Services;
-using Microsoft.Azure.Documents;
-using Microsoft.Azure.Documents.Client;
 
 namespace Elsa.Persistence.DocumentDb.Services
 {
-    public class CosmosDbWorkflowInstanceStore : IWorkflowInstanceStore
+    public class CosmosDbWorkflowInstanceStore : CosmosDbWorkflowStoreBase<WorkflowInstance, WorkflowInstanceDocument>, IWorkflowInstanceStore
     {
-        private readonly IMapper mapper;
-        private readonly IDocumentDbStorage storage;
+        public CosmosDbWorkflowInstanceStore(IMapper mapper, ICosmosDbStoreHelper<WorkflowInstanceDocument> cosmosDbStoreHelper) 
+            : base(mapper, cosmosDbStoreHelper) { }
 
-        public CosmosDbWorkflowInstanceStore(IDocumentDbStorage storage, IMapper mapper)
+        public async Task DeleteAsync(string id, CancellationToken cancellationToken = default)
         {
-            this.storage = storage;
-            this.mapper = mapper;
-        }
-
-        private async Task<DocumentClient> GetDocumentClient() => await storage.GetDocumentClient();
-        private async Task<(string Name, Uri Uri, string TenantId)> GetCollectionInfoAsync() =>
-            await storage.GetWorkflowInstanceCollectionInfoAsync();
-
-        public async Task DeleteAsync(string id,
-            CancellationToken cancellationToken = default)
-        {
-            var client = await GetDocumentClient();
-            var (_, uri, tenantId) = await GetCollectionInfoAsync();
-            var feedOptions = new FeedOptions
-            {
-                PartitionKey = new PartitionKey(tenantId)
-            };
-            var requestOptions = new RequestOptions
-            {
-                PartitionKey = new PartitionKey(tenantId)
-            };
-            var query = client
-                .CreateDocumentQuery<WorkflowInstanceDocument>(uri, feedOptions)
-                .Where(c => c.TenantId == tenantId)
-                .Where(c => c.Id == id);
-            var document = query.AsEnumerable().FirstOrDefault();
+            var document = await cosmosDbStoreHelper.FirstOrDefaultAsync(q => q.Where(c => c.Id == id));
             if (document != null)
             {
-                var documentUri = new Uri(document.SelfLink, UriKind.Relative);
-                await client.DeleteDocumentWithRetriesAsync(documentUri,
-                    requestOptions, 
-                    cancellationToken);
+                await cosmosDbStoreHelper.DeleteAsync(document, cancellationToken);
             }
         }
 
-        public async Task<WorkflowInstance> GetByCorrelationIdAsync(string correlationId,
-            CancellationToken cancellationToken = default)
+        public async Task<WorkflowInstance> GetByCorrelationIdAsync(string correlationId, CancellationToken cancellationToken = default)
         {
-            var client = await GetDocumentClient();
-            var (_, uri, tenantId) = await GetCollectionInfoAsync();
-            var feedOptions = new FeedOptions
-            {
-                PartitionKey = new PartitionKey(tenantId)
-            };
-            var query = client
-                .CreateDocumentQuery<WorkflowInstanceDocument>(uri, feedOptions)
-                .Where(c => c.TenantId == tenantId)
-                .Where(c => c.CorrelationId == correlationId);
-            var document = query.AsEnumerable().FirstOrDefault();
-
+            var document = await cosmosDbStoreHelper.FirstOrDefaultAsync(q => q.Where(c => c.CorrelationId == correlationId));
             return Map(document);
         }
 
-        public async Task<WorkflowInstance> GetByIdAsync(string id,
-            CancellationToken cancellationToken = default)
+        public async Task<WorkflowInstance> GetByIdAsync(string id, CancellationToken cancellationToken = default)
         {
-            var client = await GetDocumentClient();
-            var (_, uri, tenantId) = await GetCollectionInfoAsync();
-            var feedOptions = new FeedOptions
-            {
-                PartitionKey = new PartitionKey(tenantId)
-            };
-            var query = client
-                .CreateDocumentQuery<WorkflowInstanceDocument>(uri, feedOptions)
-                .Where(c => c.TenantId == tenantId)
-                .Where(c => c.Id == id);
-            var document = query.AsEnumerable().FirstOrDefault();
-
+            var document = await cosmosDbStoreHelper.FirstOrDefaultAsync(q => q.Where(c => c.Id == id));
             return Map(document);
         }
 
         public async Task<IEnumerable<WorkflowInstance>> ListAllAsync(CancellationToken cancellationToken = default)
         {
-            var client = await GetDocumentClient();
-            var (_, uri, tenantId) = await GetCollectionInfoAsync();
-            var feedOptions = new FeedOptions
-            {
-                PartitionKey = new PartitionKey(tenantId)
-            };
-            var query = client
-                .CreateDocumentQuery<WorkflowInstanceDocument>(uri, feedOptions)
-                .Where(c => c.TenantId == tenantId)
-                .OrderByDescending(x => x.CreatedAt);
-            var documents = await query.ToQueryResultAsync(cancellationToken);
-
+            var documents = await cosmosDbStoreHelper.ListAsync(q => q.OrderByDescending(x => x.CreatedAt), cancellationToken);
             return Map(documents);
         }
 
-        public async Task<IEnumerable<(WorkflowInstance, ActivityInstance)>> ListByBlockingActivityAsync(
-            string activityType,
-            string correlationId = null,
+        public async Task<IEnumerable<(WorkflowInstance, ActivityInstance)>> ListByBlockingActivityAsync(string activityType, string correlationId = null,
             CancellationToken cancellationToken = default)
         {
-            var client = await GetDocumentClient();
-            var (_, uri, tenantId) = await GetCollectionInfoAsync();
-            var feedOptions = new FeedOptions
+            var documents = await cosmosDbStoreHelper.ListAsync(q =>
             {
-                PartitionKey = new PartitionKey(tenantId)
-            };
-            var query = client
-                .CreateDocumentQuery<WorkflowInstanceDocument>(uri, feedOptions)
-                .Where(c => c.TenantId == tenantId)
-                .Where(x => x.Status == WorkflowStatus.Executing);
+                var query = q.Where(x => x.Status == WorkflowStatus.Executing);
+                if (!string.IsNullOrWhiteSpace(correlationId))
+                {
+                    query = query.Where(x => x.CorrelationId == correlationId);
+                }
 
-            if (!string.IsNullOrWhiteSpace(correlationId))
-            {
-                query = query.Where(x => x.CorrelationId == correlationId);
-            }
-
-            query = query.Where(x => x.BlockingActivities.Any(y => y.ActivityType == activityType));
-            query = query.OrderByDescending(x => x.CreatedAt);
-
-            var documents = await query.ToQueryResultAsync(cancellationToken);
+                query = query.Where(x => x.BlockingActivities.Any(y => y.ActivityType == activityType));
+                return query.OrderByDescending(x => x.CreatedAt);
+            }, cancellationToken);
 
             var instances = Map(documents);
             return instances.GetBlockingActivities(activityType).ToArray();
         }
 
-        public async Task<IEnumerable<WorkflowInstance>> ListByDefinitionAsync(
-            string definitionId,
-            CancellationToken cancellationToken = default)
+        public async Task<IEnumerable<WorkflowInstance>> ListByDefinitionAsync(string definitionId, CancellationToken cancellationToken = default)
         {
-            var client = await GetDocumentClient();
-            var (_, uri, tenantId) = await GetCollectionInfoAsync();
-            var feedOptions = new FeedOptions
+            var documents = await cosmosDbStoreHelper.ListAsync(q =>
             {
-                PartitionKey = new PartitionKey(tenantId)
-            };
-            var query = client
-                .CreateDocumentQuery<WorkflowInstanceDocument>(uri, feedOptions)
-                .Where(c => c.TenantId == tenantId)
-                .Where(c => c.DefinitionId == definitionId)
-                .OrderByDescending(x => x.CreatedAt);
-            var documents = await query.ToQueryResultAsync(cancellationToken);
+                return q.Where(c => c.DefinitionId == definitionId)
+                    .OrderByDescending(x => x.CreatedAt);
+            }, cancellationToken);
 
             return Map(documents);
         }
 
-        public async Task<IEnumerable<WorkflowInstance>> ListByStatusAsync(
-            string definitionId,
-            WorkflowStatus status,
+        public async Task<IEnumerable<WorkflowInstance>> ListByStatusAsync(string definitionId, WorkflowStatus status,
             CancellationToken cancellationToken = default)
         {
-            var client = await GetDocumentClient();
-            var (_, uri, tenantId) = await GetCollectionInfoAsync();
-            var feedOptions = new FeedOptions
+            var documents = await cosmosDbStoreHelper.ListAsync(q =>
             {
-                PartitionKey = new PartitionKey(tenantId)
-            };
-            var query = client.CreateDocumentQuery<WorkflowInstanceDocument>(uri, feedOptions)
-                .Where(c => c.TenantId == tenantId)
-                .Where(c => c.DefinitionId == definitionId && c.Status == status)
-                .OrderByDescending(x => x.CreatedAt);
-            var documents = await query.ToQueryResultAsync(cancellationToken);
+                return q.Where(c => c.DefinitionId == definitionId && c.Status == status)
+                    .OrderByDescending(x => x.CreatedAt);
+            }, cancellationToken);
 
             return Map(documents);
         }
 
-        public async Task<IEnumerable<WorkflowInstance>> ListByStatusAsync(
-            WorkflowStatus status,
-            CancellationToken cancellationToken = default)
+        public async Task<IEnumerable<WorkflowInstance>> ListByStatusAsync(WorkflowStatus status, CancellationToken cancellationToken = default)
         {
-            var client = await GetDocumentClient();
-            var (_, uri, tenantId) = await GetCollectionInfoAsync();
-            var feedOptions = new FeedOptions
+            var documents = await cosmosDbStoreHelper.ListAsync(q =>
             {
-                PartitionKey = new PartitionKey(tenantId)
-            };
-            var query = client.CreateDocumentQuery<WorkflowInstanceDocument>(uri, feedOptions)
-                .Where(c => c.TenantId == tenantId)
-                .Where(c => c.Status == status)
-                .OrderByDescending(x => x.CreatedAt);
-            var documents = await query.ToQueryResultAsync(cancellationToken);
+                return q.Where(c => c.Status == status)
+                    .OrderByDescending(x => x.CreatedAt);
+            }, cancellationToken);
 
             return Map(documents);
         }
 
-        public async Task<WorkflowInstance> SaveAsync(
-            WorkflowInstance instance,
-            CancellationToken cancellationToken = default)
+        public async Task<WorkflowInstance> SaveAsync(WorkflowInstance instance, CancellationToken cancellationToken = default)
         {
             var document = Map(instance);
-            var client = await GetDocumentClient();
-            var (_, uri, tenantId) = await GetCollectionInfoAsync();
-            var requestOptions = new RequestOptions
-            {
-                PartitionKey = new PartitionKey(tenantId)
-            };
-            document.TenantId = tenantId;
-            var response = await client.UpsertDocumentWithRetriesAsync(
-                uri,
-                document,
-                requestOptions,
-                cancellationToken: cancellationToken);
-
-            document = (dynamic)response.Resource;
+            document = await cosmosDbStoreHelper.SaveAsync(document, cancellationToken);
             return Map(document);
         }
-
-        private WorkflowInstanceDocument Map(WorkflowInstance source) => mapper.Map<WorkflowInstanceDocument>(source);
-        private WorkflowInstance Map(WorkflowInstanceDocument source) => mapper.Map<WorkflowInstance>(source);
-        private IEnumerable<WorkflowInstance> Map(IEnumerable<WorkflowInstanceDocument> source) => 
-            mapper.Map<IEnumerable<WorkflowInstance>>(source);
     }
 }

--- a/src/persistence/Elsa.Persistence.DocumentDb/Services/CosmosDbWorkflowStoreBase.cs
+++ b/src/persistence/Elsa.Persistence.DocumentDb/Services/CosmosDbWorkflowStoreBase.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using Elsa.Persistence.DocumentDb.Documents;
+using Elsa.Persistence.DocumentDb.Helpers;
+using Elsa.Services;
+
+namespace Elsa.Persistence.DocumentDb.Services
+{
+    public abstract class CosmosDbWorkflowStoreBase<TModel, TDocument> where TDocument : DocumentBase
+    {
+        private readonly IMapper mapper;
+        protected readonly ICosmosDbStoreHelper<TDocument> cosmosDbStoreHelper;
+
+        protected CosmosDbWorkflowStoreBase(IMapper mapper, ICosmosDbStoreHelper<TDocument> cosmosDbStoreHelper) =>
+            (this.mapper, this.cosmosDbStoreHelper) = (mapper, cosmosDbStoreHelper);
+
+        protected TDocument Map(TModel source) => mapper.Map<TDocument>(source);
+        protected TModel Map(TDocument source) => mapper.Map<TModel>(source);
+        protected IEnumerable<TModel> Map(IEnumerable<TDocument> source) => mapper.Map<IEnumerable<TModel>>(source);
+    }
+}

--- a/src/persistence/Elsa.Persistence.DocumentDb/TenantProvider.cs
+++ b/src/persistence/Elsa.Persistence.DocumentDb/TenantProvider.cs
@@ -1,0 +1,28 @@
+using Elsa.Persistence.DocumentDb.Documents;
+using Microsoft.Extensions.Options;
+
+namespace Elsa.Persistence.DocumentDb
+{
+    internal class TenantProvider : ITenantProvider
+    {
+        internal const string DEFAULT_TENANT_NAME = "default";
+
+        private readonly DocumentDbStorageOptions options;
+
+        public TenantProvider(IOptions<DocumentDbStorageOptions> options)
+        {
+            this.options = options.Value;
+        }
+
+        public string GetTenantId<T>() where T : DocumentBase
+        {
+            var collectionName = DocumentBase.GetCollectionName<T, string>();
+            if (options.CollectionInfos.TryGetValue(collectionName, out var collectionInfo) && !string.IsNullOrEmpty(collectionInfo.TenantId))
+            {
+                return collectionInfo.TenantId;
+            }
+
+            return DEFAULT_TENANT_NAME;
+        }
+    }
+}


### PR DESCRIPTION
1. Cleaned up the duplicate code
2. Enhanced the cosmos DB persistence assembly to inject the custom logic for handling tenants
3. Enhanced to inject the custom logic in Cosmos DB CURD operations