### PR TITLE
Resolve #548 - improperly connected activity

### DIFF
--- a/src/samples/Sample25/DataProcessingWorkflow.cs
+++ b/src/samples/Sample25/DataProcessingWorkflow.cs
@@ -50,8 +50,7 @@ namespace Sample25
                         ifElse
                             .When(OutcomeNames.True)
                             .Then<WriteLine>(x => x.TextExpression = new LiteralExpression("Data exceeds threshold (TRUE)"));
-                    })
-                .Then<WriteLine>(x => x.TextExpression = new JavaScriptExpression<string>("(`Finished data processing. Result: ${Absolute.Result}`)"));
+                    });
         }
     }
 }


### PR DESCRIPTION
The activity I removed would never have been executed, because it is
not connected from either of the IfElse branches.
Since this is Elsa 1.x, I've fixed it using the cheapest/quickest possible
solution which is to just remove the misleading part of the sample.