### PR TITLE
Fix MultiText without options

### DIFF
--- a/src/designer/elsa-workflows-studio/src/components/editors/properties/elsa-multi-text-property/elsa-multi-text-property.tsx
+++ b/src/designer/elsa-workflows-studio/src/components/editors/properties/elsa-multi-text-property/elsa-multi-text-property.tsx
@@ -46,6 +46,7 @@ export class ElsaMultiTextProperty {
     const fieldId = propertyName;
     const fieldName = propertyName;
     const values = parseJson(this.currentValue);
+    propertyDescriptor.options = propertyDescriptor.options || null;
     const valueType = propertyDescriptor.options !== null ? 'dropdown' : 'multi-text';
     const propertyOptions = this.createKeyValueOptions(propertyDescriptor.options);
 


### PR DESCRIPTION
My change from https://github.com/elsa-workflows/elsa-core/pull/907 combined with some of the changes that were done in parallel made MultiText without Options not render at all.

This is small fix for that.