### PR TITLE
Fix MySql does not support the EF Core concept of schemas

### DIFF
--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.MySql/DbContextOptionsBuilderExtensions.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.MySql/DbContextOptionsBuilderExtensions.cs
@@ -1,5 +1,6 @@
 using Elsa.Persistence.EntityFramework.Core;
 using Microsoft.EntityFrameworkCore;
+using Pomelo.EntityFrameworkCore.MySql.Infrastructure;
 
 namespace Elsa.Persistence.EntityFramework.MySql
 {
@@ -11,6 +12,7 @@ namespace Elsa.Persistence.EntityFramework.MySql
         public static DbContextOptionsBuilder UseMySql(this DbContextOptionsBuilder builder, string connectionString) => 
             builder.UseMySql(connectionString, ServerVersion.AutoDetect(connectionString), db => db
                 .MigrationsAssembly(typeof(MySqlElsaContextFactory).Assembly.GetName().Name)
-                .MigrationsHistoryTable(ElsaContext.MigrationsHistoryTable, ElsaContext.ElsaSchema));
+                .MigrationsHistoryTable(ElsaContext.MigrationsHistoryTable, ElsaContext.ElsaSchema)
+                .SchemaBehavior(MySqlSchemaBehavior.Ignore));
     }
 }


### PR DESCRIPTION
### error
TargetFramework: net5.0
MySql: 10.4.8-MariaDB
```c#
services
	.AddElsa(elsa => elsa
		.UseEntityFrameworkPersistence(ef => ef.UseMySql("Server=*;port=*;UserId=*;Password=*;Database=elsa;"))
		.AddConsoleActivities()
		.AddHttpActivities(opt => opt.BaseUrl = new Uri(appSettings.BaseUrl))
		.AddQuartzTemporalActivities()
		.AddActivitiesFrom<Startup>()
		.AddWorkflowsFrom<Startup>()
	);
```
#### results：
System.InvalidOperationException:
“A schema "Elsa" has been set for an object of type "CreateTableOperation" with the name of "__EFMigrationsHistory". MySQL does not support the EF Core concept of schemas. Any schema property of any "MigrationOperation" must be null. This behavior can be changed by setting the `SchemaBehavior` option in the `UseMySql` call.”

### fix
ignore the schema, see https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/pull/982