### PR TITLE
Fix build failure: ForEachWorkflowTests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,10 @@ _ReSharper*/
 [Tt]est[Rr]esult*
 .vs/
 
+# VS Code/Omnisharp crash dumps
+mono_crash.mem*.blob
+
+
 #Nuget packages folder
 packages/
 

--- a/src/core/Elsa.Abstractions/Exceptions/CannotSetActivityPropertyValueException.cs
+++ b/src/core/Elsa.Abstractions/Exceptions/CannotSetActivityPropertyValueException.cs
@@ -1,0 +1,16 @@
+namespace Elsa.Exceptions
+{
+    /// <summary>
+    /// Thrown when an error occurs whilst setting a property value into an activity.
+    /// </summary>
+    [System.Serializable]
+    public class CannotSetActivityPropertyValueException : System.Exception
+    {
+        public CannotSetActivityPropertyValueException() { }
+        public CannotSetActivityPropertyValueException(string message) : base(message) { }
+        public CannotSetActivityPropertyValueException(string message, System.Exception inner) : base(message, inner) { }
+        protected CannotSetActivityPropertyValueException(
+            System.Runtime.Serialization.SerializationInfo info,
+            System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
+    }
+}

--- a/src/core/Elsa.Abstractions/Services/ActivityPropertyProviders.cs
+++ b/src/core/Elsa.Abstractions/Services/ActivityPropertyProviders.cs
@@ -1,10 +1,12 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Elsa.Attributes;
+using Elsa.Exceptions;
 using Elsa.Services.Models;
 
 namespace Elsa.Services
@@ -56,8 +58,16 @@ namespace Elsa.Services
                 if (!providers.TryGetValue(property.Name, out var provider))
                     continue;
 
-                var value = await provider.GetValueAsync(activityExecutionContext, cancellationToken);
-                property.SetValue(activity, value);
+                try
+                {
+                    var value = await provider.GetValueAsync(activityExecutionContext, cancellationToken);
+                    property.SetValue(activity, value);
+                }
+                catch(Exception e)
+                {
+                    throw new CannotSetActivityPropertyValueException($@"An exception was thrown whilst setting '{activity?.GetType().Name}.{property.Name}'.
+See the inner exception for further details.", e);
+                }
             }
         }
 

--- a/src/core/Elsa.Core/Activities/ControlFlow/ForEach/ForEachBuilderExtensions.cs
+++ b/src/core/Elsa.Core/Activities/ControlFlow/ForEach/ForEachBuilderExtensions.cs
@@ -25,7 +25,7 @@ namespace Elsa.Activities.ControlFlow
             Action<IOutcomeBuilder> iterate,
             [CallerLineNumber] int lineNumber = default,
             [CallerFilePath] string? sourceFile = default) =>
-            builder.ForEach(activity => activity.Set(x => x.Items, context => items(context).Select(x => (object)x!)), iterate, lineNumber, sourceFile);
+            builder.ForEach(activity => activity.Set(x => x.Items, context => items(context).Select(x => (object)x!).ToList()), iterate, lineNumber, sourceFile);
 
         public static IActivityBuilder ForEach<T>(
             this IBuilder builder,
@@ -41,6 +41,6 @@ namespace Elsa.Activities.ControlFlow
             Action<IOutcomeBuilder> iterate,
             [CallerLineNumber] int lineNumber = default,
             [CallerFilePath] string? sourceFile = default) =>
-            builder.ForEach(activity => activity.Set(x => x.Items, items.Select(x => (object)x!)), iterate, lineNumber, sourceFile);
+            builder.ForEach(activity => activity.Set(x => x.Items, items.Select(x => (object)x!).ToList()), iterate, lineNumber, sourceFile);
     }
 }


### PR DESCRIPTION
It seems that some work done in these commits, for the
file `ForEachBuilderExtensions` was responsible:
* 4807ace13c54f7395e322cd81e7395163e9f2b9c
* dfbba1e1762c870da1b6c258daed8a7cfc5e5423

A couple of the extension methods were missing out a `ToList()`
which later caused an `ArgumentException` when setting a property
value via reflection.

I also added an extra exception for the set-value logic.  This way,
if/when there is a problem, the exception will indicate which property
it was trying to set at the time.