### PR TITLE
Azure Service Bus Enhancement - Add Fire And Forget Option

### DIFF
--- a/src/activities/Elsa.Activities.AzureServiceBus/Activities/SendAzureServiceBusMessage/AzureServiceBusSendActivity.cs
+++ b/src/activities/Elsa.Activities.AzureServiceBus/Activities/SendAzureServiceBusMessage/AzureServiceBusSendActivity.cs
@@ -78,14 +78,12 @@ namespace Elsa.Activities.AzureServiceBus
                 message.CorrelationId = context.WorkflowExecutionContext.CorrelationId;
 
             var sender = await GetSenderAsync();
+            
             if(SendMessageOnSuspend)
                 return Combine(Done(), new ServiceBusActionResult(sender, message));
-            else
-            {
-                await sender.SendAsync(message);
-                return Done();
-            }
-
+            
+            await sender.SendAsync(message);
+            return Done();
         }
 
         protected Message CreateMessage(Object input)

--- a/src/activities/Elsa.Activities.AzureServiceBus/Activities/SendAzureServiceBusMessage/AzureServiceBusSendActivity.cs
+++ b/src/activities/Elsa.Activities.AzureServiceBus/Activities/SendAzureServiceBusMessage/AzureServiceBusSendActivity.cs
@@ -10,8 +10,8 @@ using Microsoft.Azure.ServiceBus.Core;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Elsa.Activities.AzureServiceBus.ActivityExecutionResults;
 using NodaTime;
-using System.Threading;
 
 namespace Elsa.Activities.AzureServiceBus
 {
@@ -113,32 +113,6 @@ namespace Elsa.Activities.AzureServiceBus
                     message.UserProperties.Add(props.Key, props.Value);
 
             return message;
-        }
-    }
-    public class ServiceBusActionResult : ActivityExecutionResult
-    {
-        public ServiceBusActionResult(ISenderClient sender, Message message)
-        {
-            Sender = sender;
-            Message = message;
-        }
-
-        public ISenderClient Sender { get; }
-        public Message Message { get; }
-
-        protected override void Execute(ActivityExecutionContext activityExecutionContext)
-        {
-            var workflowInstanceId = activityExecutionContext.WorkflowExecutionContext.WorkflowInstance.Id;
-            var activityId = activityExecutionContext.ActivityBlueprint.Id;
-            var tenantId = activityExecutionContext.WorkflowExecutionContext.WorkflowBlueprint.TenantId;
-
-
-            async ValueTask ScheduleMessageAsync(WorkflowExecutionContext workflowExecutionContext, CancellationToken cancellationToken)
-            {
-                await Sender.SendAsync(Message);
-            }
-
-            activityExecutionContext.WorkflowExecutionContext.RegisterTask(ScheduleMessageAsync);
         }
     }
 }

--- a/src/activities/Elsa.Activities.AzureServiceBus/Activities/SendAzureServiceBusMessage/AzureServiceBusSendActivity.cs
+++ b/src/activities/Elsa.Activities.AzureServiceBus/Activities/SendAzureServiceBusMessage/AzureServiceBusSendActivity.cs
@@ -18,11 +18,7 @@ namespace Elsa.Activities.AzureServiceBus
     public abstract class AzureServiceBusSendActivity : Activity
     {
         private readonly IContentSerializer _serializer;
-
-        protected AzureServiceBusSendActivity(IContentSerializer serializer)
-        {
-            _serializer = serializer;
-        }
+        protected AzureServiceBusSendActivity(IContentSerializer serializer) => _serializer = serializer;
 
         [ActivityInput(SupportedSyntaxes = new[] { SyntaxNames.JavaScript, SyntaxNames.Liquid, SyntaxNames.Json })]
         public object Message { get; set; } = default!;
@@ -69,8 +65,8 @@ namespace Elsa.Activities.AzureServiceBus
         [ActivityInput(Category = PropertyCategories.Advanced, DefaultSyntax = SyntaxNames.Json, SupportedSyntaxes = new[] { SyntaxNames.JavaScript, SyntaxNames.Liquid, SyntaxNames.Json }, UIHint = ActivityInputUIHints.MultiLine)]
         public IDictionary<string, object>? UserProperties { get; set; } = new Dictionary<string, object>();
 
-        [ActivityInput(Category = PropertyCategories.Advanced,Hint = "If set, the message will be send to the Service Bus only after Workflow Suspend, usefull for Request/Response pattern", DefaultValue = false)]
-        public bool SendMessageOnSupend { get; set; }
+        [ActivityInput(Category = PropertyCategories.Advanced,Hint = "If set, the message will be sent to the Service Bus only after the workflow is suspended, which is useful for the Request/Response pattern.", DefaultValue = false)]
+        public bool SendMessageOnSuspend { get; set; }
 
         protected abstract Task<ISenderClient> GetSenderAsync();
 
@@ -82,7 +78,7 @@ namespace Elsa.Activities.AzureServiceBus
                 message.CorrelationId = context.WorkflowExecutionContext.CorrelationId;
 
             var sender = await GetSenderAsync();
-            if(SendMessageOnSupend)
+            if(SendMessageOnSuspend)
                 return Combine(Done(), new ServiceBusActionResult(sender, message));
             else
             {

--- a/src/activities/Elsa.Activities.AzureServiceBus/ActivityExecutionResults/ServiceBusActionResult.cs
+++ b/src/activities/Elsa.Activities.AzureServiceBus/ActivityExecutionResults/ServiceBusActionResult.cs
@@ -7,7 +7,6 @@ using Microsoft.Azure.ServiceBus.Core;
 
 namespace Elsa.Activities.AzureServiceBus.ActivityExecutionResults
 {
-
     public class ServiceBusActionResult : ActivityExecutionResult
     {
         public ServiceBusActionResult(ISenderClient sender, Message message)
@@ -21,11 +20,7 @@ namespace Elsa.Activities.AzureServiceBus.ActivityExecutionResults
 
         protected override void Execute(ActivityExecutionContext activityExecutionContext)
         {
-            async ValueTask ScheduleMessageAsync(WorkflowExecutionContext workflowExecutionContext, CancellationToken cancellationToken)
-            {
-                await Sender.SendAsync(Message);
-            }
-
+            async ValueTask ScheduleMessageAsync(WorkflowExecutionContext workflowExecutionContext, CancellationToken cancellationToken) => await Sender.SendAsync(Message);
             activityExecutionContext.WorkflowExecutionContext.RegisterTask(ScheduleMessageAsync);
         }
     }

--- a/src/activities/Elsa.Activities.AzureServiceBus/ActivityExecutionResults/ServiceBusActionResult.cs
+++ b/src/activities/Elsa.Activities.AzureServiceBus/ActivityExecutionResults/ServiceBusActionResult.cs
@@ -5,26 +5,28 @@ using Elsa.Services.Models;
 using Microsoft.Azure.ServiceBus;
 using Microsoft.Azure.ServiceBus.Core;
 
-namespace Elsa.Activities.AzureServiceBus.ActivityExecutionResults;
-
-public class ServiceBusActionResult : ActivityExecutionResult
+namespace Elsa.Activities.AzureServiceBus.ActivityExecutionResults
 {
-    public ServiceBusActionResult(ISenderClient sender, Message message)
-    {
-        Sender = sender;
-        Message = message;
-    }
 
-    public ISenderClient Sender { get; }
-    public Message Message { get; }
-
-    protected override void Execute(ActivityExecutionContext activityExecutionContext)
+    public class ServiceBusActionResult : ActivityExecutionResult
     {
-        async ValueTask ScheduleMessageAsync(WorkflowExecutionContext workflowExecutionContext, CancellationToken cancellationToken)
+        public ServiceBusActionResult(ISenderClient sender, Message message)
         {
-            await Sender.SendAsync(Message);
+            Sender = sender;
+            Message = message;
         }
 
-        activityExecutionContext.WorkflowExecutionContext.RegisterTask(ScheduleMessageAsync);
+        public ISenderClient Sender { get; }
+        public Message Message { get; }
+
+        protected override void Execute(ActivityExecutionContext activityExecutionContext)
+        {
+            async ValueTask ScheduleMessageAsync(WorkflowExecutionContext workflowExecutionContext, CancellationToken cancellationToken)
+            {
+                await Sender.SendAsync(Message);
+            }
+
+            activityExecutionContext.WorkflowExecutionContext.RegisterTask(ScheduleMessageAsync);
+        }
     }
 }

--- a/src/activities/Elsa.Activities.AzureServiceBus/ActivityExecutionResults/ServiceBusActionResult.cs
+++ b/src/activities/Elsa.Activities.AzureServiceBus/ActivityExecutionResults/ServiceBusActionResult.cs
@@ -1,0 +1,30 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Elsa.ActivityResults;
+using Elsa.Services.Models;
+using Microsoft.Azure.ServiceBus;
+using Microsoft.Azure.ServiceBus.Core;
+
+namespace Elsa.Activities.AzureServiceBus.ActivityExecutionResults;
+
+public class ServiceBusActionResult : ActivityExecutionResult
+{
+    public ServiceBusActionResult(ISenderClient sender, Message message)
+    {
+        Sender = sender;
+        Message = message;
+    }
+
+    public ISenderClient Sender { get; }
+    public Message Message { get; }
+
+    protected override void Execute(ActivityExecutionContext activityExecutionContext)
+    {
+        async ValueTask ScheduleMessageAsync(WorkflowExecutionContext workflowExecutionContext, CancellationToken cancellationToken)
+        {
+            await Sender.SendAsync(Message);
+        }
+
+        activityExecutionContext.WorkflowExecutionContext.RegisterTask(ScheduleMessageAsync);
+    }
+}

--- a/src/core/Elsa.Abstractions/ActivityResults/SuspendResult.cs
+++ b/src/core/Elsa.Abstractions/ActivityResults/SuspendResult.cs
@@ -18,7 +18,7 @@ namespace Elsa.ActivityResults
             activityExecutionContext.WorkflowExecutionContext.Suspend();
 
             var mediator = activityExecutionContext.ServiceProvider.GetRequiredService<IMediator>();
-            await mediator.Publish(new BlockingActivityAdded(activityExecutionContext.WorkflowExecutionContext, blockingActivity));
+            await mediator.Publish(new BlockingActivityAdded(activityExecutionContext.WorkflowExecutionContext, blockingActivity), cancellationToken);
         }
     }
 }

--- a/src/core/Elsa.Core/Handlers/ExecuteWorkflowsPostSuspensionTasks.cs
+++ b/src/core/Elsa.Core/Handlers/ExecuteWorkflowsPostSuspensionTasks.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Elsa.Events;
 using Elsa.Persistence;
+using Elsa.Services;
 using MediatR;
 
 namespace Elsa.Handlers
@@ -10,14 +11,20 @@ namespace Elsa.Handlers
     public class ExecuteWorkflowsPostSuspensionTasks : INotificationHandler<WorkflowSuspended>
     {
         private readonly IWorkflowInstanceStore _workflowInstanceStore;
+        private readonly IBookmarkIndexer _bookmarkIndexer;
 
-        public ExecuteWorkflowsPostSuspensionTasks(IWorkflowInstanceStore workflowInstanceStore)
+        public ExecuteWorkflowsPostSuspensionTasks(IWorkflowInstanceStore workflowInstanceStore, IBookmarkIndexer bookmarkIndexer)
         {
             _workflowInstanceStore = workflowInstanceStore;
+            _bookmarkIndexer = bookmarkIndexer;
         }
         
         public async Task Handle(WorkflowSuspended notification, CancellationToken cancellationToken)
         {
+            // Before processing tasks, make sure bookmarks are up to date.
+            var workflowInstance = notification.WorkflowExecutionContext.WorkflowInstance;
+            await _bookmarkIndexer.IndexBookmarksAsync(workflowInstance, cancellationToken);
+            
             try
             {
                 await notification.WorkflowExecutionContext.ProcessRegisteredTasksAsync(cancellationToken);

--- a/test/integration/Elsa.Core.IntegrationTests/Elsa.Core.IntegrationTests.csproj
+++ b/test/integration/Elsa.Core.IntegrationTests/Elsa.Core.IntegrationTests.csproj
@@ -53,6 +53,7 @@
         <ProjectReference Include="..\..\..\src\persistence\Elsa.Persistence.YesSql\Elsa.Persistence.YesSql.csproj"/>
         <ProjectReference Include="..\..\..\src\persistence\Elsa.Persistence.EntityFramework\Elsa.Persistence.EntityFramework.Core\Elsa.Persistence.EntityFramework.Core.csproj"/>
         <ProjectReference Include="..\..\..\src\persistence\Elsa.Persistence.EntityFramework\Elsa.Persistence.EntityFramework.Sqlite\Elsa.Persistence.EntityFramework.Sqlite.csproj"/>
+        <ProjectReference Include="..\..\..\src\activities\Elsa.Activities.AzureServiceBus\Elsa.Activities.AzureServiceBus.csproj" />
     </ItemGroup>
 
 </Project>

--- a/test/integration/Elsa.Core.IntegrationTests/Workflows/ServiceBusWorkflowTest.cs
+++ b/test/integration/Elsa.Core.IntegrationTests/Workflows/ServiceBusWorkflowTest.cs
@@ -1,0 +1,143 @@
+using Elsa.Builders;
+using Elsa.Models;
+using Elsa.Testing.Shared.Unit;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+using Elsa.Activities.Console;
+using Elsa.Activities.AzureServiceBus;
+using Elsa.Activities.AzureServiceBus.Services;
+using Moq;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Azure.ServiceBus.Core;
+using Microsoft.Azure.ServiceBus;
+using System.Threading;
+using Elsa.Runtime;
+using Elsa.Activities.AzureServiceBus.StartupTasks;
+using Elsa.Services;
+using Elsa.Services.Models;
+using System.Reflection;
+using Elsa.Services.Workflows;
+using Elsa.Activities.AzureServiceBus.Bookmarks;
+
+namespace Elsa.Core.IntegrationTests.Workflows
+{
+    public class ServiceBusWorkflowTest : WorkflowsUnitTestBase
+    {
+
+        public static Mock<ITopicMessageSenderFactory> TopicMessageSenderFactory = new();
+        public static Mock<ITopicMessageReceiverFactory> TopicMessageReceiverFactory = new();
+        public static Mock<ISenderClient> SenderClient = new();
+        public static Mock<IReceiverClient> ReceiverClient = new();
+        public static Mock<IWorkflowRegistry> WorkflowRegistryMoq = new();
+        public static Mock<IWorkflowLaunchpad> WorkflowLaunchpad = new();
+        
+        private static IWorkflowBlueprint ServiceBusBluePrint ;
+
+        public ServiceBusWorkflowTest(ITestOutputHelper testOutputHelper)
+            : base(testOutputHelper,
+                  services => {
+                      services
+                      .AddSingleton(TopicMessageSenderFactory.Object)
+                      .AddSingleton(TopicMessageReceiverFactory.Object)
+                      .AddSingleton<IWorkflowLaunchpad,WorkflowLaunchpad>()
+                      .AddSingleton<Scoped<IWorkflowLaunchpad>>()
+                      .AddSingleton<IServiceBusTopicsStarter, ServiceBusTopicsStarter>()
+                      .AddSingleton<IWorkflowRegistry>(WorkflowRegistryMoq.Object)
+                      .AddBookmarkProvider<TopicMessageReceivedBookmarkProvider>()
+                      .AddStartupTask<StartServiceBusTopics>();                     
+                      
+                  },
+                  options=> {
+                      options
+                        .AddActivity<SendAzureServiceBusTopicMessage>()
+                        .AddActivity<AzureServiceBusTopicMessageReceived>()
+                        
+                        ;
+
+                  })
+        {
+
+            Func<Message, CancellationToken, Task> handler = null;
+
+            SenderClient
+                .Setup(x => x.SendAsync(It.IsAny<Microsoft.Azure.ServiceBus.Message>()))
+                .Callback<Message>(msg=>
+                {
+                        //hack needed to avoid issue when getting msg from SB
+                        var systemProperties = msg.SystemProperties;
+
+                        // systemProperties.EnqueuedTimeUtc = DateTime.UtcNow.AddMinutes(1);
+                        var bindings = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.SetProperty;
+                        var value = DateTime.UtcNow.AddMinutes(1);
+                        systemProperties.GetType().InvokeMember("EnqueuedTimeUtc", bindings, Type.DefaultBinder, systemProperties, new object[] { value });
+                        // workaround "ThrowIfNotReceived" by setting "SequenceNumber" value
+                        systemProperties.GetType().InvokeMember("SequenceNumber", bindings, Type.DefaultBinder, systemProperties, new object[] { 1 });
+
+                        // message.systemProperties = systemProperties;
+                        bindings = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.SetProperty;
+                        msg.GetType().InvokeMember("SystemProperties", bindings, Type.DefaultBinder, msg, new object[] { systemProperties });
+
+                        handler!.Invoke(msg, new CancellationToken());
+
+                    })
+                .Returns(Task.FromResult(1));
+
+            ReceiverClient
+                .Setup(x => x.RegisterMessageHandler(It.IsAny<Func<Message, CancellationToken, Task>>(), It.IsAny<MessageHandlerOptions>()))
+                .Callback<Func<Message, CancellationToken, Task>, MessageHandlerOptions>((messageHandler, options) => {
+                    handler = messageHandler;
+                });
+
+            ReceiverClient
+                .Setup(x => x.Path)
+                .Returns($"testtopic2/subscriptions/testsub");
+
+            TopicMessageSenderFactory
+                .Setup(x => x.GetTopicSenderAsync(It.IsAny<string>(), default))
+                .Returns(Task.FromResult(SenderClient.Object));
+
+            TopicMessageReceiverFactory
+                .Setup(x => x.GetTopicReceiverAsync(It.IsAny<string>(), It.IsAny<string>(), default))
+                .Returns(Task.FromResult(ReceiverClient.Object));
+
+            ServiceBusBluePrint = WorkflowBuilder.Build<ServiceBusWokflow>();
+            WorkflowRegistryMoq
+                .Setup(x => x.ListActiveAsync(It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult((new List<IWorkflowBlueprint>() { ServiceBusBluePrint }).AsEnumerable()));
+
+        }
+
+        [Fact(DisplayName = "Send Message Bus after Suspend to avoid receiving response before indexing bookmark.")]
+        public async Task SendRequestAfterSuspend()
+        {
+            var runWorkflowResult = await WorkflowStarter.StartWorkflowAsync(ServiceBusBluePrint);
+            
+            var workflowInstance = runWorkflowResult.WorkflowInstance!;
+
+            Assert.Equal(WorkflowStatus.Finished, workflowInstance.WorkflowStatus);
+        }
+    }
+
+    public class ServiceBusWokflow : IWorkflow
+    {
+        public void Build(IWorkflowBuilder builder)
+        {
+            builder
+            .WriteLine(ctx =>
+            {
+                var correlationId = System.Guid.NewGuid().ToString("n");
+                ctx.WorkflowInstance.CorrelationId = correlationId;
+
+                return $"Start! - correlationId: {correlationId}";
+            })
+            .SendTopicMessage("testtopic2", "\"Hello World\"")
+            .TopicMessageReceived<string>("testtopic2", "testsub")
+            .WriteLine(ctx => "End: " + (string)ctx.Input);
+        }
+    }
+}

--- a/test/integration/Elsa.Core.IntegrationTests/Workflows/ServiceBusWorkflowTest.cs
+++ b/test/integration/Elsa.Core.IntegrationTests/Workflows/ServiceBusWorkflowTest.cs
@@ -4,7 +4,6 @@ using Elsa.Testing.Shared.Unit;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
@@ -23,79 +22,67 @@ using Elsa.Services.Models;
 using System.Reflection;
 using Elsa.Services.Workflows;
 using Elsa.Activities.AzureServiceBus.Bookmarks;
-using Rebus.Handlers;
-using Elsa.Options;
 
 namespace Elsa.Core.IntegrationTests.Workflows
 {
     public class ServiceBusWorkflowTest : WorkflowsUnitTestBase
     {
-
-        public static Mock<ITopicMessageSenderFactory> TopicMessageSenderFactory = new();
-        public static Mock<ITopicMessageReceiverFactory> TopicMessageReceiverFactory = new();
-        public static Mock<ISenderClient> SenderClient = new();
-        public static Mock<IReceiverClient> ReceiverClient = new();
-        public static Mock<IWorkflowRegistry> WorkflowRegistryMoq = new();
-        public static Mock<IWorkflowLaunchpad> WorkflowLaunchpad = new();
-        
-        private static IWorkflowBlueprint ServiceBusBluePrint ;
-        public static AutoResetEvent WaitHandleTest = new AutoResetEvent(false);
+        private static readonly Mock<ITopicMessageSenderFactory> TopicMessageSenderFactory = new();
+        private static readonly Mock<ITopicMessageReceiverFactory> TopicMessageReceiverFactory = new();
+        private static readonly Mock<ISenderClient> SenderClient = new();
+        private static readonly Mock<IReceiverClient> ReceiverClient = new();
+        private static readonly Mock<IWorkflowRegistry> WorkflowRegistryMoq = new();
+        private static readonly AutoResetEvent WaitHandleTest = new(false);
+        private static IWorkflowBlueprint _serviceBusBluePrint = default!;
 
         public ServiceBusWorkflowTest(ITestOutputHelper testOutputHelper)
             : base(testOutputHelper,
-                  services => {
-                      services
-                      .AddSingleton(TopicMessageSenderFactory.Object)
-                      .AddSingleton(TopicMessageReceiverFactory.Object)
-                      .AddSingleton<IWorkflowLaunchpad,WorkflowLaunchpad>()
-                      .AddSingleton<Scoped<IWorkflowLaunchpad>>()
-                      .AddSingleton<IServiceBusTopicsStarter, ServiceBusTopicsStarter>()
-                      .AddSingleton<IWorkflowRegistry>(WorkflowRegistryMoq.Object)
-                      .AddBookmarkProvider<TopicMessageReceivedBookmarkProvider>()
-                      .AddStartupTask<StartServiceBusTopics>();
+                services =>
+                {
+                    services
+                        .AddSingleton(TopicMessageSenderFactory.Object)
+                        .AddSingleton(TopicMessageReceiverFactory.Object)
+                        .AddSingleton<IWorkflowLaunchpad, WorkflowLaunchpad>()
+                        .AddSingleton<Scoped<IWorkflowLaunchpad>>()
+                        .AddSingleton<IServiceBusTopicsStarter, ServiceBusTopicsStarter>()
+                        .AddSingleton(WorkflowRegistryMoq.Object)
+                        .AddBookmarkProvider<TopicMessageReceivedBookmarkProvider>()
+                        .AddStartupTask<StartServiceBusTopics>();
 
-
-                      services
-                      .AddSingleton<ServiceBusWorkflow>(new ServiceBusWorkflow(WaitHandleTest));
-                  },
-                  options=> {                      
-                      options
+                    services
+                        .AddSingleton(new ServiceBusWorkflow(WaitHandleTest));
+                },
+                options =>
+                {
+                    options
                         .AddActivity<SendAzureServiceBusTopicMessage>()
                         .AddActivity<AzureServiceBusTopicMessageReceived>()
                         ;
-                  })
+                })
         {
-
-            Func<Message, CancellationToken, Task> handler = null;
+            Func<Message, CancellationToken, Task> handler = default!;
 
             SenderClient
                 .Setup(x => x.SendAsync(It.IsAny<Microsoft.Azure.ServiceBus.Message>()))
-                .Callback<Message>(msg=>
+                .Callback<Message>(msg =>
                 {
-                        //hack needed to avoid issue when getting msg from SB
-                        var systemProperties = msg.SystemProperties;
+                    // Hack needed to avoid issue when getting msg from SB.
+                    var systemProperties = msg.SystemProperties;
 
-                        // systemProperties.EnqueuedTimeUtc = DateTime.UtcNow.AddMinutes(1);
-                        var bindings = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.SetProperty;
-                        var value = DateTime.UtcNow.AddMinutes(1);
-                        systemProperties.GetType().InvokeMember("EnqueuedTimeUtc", bindings, Type.DefaultBinder, systemProperties, new object[] { value });
-                        // workaround "ThrowIfNotReceived" by setting "SequenceNumber" value
-                        systemProperties.GetType().InvokeMember("SequenceNumber", bindings, Type.DefaultBinder, systemProperties, new object[] { 1 });
+                    var bindings = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.SetProperty;
+                    var value = DateTime.UtcNow.AddMinutes(1);
 
-                        // message.systemProperties = systemProperties;
-                        bindings = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.SetProperty;
-                        msg.GetType().InvokeMember("SystemProperties", bindings, Type.DefaultBinder, msg, new object[] { systemProperties });
-
-                        handler!.Invoke(msg, new CancellationToken());
-
-                    })
+                    systemProperties.GetType().InvokeMember("EnqueuedTimeUtc", bindings, Type.DefaultBinder, systemProperties, new object[] { value });
+                    systemProperties.GetType().InvokeMember("SequenceNumber", bindings, Type.DefaultBinder, systemProperties, new object[] { 1 });
+                    bindings = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.SetProperty;
+                    msg.GetType().InvokeMember("SystemProperties", bindings, Type.DefaultBinder, msg, new object[] { systemProperties });
+                    handler!.Invoke(msg, new CancellationToken());
+                })
                 .Returns(Task.FromResult(1));
 
             ReceiverClient
                 .Setup(x => x.RegisterMessageHandler(It.IsAny<Func<Message, CancellationToken, Task>>(), It.IsAny<MessageHandlerOptions>()))
-                .Callback<Func<Message, CancellationToken, Task>, MessageHandlerOptions>((messageHandler, options) => {
-                    handler = messageHandler;
-                });
+                .Callback<Func<Message, CancellationToken, Task>, MessageHandlerOptions>((messageHandler, _) => { handler = messageHandler; });
 
             ReceiverClient
                 .Setup(x => x.Path)
@@ -109,57 +96,50 @@ namespace Elsa.Core.IntegrationTests.Workflows
                 .Setup(x => x.GetTopicReceiverAsync(It.IsAny<string>(), It.IsAny<string>(), default))
                 .Returns(Task.FromResult(ReceiverClient.Object));
 
-            ServiceBusBluePrint = WorkflowBuilder.Build<ServiceBusWorkflow>();
-            
+            _serviceBusBluePrint = WorkflowBuilder.Build<ServiceBusWorkflow>();
+
             WorkflowRegistryMoq
                 .Setup(x => x.ListActiveAsync(It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(new List<IWorkflowBlueprint>() { ServiceBusBluePrint }.AsEnumerable()));
-            
+                .Returns(Task.FromResult(new List<IWorkflowBlueprint>() { _serviceBusBluePrint }.AsEnumerable()));
+
             WorkflowRegistryMoq
                 .Setup(x => x.GetAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<VersionOptions>(), It.IsAny<CancellationToken>(), false))
-                .Returns(Task.FromResult(ServiceBusBluePrint)!);
-
+                .Returns(Task.FromResult(_serviceBusBluePrint)!);
         }
 
         [Fact(DisplayName = "Send Message Bus after Suspend to avoid receiving response before indexing bookmark.")]
         public async Task SendRequestAfterSuspend()
         {
-            var runWorkflowResult = await WorkflowStarter.StartWorkflowAsync(ServiceBusBluePrint);
-            var workflowInstance = runWorkflowResult.WorkflowInstance!;
-            var result = WaitHandleTest.WaitOne(TimeSpan.FromSeconds(2));
-            Assert.True(result);         
+            await WorkflowStarter.StartWorkflowAsync(_serviceBusBluePrint);
+            var result = WaitHandleTest.WaitOne(TimeSpan.FromSeconds(10));
+            Assert.True(result);
         }
     }
+
     public class ServiceBusWorkflow : IWorkflow
     {
-        private AutoResetEvent autoEvent_ = new AutoResetEvent(false);
-        public ServiceBusWorkflow(AutoResetEvent autoEvent)
-        {
-            this.autoEvent_ = autoEvent;
-        }
+        private readonly AutoResetEvent _autoEvent;
+        public ServiceBusWorkflow(AutoResetEvent autoEvent) => _autoEvent = autoEvent;
 
         public void Build(IWorkflowBuilder builder)
         {
             builder
-            .WriteLine(ctx =>
-            {
-                var correlationId = System.Guid.NewGuid().ToString("n");
-                ctx.WorkflowInstance.CorrelationId = correlationId;
-
-                return $"Start! - correlationId: {correlationId}";
-            })
-            .SendTopicMessage(setup =>
-            {
-                setup.Set(x => x.TopicName, "testtopic2");
-                setup.Set(x => x.Message, "\"Hello World\"");
-                setup.Set(x => x.SendMessageOnSupend, true);
-            })
-            .TopicMessageReceived<string>("testtopic2", "testsub")
-            .WriteLine(ctx =>
+                .WriteLine(ctx =>
                 {
-                    autoEvent_.Set();
-                    return "End: " + (string)ctx.Input;
-                });
+                    var correlationId = System.Guid.NewGuid().ToString("n");
+                    ctx.WorkflowInstance.CorrelationId = correlationId;
+
+                    return $"Start! - correlationId: {correlationId}";
+                })
+                .SendTopicMessage(setup =>
+                {
+                    setup.Set(x => x.TopicName, "testtopic2");
+                    setup.Set(x => x.Message, "\"Hello World\"");
+                    setup.Set(x => x.SendMessageOnSuspend, true);
+                })
+                .TopicMessageReceived<string>("testtopic2", "testsub")
+                .Then(() => _autoEvent.Set())
+                .WriteLine(ctx => "End: " + (string)ctx.Input!);
         }
     }
 }

--- a/test/integration/Elsa.Core.IntegrationTests/Workflows/ServiceBusWorkflowTest.cs
+++ b/test/integration/Elsa.Core.IntegrationTests/Workflows/ServiceBusWorkflowTest.cs
@@ -41,7 +41,6 @@ namespace Elsa.Core.IntegrationTests.Workflows
         private static IWorkflowBlueprint ServiceBusBluePrint ;
         public static AutoResetEvent WaitHandleTest = new AutoResetEvent(false);
 
-
         public ServiceBusWorkflowTest(ITestOutputHelper testOutputHelper)
             : base(testOutputHelper,
                   services => {
@@ -59,15 +58,11 @@ namespace Elsa.Core.IntegrationTests.Workflows
                       services
                       .AddSingleton<ServiceBusWorkflow>(new ServiceBusWorkflow(WaitHandleTest));
                   },
-                  options=> {
-                      
+                  options=> {                      
                       options
                         .AddActivity<SendAzureServiceBusTopicMessage>()
                         .AddActivity<AzureServiceBusTopicMessageReceived>()
                         ;
-
-                      
-
                   })
         {
 
@@ -130,17 +125,7 @@ namespace Elsa.Core.IntegrationTests.Workflows
         public async Task SendRequestAfterSuspend()
         {
             var runWorkflowResult = await WorkflowStarter.StartWorkflowAsync(ServiceBusBluePrint);
-            
             var workflowInstance = runWorkflowResult.WorkflowInstance!;
-
-            // TODO: Figure out a way to wait until Rebus processed the dispatched `ExecuteWorkflowInstanceRequest` message (which happens asynchronously in-memory).
-            // Until then, yielding control here and waiting for a few seconds works too. 
-            //await Task.Delay(TimeSpan.FromSeconds(2));
-            //Assert.Equal(WorkflowStatus.Finished, workflowInstance.WorkflowStatus);
-
-            //Or change the result of the UnitTest, We only want to be sure that
-            // the Receive Activity execute (more or less instantly.)
-            // if not, the workflow should be suspended (and wait) because Bookmark is not successfully indexed.
             var result = WaitHandleTest.WaitOne(TimeSpan.FromSeconds(2));
             Assert.True(result);         
         }

--- a/test/integration/Elsa.Core.IntegrationTests/Workflows/ServiceBusWorkflowTest.cs
+++ b/test/integration/Elsa.Core.IntegrationTests/Workflows/ServiceBusWorkflowTest.cs
@@ -124,13 +124,7 @@ namespace Elsa.Core.IntegrationTests.Workflows
         public void Build(IWorkflowBuilder builder)
         {
             builder
-                .WriteLine(ctx =>
-                {
-                    var correlationId = System.Guid.NewGuid().ToString("n");
-                    ctx.WorkflowInstance.CorrelationId = correlationId;
-
-                    return $"Start! - correlationId: {correlationId}";
-                })
+                .WriteLine(ctx => $"Start! - correlationId: {ctx.WorkflowInstance.CorrelationId}")
                 .SendTopicMessage(setup =>
                 {
                     setup.Set(x => x.TopicName, "testtopic2");

--- a/test/integration/Elsa.Core.IntegrationTests/Workflows/ServiceBusWorkflowTest.cs
+++ b/test/integration/Elsa.Core.IntegrationTests/Workflows/ServiceBusWorkflowTest.cs
@@ -58,9 +58,6 @@ namespace Elsa.Core.IntegrationTests.Workflows
 
                       services
                       .AddSingleton<ServiceBusWorkflow>(new ServiceBusWorkflow(WaitHandleTest));
-                      //.AddSingleton<IWaitHandleTest>(WaitHandleTest)
-                      //.Replace<IHandleMessages<ExecuteWorkflowInstanceRequest>, ExecuteWorkflowInstanceRequestConsumerTest>(ServiceLifetime.Transient);
-
                   },
                   options=> {
                       


### PR DESCRIPTION
This PR is a the first of Azure Service Bus Enhancement #753  , that allow to use Fire and Forget for the Topic Sender.

This allow to wait before sending the Message to the Service Bus. 
With this, we can wait for the next suspend and use a Service Bus Received Activity to receive the response. If not setting FireAndForget to false, we can have side effect and receive the message using the Topic Worker before the BookMark with Correlation Id was correctly set.

The default value is True to avoid breaking change (sent directly)