### PR TITLE
Activity Property Categories

### DIFF
--- a/Elsa.sln
+++ b/Elsa.sln
@@ -155,7 +155,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ElsaDashboard.Backend", "sr
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ElsaDashboard.WebAssembly", "src\dashboards\blazor\ElsaDashboard.WebAssembly\ElsaDashboard.WebAssembly.csproj", "{0AA2A003-C79E-4B43-803E-E1150254D2B0}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "timers", "timers", "{37D2E628-5CC1-4C8E-8C02-3B0A29E2ACAA}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "temporal", "temporal", "{37D2E628-5CC1-4C8E-8C02-3B0A29E2ACAA}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Elsa.Activities.Temporal.Quartz", "src\activities\Elsa.Activities.Temporal.Quartz\Elsa.Activities.Temporal.Quartz.csproj", "{08D9CB18-2BFB-4CF2-9763-5EE913F56D3E}"
 EndProject

--- a/src/activities/Elsa.Activities.Http/Activities/HttpEndpoint/HttpEndpoint.cs
+++ b/src/activities/Elsa.Activities.Http/Activities/HttpEndpoint/HttpEndpoint.cs
@@ -57,7 +57,7 @@ namespace Elsa.Activities.Http
         /// The <see cref="Type"/> to parse the received request content into if <seealso cref="ReadContent"/> is set to true.
         /// If not set, the content will be parse into a default type, depending on the parser associated with the received content-type header.
         /// </summary>
-        [ActivityProperty]
+        [ActivityProperty(Category = PropertyCategories.Advanced)]
         public Type? TargetType { get; set; }
 
         protected override async ValueTask<IActivityExecutionResult> OnExecuteAsync(ActivityExecutionContext context) => context.WorkflowExecutionContext.IsFirstPass ? await ExecuteInternalAsync(context.CancellationToken) : Suspend();

--- a/src/activities/Elsa.Activities.Telnyx/Activities/AnswerCall.cs
+++ b/src/activities/Elsa.Activities.Telnyx/Activities/AnswerCall.cs
@@ -25,22 +25,22 @@ namespace Elsa.Activities.Telnyx.Activities
             _telnyxClient = telnyxClient;
         }
 
-        [ActivityProperty(Label = "Call Control ID", Hint = "Unique identifier and token for controlling the call")]
+        [ActivityProperty(Label = "Call Control ID", Hint = "Unique identifier and token for controlling the call", Category = PropertyCategories.Advanced)]
         public string CallControlId { get; set; } = default!;
 
-        [ActivityProperty(Label = "Billing Group ID", Hint = "Use this field to set the Billing Group ID for the call. Must be a valid and existing Billing Group ID.")]
+        [ActivityProperty(Label = "Billing Group ID", Hint = "Use this field to set the Billing Group ID for the call. Must be a valid and existing Billing Group ID.", Category = PropertyCategories.Advanced)]
         public string? BillingGroupId { get; set; }
 
-        [ActivityProperty(Label = "Client State", Hint = "Use this field to add state to every subsequent webhook. It must be a valid Base-64 encoded string.")]
+        [ActivityProperty(Label = "Client State", Hint = "Use this field to add state to every subsequent webhook. It must be a valid Base-64 encoded string.", Category = PropertyCategories.Advanced)]
         public string? ClientState { get; set; }
 
-        [ActivityProperty(Label = "Command ID", Hint = "Use this field to avoid duplicate commands. Telnyx will ignore commands with the same Command ID.")]
+        [ActivityProperty(Label = "Command ID", Hint = "Use this field to avoid duplicate commands. Telnyx will ignore commands with the same Command ID.", Category = PropertyCategories.Advanced)]
         public string? CommandId { get; set; }
 
-        [ActivityProperty(Label = "Webhook URL", Hint = "Use this field to override the URL for which Telnyx will send subsequent webhooks to for this call.")]
+        [ActivityProperty(Label = "Webhook URL", Hint = "Use this field to override the URL for which Telnyx will send subsequent webhooks to for this call.", Category = PropertyCategories.Advanced)]
         public string? WebhookUrl { get; set; }
 
-        [ActivityProperty(Label = "Webhook URL Method", Hint = "HTTP request type used for Webhook URL", UIHint = ActivityPropertyUIHints.Dropdown, Options = new[] { "GET", "POST" })]
+        [ActivityProperty(Label = "Webhook URL Method", Hint = "HTTP request type used for Webhook URL", UIHint = ActivityPropertyUIHints.Dropdown, Options = new[] { "GET", "POST" }, Category = PropertyCategories.Advanced)]
         public string? WebhookUrlMethod { get; set; }
 
         protected override async ValueTask<IActivityExecutionResult> OnExecuteAsync(ActivityExecutionContext context)

--- a/src/activities/Elsa.Activities.Telnyx/Activities/AnswerCall.cs
+++ b/src/activities/Elsa.Activities.Telnyx/Activities/AnswerCall.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Elsa.Activities.Telnyx.Client.Models;
 using Elsa.Activities.Telnyx.Client.Services;
@@ -45,14 +46,15 @@ namespace Elsa.Activities.Telnyx.Activities
 
         protected override async ValueTask<IActivityExecutionResult> OnExecuteAsync(ActivityExecutionContext context)
         {
-            await AnswerCallAsync(context.CancellationToken);
+            await AnswerCallAsync(context);
             return Done();
         }
 
-        private async ValueTask AnswerCallAsync(CancellationToken cancellationToken)
+        private async ValueTask AnswerCallAsync(ActivityExecutionContext context)
         {
+            var callControlId = CallControlId is not null and not "" ? CallControlId : context.CorrelationId ?? throw new InvalidOperationException("Cannot answer call without a call control ID");
             var request = new AnswerCallRequest(BillingGroupId, ClientState, CommandId, WebhookUrl, WebhookUrlMethod);
-            await _telnyxClient.Calls.AnswerCallAsync(CallControlId, request, cancellationToken);
+            await _telnyxClient.Calls.AnswerCallAsync(callControlId, request, context.CancellationToken);
         }
     }
 }

--- a/src/activities/Elsa.Activities.Telnyx/Activities/GatherUsingAudio.cs
+++ b/src/activities/Elsa.Activities.Telnyx/Activities/GatherUsingAudio.cs
@@ -66,11 +66,11 @@ namespace Elsa.Activities.Telnyx.Activities
 
         protected override async ValueTask<IActivityExecutionResult> OnExecuteAsync(ActivityExecutionContext context)
         {
-            await GatherUsingAudioAsync(context.CancellationToken);
+            await GatherUsingAudioAsync(context);
             return Done();
         }
 
-        private async ValueTask GatherUsingAudioAsync(CancellationToken cancellationToken)
+        private async ValueTask GatherUsingAudioAsync(ActivityExecutionContext context)
         {
             var request = new GatherUsingAudioRequest(
                 AudioUrl,
@@ -85,10 +85,12 @@ namespace Elsa.Activities.Telnyx.Activities
                 TimeoutMillis,
                 EmptyToNull(ValidDigits)
             );
+            
+            var callControlId = CallControlId is not null and not "" ? CallControlId : context.CorrelationId ?? throw new InvalidOperationException("Cannot answer call without a call control ID");
 
             try
             {
-                await _telnyxClient.Calls.GatherUsingAudiAsync(CallControlId, request, cancellationToken);
+                await _telnyxClient.Calls.GatherUsingAudiAsync(callControlId, request, context.CancellationToken);
             }
             catch (ApiException e)
             {

--- a/src/activities/Elsa.Activities.Telnyx/Activities/GatherUsingAudio.cs
+++ b/src/activities/Elsa.Activities.Telnyx/Activities/GatherUsingAudio.cs
@@ -5,6 +5,7 @@ using Elsa.Activities.Telnyx.Client.Models;
 using Elsa.Activities.Telnyx.Client.Services;
 using Elsa.ActivityResults;
 using Elsa.Attributes;
+using Elsa.Design;
 using Elsa.Exceptions;
 using Elsa.Services;
 using Elsa.Services.Models;
@@ -27,25 +28,25 @@ namespace Elsa.Activities.Telnyx.Activities
             _telnyxClient = telnyxClient;
         }
 
-        [ActivityProperty(Label = "Call Control ID", Hint = "Unique identifier and token for controlling the call")]
+        [ActivityProperty(Label = "Call Control ID", Hint = "Unique identifier and token for controlling the call", Category = PropertyCategories.Advanced)]
         public string CallControlId { get; set; } = default!;
 
         [ActivityProperty(Label = "Audio URL", Hint = "The URL of a file to be played back at the beginning of each prompt. The URL can point to either a WAV or MP3 file.")]
         public Uri AudioUrl { get; set; } = default!;
 
-        [ActivityProperty(Label = "Client State", Hint = "Use this field to add state to every subsequent webhook. It must be a valid Base-64 encoded string.")]
+        [ActivityProperty(Label = "Client State", Hint = "Use this field to add state to every subsequent webhook. It must be a valid Base-64 encoded string.", Category = PropertyCategories.Advanced)]
         public string? ClientState { get; set; }
 
-        [ActivityProperty(Label = "Command ID", Hint = "Use this field to avoid duplicate commands. Telnyx will ignore commands with the same Command ID.")]
+        [ActivityProperty(Label = "Command ID", Hint = "Use this field to avoid duplicate commands. Telnyx will ignore commands with the same Command ID.", Category = PropertyCategories.Advanced)]
         public string? CommandId { get; set; }
 
-        [ActivityProperty(Label = "Inter Digit Timeout", Hint = "The number of milliseconds to wait for input between digits.")]
+        [ActivityProperty(Label = "Inter Digit Timeout", Hint = "The number of milliseconds to wait for input between digits.", Category = PropertyCategories.Advanced)]
         public int? InterDigitTimeoutMillis { get; set; } = 5000;
 
         [ActivityProperty(Label = "Invalid Audio Url", Hint = "The URL of a file to play when digits don't match the Valid Digits setting or the number of digits is not between Min and Max. The URL can point to either a WAV or MP3 file.")]
         public Uri? InvalidAudioUrl { get; set; }
 
-        [ActivityProperty(Label = "Valid Digits", Hint = "A list of all digits accepted as valid.")]
+        [ActivityProperty(Label = "Valid Digits", Hint = "A list of all digits accepted as valid.", Category = PropertyCategories.Advanced)]
         public string? ValidDigits { get; set; } = "0123456789#*";
 
         [ActivityProperty(Label = "Minimum Digits", Hint = "The minimum number of digits to fetch. This parameter has a minimum value of 1.")]
@@ -60,7 +61,7 @@ namespace Elsa.Activities.Telnyx.Activities
         [ActivityProperty(Label = "Terminating Digit", Hint = "The digit used to terminate input if fewer than `maximum_digits` digits have been gathered.")]
         public string? TerminatingDigit { get; set; } = "#";
 
-        [ActivityProperty(Label = "Timeout", Hint = "The number of milliseconds to wait for a DTMF response after file playback ends before a replaying the sound file.")]
+        [ActivityProperty(Label = "Timeout", Hint = "The number of milliseconds to wait for a DTMF response after file playback ends before a replaying the sound file.", Category = PropertyCategories.Advanced)]
         public int? TimeoutMillis { get; set; } = 60000;
 
         protected override async ValueTask<IActivityExecutionResult> OnExecuteAsync(ActivityExecutionContext context)

--- a/src/activities/Elsa.Activities.Telnyx/Activities/HangupCall.cs
+++ b/src/activities/Elsa.Activities.Telnyx/Activities/HangupCall.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Elsa.Activities.Telnyx.Client.Models;
 using Elsa.Activities.Telnyx.Client.Services;
@@ -38,17 +39,18 @@ namespace Elsa.Activities.Telnyx.Activities
 
         protected override async ValueTask<IActivityExecutionResult> OnExecuteAsync(ActivityExecutionContext context)
         {
-            await HangupCallAsync(context.CancellationToken);
+            await HangupCallAsync(context);
             return Done();
         }
 
-        private async ValueTask HangupCallAsync(CancellationToken cancellationToken)
+        private async ValueTask HangupCallAsync(ActivityExecutionContext context)
         {
+            var callControlId = CallControlId is not null and not "" ? CallControlId : context.CorrelationId ?? throw new InvalidOperationException("Cannot answer call without a call control ID");
             var request = new HangupCallRequest(ClientState, CommandId);
             
             try
             {
-                await _telnyxClient.Calls.HangupCallAsync(CallControlId, request, cancellationToken);
+                await _telnyxClient.Calls.HangupCallAsync(callControlId, request, context.CancellationToken);
             }
             catch (ApiException e)
             {

--- a/src/activities/Elsa.Activities.Telnyx/Activities/HangupCall.cs
+++ b/src/activities/Elsa.Activities.Telnyx/Activities/HangupCall.cs
@@ -4,6 +4,7 @@ using Elsa.Activities.Telnyx.Client.Models;
 using Elsa.Activities.Telnyx.Client.Services;
 using Elsa.ActivityResults;
 using Elsa.Attributes;
+using Elsa.Design;
 using Elsa.Exceptions;
 using Elsa.Services;
 using Elsa.Services.Models;
@@ -26,13 +27,13 @@ namespace Elsa.Activities.Telnyx.Activities
             _telnyxClient = telnyxClient;
         }
 
-        [ActivityProperty(Label = "Call Control ID", Hint = "Unique identifier and token for controlling the call")]
+        [ActivityProperty(Label = "Call Control ID", Hint = "Unique identifier and token for controlling the call", Category = PropertyCategories.Advanced)]
         public string CallControlId { get; set; } = default!;
         
-        [ActivityProperty(Label = "Client State", Hint = "Use this field to add state to every subsequent webhook. It must be a valid Base-64 encoded string.")]
+        [ActivityProperty(Label = "Client State", Hint = "Use this field to add state to every subsequent webhook. It must be a valid Base-64 encoded string.", Category = PropertyCategories.Advanced)]
         public string? ClientState { get; set; }
 
-        [ActivityProperty(Label = "Command ID", Hint = "Use this field to avoid duplicate commands. Telnyx will ignore commands with the same Command ID.")]
+        [ActivityProperty(Label = "Command ID", Hint = "Use this field to avoid duplicate commands. Telnyx will ignore commands with the same Command ID.", Category = PropertyCategories.Advanced)]
         public string? CommandId { get; set; }
 
         protected override async ValueTask<IActivityExecutionResult> OnExecuteAsync(ActivityExecutionContext context)

--- a/src/activities/Elsa.Activities.Telnyx/Activities/TransferCall.cs
+++ b/src/activities/Elsa.Activities.Telnyx/Activities/TransferCall.cs
@@ -86,11 +86,11 @@ namespace Elsa.Activities.Telnyx.Activities
 
         protected override async ValueTask<IActivityExecutionResult> OnExecuteAsync(ActivityExecutionContext context)
         {
-            await TransferCallAsync(context.CancellationToken);
+            await TransferCallAsync(context);
             return Done();
         }
 
-        private async ValueTask TransferCallAsync(CancellationToken cancellationToken)
+        private async ValueTask TransferCallAsync(ActivityExecutionContext context)
         {
             var request = new TransferCallRequest(
                 To,
@@ -111,9 +111,11 @@ namespace Elsa.Activities.Telnyx.Activities
                 WebhookUrlMethod
             );
 
+            var callControlId = CallControlId is not null and not "" ? CallControlId : context.CorrelationId ?? throw new InvalidOperationException("Cannot answer call without a call control ID");
+            
             try
             {
-                await _telnyxClient.Calls.TransferCallAsync(CallControlId, request, cancellationToken);
+                await _telnyxClient.Calls.TransferCallAsync(callControlId, request, context.CancellationToken);
             }
             catch (ApiException e)
             {

--- a/src/activities/Elsa.Activities.Telnyx/Activities/TransferCall.cs
+++ b/src/activities/Elsa.Activities.Telnyx/Activities/TransferCall.cs
@@ -29,7 +29,7 @@ namespace Elsa.Activities.Telnyx.Activities
             _telnyxClient = telnyxClient;
         }
 
-        [ActivityProperty(Label = "Call Control ID", Hint = "Unique identifier and token for controlling the call.")]
+        [ActivityProperty(Label = "Call Control ID", Hint = "Unique identifier and token for controlling the call.", Category = PropertyCategories.Advanced)]
         public string CallControlId { get; set; } = default!;
 
         [ActivityProperty(Label = "To", Hint = "The DID or SIP URI to dial out and bridge to the given call.")]
@@ -48,40 +48,40 @@ namespace Elsa.Activities.Telnyx.Activities
             Options = new[] { "disabled", "detect", "detect_beep", "detect_words", "greeting_end" })]
         public string? AnsweringMachineDetection { get; set; }
 
-        [ActivityProperty(Label = "Answering Machine Detection Configuration", Hint = "Optional configuration parameters to modify answering machine detection performance.")]
+        [ActivityProperty(Label = "Answering Machine Detection Configuration", Hint = "Optional configuration parameters to modify answering machine detection performance.", Category = PropertyCategories.Advanced)]
         public AnsweringMachineConfig? AnsweringMachineDetectionConfig { get; set; }
 
-        [ActivityProperty(Label = "Command ID", Hint = "Use this field to avoid duplicate commands. Telnyx will ignore commands with the same Command ID.")]
+        [ActivityProperty(Label = "Command ID", Hint = "Use this field to avoid duplicate commands. Telnyx will ignore commands with the same Command ID.", Category = PropertyCategories.Advanced)]
         public string? CommandId { get; set; }
 
         [ActivityProperty(Label = "Audio URL", Hint = "Audio URL to be played back when the transfer destination answers before bridging the call. The URL can point to either a WAV or MP3 file.")]
         public Uri? AudioUrl { get; set; }
 
-        [ActivityProperty(Label = "Client State", Hint = "Use this field to add state to every subsequent webhook. It must be a valid Base-64 encoded string.")]
+        [ActivityProperty(Label = "Client State", Hint = "Use this field to add state to every subsequent webhook. It must be a valid Base-64 encoded string.", Category = PropertyCategories.Advanced)]
         public string? ClientState { get; set; }
 
-        [ActivityProperty(Label = "Target Leg Client State", Hint = "Use this field to add state to every subsequent webhook for the new leg. It must be a valid Base-64 encoded string.")]
+        [ActivityProperty(Label = "Target Leg Client State", Hint = "Use this field to add state to every subsequent webhook for the new leg. It must be a valid Base-64 encoded string.", Category = PropertyCategories.Advanced)]
         public string? TargetLegClientState { get; set; }
 
-        [ActivityProperty(Label = "Custom Headers", Hint = "Custom headers to be added to the SIP INVITE.")]
+        [ActivityProperty(Label = "Custom Headers", Hint = "Custom headers to be added to the SIP INVITE.", Category = PropertyCategories.Advanced)]
         public IList<Header>? CustomHeaders { get; set; }
 
-        [ActivityProperty(Label = "SIP Authentication Username", Hint = "SIP Authentication username used for SIP challenges.")]
+        [ActivityProperty(Label = "SIP Authentication Username", Hint = "SIP Authentication username used for SIP challenges.", Category = "SIP Authentication")]
         public string? SipAuthUsername { get; set; }
 
-        [ActivityProperty(Label = "SIP Authentication Password", Hint = "SIP Authentication password used for SIP challenges.")]
+        [ActivityProperty(Label = "SIP Authentication Password", Hint = "SIP Authentication password used for SIP challenges.", Category = "SIP Authentication")]
         public string? SipAuthPassword { get; set; }
 
-        [ActivityProperty(Label = "Time Limit", Hint = "Sets the maximum duration of a Call Control Leg in seconds.")]
+        [ActivityProperty(Label = "Time Limit", Hint = "Sets the maximum duration of a Call Control Leg in seconds.", Category = PropertyCategories.Advanced)]
         public int? TimeLimitSecs { get; set; }
 
-        [ActivityProperty(Label = "Timeout", Hint = "The number of seconds that Telnyx will wait for the call to be answered by the destination to which it is being transferred.")]
+        [ActivityProperty(Label = "Timeout", Hint = "The number of seconds that Telnyx will wait for the call to be answered by the destination to which it is being transferred.", Category = PropertyCategories.Advanced)]
         public int? TimeoutSecs { get; set; }
 
-        [ActivityProperty(Label = "Webhook URL", Hint = "Use this field to override the URL for which Telnyx will send subsequent webhooks to for this call.")]
+        [ActivityProperty(Label = "Webhook URL", Hint = "Use this field to override the URL for which Telnyx will send subsequent webhooks to for this call.", Category = PropertyCategories.Advanced)]
         public string? WebhookUrl { get; set; }
 
-        [ActivityProperty(Label = "Webhook URL Method", Hint = "HTTP request type used for Webhook URL", UIHint = ActivityPropertyUIHints.Dropdown, Options = new[] { "GET", "POST" })]
+        [ActivityProperty(Label = "Webhook URL Method", Hint = "HTTP request type used for Webhook URL", UIHint = ActivityPropertyUIHints.Dropdown, Options = new[] { "GET", "POST" }, Category = PropertyCategories.Advanced)]
         public string? WebhookUrlMethod { get; set; }
 
         protected override async ValueTask<IActivityExecutionResult> OnExecuteAsync(ActivityExecutionContext context)

--- a/src/clients/Elsa.Client/Models/ActivityPropertyDescriptor.cs
+++ b/src/clients/Elsa.Client/Models/ActivityPropertyDescriptor.cs
@@ -11,5 +11,6 @@ namespace Elsa.Client.Models
         [DataMember(Order = 3)] public string? Label { get; set; }
         [DataMember(Order = 4)] public string? Hint { get; set; }
         [DataMember(Order = 5)] public JToken? Options { get; set; }
+        [DataMember(Order = 6)] public string? Category { get; set; }
     }
 }

--- a/src/core/Elsa.Abstractions/Attributes/ActivityPropertyAttribute.cs
+++ b/src/core/Elsa.Abstractions/Attributes/ActivityPropertyAttribute.cs
@@ -34,5 +34,10 @@ namespace Elsa.Attributes
         /// The name of a static method that provides options.
         /// </summary>
         public Type? OptionsProvider { get; set; }
+
+        /// <summary>
+        /// A category to group this property with.
+        /// </summary>
+        public string? Category { get; set; }
     }
 }

--- a/src/core/Elsa.Abstractions/Design/PropertyCategories.cs
+++ b/src/core/Elsa.Abstractions/Design/PropertyCategories.cs
@@ -1,0 +1,7 @@
+﻿namespace Elsa.Design
+{
+    public static class PropertyCategories
+    {
+        public const string Advanced = "Advanced";
+    }
+}

--- a/src/core/Elsa.Abstractions/Metadata/ActivityPropertyDescriptor.cs
+++ b/src/core/Elsa.Abstractions/Metadata/ActivityPropertyDescriptor.cs
@@ -6,13 +6,14 @@ namespace Elsa.Metadata
         {
         }
 
-        public ActivityPropertyDescriptor(string name, string uiHint, string label, string? hint, object? options)
+        public ActivityPropertyDescriptor(string name, string uiHint, string label, string? hint, object? options, string category)
         {
             Name = name;
             UIHint = uiHint;
             Label = label;
             Hint = hint;
             Options = options;
+            Category = category;
         }
         
         public string Name { get; set; } = default!;
@@ -20,5 +21,6 @@ namespace Elsa.Metadata
         public string Label { get; set; } = default!;
         public string? Hint { get; set; }
         public object? Options { get; set; }
+        public string? Category { get; set; }
     }
 }

--- a/src/core/Elsa.Core/Metadata/TypedActivityTypeDescriber.cs
+++ b/src/core/Elsa.Core/Metadata/TypedActivityTypeDescriber.cs
@@ -58,7 +58,8 @@ namespace Elsa.Metadata
                     _uiHintResolver.GetUIHint(propertyInfo),
                     activityPropertyAttribute.Label ?? propertyInfo.Name.Humanize(LetterCasing.Title),
                     activityPropertyAttribute.Hint,
-                    _optionsResolver.GetOptions(propertyInfo)
+                    _optionsResolver.GetOptions(propertyInfo),
+                    activityPropertyAttribute.Category
                 );
             }
         }

--- a/src/dashboards/blazor/ElsaDashboard.Shared/Surrogates/ActivityPropertyDescriptorSurrogate.cs
+++ b/src/dashboards/blazor/ElsaDashboard.Shared/Surrogates/ActivityPropertyDescriptorSurrogate.cs
@@ -1,8 +1,6 @@
 using Elsa.Client.Models;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using NodaTime;
-using NodaTime.Serialization.JsonNet;
 using ProtoBuf;
 
 namespace ElsaDashboard.Shared.Surrogates
@@ -10,17 +8,6 @@ namespace ElsaDashboard.Shared.Surrogates
     [ProtoContract(IgnoreListHandling = true)]
     public class ActivityPropertyDescriptorSurrogate
     {
-        private static readonly JsonSerializerSettings SerializerSettings;
-
-        static ActivityPropertyDescriptorSurrogate()
-        {
-            SerializerSettings = new JsonSerializerSettings().ConfigureForNodaTime(DateTimeZoneProviders.Tzdb);
-        }
-
-        public ActivityPropertyDescriptorSurrogate()
-        {
-        }
-
         public ActivityPropertyDescriptorSurrogate(ActivityPropertyDescriptor value)
         {
             Name = value.Name;
@@ -28,6 +15,7 @@ namespace ElsaDashboard.Shared.Surrogates
             Label = value.Label;
             Hint = value.Hint;
             Options = value.Options?.ToString(Formatting.None);
+            Category = value.Category;
         }
 
         [ProtoMember(1)] public string? Name { get; }
@@ -35,6 +23,7 @@ namespace ElsaDashboard.Shared.Surrogates
         [ProtoMember(3)] public string? Label { get; }
         [ProtoMember(4)] public string? Hint { get; }
         [ProtoMember(5)] public string? Options { get; }
+        [ProtoMember(6)] public string? Category { get; }
 
         public static implicit operator ActivityPropertyDescriptor?(ActivityPropertyDescriptorSurrogate? surrogate) =>
             surrogate != null
@@ -44,7 +33,8 @@ namespace ElsaDashboard.Shared.Surrogates
                     UIHint = surrogate.Type!,
                     Hint = surrogate.Hint,
                     Label = surrogate.Label,
-                    Options = surrogate.Options is null or "" ? default : JToken.Parse(surrogate.Options) 
+                    Options = surrogate.Options is null or "" ? default : JToken.Parse(surrogate.Options),
+                    Category = surrogate.Category
                 }
                 : default;
 

--- a/src/designer/elsa-workflows-studio/src/components/designers/tree/elsa-designer-tree/elsa-designer-tree.tsx
+++ b/src/designer/elsa-workflows-studio/src/components/designers/tree/elsa-designer-tree/elsa-designer-tree.tsx
@@ -71,10 +71,15 @@ export class ElsaWorkflowDesigner {
     const displayContexts: Map<ActivityDesignDisplayContext> = {};
 
     for (const model of activityModels) {
+
+      const description = model.description;
+      const bodyText = description && description.length > 0 ? description : undefined;
+      const bodyDisplay = bodyText ? <p>{bodyText}</p> : undefined;
+
       const displayContext: ActivityDesignDisplayContext = {
         activityModel: model,
         activityIcon: <ActivityIcon/>,
-        bodyDisplay: null,
+        bodyDisplay: bodyDisplay,
         outcomes: [...model.outcomes]
       };
 

--- a/src/designer/elsa-workflows-studio/src/components/editors/monaco/elsa-monaco/elsa-monaco.tsx
+++ b/src/designer/elsa-workflows-studio/src/components/editors/monaco/elsa-monaco/elsa-monaco.tsx
@@ -45,7 +45,6 @@ export class ElsaMonaco {
       filePath: libUri
     }]);
 
-    //debugger;
     const oldModel = monaco.editor.getModel(libUri);
 
     if (oldModel)
@@ -90,6 +89,7 @@ export class ElsaMonaco {
         minimap: {
           enabled: false
         },
+        automaticLayout: true,
         lineNumbers: "on",
         theme: "vs",
         roundedSelection: true,

--- a/src/designer/elsa-workflows-studio/src/index.html
+++ b/src/designer/elsa-workflows-studio/src/index.html
@@ -14,7 +14,7 @@
 </head>
 <body class="h-screen" style="background-size: 30px 30px; background-image: url(/build/assets/tile.png); background-color: #FBFBFB;">
 
-<elsa-workflow-editor id="workflowEditor" server-url="http://localhost:5000/" workflow-definition-id="7eed1333c2674370a1e9b300aa94fda2" monaco-lib-path="build/assets/js"></elsa-workflow-editor>
+<elsa-workflow-editor id="workflowEditor" server-url="https://localhost:11000/" workflow-definition-id="7eed1333c2674370a1e9b300aa94fda2" monaco-lib-path="build/assets/js"></elsa-workflow-editor>
 
 </body>
 </html>

--- a/src/designer/elsa-workflows-studio/src/models/domain.ts
+++ b/src/designer/elsa-workflows-studio/src/models/domain.ts
@@ -1,23 +1,23 @@
 ﻿import {Map} from '../utils/utils';
 
 export interface WorkflowDefinition {
-  id?: string,
-  definitionId?: string,
-  tenantId?: string,
-  name?: string,
-  displayName?: string,
-  description?: string,
-  version: number,
-  variables?: Variables,
-  customAttributes?: Variables,
-  contextOptions?: WorkflowContextOptions,
-  isSingleton?: boolean,
-  persistenceBehavior?: WorkflowPersistenceBehavior,
-  deleteCompletedInstances?: boolean,
-  isPublished?: boolean,
-  isLatest?: boolean,
-  activities: Array<ActivityDefinition>,
-  connections: Array<ConnectionDefinition>
+  id?: string;
+  definitionId?: string;
+  tenantId?: string;
+  name?: string;
+  displayName?: string;
+  description?: string;
+  version: number;
+  variables?: Variables;
+  customAttributes?: Variables;
+  contextOptions?: WorkflowContextOptions;
+  isSingleton?: boolean;
+  persistenceBehavior?: WorkflowPersistenceBehavior;
+  deleteCompletedInstances?: boolean;
+  isPublished?: boolean;
+  isLatest?: boolean;
+  activities: Array<ActivityDefinition>;
+  connections: Array<ConnectionDefinition>;
 }
 
 export interface ActivityDefinition {
@@ -106,6 +106,7 @@ export interface ActivityPropertyDescriptor {
   label?: string;
   hint?: string;
   options?: any;
+  category?: string;
 }
 
 export enum ActivityTraits {

--- a/src/designer/elsa-workflows-studio/src/plugins/if-plugin.tsx
+++ b/src/designer/elsa-workflows-studio/src/plugins/if-plugin.tsx
@@ -17,6 +17,8 @@ export class IfPlugin implements ElsaPlugin {
     const props = activityModel.properties || [];
     const condition = props.find(x => x.name == 'Condition') || { expression: '' };
     const expression = condition.expression || '';
-    context.bodyDisplay = <p>{expression}</p>;
+    const description = activityModel.description;
+    const bodyText = description && description.length > 0 ? description : expression;
+    context.bodyDisplay = <p>{bodyText}</p>;
   }
 }

--- a/src/designer/elsa-workflows-studio/src/plugins/run-javascript-plugin.tsx
+++ b/src/designer/elsa-workflows-studio/src/plugins/run-javascript-plugin.tsx
@@ -22,7 +22,5 @@ export class RunJavascriptPlugin implements ElsaPlugin {
 
     if(context.outcomes.length == 0)
       context.outcomes = ['Done'];
-
-    context.bodyDisplay = undefined;
   }
 }


### PR DESCRIPTION
This PR adds the ability to group activities properties together by annotating them with a category. The workflow designer can take advantage of this information to display grouped properties under a separate tab. For example, the `HttpEndpoint` activity has a property called `TargetType` which is considered to be an "advanced" setting. Its property now looks like this in code:

```csharp
[ActivityProperty(Category = PropertyCategories.Advanced)]
public Type? TargetType { get; set; }
```

Notice that it now has a category of "Advanced".

The activity editor uses that information to display a separate tab called "Advanced":

![image](https://user-images.githubusercontent.com/938393/111786995-b7939b80-88be-11eb-8d8b-947147697997.png)

When no category is specified, the property appears under the default "Properties" tab.
As an activity developer, you are free to use any string value for activity categories.