### PR TITLE
fix: Reset IsLatest also for not published workflows on PublishAsync

### DIFF
--- a/src/core/Elsa.Core/Services/Workflows/WorkflowPublisher.cs
+++ b/src/core/Elsa.Core/Services/Workflows/WorkflowPublisher.cs
@@ -59,7 +59,7 @@ namespace Elsa.Services.Workflows
         {
             var publishedDefinition = await _workflowDefinitionStore.FindByDefinitionIdAsync(
                 workflowDefinition.DefinitionId,
-                VersionOptions.Published,
+                VersionOptions.LatestOrPublished,
                 cancellationToken);
 
             if (publishedDefinition != null)


### PR DESCRIPTION
When an unpublished workflow is published, IsLatest is not set to false because the PublishAsync method was only looking for published workflows.