### PR TITLE
Fix plain object result converter for same object type

### DIFF
--- a/src/scripting/Elsa.Scripting.JavaScript/Services/PlainObjectResultConverter.cs
+++ b/src/scripting/Elsa.Scripting.JavaScript/Services/PlainObjectResultConverter.cs
@@ -11,6 +11,9 @@ namespace Elsa.Scripting.JavaScript.Services
             if(desiredType == typeof(object))
                 return evaluationResult;
 
+            if (evaluationResult.GetType() == desiredType || desiredType.IsAssignableFrom(evaluationResult.GetType()))
+                return evaluationResult;
+
             return wrapped.ConvertToDesiredType(evaluationResult, desiredType);
         }
 


### PR DESCRIPTION
Add capability to handle "it was already the right type"