### PR TITLE
Update activity property evaluation to store computed value

### DIFF
--- a/src/activities/Elsa.Activities.AzureServiceBus/Bookmarks/QueueMessageReceivedBookmark.cs
+++ b/src/activities/Elsa.Activities.AzureServiceBus/Bookmarks/QueueMessageReceivedBookmark.cs
@@ -28,7 +28,7 @@ namespace Elsa.Activities.AzureServiceBus.Bookmarks
             {
                 new QueueMessageReceivedBookmark
                 {
-                    QueueName = (await context.Activity.GetPropertyValueAsync(x => x.QueueName, cancellationToken))!,
+                    QueueName = (await context.ReadActivityPropertyAsync(x => x.QueueName, cancellationToken))!,
                     CorrelationId = context.ActivityExecutionContext.WorkflowExecutionContext.CorrelationId
                 }
             };

--- a/src/activities/Elsa.Activities.AzureServiceBus/Bookmarks/TopicMessageReceivedBookmark.cs
+++ b/src/activities/Elsa.Activities.AzureServiceBus/Bookmarks/TopicMessageReceivedBookmark.cs
@@ -30,8 +30,8 @@ namespace Elsa.Activities.AzureServiceBus.Bookmarks
             {
                 new TopicMessageReceivedBookmark
                 {
-                    TopicName = (await context.Activity.GetPropertyValueAsync(x => x.TopicName, cancellationToken))!,
-                    SubscriptionName = (await context.Activity.GetPropertyValueAsync(x => x.SubscriptionName, cancellationToken))!,
+                    TopicName = (await context.ReadActivityPropertyAsync(x => x.TopicName, cancellationToken))!,
+                    SubscriptionName = (await context.ReadActivityPropertyAsync(x => x.SubscriptionName, cancellationToken))!,
                     CorrelationId = context.ActivityExecutionContext.WorkflowExecutionContext.CorrelationId
                 }
             };

--- a/src/activities/Elsa.Activities.AzureServiceBus/Services/ServiceBusQueuesStarter.cs
+++ b/src/activities/Elsa.Activities.AzureServiceBus/Services/ServiceBusQueuesStarter.cs
@@ -86,7 +86,7 @@ namespace Elsa.Activities.AzureServiceBus.Services
 
                 foreach (var activity in workflowBlueprintWrapper.Filter<AzureServiceBusQueueMessageReceived>())
                 {
-                    var queueName = await activity.GetPropertyValueAsync(x => x.QueueName, cancellationToken);
+                    var queueName = await activity.EvaluatePropertyValueAsync(x => x.QueueName, cancellationToken);
 
                     if (string.IsNullOrWhiteSpace(queueName))
                     {

--- a/src/activities/Elsa.Activities.AzureServiceBus/Services/ServiceBusTopicsStarter.cs
+++ b/src/activities/Elsa.Activities.AzureServiceBus/Services/ServiceBusTopicsStarter.cs
@@ -95,8 +95,8 @@ namespace Elsa.Activities.AzureServiceBus.Services
 
                 foreach (var activity in workflowBlueprintWrapper.Filter<AzureServiceBusTopicMessageReceived>())
                 {
-                    var topicName = await activity.GetPropertyValueAsync(x => x.TopicName, cancellationToken);
-                    var subscriptionName = await activity.GetPropertyValueAsync(x => x.SubscriptionName, cancellationToken);
+                    var topicName = await activity.EvaluatePropertyValueAsync(x => x.TopicName, cancellationToken);
+                    var subscriptionName = await activity.EvaluatePropertyValueAsync(x => x.SubscriptionName, cancellationToken);
                     yield return (topicName, subscriptionName)!;
                 }
             }

--- a/src/activities/Elsa.Activities.Entity/Bookmarks/EntityChangedBookmark.cs
+++ b/src/activities/Elsa.Activities.Entity/Bookmarks/EntityChangedBookmark.cs
@@ -27,8 +27,8 @@ namespace Elsa.Activities.Entity.Bookmarks
             new[]
             {
                 new EntityChangedBookmark(
-                    entityName: await context.Activity.GetPropertyValueAsync(x => x.EntityName, cancellationToken),
-                    action: await context.Activity.GetPropertyValueAsync(x => x.Action, cancellationToken),
+                    entityName: await context.ReadActivityPropertyAsync(x => x.EntityName, cancellationToken),
+                    action: await context.ReadActivityPropertyAsync(x => x.Action, cancellationToken),
                     contextId: context.ActivityExecutionContext.WorkflowExecutionContext.WorkflowInstance.ContextId,
                     correlationId: context.ActivityExecutionContext.WorkflowExecutionContext.WorkflowInstance.CorrelationId
                 )

--- a/src/activities/Elsa.Activities.Http/Bookmarks/HttpEndpointBookmark.cs
+++ b/src/activities/Elsa.Activities.Http/Bookmarks/HttpEndpointBookmark.cs
@@ -15,9 +15,9 @@ namespace Elsa.Activities.Http.Bookmarks
     {
         public override async ValueTask<IEnumerable<IBookmark>> GetBookmarksAsync(BookmarkProviderContext<HttpEndpoint> context, CancellationToken cancellationToken)
         {
-            var path = ToLower(await context.Activity.GetPropertyValueAsync(x => x.Path, cancellationToken))!;
+            var path = ToLower(await context.ReadActivityPropertyAsync(x => x.Path, cancellationToken))!;
             var correlationId = ToLower(context.ActivityExecutionContext.WorkflowExecutionContext.CorrelationId);
-            var methods = (await context.Activity.GetPropertyValueAsync(x => x.Methods, cancellationToken))?.Select(x => x.ToLowerInvariant()) ?? Enumerable.Empty<string>();
+            var methods = (await context.ReadActivityPropertyAsync(x => x.Methods, cancellationToken))?.Select(x => x.ToLowerInvariant()) ?? Enumerable.Empty<string>();
 
             HttpEndpointBookmark CreateBookmark(string method) => new(path, method, correlationId);
             return methods.Select(CreateBookmark);

--- a/src/activities/Elsa.Activities.Http/Middleware/HttpEndpointMiddleware.cs
+++ b/src/activities/Elsa.Activities.Http/Middleware/HttpEndpointMiddleware.cs
@@ -67,12 +67,12 @@ namespace Elsa.Activities.Http.Middleware
                 var pendingWorkflowInstance = pendingWorkflowInstances[pendingWorkflow.WorkflowInstanceId];
                 var workflowBlueprintWrapper = workflowBlueprintWrappers[pendingWorkflowInstance.DefinitionId];
                 var activityWrapper = workflowBlueprintWrapper.GetActivity<HttpEndpoint>(pendingWorkflow.ActivityId!);
-                var readContent = await activityWrapper!.GetPropertyValueAsync(x => x.ReadContent, cancellationToken);
+                var readContent = await activityWrapper!.EvaluatePropertyValueAsync(x => x.ReadContent, cancellationToken);
                 var inputModel = commonInputModel;
 
                 if (readContent)
                 {
-                    var targetType = await activityWrapper.GetPropertyValueAsync(x => x.TargetType, cancellationToken);
+                    var targetType = await activityWrapper.EvaluatePropertyValueAsync(x => x.TargetType, cancellationToken);
                     inputModel = inputModel with { Body = await contentParser.ParseAsync(request, targetType, cancellationToken) };
                 }
 

--- a/src/activities/Elsa.Activities.MassTransit/Bookmarks/MessageReceivedBookmark.cs
+++ b/src/activities/Elsa.Activities.MassTransit/Bookmarks/MessageReceivedBookmark.cs
@@ -18,7 +18,7 @@ namespace Elsa.Activities.MassTransit.Bookmarks
             {
                 new MessageReceivedBookmark
                 {
-                    MessageType = (await context.Activity.GetPropertyValueAsync(x => x.MessageType, cancellationToken))!.Name,
+                    MessageType = (await context.ReadActivityPropertyAsync(x => x.MessageType, cancellationToken))!.Name,
                     CorrelationId = context.ActivityExecutionContext.WorkflowExecutionContext.CorrelationId
                 }
             };

--- a/src/activities/Elsa.Activities.Rebus/Bookmarks/MessageReceivedBookmark.cs
+++ b/src/activities/Elsa.Activities.Rebus/Bookmarks/MessageReceivedBookmark.cs
@@ -18,7 +18,7 @@ namespace Elsa.Activities.Rebus.Bookmarks
             {
                 new MessageReceivedBookmark
                 {
-                    MessageType = (await context.Activity.GetPropertyValueAsync(x => x.MessageType, cancellationToken))!.Name,
+                    MessageType = (await context.ReadActivityPropertyAsync(x => x.MessageType, cancellationToken))!.Name,
                     CorrelationId = context.ActivityExecutionContext.WorkflowExecutionContext.CorrelationId
                 }
             };

--- a/src/activities/Elsa.Activities.Temporal.Common/Bookmarks/CronBookmark.cs
+++ b/src/activities/Elsa.Activities.Temporal.Common/Bookmarks/CronBookmark.cs
@@ -17,11 +17,11 @@ namespace Elsa.Activities.Temporal.Common.Bookmarks
     {
         public override async ValueTask<IEnumerable<IBookmark>> GetBookmarksAsync(BookmarkProviderContext<Cron> context, CancellationToken cancellationToken)
         {
-            var cronExpression = await context.Activity.GetPropertyValueAsync(x => x.CronExpression, cancellationToken);
+            var cronExpression = await context.ReadActivityPropertyAsync(x => x.CronExpression, cancellationToken);
 
             if (context.Mode == BookmarkIndexingMode.WorkflowInstance)
             {
-                var executeAt = context.Activity.GetState(x => x.ExecuteAt);
+                var executeAt = GetExecuteAt(context);
                 
                 if(executeAt == null)
                     return Enumerable.Empty<IBookmark>();
@@ -47,7 +47,7 @@ namespace Elsa.Activities.Temporal.Common.Bookmarks
 
         private Instant? GetExecuteAt(BookmarkProviderContext<Cron> context) =>
             context.Mode == BookmarkIndexingMode.WorkflowInstance
-                ? context.Activity.GetState(x => x.ExecuteAt)
+                ? context.Activity.GetPropertyValue(x => x.ExecuteAt)
                 : default;
     }
 }

--- a/src/activities/Elsa.Activities.Temporal.Common/Bookmarks/StartAtBookmark.cs
+++ b/src/activities/Elsa.Activities.Temporal.Common/Bookmarks/StartAtBookmark.cs
@@ -32,7 +32,7 @@ namespace Elsa.Activities.Temporal.Common.Bookmarks
 
         private static async Task<Instant?> GetExecuteAtAsync(BookmarkProviderContext<StartAt> context, CancellationToken cancellationToken) =>
             context.Mode == BookmarkIndexingMode.WorkflowInstance
-                ? context.Activity.GetState(x => x.ExecuteAt)
-                : await context.Activity.GetPropertyValueAsync(x => x.Instant, cancellationToken);
+                ? context.Activity.GetPropertyValue(x => x.ExecuteAt)
+                : await context.ReadActivityPropertyAsync(x => x.Instant, cancellationToken);
     }
 }

--- a/src/activities/Elsa.Activities.Temporal.Common/Bookmarks/TimerBookmark.cs
+++ b/src/activities/Elsa.Activities.Temporal.Common/Bookmarks/TimerBookmark.cs
@@ -24,7 +24,7 @@ namespace Elsa.Activities.Temporal.Common.Bookmarks
 
         public override async ValueTask<IEnumerable<IBookmark>> GetBookmarksAsync(BookmarkProviderContext<Timer> context, CancellationToken cancellationToken)
         {
-            var interval = await context.Activity.GetPropertyValueAsync(x => x.Timeout, cancellationToken);
+            var interval = await context.ReadActivityPropertyAsync(x => x.Timeout, cancellationToken);
             var executeAt = GetExecuteAt(context, interval);
 
             if (executeAt != null)
@@ -42,7 +42,7 @@ namespace Elsa.Activities.Temporal.Common.Bookmarks
 
         private Instant? GetExecuteAt(BookmarkProviderContext<Timer> context, Duration interval) =>
             context.Mode == BookmarkIndexingMode.WorkflowInstance 
-                ? context.Activity.GetState(x => x.ExecuteAt) 
+                ? context.Activity.GetPropertyValue(x => x.ExecuteAt) 
                 : _clock.GetCurrentInstant().Plus(interval);
     }
 }

--- a/src/core/Elsa.Abstractions/Services/ActivityPropertyProviders.cs
+++ b/src/core/Elsa.Abstractions/Services/ActivityPropertyProviders.cs
@@ -36,7 +36,7 @@ namespace Elsa.Services
             properties[propertyName] = provider;
         }
 
-        public IDictionary<string, IActivityPropertyValueProvider>? GetProviders(string activityId) => _providers.TryGetValue(activityId, out var properties) ? properties : null;
+        public IDictionary<string, IActivityPropertyValueProvider> GetProviders(string activityId) => _providers.TryGetValue(activityId, out var properties) ? properties : new Dictionary<string, IActivityPropertyValueProvider>();
 
         public IActivityPropertyValueProvider? GetProvider(string activityId, string propertyName) =>
             _providers.TryGetValue(activityId, out var properties) 
@@ -49,9 +49,6 @@ namespace Elsa.Services
         {
             var properties = activity.GetType().GetProperties().Where(IsActivityProperty).ToList();
             var providers = GetProviders(activity.Id);
-
-            if (providers == null)
-                return;
 
             foreach (var property in properties)
             {
@@ -69,7 +66,10 @@ namespace Elsa.Services
                     }
                     
                     if(value != null)
+                    {
                         property.SetValue(activity, value);
+                        activityExecutionContext.SetState(property.Name, value);
+                    }
                 }
                 catch(Exception e)
                 {

--- a/src/core/Elsa.Abstractions/Services/Models/ActivityBlueprintWrapper.cs
+++ b/src/core/Elsa.Abstractions/Services/Models/ActivityBlueprintWrapper.cs
@@ -18,7 +18,7 @@ namespace Elsa.Services.Models
 
         public IActivityBlueprintWrapper<TActivity> As<TActivity>() where TActivity : IActivity => new ActivityBlueprintWrapper<TActivity>(ActivityExecutionContext);
         
-        public async ValueTask<object?> GetPropertyValueAsync(string propertyName, CancellationToken cancellationToken = default)
+        public async ValueTask<object?> EvaluatePropertyValueAsync(string propertyName, CancellationToken cancellationToken = default)
         {
             var workflowBlueprint = ActivityExecutionContext.WorkflowExecutionContext.WorkflowBlueprint;
             var activityId = ActivityExecutionContext.ActivityBlueprint.Id;
@@ -41,7 +41,10 @@ namespace Elsa.Services.Models
         {
         }
 
-        public async ValueTask<T?> GetPropertyValueAsync<T>(Expression<Func<TActivity, T>> propertyExpression, CancellationToken cancellationToken = default)
+        /// <summary>
+        /// Evaluates the property provider and returns the result.
+        /// </summary>
+        public async ValueTask<T?> EvaluatePropertyValueAsync<T>(Expression<Func<TActivity, T>> propertyExpression, CancellationToken cancellationToken = default)
         {
             var workflowBlueprint = ActivityExecutionContext.WorkflowExecutionContext.WorkflowBlueprint;
             var activityId = ActivityExecutionContext.ActivityBlueprint.Id;
@@ -57,6 +60,9 @@ namespace Elsa.Services.Models
             }
         }
 
-        public T? GetState<T>(Expression<Func<TActivity, T>> propertyExpression) => ActivityExecutionContext.GetState(propertyExpression);
+        /// <summary>
+        /// Retrieves the property value from the activity's State dictionary.
+        /// </summary>
+        public T? GetPropertyValue<T>(Expression<Func<TActivity, T>> propertyExpression) => ActivityExecutionContext.GetState(propertyExpression);
     }
 }

--- a/src/core/Elsa.Abstractions/Services/Models/IActivityBlueprintWrapper.cs
+++ b/src/core/Elsa.Abstractions/Services/Models/IActivityBlueprintWrapper.cs
@@ -2,6 +2,7 @@
 using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
+using NodaTime;
 
 namespace Elsa.Services.Models
 {
@@ -9,12 +10,12 @@ namespace Elsa.Services.Models
     {
         IActivityBlueprint ActivityBlueprint { get; }
         IActivityBlueprintWrapper<TActivity> As<TActivity>() where TActivity : IActivity;
-        ValueTask<object?> GetPropertyValueAsync(string propertyName, CancellationToken cancellationToken = default);
+        ValueTask<object?> EvaluatePropertyValueAsync(string propertyName, CancellationToken cancellationToken = default);
     }
 
     public interface IActivityBlueprintWrapper<TActivity> : IActivityBlueprintWrapper where TActivity:IActivity
     {
-        ValueTask<T?> GetPropertyValueAsync<T>(Expression<Func<TActivity, T>> propertyExpression, CancellationToken cancellationToken = default);
-        T? GetState<T>(Expression<Func<TActivity, T>> propertyExpression);
+        ValueTask<T?> EvaluatePropertyValueAsync<T>(Expression<Func<TActivity, T>> propertyExpression, CancellationToken cancellationToken = default);
+        T? GetPropertyValue<T>(Expression<Func<TActivity, T>> propertyExpression);
     }
 }

--- a/src/core/Elsa.Abstractions/Services/NullActivityPropertyValueProvider.cs
+++ b/src/core/Elsa.Abstractions/Services/NullActivityPropertyValueProvider.cs
@@ -1,0 +1,12 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Elsa.Services.Models;
+
+namespace Elsa.Services
+{
+    public class NullActivityPropertyValueProvider : IActivityPropertyValueProvider
+    {
+        public static readonly NullActivityPropertyValueProvider Instance = new();
+        public ValueTask<object?> GetValueAsync(ActivityExecutionContext context, CancellationToken cancellationToken = default) => new(null);
+    }
+}

--- a/src/core/Elsa.Core/Activities/Signaling/Activities/SignalReceived/SignalReceivedBookmark.cs
+++ b/src/core/Elsa.Core/Activities/Signaling/Activities/SignalReceived/SignalReceivedBookmark.cs
@@ -20,8 +20,8 @@ namespace Elsa.Activities.Signaling
 
         private async IAsyncEnumerable<IBookmark> GetBookmarksInternalAsync(BookmarkProviderContext<SignalReceived> context, [EnumeratorCancellation] CancellationToken cancellationToken)
         {
-            var signalName = (await context.Activity.GetPropertyValueAsync(x => x.Signal, cancellationToken))!;
-            var signalScope = (await context.Activity.GetPropertyValueAsync(x => x.Scope, cancellationToken))!;
+            var signalName = (await context.ReadActivityPropertyAsync(x => x.Signal, cancellationToken))!;
+            var signalScope = (await context.ReadActivityPropertyAsync(x => x.Scope, cancellationToken))!;
 
             if (context.Mode == BookmarkIndexingMode.WorkflowBlueprint || signalScope == SignalScope.Global)
             {

--- a/src/core/Elsa.Core/Activities/Workflows/RunWorkflow/Bookmarks/RunWorkflowBookmark.cs
+++ b/src/core/Elsa.Core/Activities/Workflows/RunWorkflow/Bookmarks/RunWorkflowBookmark.cs
@@ -13,7 +13,7 @@ namespace Elsa.Activities.Workflows
     {
         public override IEnumerable<IBookmark> GetBookmarks(BookmarkProviderContext<RunWorkflow> context)
         {
-            var childWorkflowInstanceId = context.GetActivity<RunWorkflow>().GetState(x => x.ChildWorkflowInstanceId);
+            var childWorkflowInstanceId = context.GetActivity<RunWorkflow>().GetPropertyValue(x => x.ChildWorkflowInstanceId);
 
             if (string.IsNullOrWhiteSpace(childWorkflowInstanceId))
                 yield break;

--- a/src/core/Elsa.Core/Bookmarks/BookmarkIndexer.cs
+++ b/src/core/Elsa.Core/Bookmarks/BookmarkIndexer.cs
@@ -78,7 +78,7 @@ namespace Elsa.Bookmarks
                 }
 
                 var blockingActivities = workflowBlueprint.GetBlockingActivities(workflowInstance!);
-                var bookmarkedWorkflows = await ExtractBookmarksAsync(workflowBlueprint, workflowInstance, blockingActivities, true, cancellationToken).ToList();
+                var bookmarkedWorkflows = await ExtractBookmarksAsync(workflowBlueprint, workflowInstance, blockingActivities, cancellationToken).ToList();
                 var bookmarks = MapBookmarks(bookmarkedWorkflows, workflowInstance);
                 entities.AddRange(bookmarks);
             }
@@ -131,19 +131,10 @@ namespace Elsa.Bookmarks
             IWorkflowBlueprint workflowBlueprint,
             WorkflowInstance workflowInstance,
             IEnumerable<IActivityBlueprint> blockingActivities,
-            bool loadContext,
             CancellationToken cancellationToken)
         {
             // Setup workflow execution context
             var workflowExecutionContext = new WorkflowExecutionContext(_serviceProvider, workflowBlueprint, workflowInstance);
-
-            // Load workflow context.
-            workflowExecutionContext.WorkflowContext =
-                loadContext &&
-                workflowBlueprint.ContextOptions != null &&
-                !string.IsNullOrWhiteSpace(workflowInstance.ContextId)
-                    ? await _workflowContextManager.LoadContext(new LoadWorkflowContext(workflowExecutionContext), cancellationToken)
-                    : default;
 
             // Extract bookmarks for each blocking activity.
             var bookmarkedWorkflows = new List<BookmarkedWorkflow>();

--- a/src/server/Elsa.Server.Api/Services/WorkflowBlueprintMapper.cs
+++ b/src/server/Elsa.Server.Api/Services/WorkflowBlueprintMapper.cs
@@ -48,7 +48,7 @@ namespace Elsa.Server.Api.Services
             
             foreach (var valueProvider in activityPropertyValueProviders)
             {
-                var value = await activityWrapper.GetPropertyValueAsync(valueProvider.Key, cancellationToken);
+                var value = await activityWrapper.EvaluatePropertyValueAsync(valueProvider.Key, cancellationToken);
                 properties.Set(valueProvider.Key, value);
             }
 


### PR DESCRIPTION
Update activity property evaluation to store computed value as part of workflow instance state

This allows bookmarking to be optimized and fixes the issue when the system needs to access an activity's property from a workflow instance without having to re-evaluate the property value provider which may be impossible to do since there is no context.

A potential downside is increased workflow instance size, but this needs to be resolved as part of #898