### PR TITLE
State sets default value if get doesn't find it

### DIFF
--- a/src/core/Elsa.Abstractions/Extensions/StateDictionaryExtensions.cs
+++ b/src/core/Elsa.Abstractions/Extensions/StateDictionaryExtensions.cs
@@ -16,8 +16,16 @@ namespace Elsa
         {
             var item = state?.ContainsKey(key) == true ? state![key] : default;
 
-            if (item == null)
-                return defaultValue();
+            if (item == null) 
+            {
+                if (state != null)
+                {
+                    state.SetState(key, defaultValue());
+                    item = state![key];
+                }
+                else
+                    return defaultValue();
+            }
 
             return item.ConvertTo<T>()!;
         }


### PR DESCRIPTION
Which allows for normal usage of Dictionaries inside state....
This relates to problem described in #1145.

I wasn't sure when `state` could be `null` so I left it to behave as before (returning temporary object/default value).