### PR TITLE
Resolves #664 - simplify AppVeyor YML

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![Nuget (with prereleases)](https://img.shields.io/nuget/vpre/Elsa)](https://www.nuget.org/packages/Elsa/2.0.0-preview5-0)
 [![MyGet (with prereleases)](https://img.shields.io/myget/elsa-2/vpre/Elsa?label=myget)](https://www.myget.org/gallery/elsa-2)
-[![Build status](https://ci.appveyor.com/api/projects/status/wix4v6o2inamn153?svg=true)](https://ci.appveyor.com/project/sfmskywalker/elsa-2-builds)
+[![Build status](https://ci.appveyor.com/api/projects/status/github/elsa-workflows/elsa-core?svg=true&branch=feature/elsa-2.0)](https://ci.appveyor.com/project/sfmskywalker/elsa)
 [![Gitter](https://badges.gitter.im/elsa-workflows/community.svg)](https://gitter.im/elsa-workflows/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 [![Stack Overflow questions](https://img.shields.io/badge/stackoverflow-elsa_workflows-orange.svg)]( http://stackoverflow.com/questions/tagged/elsa-workflows )
 ![Docker Pulls](https://img.shields.io/docker/pulls/elsaworkflows/elsa-dashboard?label=elsa%20dashboard%3Adocker%20pulls)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,15 +28,21 @@ cache:
 install:
   - ps: >-
       Install-Product node $env:nodejs_version
+
       cd .\src\dashboards\blazor\ElsaDashboard.Application
+
       npm install --force
+
       cd ..\..\..\..\
 
 build_script:
   - ps: >-
       cd .\src\dashboards\blazor\ElsaDashboard.Application
+
       npm run build:css
+
       cd ..\..\..\..\
+      
       dotnet pack Elsa.sln --include-symbols /p:Version=$env:APPVEYOR_BUILD_VERSION
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,23 +27,17 @@ cache:
 
 install:
   - ps: >-
-    Install-Product node $env:nodejs_version
-
-    cd .\src\dashboards\blazor\ElsaDashboard.Application
-
-    npm install --force
-
-    cd ..\..\..\..\
+      Install-Product node $env:nodejs_version
+      cd .\src\dashboards\blazor\ElsaDashboard.Application
+      npm install --force
+      cd ..\..\..\..\
 
 build_script:
   - ps: >-
-    cd .\src\dashboards\blazor\ElsaDashboard.Application
-
-    npm run build:css
-
-    cd ..\..\..\..\
-
-    dotnet pack Elsa.sln --include-symbols /p:Version=$env:APPVEYOR_BUILD_VERSION
+      cd .\src\dashboards\blazor\ElsaDashboard.Application
+      npm run build:css
+      cd ..\..\..\..\
+      dotnet pack Elsa.sln --include-symbols /p:Version=$env:APPVEYOR_BUILD_VERSION
 
 test_script:
   - ps: dotnet test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-# Elsa 2 - Build (MyGet)
+# Elsa 2 - Build & deploy to MyGet
 - branches:
     only:
       - feature/elsa-2.0
@@ -55,7 +55,7 @@
       on:
         branch: feature/elsa-2.0
 
-# Elsa 2 - Preview (NuGet)
+# Elsa 2 - Build & deploy to NuGet (tagged commits only)
 - branches:
     only:
       - feature/elsa-2.0
@@ -100,105 +100,3 @@
       on:
         APPVEYOR_REPO_TAG: true
         branch: feature/elsa-2.0
-
-# Elsa 1.5.x
-- branches:
-    only:
-      - master
-
-  version: 1.5.0.{build}
-  pull_requests:
-    do_not_increment_build_number: true
-
-  skip_non_tags: true
-  skip_branch_with_pr: true
-  image: Visual Studio 2019 Preview
-  dotnet_csproj:
-    patch: true
-    file: '**\*.csproj'
-    version: '{version}'
-    version_prefix: '{version}'
-    package_version: '{version}'
-    assembly_version: '{version}'
-    file_version: '{version}'
-    informational_version: '{version}'
-  cache:
-    - src\dashboard\Elsa.Dashboard\Theme\argon-dashboard\node_modules
-    - '%APPDATA%\npm-cache'
-  build_script:
-    - ps: >-
-        cd .\src\dashboard\Elsa.Dashboard\Theme\argon-dashboard
-
-        npm install
-
-        npm install --global gulp-cli
-
-        gulp build
-
-        cd ..\..\..\..\..\
-
-        dotnet pack Elsa.sln --include-symbols
-  artifacts:
-    - path: '**/*.nupkg'
-      name: NuGet
-  deploy:
-    - provider: NuGet
-      api_key:
-        secure: WC5CCcM5ksWOJbv925FNjv91KsfqHfwEe0A61FMNB27IxvttwJsvBC9XYwK+wQnp
-      skip_symbols: true
-      on:
-        APPVEYOR_REPO_TAG: true
-        branch: master
-
-# Elsa 1.4.x
-- branches:
-    only:
-      - 1.4.x
-
-  version: 1.4.7.{build}
-  pull_requests:
-    do_not_increment_build_number: true
-  skip_non_tags: true
-  skip_branch_with_pr: true
-  image: Visual Studio 2019
-  dotnet_csproj:
-    patch: true
-    file: '**\*.csproj'
-    version: '{version}'
-    version_prefix: '{version}'
-    package_version: '{version}'
-    assembly_version: '{version}'
-    file_version: '{version}'
-    informational_version: '{version}'
-  cache:
-    - '%APPDATA%\npm-cache'
-    - src\dashboard\Elsa.Dashboard\Theme\argon-dashboard\node_modules
-  build_script:
-    - ps: >-
-        cd .\src\dashboard\Elsa.Dashboard\Theme\argon-dashboard
-
-        npm install
-
-        npm install --global gulp-cli
-
-        gulp build
-
-        cd ..\..\..\..\..\
-
-        dotnet pack Elsa.sln --include-symbols
-  artifacts:
-    - path: '**/*.nupkg'
-      name: NuGet
-  deploy:
-    - provider: NuGet
-      api_key:
-        secure: WC5CCcM5ksWOJbv925FNjv91KsfqHfwEe0A61FMNB27IxvttwJsvBC9XYwK+wQnp
-      skip_symbols: true
-      on:
-        APPVEYOR_REPO_TAG: true
-        branch: 1.4.x
-
-# "fall back" configuration for all other branches
-# no "branches" section defined
-# do not deploy at all
-- configuration: Debug

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,102 +1,71 @@
-# Elsa 2 - Build & deploy to MyGet
-- branches:
-    only:
-      - feature/elsa-2.0
+image: Previous Visual Studio 2019
 
-  version: 2.0.0-preview6.{build}
-  pull_requests:
-    do_not_increment_build_number: true
+environment:
+  nodejs_version: "11"
 
-  image: Previous Visual Studio 2019
-  environment:
-    matrix:
-      - nodejs_version: "11"
-  dotnet_csproj:
-    patch: true
-    file: '**\*.csproj'
-    version: '{version}'
-    version_prefix: '{version}'
-    package_version: '{version}'
-    assembly_version: '{version}'
-    file_version: '{version}'
-    informational_version: '{version}'
-  cache:
-    - src\dashboards\blazor\ElsaDashboard.Application\node_modules
-    - '%APPDATA%\npm-cache'
-  install:
-    - ps: >-
-        Install-Product node $env:nodejs_version
+version: 2.0.0-preview6.{build}
 
-        cd .\src\dashboards\blazor\ElsaDashboard.Application
+init:
+  - cmd: git config --global core.autocrlf true
 
-        npm install --force
+pull_requests:
+  do_not_increment_build_number: true
 
-        cd ..\..\..\..\
-  build_script:
-    - ps: >-
-        cd .\src\dashboards\blazor\ElsaDashboard.Application
+dotnet_csproj:
+  patch: true
+  file: '**\*.csproj'
+  version: '{version}'
+  version_prefix: '{version}'
+  package_version: '{version}'
+  assembly_version: '{version}'
+  file_version: '{version}'
+  informational_version: '{version}'
 
-        npm run build:css
+cache:
+  - src\dashboards\blazor\ElsaDashboard.Application\node_modules
+  - '%APPDATA%\npm-cache'
 
-        cd ..\..\..\..\
+install:
+  - ps: >-
+    Install-Product node $env:nodejs_version
 
-        dotnet pack Elsa.sln --include-symbols /p:Version=$env:APPVEYOR_BUILD_VERSION
-  test_script:
-    - ps: dotnet test
-  artifacts:
-    - path: '**/*.nupkg'
-      name: MyGet
-  deploy:
-    - provider: NuGet
-      server: https://www.myget.org/F/elsa-2/api/v2/package
-      api_key:
-        secure: JfESkwmLdWU7dzvoqKPUfMemb00wX8AEYxeHCsYWTX1LfTeECdmKdZxz7IVUpebb
-      skip_symbols: true
-      on:
-        branch: feature/elsa-2.0
+    cd .\src\dashboards\blazor\ElsaDashboard.Application
 
-# Elsa 2 - Build & deploy to NuGet (tagged commits only)
-- branches:
-    only:
-      - feature/elsa-2.0
-  version: 2.0.0-preview6.{build}
+    npm install --force
 
-  skip_non_tags: true
-  skip_branch_with_pr: true
-  image: Visual Studio 2019
-  dotnet_csproj:
-    patch: true
-    file: '**\*.csproj'
-    version: '{version}'
-    version_prefix: '{version}'
-    package_version: '{version}'
-    assembly_version: '{version}'
-    file_version: '{version}'
-    informational_version: '{version}'
-  cache:
-    - '%APPDATA%\npm-cache'
-    - src\dashboards\blazor\ElsaDashboard.Application\node_modules
-  build_script:
-    - ps: >-
-        cd .\src\dashboards\blazor\ElsaDashboard.Application
+    cd ..\..\..\..\
 
-        npm install npm@latest -g
+build_script:
+  - ps: >-
+    cd .\src\dashboards\blazor\ElsaDashboard.Application
 
-        npm install
+    npm run build:css
 
-        npm run build:css
+    cd ..\..\..\..\
 
-        cd ..\..\..\..\
+    dotnet pack Elsa.sln --include-symbols /p:Version=$env:APPVEYOR_BUILD_VERSION
 
-        dotnet pack Elsa.sln --include-symbols /p:Version=$env:APPVEYOR_BUILD_VERSION
-  artifacts:
-    - path: '**/*.nupkg'
-      name: NuGet
-  deploy:
-    - provider: NuGet
-      api_key:
-        secure: WC5CCcM5ksWOJbv925FNjv91KsfqHfwEe0A61FMNB27IxvttwJsvBC9XYwK+wQnp
-      skip_symbols: true
-      on:
-        APPVEYOR_REPO_TAG: true
-        branch: feature/elsa-2.0
+test_script:
+  - ps: dotnet test
+
+artifacts:
+  - path: '**/*.nupkg'
+    name: Packages
+
+deploy:
+  # Deploy to MyGet on every build (in the appropriate branch)
+  - provider: NuGet
+    server: https://www.myget.org/F/elsa-2/api/v2/package
+    api_key:
+      secure: JfESkwmLdWU7dzvoqKPUfMemb00wX8AEYxeHCsYWTX1LfTeECdmKdZxz7IVUpebb
+    skip_symbols: true
+    on:
+      branch: feature/elsa-2.0
+  
+  # Deploy to NuGet on builds from tags only
+  - provider: NuGet
+    api_key:
+      secure: WC5CCcM5ksWOJbv925FNjv91KsfqHfwEe0A61FMNB27IxvttwJsvBC9XYwK+wQnp
+    skip_symbols: true
+    on:
+      APPVEYOR_REPO_TAG: true


### PR DESCRIPTION
This PR will (once I finalise it) simplify the AppVeyor YML file.  The main aim is about removing redundant config.  I also spotted that the two configs for the v2 branch are mainly about deploying non-tagged builds to MyGet and tagged builds to NuGet.

There seems to be a bit of duplication between these, so while I'm here I'm going to see if I can't quickly de-dupe that as well.