### PR TITLE
Resolve #683 - Tests to prove no exception

### DIFF
--- a/test/integration/Elsa.Core.IntegrationTests/Autofixture/HostBuilderWithDuplicateActivitiesWorkflowAttributes.cs
+++ b/test/integration/Elsa.Core.IntegrationTests/Autofixture/HostBuilderWithDuplicateActivitiesWorkflowAttributes.cs
@@ -1,0 +1,80 @@
+using System.Reflection;
+using AutoFixture;
+using AutoFixture.Xunit2;
+using Elsa.Core.IntegrationTests.Workflows;
+using Elsa.Persistence.MongoDb.Extensions;
+using Elsa.Testing.Shared.AutoFixture.Customizations;
+using Microsoft.Extensions.DependencyInjection;
+using Elsa.Persistence.EntityFramework.Core.Extensions;
+using Microsoft.EntityFrameworkCore;
+using Elsa.Persistence.EntityFramework.Sqlite;
+using Elsa.Persistence.YesSql;
+using YesSql.Provider.Sqlite;
+using System.Data;
+
+namespace Elsa.Core.IntegrationTests.Autofixture
+{
+    public class HostBuilderWithDuplicateActivitiesWorkflowAttribute : CustomizeAttribute
+    {
+        public override ICustomization GetCustomization(ParameterInfo parameter)
+        {
+            return new HostBubilderUsingServicesCustomization(services => {
+                services
+                    .AddElsa(elsa => {
+                        elsa.AddWorkflow<DuplicateActivitiesWorkflow>();
+                    });
+            }, parameter);
+        }
+    }
+
+    public class HostBuilderWithDuplicateActivitiesWorkflowAndMongoDbAttribute : CustomizeAttribute
+    {
+        public override ICustomization GetCustomization(ParameterInfo parameter)
+        {
+            return new HostBubilderUsingServicesCustomization(services => {
+                services
+                    .AddElsa(elsa => {
+                        elsa.AddWorkflow<DuplicateActivitiesWorkflow>();
+                        elsa.UseMongoDbPersistence(opts => {
+                            opts.ConnectionString = "mongodb://localhost:27017";
+                            opts.DatabaseName = "IntegrationTests";
+                        });
+                    });
+            }, parameter);
+        }
+    }
+
+    public class HostBuilderWithDuplicateActivitiesWorkflowAndEntityFrameworkAttribute : CustomizeAttribute
+    {
+        public override ICustomization GetCustomization(ParameterInfo parameter)
+        {
+            return new HostBubilderUsingServicesCustomization(services => {
+                services
+                    .AddElsa(elsa => {
+                        elsa
+                            .AddWorkflow<DuplicateActivitiesWorkflow>()
+                            .UseEntityFrameworkPersistence(opts => {
+                                opts.UseSqlite("Data Source=elsa.db;", db => db.MigrationsAssembly(typeof(SqliteElsaContextFactory).Assembly.GetName().Name));
+                            });
+                    });
+            }, parameter);
+        }
+    }
+
+    public class HostBuilderWithDuplicateActivitiesWorkflowAndYesSqlAttribute : CustomizeAttribute
+    {
+        public override ICustomization GetCustomization(ParameterInfo parameter)
+        {
+            return new HostBubilderUsingServicesCustomization(services => {
+                services
+                    .AddElsa(elsa => {
+                        elsa
+                            .AddWorkflow<DuplicateActivitiesWorkflow>()
+                            .UseYesSqlPersistence(config => {
+                                config.UseSqLite("Data Source=elsa-sqlite.db;", IsolationLevel.ReadUncommitted);
+                            });
+                    });
+            }, parameter);
+        }
+    }
+}

--- a/test/integration/Elsa.Core.IntegrationTests/Elsa.Core.IntegrationTests.csproj
+++ b/test/integration/Elsa.Core.IntegrationTests/Elsa.Core.IntegrationTests.csproj
@@ -23,11 +23,12 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="YesSql.Core" Version="2.0.0-beta-1620" />
-        <PackageReference Include="YesSql.Provider.Sqlite" Version="1.0.0-beta-1620" />
+        <PackageReference Include="YesSql.Core" Version="2.0.0-beta-1637" />
+        <PackageReference Include="YesSql.Provider.Sqlite" Version="1.0.0-beta-1637" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
         <PackageReference Include="Hangfire.AspNetCore" Version="1.7.19" />
         <PackageReference Include="Hangfire.InMemory" Version="0.3.4" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.2" />
     </ItemGroup>
 
     <ItemGroup>
@@ -46,6 +47,9 @@
       <ProjectReference Include="..\..\..\src\activities\Elsa.Activities.Temporal.Hangfire\Elsa.Activities.Temporal.Hangfire.csproj" />
       <ProjectReference Include="..\..\..\src\activities\Elsa.Activities.Temporal.Quartz\Elsa.Activities.Temporal.Quartz.csproj" />
       <ProjectReference Include="..\..\..\src\persistence\Elsa.Persistence.MongoDb\Elsa.Persistence.MongoDb.csproj" />
+      <ProjectReference Include="..\..\..\src\persistence\Elsa.Persistence.YesSql\Elsa.Persistence.YesSql.csproj" />
+      <ProjectReference Include="..\..\..\src\persistence\Elsa.Persistence.EntityFramework\Elsa.Persistence.EntityFramework.Core\Elsa.Persistence.EntityFramework.Core.csproj" />
+      <ProjectReference Include="..\..\..\src\persistence\Elsa.Persistence.EntityFramework\Elsa.Persistence.EntityFramework.Sqlite\Elsa.Persistence.EntityFramework.Sqlite.csproj" />
     </ItemGroup>
 
 </Project>

--- a/test/integration/Elsa.Core.IntegrationTests/Persistence/WorkflowMayContainDuplicateActivitiesIntegrationTests.cs
+++ b/test/integration/Elsa.Core.IntegrationTests/Persistence/WorkflowMayContainDuplicateActivitiesIntegrationTests.cs
@@ -1,0 +1,80 @@
+using Xunit;
+using System.Threading.Tasks;
+using Elsa.Core.IntegrationTests.Autofixture;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using System.Threading;
+using Elsa.Services;
+using Elsa.Core.IntegrationTests.Workflows;
+using Elsa.Persistence;
+
+namespace Elsa.Core.IntegrationTests.Persistence
+{
+    public class WorkflowMayContainDuplicateActivitiesIntegrationTests
+    {
+        /* Please note that these tests might not represent _actually desired behaviour_.
+         * The tests do prove that issue #683 is no longer a problem, but it still does not seem logical
+         * that Elsa should want to allow duplicate activity IDs in a Workflow (definition or instance).
+         *
+         * It would be reasonable to remove these tests if they begin to "get in the way".
+         */
+
+        [Theory(DisplayName = "A workflow that contains duplicate activities may be run & persisted to an in-memory store"), AutoMoqData]
+        public async Task ADuplicateActivitiesWorkflowInstanceShouldBeRoundTrippableInMemory([HostBuilderWithDuplicateActivitiesWorkflow] IHostBuilder hostBuilder)
+        {
+            hostBuilder.ConfigureServices((ctx, services) => {
+                services.AddHostedService<HostedWorkflowRunner<DuplicateActivitiesWorkflow>>();
+            });
+            var host = await hostBuilder.StartAsync();
+        }
+
+        [Theory(DisplayName = "A workflow that contains duplicate activities may be run & persisted to an EF Sqlite store"), AutoMoqData]
+        public async Task ADuplicateActivitiesWorkflowInstanceShouldBeRoundTrippableWithEntityFramework([HostBuilderWithDuplicateActivitiesWorkflowAndEntityFramework] IHostBuilder hostBuilder)
+        {
+            hostBuilder.ConfigureServices((ctx, services) => {
+                services.AddHostedService<HostedWorkflowRunner<DuplicateActivitiesWorkflow>>();
+            });
+            var host = await hostBuilder.StartAsync();
+        }
+
+        [Theory(DisplayName = "A workflow that contains duplicate activities may be run & persisted to a MongoDb store"), AutoMoqData]
+        public async Task ADuplicateActivitiesWorkflowInstanceShouldBeRoundTrippableWithMongoDb([HostBuilderWithDuplicateActivitiesWorkflowAndMongoDb] IHostBuilder hostBuilder)
+        {
+            hostBuilder.ConfigureServices((ctx, services) => {
+                services.AddHostedService<HostedWorkflowRunner<DuplicateActivitiesWorkflow>>();
+            });
+            var host = await hostBuilder.StartAsync();
+        }
+
+        [Theory(DisplayName = "A workflow that contains duplicate activities may be run & persisted to a YesSQL store"), AutoMoqData]
+        public async Task ADuplicateActivitiesWorkflowInstanceShouldBeRoundTrippableWithYesSql([HostBuilderWithDuplicateActivitiesWorkflowAndYesSql] IHostBuilder hostBuilder)
+        {
+            hostBuilder.ConfigureServices((ctx, services) => {
+                services.AddHostedService<HostedWorkflowRunner<DuplicateActivitiesWorkflow>>();
+            });
+            var host = await hostBuilder.StartAsync();
+        }
+
+        class HostedWorkflowRunner<TWorkflow> : IHostedService where TWorkflow : DuplicateActivitiesWorkflow
+        {
+            readonly IWorkflowRunner workflowRunner;
+            readonly IWorkflowInstanceStore instanceStore;
+
+            public async Task StartAsync(CancellationToken cancellationToken)
+            {
+                var instance = await workflowRunner.RunWorkflowAsync<TWorkflow>();
+                var retrievedInstance = await instanceStore.FindByIdAsync(instance.Id);
+
+                Assert.NotNull(retrievedInstance);
+            }
+
+            public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+            public HostedWorkflowRunner(IWorkflowRunner workflowRunner, IWorkflowInstanceStore instanceStore)
+            {
+                this.workflowRunner = workflowRunner ?? throw new System.ArgumentNullException(nameof(workflowRunner));
+                this.instanceStore = instanceStore ?? throw new System.ArgumentNullException(nameof(instanceStore));
+            }
+        }
+    }
+}

--- a/test/integration/Elsa.Core.IntegrationTests/Workflows/DuplicateActivitiesWorkflow.cs
+++ b/test/integration/Elsa.Core.IntegrationTests/Workflows/DuplicateActivitiesWorkflow.cs
@@ -1,0 +1,19 @@
+using Elsa.Activities.Primitives;
+using Elsa.Builders;
+
+namespace Elsa.Core.IntegrationTests.Workflows
+{
+    public class DuplicateActivitiesWorkflow : IWorkflow
+    {
+        const string duplicateId = "Duplicate";
+
+        public static readonly object Result = new object();
+
+        public virtual void Build(IWorkflowBuilder builder)
+        {
+            builder
+                .StartWith<SetVariable>(a => a.Set(x => x.VariableName, "Unused").Set(x => x.Value, "Unused").Set(x => x.Id, duplicateId))
+                .Then<SetVariable>(a => a.Set(x => x.VariableName, "AlsoUnused").Set(x => x.Value, "Unused").Set(x => x.Id, duplicateId));
+        }
+    }
+}


### PR DESCRIPTION
As noted in the discussion for #683 - the issue is no longer relevant as-reported.  There might be some further consideration to be had as to _whether or not we truly wish to permit duplicate activity IDs_, but that is a conversation which does not necessarily need to happen right now.