### PR TITLE
Runtime List Options

### DIFF
--- a/src/core/Elsa.Abstractions/Design/RuntimeSelectListItemsProviderSettings.cs
+++ b/src/core/Elsa.Abstractions/Design/RuntimeSelectListItemsProviderSettings.cs
@@ -24,6 +24,7 @@ namespace Elsa.Design
         /// <summary>
         /// Optionally provide an object containing useful information for the list select items provider to determine what items to provide.
         /// </summary>
+        [JsonProperty(TypeNameHandling = TypeNameHandling.All)]
         public object? Context { get; }
     }
 }

--- a/src/designer/elsa-workflows-studio/src/components.d.ts
+++ b/src/designer/elsa-workflows-studio/src/components.d.ts
@@ -5,11 +5,10 @@
  * It contains typing information for all components that exist in this project.
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
-import { ActivityDefinitionProperty, ActivityDescriptor, ActivityModel, ActivityPropertyDescriptor, VersionOptions, WorkflowBlueprint, WorkflowDefinition, WorkflowExecutionLogRecord, WorkflowModel } from "./models";
+import { ActivityDefinitionProperty, ActivityDescriptor, ActivityModel, ActivityPropertyDescriptor, SelectListItem, VersionOptions, WorkflowBlueprint, WorkflowDefinition, WorkflowExecutionLogRecord, WorkflowModel } from "./models";
 import { LocationSegments, MatchResults, RouterHistory } from "@stencil/router";
 import { MenuItem } from "./components/controls/elsa-context-menu/models";
 import { DropdownButtonItem, DropdownButtonOrigin } from "./components/controls/elsa-dropdown-button/models";
-import { MultiTextDefinition } from "./models/domain";
 import { MonacoValueChangedArgs } from "./components/controls/elsa-monaco/elsa-monaco";
 import { Map } from "./utils/utils";
 import { ToastNotificationOptions } from "./components/shared/elsa-toast-notification/elsa-toast-notification";
@@ -21,6 +20,7 @@ export namespace Components {
     interface ElsaCheckListProperty {
         "propertyDescriptor": ActivityPropertyDescriptor;
         "propertyModel": ActivityDefinitionProperty;
+        "serverUrl": string;
     }
     interface ElsaCheckboxProperty {
         "propertyDescriptor": ActivityPropertyDescriptor;
@@ -68,11 +68,11 @@ export namespace Components {
         "values"?: Array<string>;
     }
     interface ElsaInputTagsDropdown {
-        "dropdownValues"?: Array<MultiTextDefinition>;
+        "dropdownValues"?: Array<SelectListItem>;
         "fieldId"?: string;
         "fieldName"?: string;
         "placeHolder"?: string;
-        "values"?: Array<string | MultiTextDefinition>;
+        "values"?: Array<string | SelectListItem>;
     }
     interface ElsaModalDialog {
         "hide": (animate: boolean) => Promise<void>;
@@ -105,6 +105,7 @@ export namespace Components {
     interface ElsaMultiTextProperty {
         "propertyDescriptor": ActivityPropertyDescriptor;
         "propertyModel": ActivityDefinitionProperty;
+        "serverUrl": string;
     }
     interface ElsaPager {
         "history"?: RouterHistory;
@@ -515,6 +516,7 @@ declare namespace LocalJSX {
     interface ElsaCheckListProperty {
         "propertyDescriptor"?: ActivityPropertyDescriptor;
         "propertyModel"?: ActivityDefinitionProperty;
+        "serverUrl"?: string;
     }
     interface ElsaCheckboxProperty {
         "propertyDescriptor"?: ActivityPropertyDescriptor;
@@ -565,12 +567,12 @@ declare namespace LocalJSX {
         "values"?: Array<string>;
     }
     interface ElsaInputTagsDropdown {
-        "dropdownValues"?: Array<MultiTextDefinition>;
+        "dropdownValues"?: Array<SelectListItem>;
         "fieldId"?: string;
         "fieldName"?: string;
-        "onValueChanged"?: (event: CustomEvent<Array<string | MultiTextDefinition>>) => void;
+        "onValueChanged"?: (event: CustomEvent<Array<string | SelectListItem>>) => void;
         "placeHolder"?: string;
-        "values"?: Array<string | MultiTextDefinition>;
+        "values"?: Array<string | SelectListItem>;
     }
     interface ElsaModalDialog {
     }
@@ -602,6 +604,7 @@ declare namespace LocalJSX {
     interface ElsaMultiTextProperty {
         "propertyDescriptor"?: ActivityPropertyDescriptor;
         "propertyModel"?: ActivityDefinitionProperty;
+        "serverUrl"?: string;
     }
     interface ElsaPager {
         "history"?: RouterHistory;

--- a/src/designer/elsa-workflows-studio/src/components/controls/elsa-input-tags/elsa-input-tags-dropdown.tsx
+++ b/src/designer/elsa-workflows-studio/src/components/controls/elsa-input-tags/elsa-input-tags-dropdown.tsx
@@ -1,5 +1,5 @@
 import { Component, h, Prop, Event, EventEmitter, State, Watch } from '@stencil/core';
-import { MultiTextDefinition } from '../../../models/domain';
+import { SelectListItem } from '../../../models';
 
 @Component({
     tag: 'elsa-input-tags-dropdown',
@@ -11,15 +11,15 @@ export class ElsaInputTagsDropdown {
     @Prop() fieldName?: string;
     @Prop() fieldId?: string;
     @Prop() placeHolder?: string = 'Add tag';
-    @Prop() values?: Array<string | MultiTextDefinition> = [];
-    @Prop() dropdownValues?: Array<MultiTextDefinition> = [];
-    @Event({ bubbles: true }) valueChanged: EventEmitter<Array<string | MultiTextDefinition>>;
-    @State() currentValues?: Array<MultiTextDefinition> = [];
-    @State() dropdownTags?: Array<MultiTextDefinition> = [];
+    @Prop() values?: Array<string | SelectListItem> = [];
+    @Prop() dropdownValues?: Array<SelectListItem> = [];
+    @Event({ bubbles: true }) valueChanged: EventEmitter<Array<string | SelectListItem>>;
+    @State() currentValues?: Array<SelectListItem> = [];
+    @State() dropdownTags?: Array<SelectListItem> = [];
 
     @Watch('values')
-    valuesChangedHandler(newValue: Array<string | MultiTextDefinition>) {
-        let values: Array<MultiTextDefinition> = [];
+    valuesChangedHandler(newValue: Array<string | SelectListItem>) {
+        let values: Array<SelectListItem> = [];
 
         newValue.forEach(value => {
             this.dropdownValues.forEach(tag => {
@@ -33,7 +33,7 @@ export class ElsaInputTagsDropdown {
 
     componentWillLoad() {
         this.dropdownTags = this.dropdownValues;
-        let values: Array<MultiTextDefinition> = [];
+        let values: Array<SelectListItem> = [];
 
         this.values.forEach(value => {
             this.dropdownValues.forEach(tag => {
@@ -52,7 +52,7 @@ export class ElsaInputTagsDropdown {
         e.preventDefault();
 
         const input = e.target as HTMLSelectElement;
-        const currentTag: MultiTextDefinition = {
+        const currentTag: SelectListItem = {
             text: input.options[input.selectedIndex].text.trim(),
             value: input.value
         }
@@ -60,7 +60,7 @@ export class ElsaInputTagsDropdown {
         if (currentTag.value.length == 0)
             return;
 
-        const values: Array<MultiTextDefinition> = [...this.currentValues];
+        const values: Array<SelectListItem> = [...this.currentValues];
         values.push(currentTag);
         this.currentValues = values.distinct();
         input.value = "Add";
@@ -68,7 +68,7 @@ export class ElsaInputTagsDropdown {
         await this.valueChanged.emit(values);
     }
 
-    async onDeleteTagClick(e: any, currentTag: MultiTextDefinition) {
+    async onDeleteTagClick(e: any, currentTag: SelectListItem) {
         e.preventDefault();
 
         this.currentValues = this.currentValues.filter(tag => tag.value !== currentTag.value);
@@ -77,7 +77,7 @@ export class ElsaInputTagsDropdown {
     }
 
     render() {
-        let values: Array<MultiTextDefinition> = this.currentValues || [];
+        let values: Array<SelectListItem> = this.currentValues || [];
 
         if (!Array.isArray(values))
             values = [];

--- a/src/designer/elsa-workflows-studio/src/components/editors/properties/elsa-check-list-property/elsa-check-list-property.tsx
+++ b/src/designer/elsa-workflows-studio/src/components/editors/properties/elsa-check-list-property/elsa-check-list-property.tsx
@@ -1,6 +1,9 @@
 import {Component, h, Prop, State} from '@stencil/core';
 import {ActivityDefinitionProperty, ActivityPropertyDescriptor, SyntaxNames} from "../../../../models";
 import {parseJson} from "../../../../utils/utils";
+import {getSelectListItems} from "../../../../utils/select-list-items";
+import Tunnel from "../../../../data/workflow-editor";
+import {ElsaDropdownProperty} from "../elsa-dropdown-property/elsa-dropdown-property";
 
 @Component({
   tag: 'elsa-check-list-property',
@@ -11,8 +14,11 @@ export class ElsaCheckListProperty {
 
   @Prop() propertyDescriptor: ActivityPropertyDescriptor;
   @Prop() propertyModel: ActivityDefinitionProperty;
+  @Prop({mutable: true}) serverUrl: string;
   @State() currentValue?: string;
+  
   monacoEditor: HTMLElsaMonacoElement;
+  items: any[];
 
   async componentWillLoad() {
     this.currentValue = this.propertyModel.expressions[SyntaxNames.Json] || '[]';
@@ -37,11 +43,15 @@ export class ElsaCheckListProperty {
     this.currentValue = e.detail;
   }
 
+  async componentWillRender(){
+    this.items = await getSelectListItems(this.serverUrl, this.propertyDescriptor);
+  }
+
   render() {
     const propertyDescriptor = this.propertyDescriptor;
     const propertyModel = this.propertyModel;
     const fieldId = propertyDescriptor.name;
-    const options = propertyDescriptor.options as Array<any>;
+    const items = this.items;
     const values = parseJson(this.currentValue) || [];
 
     return (
@@ -51,11 +61,11 @@ export class ElsaCheckListProperty {
                             editor-height="2.75em"
                             single-line={true}>
         <div class="max-w-lg space-y-3 my-4">
-          {options.map((option, index) => {
+          {items.map((item, index) => {
             const inputId = `${fieldId}_${index}`;
-            const optionIsString = typeof(option) == 'string';
-            const value = optionIsString ? option : option.value;
-            const text = optionIsString ? option : option.text;
+            const optionIsString = typeof(item) == 'string';
+            const value = optionIsString ? item : item.value;
+            const text = optionIsString ? item : item.text;
             const isSelected = values.findIndex(x => x == value) >= 0;
 
             return (
@@ -74,3 +84,5 @@ export class ElsaCheckListProperty {
     );
   }
 }
+
+Tunnel.injectProps(ElsaCheckListProperty, ['serverUrl']);

--- a/src/designer/elsa-workflows-studio/src/components/editors/properties/elsa-dropdown-property/elsa-dropdown-property.tsx
+++ b/src/designer/elsa-workflows-studio/src/components/editors/properties/elsa-dropdown-property/elsa-dropdown-property.tsx
@@ -2,6 +2,7 @@ import {Component, h, Prop, State} from '@stencil/core';
 import {ActivityDefinitionProperty, ActivityPropertyDescriptor, RuntimeSelectListItemsProviderSettings, SelectListItem, SyntaxNames} from "../../../../models";
 import Tunnel from "../../../../data/workflow-editor";
 import {createElsaClient} from "../../../../services/elsa-client";
+import {getSelectListItems} from "../../../../utils/select-list-items";
 
 @Component({
   tag: 'elsa-dropdown-property',
@@ -33,22 +34,7 @@ export class ElsaDropdownProperty {
   }
   
   async componentWillRender(){
-    const propertyDescriptor = this.propertyDescriptor;
-    const options = propertyDescriptor.options;
-    let items = [];
-
-    if (!!options.runtimeSelectListItemsProviderType) {
-      items = await this.fetchRuntimeItems(options);
-    } else {
-      items = options as Array<any> || [];
-    }
-    
-    this.items = items;
-  }
-  
-  async fetchRuntimeItems(options: RuntimeSelectListItemsProviderSettings): Promise<Array<SelectListItem>>{
-    const elsaClient = createElsaClient(this.serverUrl);
-    return await elsaClient.designerApi.runtimeSelectItemsApi.get(options.runtimeSelectListItemsProviderType, options.context || {});
+    this.items = await getSelectListItems(this.serverUrl, this.propertyDescriptor);
   }
 
   render() {

--- a/src/designer/elsa-workflows-studio/src/components/editors/properties/elsa-dropdown-property/elsa-dropdown-property.tsx
+++ b/src/designer/elsa-workflows-studio/src/components/editors/properties/elsa-dropdown-property/elsa-dropdown-property.tsx
@@ -21,6 +21,7 @@ export class ElsaDropdownProperty {
   async componentWillLoad() {
     const defaultSyntax = this.propertyDescriptor.defaultSyntax || SyntaxNames.Literal;
     this.currentValue = this.propertyModel.expressions[defaultSyntax] || '';
+    this.items = await getSelectListItems(this.serverUrl, this.propertyDescriptor);
   }
 
   onChange(e: Event) {
@@ -33,10 +34,6 @@ export class ElsaDropdownProperty {
     this.currentValue = e.detail;
   }
   
-  async componentWillRender(){
-    this.items = await getSelectListItems(this.serverUrl, this.propertyDescriptor);
-  }
-
   render() {
     const propertyDescriptor = this.propertyDescriptor;
     const propertyModel = this.propertyModel;

--- a/src/designer/elsa-workflows-studio/src/models/domain.ts
+++ b/src/designer/elsa-workflows-studio/src/models/domain.ts
@@ -168,11 +168,6 @@ export interface ConnectionDefinitionMapped {
   outcome: string;
 }
 
-export interface MultiTextDefinition {
-  text: string;
-  value: string;
-}
-
 export interface ActivityDefinitionProperty {
   name: string;
   syntax?: string;

--- a/src/designer/elsa-workflows-studio/src/services/elsa-client.ts
+++ b/src/designer/elsa-workflows-studio/src/services/elsa-client.ts
@@ -156,7 +156,7 @@ export const createElsaClient = function (serverUrl: string): ElsaClient {
     designerApi:{
       runtimeSelectItemsApi:{
         get: async (providerTypeName: string, context?: any): Promise<Array<SelectListItem>> => {
-          const response = await httpClient.post(`v1/designer/runtime-select-list-items/${providerTypeName}`, context);
+          const response = await httpClient.post('v1/designer/runtime-select-list-items', { providerTypeName: providerTypeName, context: context });
           return response.data;  
         }
       }

--- a/src/designer/elsa-workflows-studio/src/utils/select-list-items.ts
+++ b/src/designer/elsa-workflows-studio/src/utils/select-list-items.ts
@@ -1,0 +1,20 @@
+import {ActivityPropertyDescriptor, RuntimeSelectListItemsProviderSettings, SelectListItem} from "../models";
+import {createElsaClient, ElsaClient} from "../services/elsa-client";
+
+async function fetchRuntimeItems(serverUrl: string, options: RuntimeSelectListItemsProviderSettings): Promise<Array<SelectListItem>> {
+  const elsaClient = createElsaClient(serverUrl);
+  return await elsaClient.designerApi.runtimeSelectItemsApi.get(options.runtimeSelectListItemsProviderType, options.context || {});
+}
+
+export async function getSelectListItems(serverUrl: string, propertyDescriptor: ActivityPropertyDescriptor): Promise<Array<SelectListItem>> {
+  const options = propertyDescriptor.options;
+  let items = [];
+
+  if (!!options.runtimeSelectListItemsProviderType) {
+    items = await fetchRuntimeItems(serverUrl, options);
+  } else {
+    items = options as Array<any> || [];
+  }
+
+  return items || [];
+}

--- a/src/samples/server/Elsa.Samples.Server.Host/Activities/VehicleActivity.cs
+++ b/src/samples/server/Elsa.Samples.Server.Host/Activities/VehicleActivity.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
@@ -15,6 +16,13 @@ namespace Elsa.Samples.Server.Host.Activities
     [Action]
     public class VehicleActivity : Activity, IActivityPropertyOptionsProvider, IRuntimeSelectListItemsProvider
     {
+        private Random _random;
+        
+        public VehicleActivity()
+        {
+            _random = new Random();
+        }
+        
         [ActivityProperty(
             UIHint = ActivityPropertyUIHints.Dropdown,
             OptionsProvider = typeof(VehicleActivity),
@@ -23,15 +31,18 @@ namespace Elsa.Samples.Server.Host.Activities
         )]
         public string? Brand { get; set; }
 
-        public object GetOptions(PropertyInfo property) => new RuntimeSelectListItemsProviderSettings(GetType());
+        public object GetOptions(PropertyInfo property) => new RuntimeSelectListItemsProviderSettings(GetType(), new VehicleContext(_random.Next(100)));
 
         public ValueTask<IEnumerable<SelectListItem>> GetItemsAsync(object? context, CancellationToken cancellationToken = default)
         {
-            var brands = new[] { "BMW", "Peugot", "Tesla" };
+            var vehicleContext = (VehicleContext) context!;
+            var brands = new[] { "BMW", "Peugot", "Tesla", vehicleContext.RandomNumber.ToString() };
             var items = brands.Select(x => new SelectListItem(x)).ToList();
             return new ValueTask<IEnumerable<SelectListItem>>(items);
         }
 
         protected override IActivityExecutionResult OnExecute() => Done(Brand);
     }
+
+    public record VehicleContext(int RandomNumber);
 }

--- a/src/server/Elsa.Server.Api/Endpoints/Designer/RuntimeSelectListItems/Get.cs
+++ b/src/server/Elsa.Server.Api/Endpoints/Designer/RuntimeSelectListItems/Get.cs
@@ -14,7 +14,7 @@ namespace Elsa.Server.Api.Endpoints.Designer.RuntimeSelectListItems
 {
     [ApiController]
     [ApiVersion("1")]
-    [Route("v{apiVersion:apiVersion}/designer/runtime-select-list-items/{providerTypeName}")]
+    [Route("v{apiVersion:apiVersion}/designer/runtime-select-list-items")]
     [Produces("application/json")]
     public class Get : Controller
     {
@@ -47,11 +47,11 @@ namespace Elsa.Server.Api.Endpoints.Designer.RuntimeSelectListItems
         }
     }
 
+    [JsonObject(ItemTypeNameHandling = TypeNameHandling.All)]
     public record RuntimeSelectListItemsContextHolder
     {
-        [FromRoute] public string ProviderTypeName { get; set; } = default!;
-
-        [JsonProperty(TypeNameHandling = TypeNameHandling.All)]
+        public string ProviderTypeName { get; set; } = default!;
+        
         public object? Context { get; set; }
     };
 }


### PR DESCRIPTION
This PR adds the ability for developers to provide list option values to dropdown list controls used in the designer at runtime.

To provide values at runtime, implement `IActivityPropertyOptionsProvider` that returns an object of `RuntimeSelectListItemsProviderSettings`, which itself needs to return the class type that will provide the options. This provider needs to implement `IRuntimeSelectListItemsProvider`.

An example can be found in https://github.com/elsa-workflows/elsa-core/tree/feature/elsa-2.0/src/samples/server/Elsa.Samples.Server.Host by looking at the `VehicleActivity` that implements the necessary interfaces.