### PR TITLE
Workaround for double quotes

### DIFF
--- a/src/activities/Elsa.Activities.AzureServiceBus/Startup.cs
+++ b/src/activities/Elsa.Activities.AzureServiceBus/Startup.cs
@@ -19,7 +19,7 @@ namespace Elsa.Activities.AzureServiceBus
                 if (!string.IsNullOrWhiteSpace(options.ConnectionString)) 
                     return;
                 
-                var connectionStringName = section.GetValue<string>("ConnectionStringName");
+                var connectionStringName = section.GetValue<string>("ConnectionStringName").EscapeDoubleQuote();
                 options.ConnectionString = configuration.GetConnectionString(connectionStringName);
             });
         }

--- a/src/activities/webhooks/Elsa.Webhooks.Persistence.EntityFramework.Core/EntityFrameworkWebhookStartupBase.cs
+++ b/src/activities/webhooks/Elsa.Webhooks.Persistence.EntityFramework.Core/EntityFrameworkWebhookStartupBase.cs
@@ -17,8 +17,8 @@ namespace Elsa.Webhooks.Persistence.EntityFramework.Core
         {
             var services = elsa.Services;
             var section = configuration.GetSection($"Elsa:Features:Webhooks");
-            var connectionStringName = section.GetValue<string>("ConnectionStringIdentifier");
-            var connectionString = section.GetValue<string>("ConnectionString");
+            var connectionStringName = section.GetValue<string>("ConnectionStringIdentifier").EscapeDoubleQuote();
+            var connectionString = section.GetValue<string>("ConnectionString").EscapeDoubleQuote();
 
             if (string.IsNullOrWhiteSpace(connectionString))
             {

--- a/src/activities/webhooks/Elsa.Webhooks.Persistence.MongoDb/Startup.cs
+++ b/src/activities/webhooks/Elsa.Webhooks.Persistence.MongoDb/Startup.cs
@@ -15,8 +15,8 @@ namespace Elsa.Webhooks.Persistence.MongoDb
         {
             var services = elsa.Services;
             var section = configuration.GetSection($"Elsa:Features:Webhooks");
-            var connectionStringName = section.GetValue<string>("ConnectionStringIdentifier");
-            var connectionString = section.GetValue<string>("ConnectionString");
+            var connectionStringName = section.GetValue<string>("ConnectionStringIdentifier").EscapeDoubleQuote();
+            var connectionString = section.GetValue<string>("ConnectionString").EscapeDoubleQuote();
 
             if (string.IsNullOrWhiteSpace(connectionString))
             {
@@ -30,7 +30,7 @@ namespace Elsa.Webhooks.Persistence.MongoDb
                 connectionString = "mongodb://localhost:27017/Elsa";
 
             var webhookOptionsBuilder = new WebhookOptionsBuilder(services);
-              webhookOptionsBuilder.UseWebhookMongoDbPersistence(options => options.ConnectionString = connectionString);
+            webhookOptionsBuilder.UseWebhookMongoDbPersistence(options => options.ConnectionString = connectionString);
 
             services.AddScoped(sp => webhookOptionsBuilder.WebhookOptions.WebhookDefinitionStoreFactory(sp));
             services.Decorate<IWebhookDefinitionStore, InitializingWebhookDefinitionStore>();

--- a/src/activities/webhooks/Elsa.Webhooks.Persistence.YesSql/Startups.cs
+++ b/src/activities/webhooks/Elsa.Webhooks.Persistence.YesSql/Startups.cs
@@ -50,8 +50,8 @@ namespace Elsa.Webhooks.Persistence.YesSql
         {
             var services = elsa.Services;
             var section = configuration.GetSection($"Elsa:Features:Webhooks");
-            var connectionStringName = section.GetValue<string>("ConnectionStringIdentifier");
-            var connectionString = section.GetValue<string>("ConnectionString");
+            var connectionStringName = section.GetValue<string>("ConnectionStringIdentifier").EscapeDoubleQuote();
+            var connectionString = section.GetValue<string>("ConnectionString").EscapeDoubleQuote();
 
             if (string.IsNullOrWhiteSpace(connectionString))
             {

--- a/src/core/Elsa.Core/Extensions/ElsaOptionBuilderExtensions.cs
+++ b/src/core/Elsa.Core/Extensions/ElsaOptionBuilderExtensions.cs
@@ -117,7 +117,8 @@ namespace Elsa
                 }
                 else
                 {
-                    featureModel.Items.Add(itemKey, featureItem.Value);
+                    // Escape additional double quotes from the environment/docker overriden value
+                    featureModel.Items.Add(itemKey, featureItem.Value.EscapeDoubleQuote());
                 }
             }
         }

--- a/src/core/Elsa.Core/Extensions/StringExtensions.cs
+++ b/src/core/Elsa.Core/Extensions/StringExtensions.cs
@@ -23,5 +23,12 @@ namespace Elsa
             var converter = TypeDescriptor.GetConverter(targetType);
             return converter.CanConvertFrom(typeof(string)) ? converter.ConvertFrom(value) : default;
         }
+
+        public static string? EscapeDoubleQuote(this string value)
+        {
+            return value != null
+                ? value.Replace("\"", "")
+                : null;
+        }
     }
 }

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/EntityFrameworkCoreStartupBase.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/EntityFrameworkCoreStartupBase.cs
@@ -13,8 +13,8 @@ namespace Elsa.Persistence.EntityFramework.Core
         public override void ConfigureElsa(ElsaOptionsBuilder elsa, IConfiguration configuration)
         {
             var section = configuration.GetSection($"Elsa:Features:DefaultPersistence");
-            var connectionStringName = section.GetValue<string>("ConnectionStringIdentifier");
-            var connectionString = section.GetValue<string>("ConnectionString");
+            var connectionStringName = section.GetValue<string>("ConnectionStringIdentifier").EscapeDoubleQuote();
+            var connectionString = section.GetValue<string>("ConnectionString").EscapeDoubleQuote();
 
             if (string.IsNullOrWhiteSpace(connectionString))
             {

--- a/src/persistence/Elsa.Persistence.MongoDb/Startup.cs
+++ b/src/persistence/Elsa.Persistence.MongoDb/Startup.cs
@@ -10,8 +10,8 @@ namespace Elsa.Persistence.MongoDb
         public override void ConfigureElsa(ElsaOptionsBuilder elsa, IConfiguration configuration)
         {
             var section = configuration.GetSection($"Elsa:Features:DefaultPersistence");
-            var connectionStringName = section.GetValue<string>("ConnectionStringIdentifier");
-            var connectionString = section.GetValue<string>("ConnectionString");
+            var connectionStringName = section.GetValue<string>("ConnectionStringIdentifier").EscapeDoubleQuote();
+            var connectionString = section.GetValue<string>("ConnectionString").EscapeDoubleQuote();
 
             if (string.IsNullOrWhiteSpace(connectionString))
             {

--- a/src/persistence/Elsa.Persistence.YesSql/Startups.cs
+++ b/src/persistence/Elsa.Persistence.YesSql/Startups.cs
@@ -45,8 +45,8 @@ namespace Elsa.Persistence.YesSql
         public override void ConfigureElsa(ElsaOptionsBuilder elsa, IConfiguration configuration)
         {
             var section = configuration.GetSection($"Elsa:Features:DefaultPersistence");
-            var connectionStringName = section.GetValue<string>("ConnectionStringIdentifier");
-            var connectionString = section.GetValue<string>("ConnectionString");
+            var connectionStringName = section.GetValue<string>("ConnectionStringIdentifier").EscapeDoubleQuote();
+            var connectionString = section.GetValue<string>("ConnectionString").EscapeDoubleQuote();
 
             if (string.IsNullOrWhiteSpace(connectionString))
             {

--- a/src/samples/server/Elsa.Samples.Server.Host/Startup.cs
+++ b/src/samples/server/Elsa.Samples.Server.Host/Startup.cs
@@ -69,10 +69,10 @@ namespace Elsa.Samples.Server.Host
                     .AddFeatures(startups, Configuration)
                     .ConfigureWorkflowChannels(options => elsaSection.GetSection("WorkflowChannels").Bind(options))
                 );
-            
+
             // Hangfire.
             services.AddHangfire(configuration => configuration.UseSqlServerStorage(Configuration.GetConnectionString("SqlServer")));
-            services.AddHangfireServer((sp, options)=> options.ConfigureForElsaDispatchers(sp));
+            services.AddHangfireServer((sp, options) => options.ConfigureForElsaDispatchers(sp));
 
             // Elsa API endpoints.
             services


### PR DESCRIPTION
Workaround for double quotes. Given that based on Jen's investigation only variables wrapped with double quotes are allowed in the project environment we need to escape additional double quotes.

Sipke, can you do a code review and merge if it is fine with you please?