### PR TITLE
Fix EFCore.BulkExtensions does not support MySQL

### DIFF
--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/Extensions/MySqlDatabaseFacadeExtensions.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/Extensions/MySqlDatabaseFacadeExtensions.cs
@@ -1,0 +1,9 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
+namespace Elsa.Persistence.EntityFramework.Core.Extensions
+{
+    internal static class MySqlDatabaseFacadeExtensions
+    {
+        public static bool IsMySql(this DatabaseFacade database) => database.ProviderName == "Pomelo.EntityFrameworkCore.MySql";
+    }
+}

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/Extensions/QueryableBulkExtensions.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/Extensions/QueryableBulkExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using EFCore.BulkExtensions;
@@ -10,9 +10,10 @@ namespace Elsa.Persistence.EntityFramework.Core.Extensions
     {
         public static async Task<int> BatchDeleteWithWorkAroundAsync<T>(this IQueryable<T> queryable, ElsaContext elsaContext, CancellationToken cancellationToken = default) where T : class
         {
-            if (elsaContext.Database.IsPostgres())
+            if (elsaContext.Database.IsPostgres() || elsaContext.Database.IsMySql())
             {
-                // Need this workaround until https://github.com/borisdj/EFCore.BulkExtensions/issues/67 is solved.    
+                // Need this workaround until https://github.com/borisdj/EFCore.BulkExtensions/issues/67
+                // and https://github.com/borisdj/EFCore.BulkExtensions/issues/553 is solved.
                 var records = await queryable.ToListAsync(cancellationToken);
 
                 foreach (var @record in records) 
@@ -20,7 +21,7 @@ namespace Elsa.Persistence.EntityFramework.Core.Extensions
 
                 return records.Count;
             }
-            
+
             return await queryable.BatchDeleteAsync(cancellationToken);
         }
     }


### PR DESCRIPTION
### error
TargetFramework: net5.0
MySql: 10.4.8-MariaDB

handle an incoming HTTP request:
```
ArgumentOutOfRangeException: Length cannot be less than zero. (Parameter 'length')
string.Substring(int startIndex, int length)
EFCore.BulkExtensions.SQLAdapters.SQLServer.SqlServerDialect.GetBatchSqlReformatTableAliasAndTopStatement(string sqlQuery)
EFCore.BulkExtensions.BatchUtil.GetBatchSql(IQueryable query, DbContext context, bool isUpdate)
EFCore.BulkExtensions.BatchUtil.GetSqlDelete(IQueryable query, DbContext context)
EFCore.BulkExtensions.IQueryableBatchExtensions.GetBatchDeleteArguments(IQueryable query)
EFCore.BulkExtensions.IQueryableBatchExtensions.BatchDeleteAsync(IQueryable query, CancellationToken cancellationToken)
Elsa.Persistence.EntityFramework.Core.Extensions.QueryableBulkExtensions.BatchDeleteWithWorkAroundAsync<T>(IQueryable<T> queryable, ElsaContext elsaContext, CancellationToken cancellationToken) in QueryableBulkExtensions.cs

24 return await queryable.BatchDeleteAsync(cancellationToken);

Elsa.Persistence.EntityFramework.Core.Stores.EntityFrameworkStore<T>+<>c__DisplayClass11_0+<<DeleteManyAsync>b__0>d.MoveNext() in EntityFrameworkStore.cs
```

EFCore.BulkExtensions does not support MySQL, see https://github.com/borisdj/EFCore.BulkExtensions/issues/553#issuecomment-841681251

### fix
additional handling of mysql