### PR TITLE
Added null checks in ControllerModelConvention

### DIFF
--- a/src/dashboard/Elsa.Dashboard/Conventions/ElsaConvention.cs
+++ b/src/dashboard/Elsa.Dashboard/Conventions/ElsaConvention.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices.ComTypes;
 using Microsoft.AspNetCore.Mvc.ApplicationModels;
 
 namespace Elsa.Dashboard.Conventions
@@ -8,7 +9,7 @@ namespace Elsa.Dashboard.Conventions
 
         public void Apply(ControllerModel controller)
         {
-            if (controller.RouteValues["area"] == AreaName)
+            if (controller.RouteValues.TryGetValue("area", out var areaName) && areaName == AreaName)
             {
                 ApplyConvention(controller);
             }


### PR DESCRIPTION
RouteValues dictionary will not have area as a key all the time if in-case we have controllers without areas