### PR TITLE
Fix CORS issue in Dashboard Monolith sample project

### DIFF
--- a/src/samples/dashboard/aspnetcore/ElsaDashboard.Samples.AspNetCore.Monolith/Startup.cs
+++ b/src/samples/dashboard/aspnetcore/ElsaDashboard.Samples.AspNetCore.Monolith/Startup.cs
@@ -60,9 +60,9 @@ namespace ElsaDashboard.Samples.AspNetCore.Monolith
                 app.UseHsts();
             }
 
+            app.UseCors();
             app.UseStaticFiles();
             app.UseHttpActivities();
-            app.UseCors();
             app.UseRouting();
             app.UseAuthorization();
             app.UseEndpoints(endpoints =>


### PR DESCRIPTION
Moving `app.UseCors()` to the top of the Http Pipeline config fixes some CORS problems I found (closes #1039)