### PR TITLE
Temporarily disable docker deployment

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -121,6 +121,8 @@ deploy:
     on:
       APPVEYOR_REPO_TAG: true
 
-deploy_script:
-  - docker login -u="$env:docker_user" -p="$env:docker_pass"
-  - docker push elsaworkflows/elsadashboard-samples-monolith
+# Docker deployments temporarily disabled due to authentication issue
+# this is causing failing builds.
+#deploy_script:
+#  - docker login -u="$env:docker_user" -p="$env:docker_pass"
+#  - docker push elsaworkflows/elsadashboard-samples-monolith


### PR DESCRIPTION
It looks like the docker credentials are incorrect, because
builds are failing with an auth problem.  For example build 2.0.0-preview7.1704:
  https://ci.appveyor.com/project/sfmskywalker/elsa/builds/38438996#L6715

This can be re-enabled once the auth issue is fixed.  There should be
no real harm in disabling it, since it's not working at the moment anyway.