### PR TITLE
Improve Finish activity

### DIFF
--- a/src/core/Elsa.Core/Activities/ControlFlow/Finish/Finish.cs
+++ b/src/core/Elsa.Core/Activities/ControlFlow/Finish/Finish.cs
@@ -6,7 +6,6 @@ using Elsa.Attributes;
 using Elsa.Models;
 using Elsa.Services;
 using Elsa.Services.Models;
-using NetBox.Extensions;
 
 // ReSharper disable once CheckNamespace
 namespace Elsa.Activities.ControlFlow
@@ -37,7 +36,7 @@ namespace Elsa.Activities.ControlFlow
                 await context.WorkflowExecutionContext.RemoveBlockingActivityAsync(blockingActivity);
             
             // Evict & remove any scope activities within the scope of the composite activity.
-            var scopes = Enumerable.AsEnumerable(context.WorkflowInstance.Scopes).Reverse().ToList();
+            var scopes = context.WorkflowInstance.Scopes.AsEnumerable().Reverse().ToList();
             var containedScopeActivityIds = parentBlueprint == null ? scopes : parentBlueprint.Activities.Where(x => scopes.Contains(x.Id)).Select(x => x.Id).ToList();
 
             foreach (var scope in containedScopeActivityIds)
@@ -47,7 +46,7 @@ namespace Elsa.Activities.ControlFlow
                 scopes.Remove(scope);
             }
             
-            context.WorkflowInstance.Scopes = new SimpleStack<string>(((IEnumerable<string>)scopes).Reverse());
+            context.WorkflowInstance.Scopes = new SimpleStack<string>(scopes.AsEnumerable().Reverse());
             
             // Return output
             var output = new FinishOutput(OutputValue, OutcomeNames);

--- a/src/core/Elsa.Core/Activities/ControlFlow/Finish/Finish.cs
+++ b/src/core/Elsa.Core/Activities/ControlFlow/Finish/Finish.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Elsa.ActivityResults;
 using Elsa.Attributes;
 using Elsa.Models;
@@ -31,7 +32,8 @@ namespace Elsa.Activities.ControlFlow
             blockingActivities.RemoveWhere(x => containedBlockingActivityIds.Contains(x.ActivityId));
             var output = new FinishOutput(OutputValue, OutcomeNames);
             context.WorkflowExecutionContext.WorkflowInstance.Output = output;
-            return Done(output);
+            
+            return Output(output);
         }
     }
 }

--- a/src/core/Elsa.Core/Activities/ControlFlow/Join/Join.cs
+++ b/src/core/Elsa.Core/Activities/ControlFlow/Join/Join.cs
@@ -96,11 +96,8 @@ namespace Elsa.Activities.ControlFlow
                     blockingActivityAncestors = blockingActivityAncestors.Concat(compositeBlockingActivityAncestors).ToList();
                 }
 
-                if (fork == null || blockingActivityAncestors.Contains(fork.Id))
-                {
-                    workflowExecutionContext.WorkflowInstance.BlockingActivities.Remove(blockingActivity);
-                    await _mediator.Publish(new BlockingActivityRemoved(workflowExecutionContext, blockingActivity));
-                }
+                if (fork == null || blockingActivityAncestors.Contains(fork.Id)) 
+                    await workflowExecutionContext.RemoveBlockingActivityAsync(blockingActivity);
             }
         }
 

--- a/src/core/Elsa.Core/Handlers/RescheduleBranchingActivitiesAndContainers.cs
+++ b/src/core/Elsa.Core/Handlers/RescheduleBranchingActivitiesAndContainers.cs
@@ -18,10 +18,14 @@ namespace Elsa.Handlers
             var workflowExecutionContext = activityExecutionContext.WorkflowExecutionContext;
 
             // Check to see if a suspension / completion has been instructed. If so, do nothing.
-            if (workflowExecutionContext.HasScheduledActivities || workflowExecutionContext.Status != WorkflowStatus.Running || !workflowExecutionContext.WorkflowInstance.Scopes.Any())
+            if (workflowExecutionContext.HasScheduledActivities || workflowExecutionContext.Status != WorkflowStatus.Running)
+                return Task.CompletedTask;
+            
+            // Check if we are within a scope.
+            if(!workflowExecutionContext.WorkflowInstance.Scopes.Any())
                 return Task.CompletedTask;
 
-            // No suspension has been instructed, so re-schedule any container activities.
+            // Re-schedule the current scope activity.
             var parentActivityId = workflowExecutionContext.WorkflowInstance.Scopes.Pop();
             workflowExecutionContext.ScheduleActivity(parentActivityId, activityExecutionContext.Output);
             

--- a/src/core/Elsa.Core/Handlers/RescheduleBranchingActivitiesAndContainers.cs
+++ b/src/core/Elsa.Core/Handlers/RescheduleBranchingActivitiesAndContainers.cs
@@ -17,10 +17,11 @@ namespace Elsa.Handlers
             var activityExecutionContext = notification.ActivityExecutionContext;
             var workflowExecutionContext = activityExecutionContext.WorkflowExecutionContext;
 
-            // If no suspension has been instructed, re-schedule any container activities.
+            // Check to see if a suspension / completion has been instructed. If so, do nothing.
             if (workflowExecutionContext.HasScheduledActivities || workflowExecutionContext.Status != WorkflowStatus.Running || !workflowExecutionContext.WorkflowInstance.Scopes.Any())
                 return Task.CompletedTask;
 
+            // No suspension has been instructed, so re-schedule any container activities.
             var parentActivityId = workflowExecutionContext.WorkflowInstance.Scopes.Pop();
             workflowExecutionContext.ScheduleActivity(parentActivityId, activityExecutionContext.Output);
             

--- a/src/core/Elsa.Core/Services/WorkflowRunner.cs
+++ b/src/core/Elsa.Core/Services/WorkflowRunner.cs
@@ -355,7 +355,7 @@ namespace Elsa.Services
                 workflowExecutionContext.Suspend();
 
             if (workflowExecutionContext.Status == WorkflowStatus.Running)
-                workflowExecutionContext.Complete();
+                await workflowExecutionContext.CompleteAsync();
         }
 
         private async ValueTask<IActivityExecutionResult?> TryExecuteActivityAsync(


### PR DESCRIPTION
The changes in this PR improve the behavior of the Finish activity so that:

* It can be used within composite activities to exit early while also cleaning up any blocking activities + contained scopes
* It can be used within the workflow itself (root composite activity) to complete the workflow directly while cleaning up any blocking activities.