### PR TITLE
Fix to support Interfaces as MassTransit messages

### DIFF
--- a/src/activities/Elsa.Activities.MassTransit/Activities/ReceiveMassTransitMessage/ReceiveMassTransitMessage.cs
+++ b/src/activities/Elsa.Activities.MassTransit/Activities/ReceiveMassTransitMessage/ReceiveMassTransitMessage.cs
@@ -17,7 +17,7 @@ namespace Elsa.Activities.MassTransit
         [ActivityProperty(Hint = "The assembly-qualified type name of the message to receive.")]
         public Type? MessageType { get; set; }
 
-        protected override bool OnCanExecute(ActivityExecutionContext context) => context.Input?.GetType() == MessageType;
+        protected override bool OnCanExecute(ActivityExecutionContext context) => MessageType?.IsAssignableFrom(context.Input?.GetType()) ?? false;
 
         protected override IActivityExecutionResult OnExecute(ActivityExecutionContext context) => context.WorkflowExecutionContext.IsFirstPass ? ExecuteInternal(context) : Suspend();
 

--- a/src/samples/aspnet/Elsa.Samples.MassTransitRabbitMq/Controllers/TriggerMessageController.cs
+++ b/src/samples/aspnet/Elsa.Samples.MassTransitRabbitMq/Controllers/TriggerMessageController.cs
@@ -1,3 +1,4 @@
+using System;
 using MassTransit;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
@@ -31,6 +32,18 @@ namespace Elsa.Samples.MassTransitRabbitMq.Controllers
         {
             var message = new SecondMessage();
             await _publishEndpoint.Publish(message);
+            return Ok();
+        }
+
+        [Route("interface")]
+        [HttpPost]
+        public async Task<IActionResult> TriggerInterface()
+        {
+            var message = new
+            {
+                CorrelationId = Guid.Parse("e9ca46dd-36b9-4fc4-b7db-3bb7190e4488")
+            };
+            await _publishEndpoint.Publish<IInterfaceMessage>(message);
             return Ok();
         }
     }

--- a/src/samples/aspnet/Elsa.Samples.MassTransitRabbitMq/Messages/FirstMessage.cs
+++ b/src/samples/aspnet/Elsa.Samples.MassTransitRabbitMq/Messages/FirstMessage.cs
@@ -6,7 +6,7 @@ namespace Elsa.Samples.MassTransitRabbitMq.Messages
     {    
         public Guid CorrelationId { get; private set; }
 
-        public SecondMessage()
+        public FirstMessage()
         {
             CorrelationId = Guid.Parse("e9ca46dd-36b9-4fc4-b7db-3bb7190e4488");
         }

--- a/src/samples/aspnet/Elsa.Samples.MassTransitRabbitMq/Messages/IInterfaceMessage.cs
+++ b/src/samples/aspnet/Elsa.Samples.MassTransitRabbitMq/Messages/IInterfaceMessage.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Elsa.Samples.MassTransitRabbitMq.Messages
+{
+    public interface IInterfaceMessage
+    {
+        Guid CorrelationId { get; set; }
+    }
+}

--- a/src/samples/aspnet/Elsa.Samples.MassTransitRabbitMq/Messages/SecondMessage.cs
+++ b/src/samples/aspnet/Elsa.Samples.MassTransitRabbitMq/Messages/SecondMessage.cs
@@ -6,7 +6,7 @@ namespace Elsa.Samples.MassTransitRabbitMq.Messages
     {    
         public Guid CorrelationId { get; private set; }
 
-        public FirstMessage()
+        public SecondMessage()
         {
             CorrelationId = Guid.Parse("e9ca46dd-36b9-4fc4-b7db-3bb7190e4488");
         }

--- a/src/samples/aspnet/Elsa.Samples.MassTransitRabbitMq/Startup.cs
+++ b/src/samples/aspnet/Elsa.Samples.MassTransitRabbitMq/Startup.cs
@@ -23,6 +23,7 @@ namespace Elsa.Samples.MassTransitRabbitMq
                     // Add workflow consumer for message
                     x.AddConsumer(CreateWorkflowConsumer(typeof(FirstMessage)));
                     x.AddConsumer(CreateWorkflowConsumer(typeof(SecondMessage)));
+                    x.AddConsumer(CreateWorkflowConsumer(typeof(IInterfaceMessage)));
 
                     // Configure rabbitmq
                     x.UsingRabbitMq((ctx, cfg) =>
@@ -38,6 +39,7 @@ namespace Elsa.Samples.MassTransitRabbitMq
                     .AddConsoleActivities()
                     .AddMassTransitActivities()
                     .AddWorkflow<TestWorkflow>()
+                    .AddWorkflow<InterfaceTestWorkflow>()
                 );
         }
 

--- a/src/samples/aspnet/Elsa.Samples.MassTransitRabbitMq/Workflows/InterfaceTestWorkflow.cs
+++ b/src/samples/aspnet/Elsa.Samples.MassTransitRabbitMq/Workflows/InterfaceTestWorkflow.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Elsa.Activities.Console;
+using Elsa.Activities.MassTransit;
+using Elsa.Builders;
+using Elsa.Samples.MassTransitRabbitMq.Messages;
+
+namespace Elsa.Samples.MassTransitRabbitMq.Workflows
+{
+    public class InterfaceTestWorkflow : IWorkflow
+    {
+        public void Build(IWorkflowBuilder builder)
+        {
+            builder
+                .ReceiveMassTransitMessage(
+                    activity => activity.Set(x => x.MessageType, x => typeof(IInterfaceMessage))
+                )
+                .WriteLine(context => $"Received interface message");
+        }
+    }
+}


### PR DESCRIPTION
With this PR, I will address this issues:

**Use interfaces as messages**
MassTransit strongly suggest to use interfaces as messages (see https://masstransit-project.com/usage/messages.html#messages).
Now, interfaces will implemented using GreenPipes and the given message type will never be the same as the originally defined interface.
I updated the MessageType check, using IsAssignableFrom rather than Equals.

**Updated Test-Project**
Additionally I added another Test-Endpoint and a Test-Workflow in the MassTransit example project to test this behaviour.

**Small typo in test-project**
Finally, I found a typo in the Test-Project classes and fixed this also.


If there are any codestyle issues or anything else, please let me know.

Hope this helps :)