### PR TITLE
Resolve #486 - Signal input is emitted as output

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,8 +10,6 @@ environment:
   sonarcloud_project_name: elsa-workflows_elsa-core
   sonarcloud_api_key:
     secure: qaE9kOVkGGFM7ZMf3YeliZxDU9udTCy6W5xXHJ9T+tXv5qXPMYlIdR7hyNgxW04A
-  sample_variable:
-    secure: MrPipn2VVHXu68PxZWztGA==
 
 version: 2.0.0-preview7.{build}
 
@@ -48,18 +46,19 @@ install:
       dotnet tool install --global dotnet-sonarscanner
 
 before_build:
-  - cmd: echo "The sample variable is %sample_variable%"
-  - cmd: >-
-      dotnet-sonarscanner begin
-      /k:%sonarcloud_project_name%
-      /v:AppVeyor_build_%APPVEYOR_BUILD_VERSION%
-      /o:%sonarcloud_org_name%
-      /s:%APPVEYOR_BUILD_FOLDER%\.SonarQube.Analysis.xml
+  - ps: >-
+      if(-Not $env:APPVEYOR_PULL_REQUEST_NUMBER) {
+      & dotnet-sonarscanner begin
+      /k:$env:sonarcloud_project_name
+      /v:AppVeyor_build_$env:APPVEYOR_BUILD_VERSION
+      /o:$env:sonarcloud_org_name
+      /s:$env:APPVEYOR_BUILD_FOLDER\.SonarQube.Analysis.xml
       /d:sonar.host.url="https://sonarcloud.io"
-      /d:sonar.login=%sonarcloud_api_key%
-      /d:sonar.cs.xunit.reportsPaths=%APPVEYOR_BUILD_FOLDER%\**\TestResults\TestResults.xml
-      /d:sonar.cs.opencover.reportsPaths=%APPVEYOR_BUILD_FOLDER%\**\TestResults\*\coverage.opencover.xml
-      /d:sonar.branch.name=%APPVEYOR_REPO_BRANCH%
+      /d:sonar.login=$env:sonarcloud_api_key
+      /d:sonar.cs.xunit.reportsPaths=$env:APPVEYOR_BUILD_FOLDER\**\TestResults\TestResults.xml
+      /d:sonar.cs.opencover.reportsPaths=$env:APPVEYOR_BUILD_FOLDER\**\TestResults\*\coverage.opencover.xml
+      /d:sonar.branch.name=$env:APPVEYOR_REPO_BRANCH
+      }
 
 build_script:
   - ps: >-
@@ -75,7 +74,7 @@ test_script:
   - ps: dotnet test --collect:"XPlat Code Coverage" --logger:xunit -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
 
 after_test:
-  - cmd: dotnet-sonarscanner end /d:sonar.login=%sonarcloud_api_key%
+  - ps: if(-Not $env:APPVEYOR_PULL_REQUEST_NUMBER) { & dotnet-sonarscanner end /d:sonar.login=$env:sonarcloud_api_key }
   - ps: dotnet pack Elsa.sln --include-symbols /p:Version="$env:APPVEYOR_BUILD_VERSION"
 
 artifacts:

--- a/test/unit/Elsa.UnitTests/Activities/Signaling/SignalReceivedTests.cs
+++ b/test/unit/Elsa.UnitTests/Activities/Signaling/SignalReceivedTests.cs
@@ -1,0 +1,81 @@
+using System.Threading.Tasks;
+using Elsa.Services.Models;
+using Elsa.Activities.Signaling.Models;
+using Xunit;
+using Elsa.ActivityResults;
+using System.Linq;
+
+namespace Elsa.Activities.Signaling
+{
+    public class SignalReceivedTests
+    {
+        [Theory(DisplayName = "The CanExecuteAsync method should return a task of false if the signal name does not match the triggered signal"), AutoMoqData]
+        public async Task CanExecuteAsyncShouldReturnATaskOfFalseIfTheSignalNameDoesNotMatch(SignalReceived sut,
+                                                                                             Signal triggeredSignal)
+        {
+            var context = new ActivityExecutionContext(default, default, default, triggeredSignal, default, default);
+            triggeredSignal.SignalName = "Yes";
+            sut.Signal = "No";
+
+            var result = await sut.CanExecuteAsync(context);
+
+            Assert.False(result);
+        }
+
+        [Theory(DisplayName = "The CanExecuteAsync method should return a task of true if the signal name matches the triggered signal"), AutoMoqData]
+        public async Task CanExecuteAsyncShouldReturnATaskOfTrueIfTheSignalNameMatchs(SignalReceived sut,
+                                                                                      string signalName,
+                                                                                      Signal triggeredSignal)
+        {
+            var context = new ActivityExecutionContext(default, default, default, triggeredSignal, default, default);
+            triggeredSignal.SignalName = signalName;
+            sut.Signal = signalName;
+
+            var result = await sut.CanExecuteAsync(context);
+
+            Assert.True(result);
+        }
+
+        [Theory(DisplayName = "The CanExecuteAsync method should return a task of false if the input from the context is not a triggered signal"), AutoMoqData]
+        public async Task CanExecuteAsyncShouldReturnATaskOfFalseIfTheInputIsNotATriggeredSignal(SignalReceived sut,
+                                                                                                 string signalName,
+                                                                                                 object notASignal)
+        {
+            var context = new ActivityExecutionContext(default, default, default, notASignal, default, default);
+            sut.Signal = signalName;
+
+            var result = await sut.CanExecuteAsync(context);
+
+            Assert.False(result);
+        }
+
+        [Theory(DisplayName = "The ResumeAsync method should return a combined 'Done' Outcome & Output result"), AutoMoqData]
+        public async Task ResumeAsyncShouldReturnCombinedDoneAndOutputResult(SignalReceived sut, Signal triggeredSignal, object signalInput)
+        {
+            var context = new ActivityExecutionContext(default, default, default, triggeredSignal, default, default);
+            triggeredSignal.Input = signalInput;
+            
+            var result = await sut.ResumeAsync(context);
+
+            Assert.True((result is CombinedResult combinedResult)
+                        && combinedResult.Results.Any(res => res is OutcomeResult outcome && outcome.Outcomes.Any(o => o == OutcomeNames.Done))
+                        && combinedResult.Results.Any(res => res is OutputResult),
+                        $"The result is {nameof(CombinedResult)} which contains both a {nameof(OutcomeResult)} (of \"Done\") and a {nameof(OutputResult)}.");
+        }
+
+        [Theory(DisplayName = "The ResumeAsync method should include the original signal input within the Output result"), AutoMoqData]
+        public async Task ResumeAsyncShouldReturnOriginalSignalInputWithinDoneResult(SignalReceived sut, Signal triggeredSignal, object signalInput)
+        {
+            var context = new ActivityExecutionContext(default, default, default, triggeredSignal, default, default);
+            triggeredSignal.Input = signalInput;
+            
+            var result = await sut.ResumeAsync(context);
+            var resultOutput = ((CombinedResult) result).Results
+                .OfType<OutputResult>()
+                ?.FirstOrDefault()
+                ?.Output;
+
+            Assert.Same(signalInput, resultOutput);
+        }
+    }
+}


### PR DESCRIPTION
It actually turns out that no change is required to the `SignalReceived`
activity in order to achieve this.  As these unit tests prove & document,
that is already the current behaviour.

The only risks I see is that I have either:
* Misunderstood how an `OutputResult` is used when part of a `CombinedResult` - it certainly seems that this is the endorsed way of communicating "Activity output"
* Misunderstood the intended meaning of `Signal.Input` - presumably this is the expected manner in which "Input" will be provided when triggering a signal