### PR TITLE
Method to skip adding core activites automatically.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,10 @@ _ReSharper*/
 [Tt]est[Rr]esult*
 .vs/
 
+# VS Code/Omnisharp crash dumps
+mono_crash.mem*.blob
+
+
 #Nuget packages folder
 packages/
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -121,6 +121,8 @@ deploy:
     on:
       APPVEYOR_REPO_TAG: true
 
-deploy_script:
-  - docker login -u="$env:docker_user" -p="$env:docker_pass"
-  - docker push elsaworkflows/elsadashboard-samples-monolith
+# Docker deployments temporarily disabled due to authentication issue
+# this is causing failing builds.
+#deploy_script:
+#  - docker login -u="$env:docker_user" -p="$env:docker_pass"
+#  - docker push elsaworkflows/elsadashboard-samples-monolith

--- a/src/core/Elsa.Abstractions/Exceptions/CannotSetActivityPropertyValueException.cs
+++ b/src/core/Elsa.Abstractions/Exceptions/CannotSetActivityPropertyValueException.cs
@@ -1,0 +1,16 @@
+namespace Elsa.Exceptions
+{
+    /// <summary>
+    /// Thrown when an error occurs whilst setting a property value into an activity.
+    /// </summary>
+    [System.Serializable]
+    public class CannotSetActivityPropertyValueException : System.Exception
+    {
+        public CannotSetActivityPropertyValueException() { }
+        public CannotSetActivityPropertyValueException(string message) : base(message) { }
+        public CannotSetActivityPropertyValueException(string message, System.Exception inner) : base(message, inner) { }
+        protected CannotSetActivityPropertyValueException(
+            System.Runtime.Serialization.SerializationInfo info,
+            System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
+    }
+}

--- a/src/core/Elsa.Abstractions/Services/ActivityPropertyProviders.cs
+++ b/src/core/Elsa.Abstractions/Services/ActivityPropertyProviders.cs
@@ -1,10 +1,12 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Elsa.Attributes;
+using Elsa.Exceptions;
 using Elsa.Services.Models;
 
 namespace Elsa.Services
@@ -56,8 +58,16 @@ namespace Elsa.Services
                 if (!providers.TryGetValue(property.Name, out var provider))
                     continue;
 
-                var value = await provider.GetValueAsync(activityExecutionContext, cancellationToken);
-                property.SetValue(activity, value);
+                try
+                {
+                    var value = await provider.GetValueAsync(activityExecutionContext, cancellationToken);
+                    property.SetValue(activity, value);
+                }
+                catch(Exception e)
+                {
+                    throw new CannotSetActivityPropertyValueException($@"An exception was thrown whilst setting '{activity?.GetType().Name}.{property.Name}'.
+See the inner exception for further details.", e);
+                }
             }
         }
 

--- a/src/core/Elsa.Core/Activities/ControlFlow/ForEach/ForEachBuilderExtensions.cs
+++ b/src/core/Elsa.Core/Activities/ControlFlow/ForEach/ForEachBuilderExtensions.cs
@@ -25,7 +25,7 @@ namespace Elsa.Activities.ControlFlow
             Action<IOutcomeBuilder> iterate,
             [CallerLineNumber] int lineNumber = default,
             [CallerFilePath] string? sourceFile = default) =>
-            builder.ForEach(activity => activity.Set(x => x.Items, context => items(context).Select(x => (object)x!)), iterate, lineNumber, sourceFile);
+            builder.ForEach(activity => activity.Set(x => x.Items, context => items(context).Select(x => (object)x!).ToList()), iterate, lineNumber, sourceFile);
 
         public static IActivityBuilder ForEach<T>(
             this IBuilder builder,
@@ -41,6 +41,6 @@ namespace Elsa.Activities.ControlFlow
             Action<IOutcomeBuilder> iterate,
             [CallerLineNumber] int lineNumber = default,
             [CallerFilePath] string? sourceFile = default) =>
-            builder.ForEach(activity => activity.Set(x => x.Items, items.Select(x => (object)x!)), iterate, lineNumber, sourceFile);
+            builder.ForEach(activity => activity.Set(x => x.Items, items.Select(x => (object)x!).ToList()), iterate, lineNumber, sourceFile);
     }
 }

--- a/src/core/Elsa.Core/ElsaOptions.cs
+++ b/src/core/Elsa.Core/ElsaOptions.cs
@@ -77,7 +77,14 @@ namespace Elsa
         internal Action<IServiceProvider, JsonSerializer> JsonSerializerConfigurer { get; private set; }
         internal Action AddAutoMapper { get; private set; }
         internal Action<ServiceBusEndpointConfigurationContext> ConfigureServiceBusEndpoint { get; private set; }
-        
+        internal bool WithCoreActivities { get; private set; } = true;
+
+        public ElsaOptions NoCoreActivities()
+        {
+            WithCoreActivities = false;
+            return this;
+        }
+
         public ElsaOptions AddActivity<T>() where T : IActivity => AddActivity(typeof(T));
 
         public ElsaOptions AddActivity(Type activityType)

--- a/src/core/Elsa.Core/Extensions/ElsaServiceCollectionExtensions.cs
+++ b/src/core/Elsa.Core/Extensions/ElsaServiceCollectionExtensions.cs
@@ -191,8 +191,13 @@ namespace Microsoft.Extensions.DependencyInjection
             return options;
         }
 
-        private static ElsaOptions AddCoreActivities(this ElsaOptions services) => services
-            .AddActivitiesFrom<ElsaOptions>()
-            .AddActivitiesFrom<CompositeActivity>();
+        private static ElsaOptions AddCoreActivities(this ElsaOptions services)
+        {
+            if (services.WithCoreActivities)
+                return services
+                    .AddActivitiesFrom<ElsaOptions>()
+                    .AddActivitiesFrom<CompositeActivity>();
+            return services;
+        }
     }
 }


### PR DESCRIPTION
As discussed in https://github.com/elsa-workflows/elsa-core/discussions/802 added method to options called `NoCoreActivities()` , this enables user of Elsa to easily control which of the core activities will be available. 

For example, to have only SetVariable activity:
`
            services

                .AddElsa(options => options

                    .NoCoreActivities()

                    .UseEntityFrameworkPersistence(ef => ef.UseSqlite())

                    .AddActivity<Elsa.Activities.Primitives.SetVariable>()

                );
`