### PR TITLE
Enabling directly named properties used using SetupActivity (not just through C# property name)

### DIFF
--- a/src/core/Elsa.Core/Builders/SetupActivity.cs
+++ b/src/core/Elsa.Core/Builders/SetupActivity.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
@@ -12,23 +12,27 @@ namespace Elsa.Builders
         public IDictionary<string, Func<ActivityExecutionContext, ValueTask<object?>>> ValueProviders { get; } = new Dictionary<string, Func<ActivityExecutionContext, ValueTask<object?>>>();
         public IDictionary<string, string> StorageProviders { get; } = new Dictionary<string, string>();
 
-        public ISetupActivity<T> Set<TProperty>(Expression<Func<T, TProperty?>> propertyAccessor, Func<ActivityExecutionContext, ValueTask<TProperty?>> valueFactory)
+
+        public ISetupActivity<T> Set<TProperty>(string propertyName, Func<ActivityExecutionContext, ValueTask<TProperty?>> valueFactory)
         {
-            var propertyInfo = propertyAccessor.GetProperty()!;
-            ValueProviders[propertyInfo.Name] = async context => await valueFactory(context);
+            ValueProviders[propertyName] = async context => await valueFactory(context);
             return this;
         }
-        
-        public ISetupActivity<T> WithStorageFor<TProperty>(Expression<Func<T, TProperty?>> propertyAccessor, string? storageProviderName)
+
+        public ISetupActivity<T> WithStorageFor<TProperty>(string propertyName, string? storageProviderName)
         {
-            var propertyInfo = propertyAccessor.GetProperty()!;
-            
-            if(storageProviderName != null)
-                StorageProviders[propertyInfo.Name] = storageProviderName;
+            if (storageProviderName != null)
+                StorageProviders[propertyName] = storageProviderName;
             else
-                StorageProviders.Remove(propertyInfo.Name);
-            
+                StorageProviders.Remove(propertyName);
+
             return this;
         }
+
+        public ISetupActivity<T> Set<TProperty>(Expression<Func<T, TProperty?>> propertyAccessor, Func<ActivityExecutionContext, ValueTask<TProperty?>> valueFactory) =>
+            Set(propertyAccessor.GetProperty()!.Name, valueFactory);
+        
+        public ISetupActivity<T> WithStorageFor<TProperty>(Expression<Func<T, TProperty?>> propertyAccessor, string? storageProviderName) =>
+            WithStorageFor<T>(propertyAccessor.GetProperty()!.Name, storageProviderName);
     }
 }


### PR DESCRIPTION
This solves #1146.

I needed to leave existing methods in ISetupActivity and SetupActivity because when I tried to move them to SetupActivityExtensions it started complaining that `propertyAccessor.GetProperty()` is not accessible/defined.

So I'll leave that to someone more clever than I am :)......