### PR TITLE
Serialization Error. Case of a "Fault" Outcome using a single message string.

### DIFF
--- a/src/core/Elsa.Core/Serialization/Converters/ExceptionConverter.cs
+++ b/src/core/Elsa.Core/Serialization/Converters/ExceptionConverter.cs
@@ -15,6 +15,12 @@ namespace Elsa.Serialization.Converters
 
         public override Exception ReadJson(JsonReader reader, Type objectType, Exception existingValue, bool hasExistingValue, JsonSerializer serializer)
         {
+            // Fix to allow null values in exceptions
+            if (reader.TokenType == JsonToken.Null)
+            {
+                return null;
+            }
+
             //reader will throw exception if not read to end
             var jObject = JObject.Load(reader);
             var ex = System.Text.Json.JsonSerializer.Deserialize<Exception>(jObject.ToString());


### PR DESCRIPTION
Serialization Error. Case of a "Fault" Outcome using a single message string without "Exception". This serializer fails when a null value is received breakin the Designer. Now it's fixed.

Steps to reproduce this:
- Create a new Workflow in Elsa Designer 1
- Add a ReceiveHttpRequest with a path "/test1"
- Add a WriteHttpResponse
- Add another WriteHttpResponse
- Execute the workflow with "/test1"

WriteHttpResponse creates this fault that breaks the system:
       return Fault("Response has already started");