### PR TITLE
Multi targeting for .NET Core 3.1 and .NET 5

### DIFF
--- a/src/activities/Elsa.Activities.Conductor/Elsa.Activities.Conductor.csproj
+++ b/src/activities/Elsa.Activities.Conductor/Elsa.Activities.Conductor.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\configureawait.props" />
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>netstandard2.1</TargetFramework>
         <Description>
             Elsa is a set of workflow libraries and tools that enable lean and mean workflowing capabilities in any .NET Core application.
             This package provides activities to implement conductor-style workflows where Elsa sends commands to your application, which responds asynchronously with events.

--- a/src/activities/Elsa.Activities.Http/Elsa.Activities.Http.csproj
+++ b/src/activities/Elsa.Activities.Http/Elsa.Activities.Http.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\configureawait.props" />
     
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>        
         <Description>
             Elsa is a set of workflow libraries and tools that enable lean and mean workflowing capabilities in any .NET Core application.
             This package provides the following Console activities:

--- a/src/activities/Elsa.Activities.Http/Parsers/JsonHttpResponseBodyParser.cs
+++ b/src/activities/Elsa.Activities.Http/Parsers/JsonHttpResponseBodyParser.cs
@@ -15,8 +15,11 @@ namespace Elsa.Activities.Http.Parsers
 
         public async Task<object> ParseAsync(HttpResponseMessage response, CancellationToken cancellationToken)
         {
+#if NET
             var json = (await response.Content.ReadAsStringAsync(cancellationToken)).Trim();
-            
+#else
+            var json = (await response.Content.ReadAsStringAsync()).Trim();
+#endif
             if(json.StartsWith('['))
                 return JsonConvert.DeserializeObject<ExpandoObject[]>(json)!;
             

--- a/src/activities/Elsa.Activities.Webhooks/Elsa.Activities.Webhooks.csproj
+++ b/src/activities/Elsa.Activities.Webhooks/Elsa.Activities.Webhooks.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\configureawait.props" />
     
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
         <Description>
             Elsa is a set of workflow libraries and tools that enable lean and mean workflowing capabilities in any .NET Core application.
             This package provides the Webhooks activities.

--- a/src/dashboards/ElsaDashboard/ElsaDashboard.Web.csproj
+++ b/src/dashboards/ElsaDashboard/ElsaDashboard.Web.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/designer/bindings/aspnet/Elsa.Designer.Components.Web/Elsa.Designer.Components.Web.csproj
+++ b/src/designer/bindings/aspnet/Elsa.Designer.Components.Web/Elsa.Designer.Components.Web.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\..\..\configureawait.props" />
     
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
         <Description>
             Elsa is a set of workflow libraries and tools that enable lean and mean workflowing capabilities in any .NET Core application.
             This package provides ASP.NET Core component bindings for the Elsa Designer web component.
@@ -16,8 +16,12 @@
         <SupportedPlatform Include="browser" />
     </ItemGroup>
 
-    <ItemGroup>
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0'">
         <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="5.0.6" />
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1'">
+        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.16" />
     </ItemGroup>
 
 </Project>

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.MySql/Elsa.Persistence.EntityFramework.MySql.csproj
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.MySql/Elsa.Persistence.EntityFramework.MySql.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\..\configureawait.props" />
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.1</TargetFramework>
+        <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
         <Description>
             Elsa is a set of workflow libraries and tools that enable lean and mean workflowing capabilities in any .NET Core application.
             This package provides Entity Framework Core migrations for the MySql database provider.

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.MySql/Elsa.Persistence.EntityFramework.MySql.csproj
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.MySql/Elsa.Persistence.EntityFramework.MySql.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\..\configureawait.props" />
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>netstandard2.1</TargetFramework>
         <Description>
             Elsa is a set of workflow libraries and tools that enable lean and mean workflowing capabilities in any .NET Core application.
             This package provides Entity Framework Core migrations for the MySql database provider.

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.PostgreSql/Elsa.Persistence.EntityFramework.PostgreSql.csproj
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.PostgreSql/Elsa.Persistence.EntityFramework.PostgreSql.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\..\configureawait.props" />
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>netstandard2.1</TargetFramework>
         <Description>
             Elsa is a set of workflow libraries and tools that enable lean and mean workflowing capabilities in any .NET Core application.
             This package provides Entity Framework Core migrations for the PostgreSql database provider.

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.PostgreSql/Elsa.Persistence.EntityFramework.PostgreSql.csproj
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.PostgreSql/Elsa.Persistence.EntityFramework.PostgreSql.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\..\configureawait.props" />
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.1</TargetFramework>
+        <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
         <Description>
             Elsa is a set of workflow libraries and tools that enable lean and mean workflowing capabilities in any .NET Core application.
             This package provides Entity Framework Core migrations for the PostgreSql database provider.

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.SqlServer/Elsa.Persistence.EntityFramework.SqlServer.csproj
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.SqlServer/Elsa.Persistence.EntityFramework.SqlServer.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\..\configureawait.props" />
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>netstandard2.1</TargetFramework>
         <Description>
             Elsa is a set of workflow libraries and tools that enable lean and mean workflowing capabilities in any .NET Core application.
             This package provides Entity Framework Core migrations for the SQL Server database provider.

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.SqlServer/Elsa.Persistence.EntityFramework.SqlServer.csproj
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.SqlServer/Elsa.Persistence.EntityFramework.SqlServer.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\..\configureawait.props" />
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.1</TargetFramework>
+        <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>        
         <Description>
             Elsa is a set of workflow libraries and tools that enable lean and mean workflowing capabilities in any .NET Core application.
             This package provides Entity Framework Core migrations for the SQL Server database provider.

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Sqlite/Elsa.Persistence.EntityFramework.Sqlite.csproj
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Sqlite/Elsa.Persistence.EntityFramework.Sqlite.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\..\configureawait.props" />
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.1</TargetFramework>
+        <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
         <Description>
             Elsa is a set of workflow libraries and tools that enable lean and mean workflowing capabilities in any .NET Core application.
             This package provides Entity Framework Core migrations for the Sqlite database provider.

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Sqlite/Elsa.Persistence.EntityFramework.Sqlite.csproj
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Sqlite/Elsa.Persistence.EntityFramework.Sqlite.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\..\configureawait.props" />
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>netstandard2.1</TargetFramework>
         <Description>
             Elsa is a set of workflow libraries and tools that enable lean and mean workflowing capabilities in any .NET Core application.
             This package provides Entity Framework Core migrations for the Sqlite database provider.

--- a/src/server/Elsa.Server.Api/Elsa.Server.Api.csproj
+++ b/src/server/Elsa.Server.Api/Elsa.Server.Api.csproj
@@ -4,18 +4,19 @@
     <Import Project="..\..\..\configureawait.props" />
     
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
         <Description>
             Elsa is a set of workflow libraries and tools that enable lean and mean workflowing capabilities in any .NET Core application.
             This package provides API endpoints to interact with the workflow host.
         </Description>       
         <PackageTags>elsa, workflows, asp.net core</PackageTags>
+        <OpenApiGenerateDocumentsOnBuild>false</OpenApiGenerateDocumentsOnBuild>
     </PropertyGroup>
     
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.6" />
+        
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.0.0" />
         <PackageReference Include="NodaTime.Serialization.SystemTextJson" Version="1.0.0" />
@@ -23,6 +24,14 @@
         <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.1.4" />
         <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="7.0.2" />
         <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.1.4" />
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0'">
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.6" />
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1'">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.16" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/server/Elsa.Server.Orleans/Elsa.Server.Orleans.csproj
+++ b/src/server/Elsa.Server.Orleans/Elsa.Server.Orleans.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\configureawait.props" />
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>netstandard2.1</TargetFramework>
         <Description>
             Elsa is a set of workflow libraries and tools that enable lean and mean workflowing capabilities in any .NET Core application.
             This package provides Orleans grains that handle workflow dispatch.


### PR DESCRIPTION
Hi,

I created this pull request as an attempt to support multi targeting both .NET Core 3.1 and .NET 5 for Elsa 2.

I have not included any multi targeting on samples or tests right now.

I have tested by running monolith sample while targeting .NET Core 3.1 instead of .NET 5.
