### PR TITLE
Add support for dynamic outcome provider

### DIFF
--- a/src/core/Elsa.Abstractions/Attributes/ActivityAttribute.cs
+++ b/src/core/Elsa.Abstractions/Attributes/ActivityAttribute.cs
@@ -11,6 +11,6 @@ namespace Elsa.Attributes
         public string? Description { get; set; }
         public string? Category { get; set; }
         public ActivityTraits Traits { get; set; } = ActivityTraits.Action;
-        public string[]? Outcomes { get; set; }
+        public object? Outcomes { get; set; }
     }
 }

--- a/src/core/Elsa.Abstractions/Metadata/ActivityDescriberExtensions.cs
+++ b/src/core/Elsa.Abstractions/Metadata/ActivityDescriberExtensions.cs
@@ -1,9 +1,11 @@
+using System.Threading;
+using System.Threading.Tasks;
 using Elsa.Services;
 
 namespace Elsa.Metadata
 {
     public static class ActivityDescriberExtensions
     {
-        public static ActivityDescriptor? Describe<T>(this IDescribesActivityType type) where T : IActivity => type.Describe(typeof(T));
+        public static async Task<ActivityDescriptor?> DescribeAsync<T>(this IDescribesActivityType type, CancellationToken cancellationToken = default) where T : IActivity => await type.DescribeAsync(typeof(T), cancellationToken);
     }
 }

--- a/src/core/Elsa.Abstractions/Metadata/IDescribesActivityType.cs
+++ b/src/core/Elsa.Abstractions/Metadata/IDescribesActivityType.cs
@@ -1,9 +1,11 @@
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Elsa.Metadata
 {
     public interface IDescribesActivityType
     {
-        ActivityDescriptor? Describe(Type activityType);
+        Task<ActivityDescriptor?> DescribeAsync(Type activityType, CancellationToken cancellationToken = default);
     }
 }

--- a/src/core/Elsa.Abstractions/Metadata/IOutcomesProvider.cs
+++ b/src/core/Elsa.Abstractions/Metadata/IOutcomesProvider.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Elsa.Metadata
+{
+    public interface IOutcomesProvider
+    {
+        ValueTask<IEnumerable<string>> GetOutcomesAsync(CancellationToken cancellationToken);
+    }
+}

--- a/src/core/Elsa.Abstractions/Metadata/OutcomesProvider.cs
+++ b/src/core/Elsa.Abstractions/Metadata/OutcomesProvider.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Elsa.Metadata
+{
+    public abstract class OutcomesProvider : IOutcomesProvider
+    {
+        public virtual ValueTask<IEnumerable<string>> GetOutcomesAsync(CancellationToken cancellationToken) => new(GetOutcomes());
+        protected virtual IEnumerable<string> GetOutcomes() => Enumerable.Empty<string>();
+    }
+}

--- a/src/core/Elsa.Core/Metadata/TypedActivityTypeDescriber.cs
+++ b/src/core/Elsa.Core/Metadata/TypedActivityTypeDescriber.cs
@@ -2,8 +2,12 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using AutoMapper.Internal;
 using Elsa.Attributes;
 using Humanizer;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Elsa.Metadata
 {
@@ -12,15 +16,17 @@ namespace Elsa.Metadata
         private readonly IActivityPropertyOptionsResolver _optionsResolver;
         private readonly IActivityPropertyUIHintResolver _uiHintResolver;
         private readonly IActivityPropertyDefaultValueResolver _defaultValueResolver;
+        private readonly IServiceScopeFactory _serviceScopeFactory;
 
-        public TypedActivityTypeDescriber(IActivityPropertyOptionsResolver optionsResolver, IActivityPropertyUIHintResolver uiHintResolver, IActivityPropertyDefaultValueResolver defaultValueResolver)
+        public TypedActivityTypeDescriber(IActivityPropertyOptionsResolver optionsResolver, IActivityPropertyUIHintResolver uiHintResolver, IActivityPropertyDefaultValueResolver defaultValueResolver, IServiceScopeFactory serviceScopeFactory)
         {
             _optionsResolver = optionsResolver;
             _uiHintResolver = uiHintResolver;
             _defaultValueResolver = defaultValueResolver;
+            _serviceScopeFactory = serviceScopeFactory;
         }
 
-        public ActivityDescriptor? Describe(Type activityType)
+        public async Task<ActivityDescriptor?> DescribeAsync(Type activityType, CancellationToken cancellationToken = default)
         {
             var activityAttribute = activityType.GetCustomAttribute<ActivityAttribute>(false);
             var typeName = activityAttribute?.Type ?? activityType.Name;
@@ -28,7 +34,7 @@ namespace Elsa.Metadata
             var description = activityAttribute?.Description;
             var category = activityAttribute?.Category ?? "Miscellaneous";
             var traits = activityAttribute?.Traits ?? ActivityTraits.Action;
-            var outcomes = activityAttribute?.Outcomes ?? new[] { OutcomeNames.Done };
+            var outcomes = await GetOutcomesAsync(activityAttribute, cancellationToken);
             var properties = activityType.GetProperties();
             var inputProperties = DescribeInputProperties(properties);
             var outputProperties = DescribeOutputProperties(properties);
@@ -44,6 +50,29 @@ namespace Elsa.Metadata
                 OutputProperties = outputProperties.ToArray(),
                 Outcomes = outcomes,
             };
+        }
+
+        private async Task<string[]> GetOutcomesAsync(ActivityAttribute? activityAttribute, CancellationToken cancellationToken)
+        {
+            var outcomesObj = activityAttribute?.Outcomes;
+            
+            if (outcomesObj == null)
+                return new[] { OutcomeNames.Done };
+
+            var outcomesType = outcomesObj.GetType();
+
+            if (outcomesType.IsArray)
+                return (string[]) outcomesObj;
+
+            if (outcomesObj is Type providerType && typeof(IOutcomesProvider).IsAssignableFrom(providerType))
+            {
+                using var scope = _serviceScopeFactory.CreateScope();
+                var provider = (IOutcomesProvider) ActivatorUtilities.GetServiceOrCreateInstance(scope.ServiceProvider, providerType);
+                var providedOutcomes = await provider.GetOutcomesAsync(cancellationToken);
+                return providedOutcomes.ToArray();
+            }
+
+            throw new NotSupportedException("The specified outcomes type is not supported. Only string[] and typeof(IOutcomesProvider) are supported.");
         }
 
         private IEnumerable<ActivityInputDescriptor> DescribeInputProperties(IEnumerable<PropertyInfo> properties)


### PR DESCRIPTION
This PR allows you to either provide a `string[]` value for an `ActivityDefinition`'s `Outcomes` property as normal, like so:

```csharp
[ActivityDefinition(Outcomes = new[] {"Done", "Cancelled", "Etc..."})]
```

And now also like so:

```csharp
[ActivityDefinition(Outcomes = typeof(MyOutcomesProvider))]
```

Where `MyOutcomesProvider` implements `IOutcomesProvider` or inherits from `OutcomesProvider`, like so:

```csharp
public class MyOutcomesProvider : OutcomesProvider
{
   protected override IEnumerable<string> GetOutcomes() => new[] { "Dynamic Outcome 1", "Dynamic Outcome 2" };
}
```

Fixes #873