### PR TITLE
Persistable input

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,25 +46,25 @@ install:
 
       cd ..\..\..\..\..
 
-#      dotnet tool install --global dotnet-sonarscanner
+      dotnet tool install --global dotnet-sonarscanner
 
 before_build:
   - cmd: >-
       docker-compose -f docker-compose.yaml up -d mongodb postgres
 
-#  - ps: >-
-#      if(-Not $env:APPVEYOR_PULL_REQUEST_NUMBER) {
-#      & dotnet-sonarscanner begin
-#      /k:$env:sonarcloud_project_name
-#      /v:AppVeyor_build_$env:APPVEYOR_BUILD_VERSION
-#      /o:$env:sonarcloud_org_name
-#      /s:$env:APPVEYOR_BUILD_FOLDER\.SonarQube.Analysis.xml
-#      /d:sonar.host.url="https://sonarcloud.io"
-#      /d:sonar.login=$env:sonarcloud_api_key
-#      /d:sonar.cs.xunit.reportsPaths=$env:APPVEYOR_BUILD_FOLDER\**\TestResults\TestResults.xml
-#      /d:sonar.cs.opencover.reportsPaths=$env:APPVEYOR_BUILD_FOLDER\**\TestResults\*\coverage.opencover.xml
-#      /d:sonar.branch.name=$env:APPVEYOR_REPO_BRANCH
-#      }
+  - ps: >-
+      if(-Not $env:APPVEYOR_PULL_REQUEST_NUMBER) {
+      & dotnet-sonarscanner begin
+      /k:$env:sonarcloud_project_name
+      /v:AppVeyor_build_$env:APPVEYOR_BUILD_VERSION
+      /o:$env:sonarcloud_org_name
+      /s:$env:APPVEYOR_BUILD_FOLDER\.SonarQube.Analysis.xml
+      /d:sonar.host.url="https://sonarcloud.io"
+      /d:sonar.login=$env:sonarcloud_api_key
+      /d:sonar.cs.xunit.reportsPaths=$env:APPVEYOR_BUILD_FOLDER\**\TestResults\TestResults.xml
+      /d:sonar.cs.opencover.reportsPaths=$env:APPVEYOR_BUILD_FOLDER\**\TestResults\*\coverage.opencover.xml
+      /d:sonar.branch.name=$env:APPVEYOR_REPO_BRANCH
+      }
 
 build_script:
   - ps: >-
@@ -82,9 +82,9 @@ build_script:
 
 # before_test:
 
-# test_script:
-#  - ps: dotnet test --collect:"XPlat Code Coverage" --logger:xunit -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
-#  - ps: dotnet test
+ test_script:
+  - ps: dotnet test --collect:"XPlat Code Coverage" --logger:xunit -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
+  - ps: dotnet test
 
 after_test:
   - ps: >-

--- a/src/activities/Elsa.Activities.AzureServiceBus/Bookmarks/QueueMessageReceivedBookmark.cs
+++ b/src/activities/Elsa.Activities.AzureServiceBus/Bookmarks/QueueMessageReceivedBookmark.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Elsa.Services;
 using Elsa.Services.Bookmarks;
 
 namespace Elsa.Activities.AzureServiceBus.Bookmarks

--- a/src/activities/Elsa.Activities.AzureServiceBus/Bookmarks/TopicMessageReceivedBookmark.cs
+++ b/src/activities/Elsa.Activities.AzureServiceBus/Bookmarks/TopicMessageReceivedBookmark.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Elsa.Services;
 using Elsa.Services.Bookmarks;
 
 namespace Elsa.Activities.AzureServiceBus.Bookmarks

--- a/src/activities/Elsa.Activities.AzureServiceBus/Services/WorkerBase.cs
+++ b/src/activities/Elsa.Activities.AzureServiceBus/Services/WorkerBase.cs
@@ -4,8 +4,10 @@ using System.Threading;
 using System.Threading.Tasks;
 using Elsa.Activities.AzureServiceBus.Models;
 using Elsa.Activities.AzureServiceBus.Options;
+using Elsa.Models;
 using Elsa.Services;
 using Elsa.Services.Bookmarks;
+using Elsa.Services.Models;
 using Microsoft.Azure.ServiceBus;
 using Microsoft.Azure.ServiceBus.Core;
 using Microsoft.Extensions.Logging;
@@ -72,9 +74,9 @@ namespace Elsa.Activities.AzureServiceBus.Services
             };
 
             var bookmark = CreateBookmark(message);
-            var launchContext = new CollectWorkflowsContext(ActivityType, bookmark, correlationId);
+            var launchContext = new WorkflowsQuery(ActivityType, bookmark, correlationId);
             
-            await _workflowLaunchpad.UseServiceAsync(service => service.CollectAndDispatchWorkflowsAsync(launchContext, model, cancellationToken));
+            await _workflowLaunchpad.UseServiceAsync(service => service.CollectAndDispatchWorkflowsAsync(launchContext, new WorkflowInput(model), cancellationToken));
         }
 
         private Task ExceptionReceivedHandler(ExceptionReceivedEventArgs e)

--- a/src/activities/Elsa.Activities.Conductor/Endpoints/Conductor/Events/Dispatch.cs
+++ b/src/activities/Elsa.Activities.Conductor/Endpoints/Conductor/Events/Dispatch.cs
@@ -1,7 +1,9 @@
 ﻿using System.Threading.Tasks;
 using Elsa.Activities.Conductor.Models;
 using Elsa.Activities.Conductor.Providers.Bookmarks;
+using Elsa.Models;
 using Elsa.Services;
+using Elsa.Services.Models;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Elsa.Activities.Conductor.Endpoints.Conductor.Events
@@ -18,8 +20,8 @@ namespace Elsa.Activities.Conductor.Endpoints.Conductor.Events
         public async Task<IActionResult> Handle(string eventName, EventModel model)
         {
             var bookmark = new EventBookmark(eventName.ToLowerInvariant());
-            var context = new CollectWorkflowsContext(nameof(EventReceived), bookmark, model.CorrelationId, model.WorkflowInstanceId);
-            var pendingWorkflows = await _workflowLaunchpad.CollectAndDispatchWorkflowsAsync(context, model);
+            var context = new WorkflowsQuery(nameof(EventReceived), bookmark, model.CorrelationId, model.WorkflowInstanceId);
+            var pendingWorkflows = await _workflowLaunchpad.CollectAndDispatchWorkflowsAsync(context, new WorkflowInput(model));
             
             return Accepted(pendingWorkflows);
         }

--- a/src/activities/Elsa.Activities.Conductor/Endpoints/Conductor/Events/Execute.cs
+++ b/src/activities/Elsa.Activities.Conductor/Endpoints/Conductor/Events/Execute.cs
@@ -1,7 +1,9 @@
 ﻿using System.Threading.Tasks;
 using Elsa.Activities.Conductor.Models;
 using Elsa.Activities.Conductor.Providers.Bookmarks;
+using Elsa.Models;
 using Elsa.Services;
+using Elsa.Services.Models;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Elsa.Activities.Conductor.Endpoints.Conductor.Events
@@ -18,8 +20,8 @@ namespace Elsa.Activities.Conductor.Endpoints.Conductor.Events
         public async Task<IActionResult> Handle(string eventName, EventModel model)
         {
             var bookmark = new EventBookmark(eventName);
-            var context = new CollectWorkflowsContext(nameof(EventReceived), bookmark, model.CorrelationId, model.WorkflowInstanceId);
-            var pendingWorkflows = await _workflowLaunchpad.CollectAndExecuteWorkflowsAsync(context, model);
+            var context = new WorkflowsQuery(nameof(EventReceived), bookmark, model.CorrelationId, model.WorkflowInstanceId);
+            var pendingWorkflows = await _workflowLaunchpad.CollectAndExecuteWorkflowsAsync(context, new WorkflowInput(model));
             
             return Accepted(pendingWorkflows);
         }

--- a/src/activities/Elsa.Activities.Conductor/Endpoints/Conductor/Tasks/Dispatch.cs
+++ b/src/activities/Elsa.Activities.Conductor/Endpoints/Conductor/Tasks/Dispatch.cs
@@ -1,7 +1,9 @@
 ﻿using System.Threading.Tasks;
 using Elsa.Activities.Conductor.Models;
 using Elsa.Activities.Conductor.Providers.Bookmarks;
+using Elsa.Models;
 using Elsa.Services;
+using Elsa.Services.Models;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Elsa.Activities.Conductor.Endpoints.Conductor.Tasks
@@ -18,8 +20,8 @@ namespace Elsa.Activities.Conductor.Endpoints.Conductor.Tasks
         public async Task<IActionResult> Handle(string taskName, TaskResultModel model)
         {
             var bookmark = new TaskBookmark(taskName.ToLowerInvariant());
-            var context = new CollectWorkflowsContext(nameof(RunTask), bookmark, model.CorrelationId, model.WorkflowInstanceId);
-            var pendingWorkflows = await _workflowLaunchpad.CollectAndDispatchWorkflowsAsync(context, model);
+            var context = new WorkflowsQuery(nameof(RunTask), bookmark, model.CorrelationId, model.WorkflowInstanceId);
+            var pendingWorkflows = await _workflowLaunchpad.CollectAndDispatchWorkflowsAsync(context, new WorkflowInput(model));
             
             return Accepted(pendingWorkflows);
         }

--- a/src/activities/Elsa.Activities.Conductor/Endpoints/Conductor/Tasks/Execute.cs
+++ b/src/activities/Elsa.Activities.Conductor/Endpoints/Conductor/Tasks/Execute.cs
@@ -1,7 +1,9 @@
 ﻿using System.Threading.Tasks;
 using Elsa.Activities.Conductor.Models;
 using Elsa.Activities.Conductor.Providers.Bookmarks;
+using Elsa.Models;
 using Elsa.Services;
+using Elsa.Services.Models;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Elsa.Activities.Conductor.Endpoints.Conductor.Tasks
@@ -18,8 +20,8 @@ namespace Elsa.Activities.Conductor.Endpoints.Conductor.Tasks
         public async Task<IActionResult> Handle(string taskName, TaskResultModel model)
         {
             var bookmark = new TaskBookmark(taskName.ToLowerInvariant());
-            var context = new CollectWorkflowsContext(nameof(RunTask), bookmark, model.CorrelationId, model.WorkflowInstanceId);
-            var pendingWorkflows = await _workflowLaunchpad.CollectAndExecuteWorkflowsAsync(context, model);
+            var context = new WorkflowsQuery(nameof(RunTask), bookmark, model.CorrelationId, model.WorkflowInstanceId);
+            var pendingWorkflows = await _workflowLaunchpad.CollectAndExecuteWorkflowsAsync(context, new WorkflowInput(model));
             
             return Accepted(pendingWorkflows);
         }

--- a/src/activities/Elsa.Activities.Conductor/Providers/ActivityTypes/CommandActivityTypeProvider.cs
+++ b/src/activities/Elsa.Activities.Conductor/Providers/ActivityTypes/CommandActivityTypeProvider.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Elsa.Activities.Conductor.Models;
 using Elsa.Activities.Conductor.Services;
 using Elsa.Metadata;
+using Elsa.Providers.Activities;
 using Elsa.Services;
 using Elsa.Services.Models;
 

--- a/src/activities/Elsa.Activities.Conductor/Providers/ActivityTypes/EventActivityTypeProvider.cs
+++ b/src/activities/Elsa.Activities.Conductor/Providers/ActivityTypes/EventActivityTypeProvider.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Elsa.Activities.Conductor.Models;
 using Elsa.Activities.Conductor.Services;
 using Elsa.Metadata;
+using Elsa.Providers.Activities;
 using Elsa.Services;
 using Elsa.Services.Models;
 

--- a/src/activities/Elsa.Activities.Conductor/Providers/ActivityTypes/TaskActivityTypeProvider.cs
+++ b/src/activities/Elsa.Activities.Conductor/Providers/ActivityTypes/TaskActivityTypeProvider.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Elsa.Activities.Conductor.Models;
 using Elsa.Activities.Conductor.Services;
 using Elsa.Metadata;
+using Elsa.Providers.Activities;
 using Elsa.Services;
 using Elsa.Services.Models;
 

--- a/src/activities/Elsa.Activities.Conductor/Providers/Bookmarks/EventBookmarkProvider.cs
+++ b/src/activities/Elsa.Activities.Conductor/Providers/Bookmarks/EventBookmarkProvider.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Elsa.Services;
 using Elsa.Services.Bookmarks;
 
 namespace Elsa.Activities.Conductor.Providers.Bookmarks

--- a/src/activities/Elsa.Activities.Conductor/Providers/Bookmarks/TaskBookmarkProvider.cs
+++ b/src/activities/Elsa.Activities.Conductor/Providers/Bookmarks/TaskBookmarkProvider.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Elsa.Services;
 using Elsa.Services.Bookmarks;
 
 namespace Elsa.Activities.Conductor.Providers.Bookmarks

--- a/src/activities/Elsa.Activities.Entity/Bookmarks/EntityChangedBookmark.cs
+++ b/src/activities/Elsa.Activities.Entity/Bookmarks/EntityChangedBookmark.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Elsa.Services;
 using Elsa.Services.Bookmarks;
 
 namespace Elsa.Activities.Entity.Bookmarks

--- a/src/activities/Elsa.Activities.Entity/Extensions/WorkflowRunnerExtensions.cs
+++ b/src/activities/Elsa.Activities.Entity/Extensions/WorkflowRunnerExtensions.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Elsa.Activities.Entity.Bookmarks;
 using Elsa.Activities.Entity.Models;
+using Elsa.Models;
 using Elsa.Services;
 
 namespace Elsa.Activities.Entity.Extensions
@@ -29,7 +30,7 @@ namespace Elsa.Activities.Entity.Extensions
                 contextId
             );
 
-            await workflowDispatcher.DispatchAsync(new TriggerWorkflowsRequest(activityType, bookmark, input, correlationId, default, contextId, TenantId), cancellationToken);
+            await workflowDispatcher.DispatchAsync(new TriggerWorkflowsRequest(activityType, bookmark, new WorkflowInput(input), correlationId, default, contextId, TenantId), cancellationToken);
         }
     }
 }

--- a/src/activities/Elsa.Activities.Http/Bookmarks/HttpEndpointBookmark.cs
+++ b/src/activities/Elsa.Activities.Http/Bookmarks/HttpEndpointBookmark.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Elsa.Services;
 using Elsa.Services.Bookmarks;
 using Microsoft.AspNetCore.Http;
 

--- a/src/activities/Elsa.Activities.MassTransit/Bookmarks/MessageReceivedBookmark.cs
+++ b/src/activities/Elsa.Activities.MassTransit/Bookmarks/MessageReceivedBookmark.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Elsa.Services;
 using Elsa.Services.Bookmarks;
 
 namespace Elsa.Activities.MassTransit.Bookmarks

--- a/src/activities/Elsa.Activities.MassTransit/Consumers/WorkflowConsumer.cs
+++ b/src/activities/Elsa.Activities.MassTransit/Consumers/WorkflowConsumer.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Elsa.Activities.MassTransit.Bookmarks;
 using Elsa.Activities.MassTransit.Consumers.MessageCorrelation;
 using Elsa.Services;
+using Elsa.Services.Models;
 using MassTransit;
 using MediatR;
 
@@ -43,7 +44,7 @@ namespace Elsa.Activities.MassTransit.Consumers
                 MessageType = message.GetType().Name
             };
 
-            await _workflowLaunchpad.CollectAndExecuteWorkflowsAsync(new CollectWorkflowsContext(
+            await _workflowLaunchpad.CollectAndExecuteWorkflowsAsync(new WorkflowsQuery(
                 nameof(ReceiveMassTransitMessage),
                 bookmark,
                 correlationId.ToString()

--- a/src/activities/Elsa.Activities.Rebus/Bookmarks/MessageReceivedBookmark.cs
+++ b/src/activities/Elsa.Activities.Rebus/Bookmarks/MessageReceivedBookmark.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Elsa.Services;
 using Elsa.Services.Bookmarks;
 
 namespace Elsa.Activities.Rebus.Bookmarks

--- a/src/activities/Elsa.Activities.Rebus/Consumers/MessageConsumer.cs
+++ b/src/activities/Elsa.Activities.Rebus/Consumers/MessageConsumer.cs
@@ -1,6 +1,7 @@
 using System.Threading.Tasks;
 using Elsa.Activities.Rebus.Bookmarks;
 using Elsa.Services;
+using Elsa.Services.Models;
 using Rebus.Extensions;
 using Rebus.Handlers;
 using Rebus.Messages;
@@ -23,7 +24,7 @@ namespace Elsa.Activities.Rebus.Consumers
         public async Task Handle(T message)
         {
             var correlationId = MessageContext.Current.TransportMessage.Headers.GetValueOrNull(Headers.CorrelationId);
-            await _workflowLaunchpad.CollectAndExecuteWorkflowsAsync(new CollectWorkflowsContext(
+            await _workflowLaunchpad.CollectAndExecuteWorkflowsAsync(new WorkflowsQuery(
                 nameof(RebusMessageReceived),
                 new MessageReceivedBookmark { MessageType = message.GetType().Name },
                 correlationId,

--- a/src/activities/Elsa.Activities.Telnyx/Handlers/ResumeWebhookDrivenActivity.cs
+++ b/src/activities/Elsa.Activities.Telnyx/Handlers/ResumeWebhookDrivenActivity.cs
@@ -7,8 +7,10 @@ using Elsa.Activities.Telnyx.Models;
 using Elsa.Activities.Telnyx.Providers.Bookmarks;
 using Elsa.Activities.Telnyx.Webhooks.Events;
 using Elsa.Activities.Telnyx.Webhooks.Payloads.Call;
+using Elsa.Models;
 using Elsa.Services;
 using Elsa.Services.Bookmarks;
+using Elsa.Services.Models;
 using MediatR;
 
 namespace Elsa.Activities.Telnyx.Handlers
@@ -40,8 +42,8 @@ namespace Elsa.Activities.Telnyx.Handlers
 
             var correlationId = GetCorrelationId(receivedPayload);
             var bookmark = CreateBookmark();
-            var context = new CollectWorkflowsContext(ActivityTypeName, bookmark, correlationId);
-            await _workflowLaunchpad.CollectAndDispatchWorkflowsAsync(context, receivedPayload, cancellationToken);
+            var context = new WorkflowsQuery(ActivityTypeName, bookmark, correlationId);
+            await _workflowLaunchpad.CollectAndDispatchWorkflowsAsync(context, new WorkflowInput(receivedPayload), cancellationToken);
         }
 
         protected virtual IBookmark CreateBookmark() => new GatherUsingSpeakBookmark();

--- a/src/activities/Elsa.Activities.Telnyx/Providers/ActivityTypes/NotificationActivityTypeProvider.cs
+++ b/src/activities/Elsa.Activities.Telnyx/Providers/ActivityTypes/NotificationActivityTypeProvider.cs
@@ -9,6 +9,7 @@ using Elsa.Activities.Telnyx.Webhooks.Attributes;
 using Elsa.Activities.Telnyx.Webhooks.Payloads.Abstract;
 using Elsa.Activities.Telnyx.Webhooks.Payloads.Call;
 using Elsa.Metadata;
+using Elsa.Providers.Activities;
 using Elsa.Services;
 using Elsa.Services.Models;
 

--- a/src/activities/Elsa.Activities.Telnyx/Providers/Bookmarks/AnswerCallBookmark.cs
+++ b/src/activities/Elsa.Activities.Telnyx/Providers/Bookmarks/AnswerCallBookmark.cs
@@ -1,4 +1,5 @@
 ﻿using Elsa.Activities.Telnyx.Activities;
+using Elsa.Services;
 using Elsa.Services.Bookmarks;
 
 namespace Elsa.Activities.Telnyx.Providers.Bookmarks

--- a/src/activities/Elsa.Activities.Telnyx/Providers/Bookmarks/BridgeCallsBookmark.cs
+++ b/src/activities/Elsa.Activities.Telnyx/Providers/Bookmarks/BridgeCallsBookmark.cs
@@ -1,4 +1,5 @@
 using Elsa.Activities.Telnyx.Activities;
+using Elsa.Services;
 using Elsa.Services.Bookmarks;
 
 namespace Elsa.Activities.Telnyx.Providers.Bookmarks

--- a/src/activities/Elsa.Activities.Telnyx/Providers/Bookmarks/DialBookmark.cs
+++ b/src/activities/Elsa.Activities.Telnyx/Providers/Bookmarks/DialBookmark.cs
@@ -1,4 +1,5 @@
 using Elsa.Activities.Telnyx.Activities;
+using Elsa.Services;
 using Elsa.Services.Bookmarks;
 
 namespace Elsa.Activities.Telnyx.Providers.Bookmarks

--- a/src/activities/Elsa.Activities.Telnyx/Providers/Bookmarks/GatherUsingAudioBookmark.cs
+++ b/src/activities/Elsa.Activities.Telnyx/Providers/Bookmarks/GatherUsingAudioBookmark.cs
@@ -1,4 +1,5 @@
 ﻿using Elsa.Activities.Telnyx.Activities;
+using Elsa.Services;
 using Elsa.Services.Bookmarks;
 
 namespace Elsa.Activities.Telnyx.Providers.Bookmarks

--- a/src/activities/Elsa.Activities.Telnyx/Providers/Bookmarks/GatherUsingSpeakBookmark.cs
+++ b/src/activities/Elsa.Activities.Telnyx/Providers/Bookmarks/GatherUsingSpeakBookmark.cs
@@ -1,4 +1,5 @@
 ﻿using Elsa.Activities.Telnyx.Activities;
+using Elsa.Services;
 using Elsa.Services.Bookmarks;
 
 namespace Elsa.Activities.Telnyx.Providers.Bookmarks

--- a/src/activities/Elsa.Activities.Telnyx/Providers/Bookmarks/NotificationBookmarkProvider.cs
+++ b/src/activities/Elsa.Activities.Telnyx/Providers/Bookmarks/NotificationBookmarkProvider.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using Elsa.Activities.Telnyx.Providers.ActivityTypes;
+using Elsa.Services;
 using Elsa.Services.Bookmarks;
 
 namespace Elsa.Activities.Telnyx.Providers.Bookmarks

--- a/src/activities/Elsa.Activities.Telnyx/Providers/Bookmarks/PlayAudioBookmark.cs
+++ b/src/activities/Elsa.Activities.Telnyx/Providers/Bookmarks/PlayAudioBookmark.cs
@@ -1,4 +1,5 @@
 ﻿using Elsa.Activities.Telnyx.Activities;
+using Elsa.Services;
 using Elsa.Services.Bookmarks;
 
 namespace Elsa.Activities.Telnyx.Providers.Bookmarks

--- a/src/activities/Elsa.Activities.Telnyx/Providers/Bookmarks/SpeakTextBookmark.cs
+++ b/src/activities/Elsa.Activities.Telnyx/Providers/Bookmarks/SpeakTextBookmark.cs
@@ -1,4 +1,5 @@
 ﻿using Elsa.Activities.Telnyx.Activities;
+using Elsa.Services;
 using Elsa.Services.Bookmarks;
 
 namespace Elsa.Activities.Telnyx.Providers.Bookmarks

--- a/src/activities/Elsa.Activities.Telnyx/Providers/Bookmarks/StartRecordingBookmark.cs
+++ b/src/activities/Elsa.Activities.Telnyx/Providers/Bookmarks/StartRecordingBookmark.cs
@@ -1,4 +1,5 @@
 ﻿using Elsa.Activities.Telnyx.Activities;
+using Elsa.Services;
 using Elsa.Services.Bookmarks;
 
 namespace Elsa.Activities.Telnyx.Providers.Bookmarks

--- a/src/activities/Elsa.Activities.Telnyx/Providers/Bookmarks/StopAudioPlaybackBookmark.cs
+++ b/src/activities/Elsa.Activities.Telnyx/Providers/Bookmarks/StopAudioPlaybackBookmark.cs
@@ -1,4 +1,5 @@
 ﻿using Elsa.Activities.Telnyx.Activities;
+using Elsa.Services;
 using Elsa.Services.Bookmarks;
 
 namespace Elsa.Activities.Telnyx.Providers.Bookmarks

--- a/src/activities/Elsa.Activities.Telnyx/Providers/Bookmarks/TransferCallBookmark.cs
+++ b/src/activities/Elsa.Activities.Telnyx/Providers/Bookmarks/TransferCallBookmark.cs
@@ -1,4 +1,5 @@
 ﻿using Elsa.Activities.Telnyx.Activities;
+using Elsa.Services;
 using Elsa.Services.Bookmarks;
 
 namespace Elsa.Activities.Telnyx.Providers.Bookmarks

--- a/src/activities/Elsa.Activities.Telnyx/Webhooks/Handlers/TriggerWebhookActivities.cs
+++ b/src/activities/Elsa.Activities.Telnyx/Webhooks/Handlers/TriggerWebhookActivities.cs
@@ -7,7 +7,9 @@ using Elsa.Activities.Telnyx.Webhooks.Events;
 using Elsa.Activities.Telnyx.Webhooks.Payloads.Abstract;
 using Elsa.Activities.Telnyx.Webhooks.Payloads.Call;
 using Elsa.Activities.Telnyx.Webhooks.Services;
+using Elsa.Models;
 using Elsa.Services;
+using Elsa.Services.Models;
 using MediatR;
 using Microsoft.Extensions.Logging;
 
@@ -41,9 +43,9 @@ namespace Elsa.Activities.Telnyx.Webhooks.Handlers
 
             var correlationId = GetCorrelationId(payload);
             var bookmark = new NotificationBookmark(eventType);
-            var context = new CollectWorkflowsContext(activityType, bookmark, correlationId);
+            var context = new WorkflowsQuery(activityType, bookmark, correlationId);
 
-            await _workflowLaunchpad.CollectAndDispatchWorkflowsAsync(context, webhook, cancellationToken);
+            await _workflowLaunchpad.CollectAndDispatchWorkflowsAsync(context, new WorkflowInput(webhook), cancellationToken);
         }
         
         private string GetCorrelationId(Payload payload)

--- a/src/activities/Elsa.Activities.Temporal.Common/Bookmarks/CronBookmark.cs
+++ b/src/activities/Elsa.Activities.Temporal.Common/Bookmarks/CronBookmark.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Elsa.Services;
 using Elsa.Services.Bookmarks;
 using NodaTime;
 

--- a/src/activities/Elsa.Activities.Temporal.Common/Bookmarks/StartAtBookmark.cs
+++ b/src/activities/Elsa.Activities.Temporal.Common/Bookmarks/StartAtBookmark.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Elsa.Services;
 using Elsa.Services.Bookmarks;
 using NodaTime;
 

--- a/src/activities/Elsa.Activities.Temporal.Common/Bookmarks/TimerBookmark.cs
+++ b/src/activities/Elsa.Activities.Temporal.Common/Bookmarks/TimerBookmark.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Elsa.Services;
 using Elsa.Services.Bookmarks;
 using NodaTime;
 

--- a/src/activities/Elsa.Activities.UserTask/Bookmarks/UserTaskBookmark.cs
+++ b/src/activities/Elsa.Activities.UserTask/Bookmarks/UserTaskBookmark.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Elsa.Services;
 using Elsa.Services.Bookmarks;
 
 namespace Elsa.Activities.UserTask.Bookmarks

--- a/src/activities/webhooks/Elsa.Activities.Webhooks/ActivityTypes/WebhookActivityTypeProvider.cs
+++ b/src/activities/webhooks/Elsa.Activities.Webhooks/ActivityTypes/WebhookActivityTypeProvider.cs
@@ -7,6 +7,7 @@ using Elsa.Design;
 using Elsa.Expressions;
 using Elsa.Metadata;
 using Elsa.Persistence.Specifications;
+using Elsa.Providers.Activities;
 using Elsa.Services;
 using Elsa.Services.Models;
 using Elsa.Webhooks.Models;

--- a/src/activities/webhooks/Elsa.Activities.Webhooks/Bookmarks/WebhookBookmark.cs
+++ b/src/activities/webhooks/Elsa.Activities.Webhooks/Bookmarks/WebhookBookmark.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Elsa.Activities.Http;
 using Elsa.Activities.Http.Bookmarks;
 using Elsa.Activities.Webhooks.ActivityTypes;
+using Elsa.Services;
 using Elsa.Services.Bookmarks;
 
 namespace Elsa.Activities.Webhooks.Bookmarks

--- a/src/activities/webhooks/Elsa.Activities.Webhooks/Extensions/WebhookOptionsBuilderExtensions.cs
+++ b/src/activities/webhooks/Elsa.Activities.Webhooks/Extensions/WebhookOptionsBuilderExtensions.cs
@@ -1,6 +1,7 @@
 using Elsa.Activities.Webhooks.ActivityTypes;
 using Elsa.Activities.Webhooks.Bookmarks;
 using Elsa.Activities.Webhooks.Handlers;
+using Elsa.Providers.Activities;
 using Elsa.Services;
 using Microsoft.Extensions.DependencyInjection;
 

--- a/src/core/Elsa.Abstractions/Events/WorkflowInputUpdated.cs
+++ b/src/core/Elsa.Abstractions/Events/WorkflowInputUpdated.cs
@@ -1,0 +1,15 @@
+using Elsa.Models;
+using MediatR;
+
+namespace Elsa.Events
+{
+    public class WorkflowInputUpdated : INotification
+    {
+        public WorkflowInputUpdated(WorkflowInstance workflowInstance)
+        {
+            WorkflowInstance = workflowInstance;
+        }
+
+        public WorkflowInstance WorkflowInstance { get; }
+    }
+}

--- a/src/core/Elsa.Abstractions/Extensions/BookmarkFinderExtensions.cs
+++ b/src/core/Elsa.Abstractions/Extensions/BookmarkFinderExtensions.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Elsa.Services;
-using Elsa.Services.Bookmarks;
 
 namespace Elsa
 {

--- a/src/core/Elsa.Abstractions/Extensions/ServiceCollectionExtensions.cs
+++ b/src/core/Elsa.Abstractions/Extensions/ServiceCollectionExtensions.cs
@@ -1,8 +1,8 @@
 using System.Reflection;
 using Elsa;
-using Elsa.Providers.Workflow;
 using Elsa.Providers.WorkflowContexts;
-using Elsa.Services.Bookmarks;
+using Elsa.Providers.Workflows;
+using Elsa.Services;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection

--- a/src/core/Elsa.Abstractions/Extensions/TriggerFinderExtensions.cs
+++ b/src/core/Elsa.Abstractions/Extensions/TriggerFinderExtensions.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Elsa.Services;
-using Elsa.Services.Bookmarks;
 
 namespace Elsa
 {

--- a/src/core/Elsa.Abstractions/Models/WorkflowInput.cs
+++ b/src/core/Elsa.Abstractions/Models/WorkflowInput.cs
@@ -1,0 +1,4 @@
+namespace Elsa.Models
+{
+    public record WorkflowInput(object? Input = default, string? StorageProviderName = default);
+}

--- a/src/core/Elsa.Abstractions/Models/WorkflowInstance.cs
+++ b/src/core/Elsa.Abstractions/Models/WorkflowInstance.cs
@@ -30,6 +30,7 @@ namespace Elsa.Models
         public Instant? CancelledAt { get; set; }
         public Instant? FaultedAt { get; set; }
         public Variables Variables { get; set; }
+        public WorkflowInputReference? Input { get; set; }
         public WorkflowOutputReference? Output { get; set; }
         public IDictionary<string, IDictionary<string, object?>> ActivityData { get; set; } = new Dictionary<string, IDictionary<string, object?>>();
 

--- a/src/core/Elsa.Abstractions/Models/WorkflowPersistenceBehavior.cs
+++ b/src/core/Elsa.Abstractions/Models/WorkflowPersistenceBehavior.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
 namespace Elsa.Models
@@ -18,14 +17,13 @@ namespace Elsa.Models
         WorkflowBurst,
 
         /// <summary>
-        /// Workflow instances are persisted after the workflow executed scheduled activities.
+        /// Workflow instances are persisted after the workflow executed an activity.
         /// </summary>
         WorkflowPassCompleted,
 
         /// <summary>
         /// Workflow instances are persisted after each activity that executed.
         /// </summary>
-        [Obsolete("Use WorkflowPassCompleted instead")]
         ActivityExecuted
     }
 }

--- a/src/core/Elsa.Abstractions/Providers/Activities/IActivityProvider.cs
+++ b/src/core/Elsa.Abstractions/Providers/Activities/IActivityProvider.cs
@@ -3,7 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Elsa.Services.Models;
 
-namespace Elsa.Services
+namespace Elsa.Providers.Activities
 {
     public interface IActivityTypeProvider
     {

--- a/src/core/Elsa.Abstractions/Providers/Workflows/IWorkflowProvider.cs
+++ b/src/core/Elsa.Abstractions/Providers/Workflows/IWorkflowProvider.cs
@@ -3,7 +3,7 @@ using System.Threading;
 using Elsa.Services;
 using Elsa.Services.Models;
 
-namespace Elsa.Providers.Workflow
+namespace Elsa.Providers.Workflows
 {
     /// <summary>
     /// Represents a source of workflows for the <see cref="IWorkflowRegistry"/>

--- a/src/core/Elsa.Abstractions/Providers/Workflows/WorkflowProvider.cs
+++ b/src/core/Elsa.Abstractions/Providers/Workflows/WorkflowProvider.cs
@@ -2,10 +2,9 @@
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
-using Elsa.Providers.Workflow;
 using Elsa.Services.Models;
 
-namespace Elsa.Services
+namespace Elsa.Providers.Workflows
 {
     public abstract class WorkflowProvider : IWorkflowProvider
     {

--- a/src/core/Elsa.Abstractions/Services/Bookmarks/BookmarkFinderResult.cs
+++ b/src/core/Elsa.Abstractions/Services/Bookmarks/BookmarkFinderResult.cs
@@ -1,4 +1,4 @@
-﻿namespace Elsa.Services.Bookmarks
+﻿namespace Elsa.Services
 {
     public class BookmarkFinderResult
     {

--- a/src/core/Elsa.Abstractions/Services/Bookmarks/BookmarkIndexingMode.cs
+++ b/src/core/Elsa.Abstractions/Services/Bookmarks/BookmarkIndexingMode.cs
@@ -1,4 +1,4 @@
-﻿namespace Elsa.Services.Bookmarks
+﻿namespace Elsa.Services
 {
     public enum BookmarkIndexingMode
     {

--- a/src/core/Elsa.Abstractions/Services/Bookmarks/BookmarkProvider.cs
+++ b/src/core/Elsa.Abstractions/Services/Bookmarks/BookmarkProvider.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Elsa.Services.Bookmarks
+namespace Elsa.Services
 {
     public abstract class BookmarkProvider<T> : IBookmarkProvider where T : IBookmark
     {

--- a/src/core/Elsa.Abstractions/Services/Bookmarks/BookmarkProviderContext.cs
+++ b/src/core/Elsa.Abstractions/Services/Bookmarks/BookmarkProviderContext.cs
@@ -4,7 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Elsa.Services.Models;
 
-namespace Elsa.Services.Bookmarks
+namespace Elsa.Services
 {
     public class BookmarkProviderContext
     {

--- a/src/core/Elsa.Abstractions/Services/Bookmarks/BookmarkResult.cs
+++ b/src/core/Elsa.Abstractions/Services/Bookmarks/BookmarkResult.cs
@@ -1,4 +1,4 @@
-namespace Elsa.Services.Bookmarks
+namespace Elsa.Services
 {
     public record BookmarkResult(IBookmark Bookmark, string? ActivityTypeName = default);
 }

--- a/src/core/Elsa.Abstractions/Services/Bookmarks/BookmarkedWorkflow.cs
+++ b/src/core/Elsa.Abstractions/Services/Bookmarks/BookmarkedWorkflow.cs
@@ -1,6 +1,6 @@
 ﻿using Elsa.Services.Models;
 
-namespace Elsa.Services.Bookmarks
+namespace Elsa.Services
 {
     public class BookmarkedWorkflow
     {

--- a/src/core/Elsa.Abstractions/Services/Bookmarks/IBookmark.cs
+++ b/src/core/Elsa.Abstractions/Services/Bookmarks/IBookmark.cs
@@ -1,4 +1,4 @@
-﻿namespace Elsa.Services.Bookmarks
+﻿namespace Elsa.Services
 {
     public interface IBookmark
     {

--- a/src/core/Elsa.Abstractions/Services/Bookmarks/IBookmarkFinder.cs
+++ b/src/core/Elsa.Abstractions/Services/Bookmarks/IBookmarkFinder.cs
@@ -2,7 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Elsa.Services.Bookmarks
+namespace Elsa.Services
 {
     public interface IBookmarkFinder
     {

--- a/src/core/Elsa.Abstractions/Services/Bookmarks/IBookmarkHasher.cs
+++ b/src/core/Elsa.Abstractions/Services/Bookmarks/IBookmarkHasher.cs
@@ -1,4 +1,4 @@
-﻿namespace Elsa.Services.Bookmarks
+﻿namespace Elsa.Services
 {
     public interface IBookmarkHasher
     {

--- a/src/core/Elsa.Abstractions/Services/Bookmarks/IBookmarkIndexer.cs
+++ b/src/core/Elsa.Abstractions/Services/Bookmarks/IBookmarkIndexer.cs
@@ -3,7 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Elsa.Models;
 
-namespace Elsa.Services.Bookmarks
+namespace Elsa.Services
 {
     public interface IBookmarkIndexer
     {

--- a/src/core/Elsa.Abstractions/Services/Bookmarks/IBookmarkProvider.cs
+++ b/src/core/Elsa.Abstractions/Services/Bookmarks/IBookmarkProvider.cs
@@ -2,7 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Elsa.Services.Bookmarks
+namespace Elsa.Services
 {
     public interface IBookmarkProvider
     {

--- a/src/core/Elsa.Abstractions/Services/Bookmarks/NullBookmark.cs
+++ b/src/core/Elsa.Abstractions/Services/Bookmarks/NullBookmark.cs
@@ -1,4 +1,4 @@
-﻿namespace Elsa.Services.Bookmarks
+﻿namespace Elsa.Services
 {
     public class NullBookmark : IBookmark
     {

--- a/src/core/Elsa.Abstractions/Services/Dispatch/Models.cs
+++ b/src/core/Elsa.Abstractions/Services/Dispatch/Models.cs
@@ -6,5 +6,5 @@ namespace Elsa.Services
 
     public record ExecuteWorkflowDefinitionRequest(string WorkflowDefinitionId, string? ActivityId = default, object? Input = default, string? CorrelationId = default, string? ContextId = default, string? TenantId = default);
 
-    public record ExecuteWorkflowInstanceRequest(string WorkflowInstanceId, string? ActivityId, object? Input = default);
+    public record ExecuteWorkflowInstanceRequest(string WorkflowInstanceId, string? ActivityId = default, object? Input = default);
 }

--- a/src/core/Elsa.Abstractions/Services/Dispatch/Models.cs
+++ b/src/core/Elsa.Abstractions/Services/Dispatch/Models.cs
@@ -1,10 +1,10 @@
-﻿using Elsa.Services.Bookmarks;
+﻿using Elsa.Models;
 
 namespace Elsa.Services
 {
-    public record TriggerWorkflowsRequest(string ActivityType, IBookmark Bookmark, object? Input = default, string? CorrelationId = default, string? WorkflowInstanceId = default, string? ContextId = default, string? TenantId = default);
+    public record TriggerWorkflowsRequest(string ActivityType, IBookmark Bookmark, WorkflowInput? Input = default, string? CorrelationId = default, string? WorkflowInstanceId = default, string? ContextId = default, string? TenantId = default);
 
-    public record ExecuteWorkflowDefinitionRequest(string WorkflowDefinitionId, string? ActivityId = default, object? Input = default, string? CorrelationId = default, string? ContextId = default, string? TenantId = default);
+    public record ExecuteWorkflowDefinitionRequest(string WorkflowDefinitionId, string? ActivityId = default, WorkflowInput? Input = default, string? CorrelationId = default, string? ContextId = default, string? TenantId = default);
 
-    public record ExecuteWorkflowInstanceRequest(string WorkflowInstanceId, string? ActivityId = default, object? Input = default);
+    public record ExecuteWorkflowInstanceRequest(string WorkflowInstanceId, string? ActivityId = default, WorkflowInput? Input = default);
 }

--- a/src/core/Elsa.Abstractions/Services/Models/StartWorkflowArgs.cs
+++ b/src/core/Elsa.Abstractions/Services/Models/StartWorkflowArgs.cs
@@ -1,0 +1,6 @@
+using Elsa.Models;
+
+namespace Elsa.Services.Models
+{
+    public record StartWorkflowArgs(string? ActivityId = default, WorkflowInput? Input = default, string? CorrelationId = default, string? ContextId = default);
+}

--- a/src/core/Elsa.Abstractions/Services/Models/StartableWorkflowsQuery.cs
+++ b/src/core/Elsa.Abstractions/Services/Models/StartableWorkflowsQuery.cs
@@ -1,0 +1,4 @@
+namespace Elsa.Services.Models
+{
+    public record StartableWorkflowsQuery(string WorkflowDefinitionId, string? ActivityId = default, string? CorrelationId = default, string? ContextId = default, string? TenantId = default);
+}

--- a/src/core/Elsa.Abstractions/Services/Models/WorkflowInputReference.cs
+++ b/src/core/Elsa.Abstractions/Services/Models/WorkflowInputReference.cs
@@ -1,0 +1,4 @@
+namespace Elsa.Services.Models
+{
+    public record WorkflowInputReference(string? ProviderName);
+}

--- a/src/core/Elsa.Abstractions/Services/Models/WorkflowsQuery.cs
+++ b/src/core/Elsa.Abstractions/Services/Models/WorkflowsQuery.cs
@@ -1,0 +1,4 @@
+namespace Elsa.Services.Models
+{
+    public record WorkflowsQuery(string ActivityType, IBookmark? Bookmark, string? CorrelationId = default, string? WorkflowInstanceId = default, string? ContextId = default, string? TenantId = default);
+}

--- a/src/core/Elsa.Abstractions/Services/Triggers/ITriggerFinder.cs
+++ b/src/core/Elsa.Abstractions/Services/Triggers/ITriggerFinder.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Elsa.Services.Bookmarks;
 
 namespace Elsa.Services
 {

--- a/src/core/Elsa.Abstractions/Services/Triggers/TriggerFinderResult.cs
+++ b/src/core/Elsa.Abstractions/Services/Triggers/TriggerFinderResult.cs
@@ -1,5 +1,4 @@
-﻿using Elsa.Services.Bookmarks;
-using Elsa.Services.Models;
+﻿using Elsa.Services.Models;
 
 namespace Elsa.Services
 {

--- a/src/core/Elsa.Abstractions/Services/Triggers/WorkflowTrigger.cs
+++ b/src/core/Elsa.Abstractions/Services/Triggers/WorkflowTrigger.cs
@@ -1,5 +1,4 @@
-﻿using Elsa.Services.Bookmarks;
-using Elsa.Services.Models;
+﻿using Elsa.Services.Models;
 
 namespace Elsa.Services
 {

--- a/src/core/Elsa.Abstractions/Services/Workflows/IBuildsAndResumesWorkflow.cs
+++ b/src/core/Elsa.Abstractions/Services/Workflows/IBuildsAndResumesWorkflow.cs
@@ -11,7 +11,7 @@ namespace Elsa.Services
         Task<RunWorkflowResult> BuildAndResumeWorkflowAsync<T>(
             WorkflowInstance workflowInstance,
             string? activityId = default,
-            object? input = default,
+            WorkflowInput? input = default,
             CancellationToken cancellationToken = default)
             where T : IWorkflow;
 
@@ -19,7 +19,7 @@ namespace Elsa.Services
             IWorkflow workflow,
             WorkflowInstance workflowInstance,
             string? activityId = default,
-            object? input = default,
+            WorkflowInput? input = default,
             CancellationToken cancellationToken = default);
     }
 }

--- a/src/core/Elsa.Abstractions/Services/Workflows/IBuildsAndStartsWorkflow.cs
+++ b/src/core/Elsa.Abstractions/Services/Workflows/IBuildsAndStartsWorkflow.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
 using Elsa.Builders;
+using Elsa.Models;
 using Elsa.Services.Models;
 
 namespace Elsa.Services
@@ -9,7 +10,7 @@ namespace Elsa.Services
     {
         Task<RunWorkflowResult> BuildAndStartWorkflowAsync<T>(
             string? activityId = default,
-            object? input = default,
+            WorkflowInput? input = default,
             string? correlationId = default,
             string? contextId = default,
             CancellationToken cancellationToken = default)
@@ -18,7 +19,7 @@ namespace Elsa.Services
         public Task<RunWorkflowResult> BuildAndStartWorkflowAsync(
             IWorkflow workflow,
             string? activityId = default,
-            object? input = default,
+            WorkflowInput? input = default,
             string? correlationId = default,
             string? contextId = default,
             CancellationToken cancellationToken = default);

--- a/src/core/Elsa.Abstractions/Services/Workflows/IFindsAndResumesWorkflows.cs
+++ b/src/core/Elsa.Abstractions/Services/Workflows/IFindsAndResumesWorkflows.cs
@@ -1,6 +1,6 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
-using Elsa.Services.Bookmarks;
+using Elsa.Models;
 
 namespace Elsa.Services
 {
@@ -10,7 +10,7 @@ namespace Elsa.Services
             string activityType,
             IBookmark bookmark,
             string? tenantId,
-            object? input = default,
+            WorkflowInput? input = default,
             string? correlationId = default,
             string? contextId = default,
             CancellationToken cancellationToken = default);

--- a/src/core/Elsa.Abstractions/Services/Workflows/IFindsAndStartsWorkflows.cs
+++ b/src/core/Elsa.Abstractions/Services/Workflows/IFindsAndStartsWorkflows.cs
@@ -1,6 +1,6 @@
 using System.Threading;
 using System.Threading.Tasks;
-using Elsa.Services.Bookmarks;
+using Elsa.Models;
 
 namespace Elsa.Services
 {
@@ -10,7 +10,7 @@ namespace Elsa.Services
             string activityType,
             IBookmark bookmark,
             string? tenantId,
-            object? input = default,
+            WorkflowInput? input = default,
             string? contextId = default,
             CancellationToken cancellationToken = default);
     }

--- a/src/core/Elsa.Abstractions/Services/Workflows/IResumesWorkflow.cs
+++ b/src/core/Elsa.Abstractions/Services/Workflows/IResumesWorkflow.cs
@@ -10,7 +10,7 @@ namespace Elsa.Services
         Task<RunWorkflowResult> ResumeWorkflowAsync(
             WorkflowInstance workflowInstance,
             string? activityId = default,
-            object? input = default,
+            WorkflowInput? input = default,
             CancellationToken cancellationToken = default);
     }
 }

--- a/src/core/Elsa.Abstractions/Services/Workflows/IResumesWorkflows.cs
+++ b/src/core/Elsa.Abstractions/Services/Workflows/IResumesWorkflows.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Elsa.Services.Bookmarks;
+using Elsa.Models;
 
 namespace Elsa.Services
 {
@@ -9,7 +9,7 @@ namespace Elsa.Services
     {
         Task ResumeWorkflowsAsync(
             IEnumerable<BookmarkFinderResult> results,
-            object? input = default,
+            WorkflowInput? input = default,
             CancellationToken cancellationToken = default);
     }
 }

--- a/src/core/Elsa.Abstractions/Services/Workflows/IStartsWorkflow.cs
+++ b/src/core/Elsa.Abstractions/Services/Workflows/IStartsWorkflow.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
+using Elsa.Models;
 using Elsa.Services.Models;
 
 namespace Elsa.Services
@@ -9,7 +10,7 @@ namespace Elsa.Services
         Task<RunWorkflowResult> StartWorkflowAsync(
             IWorkflowBlueprint workflowBlueprint,
             string? activityId = default,
-            object? input = default,
+            WorkflowInput? input = default,
             string? correlationId = default,
             string? contextId = default,
             CancellationToken cancellationToken = default);

--- a/src/core/Elsa.Abstractions/Services/Workflows/IStartsWorkflows.cs
+++ b/src/core/Elsa.Abstractions/Services/Workflows/IStartsWorkflows.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Elsa.Models;
 using Elsa.Services.Models;
 
 namespace Elsa.Services
@@ -9,7 +10,7 @@ namespace Elsa.Services
     {
         Task<IEnumerable<RunWorkflowResult>> StartWorkflowsAsync(
             IEnumerable<TriggerFinderResult> results,
-            object? input = default,
+            WorkflowInput? input = default,
             string? contextId = default,
             CancellationToken cancellationToken = default);
     }

--- a/src/core/Elsa.Abstractions/Services/Workflows/IWorkflowInstanceExecutor.cs
+++ b/src/core/Elsa.Abstractions/Services/Workflows/IWorkflowInstanceExecutor.cs
@@ -10,7 +10,7 @@ namespace Elsa.Services
     /// </summary>
     public interface IWorkflowInstanceExecutor
     {
-        Task<RunWorkflowResult> ExecuteAsync(string workflowInstanceId, string? activityId, object? input = default, CancellationToken cancellationToken = default);
-        Task<RunWorkflowResult> ExecuteAsync(WorkflowInstance workflowInstance, string? activityId, object? input = default, CancellationToken cancellationToken = default);
+        Task<RunWorkflowResult> ExecuteAsync(string workflowInstanceId, string? activityId, WorkflowInput? input = default, CancellationToken cancellationToken = default);
+        Task<RunWorkflowResult> ExecuteAsync(WorkflowInstance workflowInstance, string? activityId, WorkflowInput? input = default, CancellationToken cancellationToken = default);
     }
 }

--- a/src/core/Elsa.Abstractions/Services/Workflows/IWorkflowLaunchpad.cs
+++ b/src/core/Elsa.Abstractions/Services/Workflows/IWorkflowLaunchpad.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Elsa.Services.Bookmarks;
+using Elsa.Models;
 using Elsa.Services.Models;
 
 namespace Elsa.Services
@@ -14,88 +14,84 @@ namespace Elsa.Services
         /// <summary>
         /// Collects and creates workflow instances that are ready for execution. This takes into account both resumable (suspended) workflows as well as startable workflows.
         /// </summary>
-        Task<IEnumerable<CollectedWorkflow>> CollectWorkflowsAsync(CollectWorkflowsContext context, CancellationToken cancellationToken = default);
+        Task<IEnumerable<CollectedWorkflow>> FindWorkflowsAsync(WorkflowsQuery query, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Collects and creates workflow instances for startable workflows.
         /// </summary>
-        /// <param name="context"></param>
+        /// <param name="query"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<IEnumerable<StartableWorkflow>> CollectStartableWorkflowsAsync(CollectWorkflowsContext context, CancellationToken cancellationToken = default);
+        Task<IEnumerable<StartableWorkflow>> FindStartableWorkflowsAsync(WorkflowsQuery query, CancellationToken cancellationToken = default);
         
         /// <summary>
         /// Creates a new workflow instance with execution pending for the specified workflow blueprint using the specified starting activity ID.
         /// </summary>
-        Task<StartableWorkflow?> CollectStartableWorkflowAsync(string workflowDefinitionId, string? activityId = default, string? correlationId = default, string? contextId = default, string? tenantId = default, CancellationToken cancellationToken = default);
+        Task<StartableWorkflow?> FindStartableWorkflowAsync(string workflowDefinitionId, string? activityId = default, string? correlationId = default, string? contextId = default, string? tenantId = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Creates a new workflow instance with execution pending for the specified workflow blueprint using the specified starting activity ID.
         /// </summary>
-        Task<StartableWorkflow?> CollectStartableWorkflowAsync(IWorkflowBlueprint workflowBlueprint, string? activityId = default, string? correlationId = default, string? contextId = default, string? tenantId = default, CancellationToken cancellationToken = default);
+        Task<StartableWorkflow?> FindStartableWorkflowAsync(IWorkflowBlueprint workflowBlueprint, string? activityId = default, string? correlationId = default, string? contextId = default, string? tenantId = default, CancellationToken cancellationToken = default);
         
         /// <summary>
         /// Collects and executes the specified startable workflow.
         /// </summary>
-        Task CollectAndExecuteStartableWorkflowAsync(string workflowDefinitionId, string? activityId = default, string? correlationId = default, string? contextId = default, object? input = default, string? tenantId = default, CancellationToken cancellationToken = default);
+        Task FindAndExecuteStartableWorkflowAsync(string workflowDefinitionId, string? activityId = default, string? correlationId = default, string? contextId = default, WorkflowInput? input = default, string? tenantId = default, CancellationToken cancellationToken = default);
         
         /// <summary>
         /// Collects and executes the specified startable workflow.
         /// </summary>
-        Task<RunWorkflowResult> CollectAndExecuteStartableWorkflowAsync(IWorkflowBlueprint workflowBlueprint, string? activityId = default, string? correlationId = default, string? contextId = default, object? input = default, CancellationToken cancellationToken = default);
+        Task<RunWorkflowResult> FindAndExecuteStartableWorkflowAsync(IWorkflowBlueprint workflowBlueprint, string? activityId = default, string? correlationId = default, string? contextId = default, WorkflowInput? input = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Executes a list of pending workflows.
         /// </summary>
-        Task ExecutePendingWorkflowsAsync(IEnumerable<CollectedWorkflow> pendingWorkflows, object? input = default, CancellationToken cancellationToken = default);
+        Task ExecutePendingWorkflowsAsync(IEnumerable<CollectedWorkflow> pendingWorkflows, WorkflowInput? input = default, CancellationToken cancellationToken = default);
         
         /// <summary>
         /// Executes a pending workflow.
         /// </summary>
-        Task ExecutePendingWorkflowAsync(CollectedWorkflow collectedWorkflow, object? input = default, CancellationToken cancellationToken = default);
+        Task ExecutePendingWorkflowAsync(CollectedWorkflow collectedWorkflow, WorkflowInput? input = default, CancellationToken cancellationToken = default);
         
         /// <summary>
         /// Executes a pending workflow.
         /// </summary>
-        Task<RunWorkflowResult> ExecutePendingWorkflowAsync(string workflowInstanceId, string? activityId = default, object? input = default, CancellationToken cancellationToken = default);
+        Task<RunWorkflowResult> ExecutePendingWorkflowAsync(string workflowInstanceId, string? activityId = default, WorkflowInput? input = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Dispatches a list of pending workflows for execution.
         /// </summary>
-        Task DispatchPendingWorkflowsAsync(IEnumerable<CollectedWorkflow> pendingWorkflows, object? input = default, CancellationToken cancellationToken = default);
+        Task DispatchPendingWorkflowsAsync(IEnumerable<CollectedWorkflow> pendingWorkflows, WorkflowInput? input = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Dispatches a pending workflow for execution.
         /// </summary>
-        Task DispatchPendingWorkflowAsync(CollectedWorkflow collectedWorkflow, object? input = default, CancellationToken cancellationToken = default);
+        Task DispatchPendingWorkflowAsync(CollectedWorkflow collectedWorkflow, WorkflowInput? input = default, CancellationToken cancellationToken = default);
         
         /// <summary>
         /// Dispatches a pending workflow for execution.
         /// </summary>
-        Task DispatchPendingWorkflowAsync(string workflowInstanceId, string? activityId = default, object? input = default, CancellationToken cancellationToken = default);
+        Task DispatchPendingWorkflowAsync(string workflowInstanceId, string? activityId = default, WorkflowInput? input = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Executes the specified startable workflow.
         /// </summary>
-        Task<RunWorkflowResult> ExecuteStartableWorkflowAsync(StartableWorkflow startableWorkflow, object? input = default, CancellationToken cancellationToken = default);
+        Task<RunWorkflowResult> ExecuteStartableWorkflowAsync(StartableWorkflow startableWorkflow, WorkflowInput? input = default, CancellationToken cancellationToken = default);
         
         /// <summary>
         /// Dispatches the specified startable workflow.
         /// </summary>
-        Task<CollectedWorkflow> DispatchStartableWorkflowAsync(StartableWorkflow startableWorkflow, object? input = default, CancellationToken cancellationToken = default);
+        Task<CollectedWorkflow> DispatchStartableWorkflowAsync(StartableWorkflow startableWorkflow, WorkflowInput? input = default, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Collects and executes workflows that are ready for execution. This takes into account both resumable (suspended) workflows as well as startable workflows.
         /// </summary>
-        Task<IEnumerable<CollectedWorkflow>> CollectAndExecuteWorkflowsAsync(CollectWorkflowsContext context, object? input = default, CancellationToken cancellationToken = default);
+        Task<IEnumerable<CollectedWorkflow>> CollectAndExecuteWorkflowsAsync(WorkflowsQuery query, WorkflowInput? input = default, CancellationToken cancellationToken = default);
         
         /// <summary>
         /// Collects and dispatches workflows that are ready for execution. This takes into account both resumable (suspended) workflows as well as startable workflows.
         /// </summary>
-        Task<IEnumerable<CollectedWorkflow>> CollectAndDispatchWorkflowsAsync(CollectWorkflowsContext context, object? input = default, CancellationToken cancellationToken = default);
+        Task<IEnumerable<CollectedWorkflow>> CollectAndDispatchWorkflowsAsync(WorkflowsQuery query, WorkflowInput? input = default, CancellationToken cancellationToken = default);
     }
-
-    public record CollectWorkflowsContext(string ActivityType, IBookmark? Bookmark, string? CorrelationId = default, string? WorkflowInstanceId = default, string? ContextId = default, string? TenantId = default);
-
-    public record CollectStartableWorkflowsContext(string WorkflowDefinitionId, string? ActivityId = default, string? CorrelationId = default, string? ContextId = default, string? TenantId = default);
 }

--- a/src/core/Elsa.Abstractions/Services/Workflows/IWorkflowRunner.cs
+++ b/src/core/Elsa.Abstractions/Services/Workflows/IWorkflowRunner.cs
@@ -11,7 +11,7 @@ namespace Elsa.Services
             IWorkflowBlueprint workflowDefinition,
             WorkflowInstance workflowInstance,
             string? activityId = default,
-            object? input = default,
+            WorkflowInput? input = default,
             CancellationToken cancellationToken = default);
     }
 }

--- a/src/core/Elsa.Abstractions/Services/Workflows/IWorkflowTriggerInterruptor.cs
+++ b/src/core/Elsa.Abstractions/Services/Workflows/IWorkflowTriggerInterruptor.cs
@@ -11,10 +11,10 @@ namespace Elsa.Services
     /// </summary>
     public interface IWorkflowTriggerInterruptor
     {
-        Task<RunWorkflowResult> InterruptActivityAsync(WorkflowInstance workflowInstance, string activityId, object? input = default, CancellationToken cancellationToken = default);
-        Task<RunWorkflowResult> InterruptActivityAsync(IWorkflowBlueprint workflowBlueprint, WorkflowInstance workflowInstance, string activityId, object? input = default, CancellationToken cancellationToken = default);
-        Task<IEnumerable<RunWorkflowResult>> InterruptActivityTypeAsync(IWorkflowBlueprint workflowBlueprint, WorkflowInstance workflowInstance, string activityType, object? input = default, CancellationToken cancellationToken = default);
-        Task<IEnumerable<RunWorkflowResult>> InterruptActivityTypeAsync(WorkflowInstance workflowInstance, string activityType, object? input = default, CancellationToken cancellationToken = default);
-        Task<IEnumerable<RunWorkflowResult>> InterruptActivityTypeAsync(string activityType, object? input = default, CancellationToken cancellationToken = default);
+        Task<RunWorkflowResult> InterruptActivityAsync(WorkflowInstance workflowInstance, string activityId, WorkflowInput? input = default, CancellationToken cancellationToken = default);
+        Task<RunWorkflowResult> InterruptActivityAsync(IWorkflowBlueprint workflowBlueprint, WorkflowInstance workflowInstance, string activityId, WorkflowInput? input = default, CancellationToken cancellationToken = default);
+        Task<IEnumerable<RunWorkflowResult>> InterruptActivityTypeAsync(IWorkflowBlueprint workflowBlueprint, WorkflowInstance workflowInstance, string activityType, WorkflowInput? input = default, CancellationToken cancellationToken = default);
+        Task<IEnumerable<RunWorkflowResult>> InterruptActivityTypeAsync(WorkflowInstance workflowInstance, string activityType, WorkflowInput? input = default, CancellationToken cancellationToken = default);
+        Task<IEnumerable<RunWorkflowResult>> InterruptActivityTypeAsync(string activityType, WorkflowInput? input = default, CancellationToken cancellationToken = default);
     }
 }

--- a/src/core/Elsa.Core/Activities/Signaling/Activities/InterruptTrigger/InterruptTrigger.cs
+++ b/src/core/Elsa.Core/Activities/Signaling/Activities/InterruptTrigger/InterruptTrigger.cs
@@ -2,6 +2,7 @@ using System.Threading.Tasks;
 using Elsa.ActivityResults;
 using Elsa.Attributes;
 using Elsa.Expressions;
+using Elsa.Models;
 using Elsa.Persistence;
 using Elsa.Services;
 using Elsa.Services.Models;
@@ -40,7 +41,7 @@ namespace Elsa.Activities.Signaling
         protected override async ValueTask<IActivityExecutionResult> OnExecuteAsync(ActivityExecutionContext context)
         {
             var workflowInstance = await _workflowInstanceManager.FindByIdAsync(WorkflowInstanceId, context.CancellationToken);
-            await _workflowTriggerInterruptor.InterruptActivityAsync(workflowInstance!, BlockingActivityId, Input, context.CancellationToken);
+            await _workflowTriggerInterruptor.InterruptActivityAsync(workflowInstance!, BlockingActivityId, new WorkflowInput(Input), context.CancellationToken);
             return Done();
         }
     }

--- a/src/core/Elsa.Core/Activities/Signaling/Activities/SignalReceived/SignalReceivedBookmarkProvider.cs
+++ b/src/core/Elsa.Core/Activities/Signaling/Activities/SignalReceived/SignalReceivedBookmarkProvider.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Elsa.Services;
 using Elsa.Services.Bookmarks;
 
 // ReSharper disable once CheckNamespace

--- a/src/core/Elsa.Core/Activities/Signaling/Services/Signaler.cs
+++ b/src/core/Elsa.Core/Activities/Signaling/Services/Signaler.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Elsa.Activities.Signaling.Models;
+using Elsa.Models;
 using Elsa.Services;
 using Elsa.Services.Models;
 
@@ -34,14 +35,14 @@ namespace Elsa.Activities.Signaling.Services
         {
             var normalizedSignal = signal.ToLowerInvariant();
 
-            return await _workflowLaunchpad.CollectAndExecuteWorkflowsAsync(new CollectWorkflowsContext(
+            return await _workflowLaunchpad.CollectAndExecuteWorkflowsAsync(new WorkflowsQuery(
                 nameof(SignalReceived),
                 new SignalReceivedBookmark { Signal = normalizedSignal },
                 correlationId,
                 workflowInstanceId,
                 default,
                 TenantId
-            ), new Signal(normalizedSignal, input), cancellationToken);
+            ), new WorkflowInput(new Signal(normalizedSignal, input)), cancellationToken);
         }
 
         public async Task<IEnumerable<CollectedWorkflow>> DispatchSignalTokenAsync(string token, object? input = default, CancellationToken cancellationToken = default)
@@ -56,7 +57,7 @@ namespace Elsa.Activities.Signaling.Services
         {
             var normalizedSignal = signal.ToLowerInvariant();
             
-            return await _workflowLaunchpad.CollectAndDispatchWorkflowsAsync(new CollectWorkflowsContext(
+            return await _workflowLaunchpad.CollectAndDispatchWorkflowsAsync(new WorkflowsQuery(
                     nameof(SignalReceived),
                     new SignalReceivedBookmark { Signal = normalizedSignal },
                     correlationId,
@@ -64,7 +65,7 @@ namespace Elsa.Activities.Signaling.Services
                     default,
                     TenantId
                 ),
-                new Signal(normalizedSignal, input),
+                new WorkflowInput(new Signal(normalizedSignal, input)),
                 cancellationToken);
         }
     }

--- a/src/core/Elsa.Core/Activities/Workflows/RunWorkflow/Bookmarks/RunWorkflowBookmark.cs
+++ b/src/core/Elsa.Core/Activities/Workflows/RunWorkflow/Bookmarks/RunWorkflowBookmark.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Elsa.Services;
 using Elsa.Services.Bookmarks;
 
 // ReSharper disable once CheckNamespace

--- a/src/core/Elsa.Core/Activities/Workflows/RunWorkflow/Handlers/ResumeParentWorkflow.cs
+++ b/src/core/Elsa.Core/Activities/Workflows/RunWorkflow/Handlers/ResumeParentWorkflow.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
 using Elsa.Events;
+using Elsa.Models;
 using Elsa.Providers.WorkflowStorage;
 using Elsa.Services;
 using Elsa.Services.Models;
@@ -41,7 +42,7 @@ namespace Elsa.Activities.Workflows
                 ChildWorkflowInstanceId = workflowInstanceId
             };
 
-            await _workflowScheduler.FindAndResumeWorkflowsAsync(nameof(RunWorkflow), trigger, tenantId, input, cancellationToken: cancellationToken);
+            await _workflowScheduler.FindAndResumeWorkflowsAsync(nameof(RunWorkflow), trigger, tenantId, new WorkflowInput(input), cancellationToken: cancellationToken);
         }
     }
 }

--- a/src/core/Elsa.Core/Activities/Workflows/RunWorkflow/RunWorkflow.cs
+++ b/src/core/Elsa.Core/Activities/Workflows/RunWorkflow/RunWorkflow.cs
@@ -101,7 +101,7 @@ namespace Elsa.Activities.Workflows
             if (workflowBlueprint == null || workflowBlueprint.Id == context.WorkflowInstance.DefinitionId)
                 return Outcome("Not Found");
 
-            var result = await _startsWorkflow.StartWorkflowAsync(workflowBlueprint!, TenantId, Input, CorrelationId, ContextId, cancellationToken);
+            var result = await _startsWorkflow.StartWorkflowAsync(workflowBlueprint!, TenantId, new WorkflowInput(Input), CorrelationId, ContextId, cancellationToken);
             var workflowInstance = result.WorkflowInstance!;
             var workflowStatus = result.WorkflowInstance!.WorkflowStatus;
 

--- a/src/core/Elsa.Core/Decorators/LockingWorkflowInstanceExecutor.cs
+++ b/src/core/Elsa.Core/Decorators/LockingWorkflowInstanceExecutor.cs
@@ -31,7 +31,7 @@ namespace Elsa.Decorators
             _logger = logger;
         }
 
-        public async Task<RunWorkflowResult> ExecuteAsync(string workflowInstanceId, string? activityId, object? input = default, CancellationToken cancellationToken = default)
+        public async Task<RunWorkflowResult> ExecuteAsync(string workflowInstanceId, string? activityId, WorkflowInput? input = default, CancellationToken cancellationToken = default)
         {
             var workflowInstanceLockKey = $"workflow-instance:{workflowInstanceId}";
             await using var workflowInstanceLockHandle = await _distributedLockProvider.AcquireLockAsync(workflowInstanceLockKey, _elsaOptions.DistributedLockTimeout, cancellationToken);
@@ -69,7 +69,7 @@ namespace Elsa.Decorators
             }
         }
 
-        public async Task<RunWorkflowResult> ExecuteAsync(WorkflowInstance workflowInstance, string? activityId, object? input = default, CancellationToken cancellationToken = default) =>
+        public async Task<RunWorkflowResult> ExecuteAsync(WorkflowInstance workflowInstance, string? activityId, WorkflowInput? input = default, CancellationToken cancellationToken = default) =>
             await _workflowInstanceExecutor.ExecuteAsync(workflowInstance, activityId, input, cancellationToken);
     }
 }

--- a/src/core/Elsa.Core/Extensions/ElsaServiceCollectionExtensions.cs
+++ b/src/core/Elsa.Core/Extensions/ElsaServiceCollectionExtensions.cs
@@ -18,6 +18,7 @@ using Elsa.Mapping;
 using Elsa.Metadata;
 using Elsa.Persistence;
 using Elsa.Persistence.Decorators;
+using Elsa.Providers.Activities;
 using Elsa.Providers.ActivityTypes;
 using Elsa.Providers.Workflows;
 using Elsa.Providers.WorkflowStorage;

--- a/src/core/Elsa.Core/Handlers/PersistWorkflow.cs
+++ b/src/core/Elsa.Core/Handlers/PersistWorkflow.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using Elsa.Events;
 using Elsa.Models;
 using Elsa.Persistence;
-using Elsa.Services.Models;
 using MediatR;
 using Microsoft.Extensions.Logging;
 
@@ -15,7 +14,8 @@ namespace Elsa.Handlers
         INotificationHandler<WorkflowFaulted>,
         INotificationHandler<WorkflowExecutionPassCompleted>,
         INotificationHandler<WorkflowExecutionBurstCompleted>,
-        INotificationHandler<WorkflowExecutionFinished>
+        INotificationHandler<WorkflowExecutionFinished>,
+        INotificationHandler<WorkflowInputUpdated>
     {
         private readonly IWorkflowInstanceStore _workflowInstanceStore;
         private readonly ILogger _logger;
@@ -31,7 +31,7 @@ namespace Elsa.Handlers
             var behavior = notification.WorkflowExecutionContext.WorkflowBlueprint.PersistenceBehavior;
             
             if (behavior == WorkflowPersistenceBehavior.Suspended)
-                await SaveWorkflowAsync(notification.WorkflowExecutionContext, cancellationToken);
+                await SaveWorkflowAsync(notification.WorkflowExecutionContext.WorkflowInstance, cancellationToken);
         }
 
         public async Task Handle(WorkflowExecutionBurstCompleted notification, CancellationToken cancellationToken)
@@ -39,7 +39,7 @@ namespace Elsa.Handlers
             var behavior = notification.WorkflowExecutionContext.WorkflowBlueprint.PersistenceBehavior;
             
             if (behavior == WorkflowPersistenceBehavior.WorkflowBurst)
-                await SaveWorkflowAsync(notification.WorkflowExecutionContext, cancellationToken);
+                await SaveWorkflowAsync(notification.WorkflowExecutionContext.WorkflowInstance, cancellationToken);
         }
 
         public async Task Handle(WorkflowExecutionPassCompleted notification, CancellationToken cancellationToken)
@@ -47,7 +47,7 @@ namespace Elsa.Handlers
             var behavior = notification.WorkflowExecutionContext.WorkflowBlueprint.PersistenceBehavior;
 
             if (behavior == WorkflowPersistenceBehavior.WorkflowPassCompleted || behavior == WorkflowPersistenceBehavior.ActivityExecuted || notification.ActivityExecutionContext.ActivityBlueprint.PersistWorkflow)
-                await SaveWorkflowAsync(notification.WorkflowExecutionContext, cancellationToken);
+                await SaveWorkflowAsync(notification.WorkflowExecutionContext.WorkflowInstance, cancellationToken);
         }
 
         public async Task Handle(WorkflowExecuted notification, CancellationToken cancellationToken)
@@ -55,7 +55,7 @@ namespace Elsa.Handlers
             var behavior = notification.WorkflowExecutionContext.WorkflowBlueprint.PersistenceBehavior;
 
             if (behavior == WorkflowPersistenceBehavior.WorkflowPassCompleted || behavior == WorkflowPersistenceBehavior.WorkflowBurst)
-                await SaveWorkflowAsync(notification.WorkflowExecutionContext, cancellationToken);
+                await SaveWorkflowAsync(notification.WorkflowExecutionContext.WorkflowInstance, cancellationToken);
         }
 
         public async Task Handle(WorkflowExecutionFinished notification, CancellationToken cancellationToken)
@@ -69,24 +69,21 @@ namespace Elsa.Handlers
             }
             else
             {
-                await SaveWorkflowAsync(notification.WorkflowExecutionContext, cancellationToken);
+                await SaveWorkflowAsync(notification.WorkflowExecutionContext.WorkflowInstance, cancellationToken);
             }
         }
         
-        public async Task Handle(WorkflowFaulted notification, CancellationToken cancellationToken)
-        {
-            await SaveWorkflowAsync(notification.WorkflowExecutionContext, cancellationToken);
-        }
+        public async Task Handle(WorkflowInputUpdated notification, CancellationToken cancellationToken) => await SaveWorkflowAsync(notification.WorkflowInstance, cancellationToken);
+        public async Task Handle(WorkflowFaulted notification, CancellationToken cancellationToken) => await SaveWorkflowAsync(notification.WorkflowExecutionContext.WorkflowInstance, cancellationToken);
 
-        private async ValueTask SaveWorkflowAsync(WorkflowExecutionContext workflowExecutionContext, CancellationToken cancellationToken)
+        private async ValueTask SaveWorkflowAsync(WorkflowInstance workflowInstance, CancellationToken cancellationToken)
         {
-            _logger.LogTrace("Persisting workflow instance {instanceId}", workflowExecutionContext.WorkflowInstance.Id);
+            _logger.LogTrace("Persisting workflow instance {instanceId}", workflowInstance.Id);
 
             // Can't prune data - we need to figure out a better way to remove activity output data.
             // Doing it right now causes issues when transferring output data from composite activities.
             //workflowExecutionContext.PruneActivityData();
             
-            var workflowInstance = workflowExecutionContext.WorkflowInstance;
             await _workflowInstanceStore.SaveAsync(workflowInstance, cancellationToken);
 
             _logger.LogDebug("Committed workflow {WorkflowInstanceId} to storage", workflowInstance.Id);

--- a/src/core/Elsa.Core/Handlers/UpdateBookmarks.cs
+++ b/src/core/Elsa.Core/Handlers/UpdateBookmarks.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Elsa.Events;
+using Elsa.Services;
 using Elsa.Services.Bookmarks;
 using MediatR;
 

--- a/src/core/Elsa.Core/Providers/ActivityTypes/TypeBasedActivityProvider.cs
+++ b/src/core/Elsa.Core/Providers/ActivityTypes/TypeBasedActivityProvider.cs
@@ -5,6 +5,7 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Elsa.Metadata;
+using Elsa.Providers.Activities;
 using Elsa.Services;
 using Elsa.Services.Models;
 

--- a/src/core/Elsa.Core/Services/Dispatch/Consumers/ExecuteWorkflowDefinitionRequestConsumer.cs
+++ b/src/core/Elsa.Core/Services/Dispatch/Consumers/ExecuteWorkflowDefinitionRequestConsumer.cs
@@ -30,7 +30,7 @@ namespace Elsa.Services.Dispatch.Consumers
                 return;
             }
             
-            var startableWorkflow = await _workflowLaunchpad.CollectStartableWorkflowAsync(workflowBlueprint, message.ActivityId, message.CorrelationId, message.ContextId, tenantId);
+            var startableWorkflow = await _workflowLaunchpad.FindStartableWorkflowAsync(workflowBlueprint, message.ActivityId, message.CorrelationId, message.ContextId, tenantId);
 
             if (startableWorkflow == null)
             {

--- a/src/core/Elsa.Core/Services/Dispatch/Consumers/ExecuteWorkflowInstanceRequestConsumer.cs
+++ b/src/core/Elsa.Core/Services/Dispatch/Consumers/ExecuteWorkflowInstanceRequestConsumer.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using Elsa.Models;
 using Rebus.Handlers;
 
 namespace Elsa.Services.Dispatch.Consumers
@@ -11,7 +12,7 @@ namespace Elsa.Services.Dispatch.Consumers
 
         public async Task Handle(ExecuteWorkflowInstanceRequest message)
         {
-            await _workflowInstanceExecutor.ExecuteAsync(message.WorkflowInstanceId, message.ActivityId, message.Input);
+            await _workflowInstanceExecutor.ExecuteAsync(message.WorkflowInstanceId, message.ActivityId, new WorkflowInput(message.Input));
         }
     }
 }

--- a/src/core/Elsa.Core/Services/Dispatch/Consumers/TriggerWorkflowsRequestConsumer.cs
+++ b/src/core/Elsa.Core/Services/Dispatch/Consumers/TriggerWorkflowsRequestConsumer.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using Elsa.Services.Models;
 using Rebus.Handlers;
 
 namespace Elsa.Services.Dispatch.Consumers
@@ -14,7 +15,7 @@ namespace Elsa.Services.Dispatch.Consumers
 
         public async Task Handle(TriggerWorkflowsRequest message)
         {
-            var pendingWorkflows = await _workflowLaunchpad.CollectWorkflowsAsync(new CollectWorkflowsContext(
+            var pendingWorkflows = await _workflowLaunchpad.FindWorkflowsAsync(new WorkflowsQuery(
                 message.ActivityType, 
                 message.Bookmark,
                 message.CorrelationId, 

--- a/src/core/Elsa.Core/Services/Workflows/ActivityTypeService.cs
+++ b/src/core/Elsa.Core/Services/Workflows/ActivityTypeService.cs
@@ -7,6 +7,7 @@ using Elsa.Caching;
 using Elsa.Events;
 using Elsa.Exceptions;
 using Elsa.Metadata;
+using Elsa.Providers.Activities;
 using Elsa.Services.Models;
 using MediatR;
 using Microsoft.Extensions.Caching.Memory;

--- a/src/core/Elsa.Core/Services/Workflows/WorkflowInstanceExecutor.cs
+++ b/src/core/Elsa.Core/Services/Workflows/WorkflowInstanceExecutor.cs
@@ -21,7 +21,7 @@ namespace Elsa.Services.Workflows
             _logger = logger;
         }
 
-        public async Task<RunWorkflowResult> ExecuteAsync(string workflowInstanceId, string? activityId, object? input = default, CancellationToken cancellationToken = default)
+        public async Task<RunWorkflowResult> ExecuteAsync(string workflowInstanceId, string? activityId, WorkflowInput? input = default, CancellationToken cancellationToken = default)
         {
             var workflowInstance = await WorkflowInstanceStore.FindByIdAsync(workflowInstanceId, cancellationToken);
 
@@ -35,7 +35,7 @@ namespace Elsa.Services.Workflows
                 cancellationToken);
         }
 
-        public async Task<RunWorkflowResult> ExecuteAsync(WorkflowInstance workflowInstance, string? activityId, object? input = default, CancellationToken cancellationToken = default)
+        public async Task<RunWorkflowResult> ExecuteAsync(WorkflowInstance workflowInstance, string? activityId, WorkflowInput? input = default, CancellationToken cancellationToken = default)
         {
             if (!ValidatePreconditions(workflowInstance.Id, workflowInstance, activityId))
                 return new RunWorkflowResult(workflowInstance, activityId, false);

--- a/src/core/Elsa.Core/Services/Workflows/WorkflowInstanceExecutor.cs
+++ b/src/core/Elsa.Core/Services/Workflows/WorkflowInstanceExecutor.cs
@@ -24,14 +24,15 @@ namespace Elsa.Services.Workflows
         public async Task<RunWorkflowResult> ExecuteAsync(string workflowInstanceId, string? activityId, object? input = default, CancellationToken cancellationToken = default)
         {
             var workflowInstance = await WorkflowInstanceStore.FindByIdAsync(workflowInstanceId, cancellationToken);
-            
+
             if (!ValidatePreconditions(workflowInstanceId, workflowInstance, activityId))
                 return new RunWorkflowResult(workflowInstance, activityId, false);
-            
+
             return await _workflowRunner.ResumeWorkflowAsync(
                 workflowInstance!,
                 activityId,
-                input, cancellationToken);
+                input,
+                cancellationToken);
         }
 
         public async Task<RunWorkflowResult> ExecuteAsync(WorkflowInstance workflowInstance, string? activityId, object? input = default, CancellationToken cancellationToken = default)
@@ -42,7 +43,8 @@ namespace Elsa.Services.Workflows
             return await _workflowRunner.ResumeWorkflowAsync(
                 workflowInstance!,
                 activityId,
-                input, cancellationToken);
+                input,
+                cancellationToken);
         }
 
         private bool ValidatePreconditions(string? workflowInstanceId, WorkflowInstance? workflowInstance, string? activityId)

--- a/src/core/Elsa.Core/Services/Workflows/WorkflowRegistry.cs
+++ b/src/core/Elsa.Core/Services/Workflows/WorkflowRegistry.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 using Elsa.Models;
 using Elsa.Persistence;
 using Elsa.Persistence.Specifications.WorkflowInstances;
-using Elsa.Providers.Workflow;
+using Elsa.Providers.Workflows;
 using Elsa.Services.Models;
 using Open.Linq.AsyncExtensions;
 

--- a/src/core/Elsa.Core/Services/Workflows/WorkflowResumer.cs
+++ b/src/core/Elsa.Core/Services/Workflows/WorkflowResumer.cs
@@ -33,7 +33,7 @@ namespace Elsa.Services.Workflows
             string activityType,
             IBookmark bookmark,
             string? tenantId,
-            object? input = default,
+            WorkflowInput? input = default,
             string? correlationId = default,
             string? contextId = default,
             CancellationToken cancellationToken = default)
@@ -42,7 +42,7 @@ namespace Elsa.Services.Workflows
             await ResumeWorkflowsAsync(results, input, cancellationToken);
         }
 
-        public async Task ResumeWorkflowsAsync(IEnumerable<BookmarkFinderResult> results, object? input = default, CancellationToken cancellationToken = default)
+        public async Task ResumeWorkflowsAsync(IEnumerable<BookmarkFinderResult> results, WorkflowInput? input = default, CancellationToken cancellationToken = default)
         {
             foreach (var result in results)
             {
@@ -53,19 +53,19 @@ namespace Elsa.Services.Workflows
             }
         }
 
-        public async Task<RunWorkflowResult> BuildAndResumeWorkflowAsync<T>(WorkflowInstance workflowInstance, string? activityId = default, object? input = default, CancellationToken cancellationToken = default) where T : IWorkflow
+        public async Task<RunWorkflowResult> BuildAndResumeWorkflowAsync<T>(WorkflowInstance workflowInstance, string? activityId = default, WorkflowInput? input = default, CancellationToken cancellationToken = default) where T : IWorkflow
         {
             var workflowBlueprint = _workflowBuilderFactory().Build<T>();
             return await _workflowRunner.RunWorkflowAsync(workflowBlueprint, workflowInstance, activityId, input, cancellationToken);
         }
 
-        public async Task<RunWorkflowResult> BuildAndResumeWorkflowAsync(IWorkflow workflow, WorkflowInstance workflowInstance, string? activityId = default, object? input = default, CancellationToken cancellationToken = default)
+        public async Task<RunWorkflowResult> BuildAndResumeWorkflowAsync(IWorkflow workflow, WorkflowInstance workflowInstance, string? activityId = default, WorkflowInput? input = default, CancellationToken cancellationToken = default)
         {
             var workflowBlueprint = _workflowBuilderFactory().Build(workflow);
             return await _workflowRunner.RunWorkflowAsync(workflowBlueprint, workflowInstance, activityId, input, cancellationToken);
         }
 
-        public async Task<RunWorkflowResult> ResumeWorkflowAsync(WorkflowInstance workflowInstance, string? activityId = default, object? input = default, CancellationToken cancellationToken = default)
+        public async Task<RunWorkflowResult> ResumeWorkflowAsync(WorkflowInstance workflowInstance, string? activityId = default, WorkflowInput? input = default, CancellationToken cancellationToken = default)
         {
             var workflowBlueprint = await _workflowRegistry.GetAsync(
                 workflowInstance.DefinitionId,

--- a/src/core/Elsa.Core/Services/Workflows/WorkflowRunner.cs
+++ b/src/core/Elsa.Core/Services/Workflows/WorkflowRunner.cs
@@ -49,22 +49,22 @@ namespace Elsa.Services.Workflows
             IWorkflowBlueprint workflowBlueprint,
             WorkflowInstance workflowInstance,
             string? activityId = default,
-            object? input = default,
+            WorkflowInput? input = default,
             CancellationToken cancellationToken = default)
         {
             using var loggingScope = _logger.BeginScope(new Dictionary<string, object> { ["WorkflowInstanceId"] = workflowInstance.Id });
             using var workflowExecutionScope = _serviceScopeFactory.CreateScope();
 
-            if (input != null)
+            if (input?.Input != null)
             {
                 var workflowStorageContext = new WorkflowStorageContext(workflowInstance, workflowBlueprint.Id);
-                var inputStorageProvider = _workflowStorageService.GetProviderByNameOrDefault();
-                await inputStorageProvider.SaveAsync(workflowStorageContext, nameof(WorkflowInstance.Input), input, cancellationToken);
+                var inputStorageProvider = _workflowStorageService.GetProviderByNameOrDefault(input.StorageProviderName);
+                await inputStorageProvider.SaveAsync(workflowStorageContext, nameof(WorkflowInstance.Input), input.Input, cancellationToken);
                 workflowInstance.Input = new WorkflowInputReference(inputStorageProvider.Name);
                 await _mediator.Publish(new WorkflowInputUpdated(workflowInstance), cancellationToken);
             }
 
-            var workflowExecutionContext = new WorkflowExecutionContext(workflowExecutionScope.ServiceProvider, workflowBlueprint, workflowInstance, input);
+            var workflowExecutionContext = new WorkflowExecutionContext(workflowExecutionScope.ServiceProvider, workflowBlueprint, workflowInstance, input?.Input);
 
             if (!string.IsNullOrWhiteSpace(workflowInstance.ContextId))
             {

--- a/src/core/Elsa.Core/Services/Workflows/WorkflowStarter.cs
+++ b/src/core/Elsa.Core/Services/Workflows/WorkflowStarter.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Elsa.Builders;
+using Elsa.Models;
 using Elsa.Persistence;
 using Elsa.Services.Bookmarks;
 using Elsa.Services.Models;
@@ -28,7 +29,7 @@ namespace Elsa.Services.Workflows
             _workflowInstanceStore = workflowInstanceStore;
         }
 
-        public async Task FindAndStartWorkflowsAsync(string activityType, IBookmark bookmark, string? tenantId, object? input = default, string? contextId = default, CancellationToken cancellationToken = default)
+        public async Task FindAndStartWorkflowsAsync(string activityType, IBookmark bookmark, string? tenantId, WorkflowInput? input = default, string? contextId = default, CancellationToken cancellationToken = default)
         {
             var results = await _triggerFinder.FindTriggersAsync(activityType, bookmark, tenantId, cancellationToken).ToList();
             await StartWorkflowsAsync(results, input, contextId, cancellationToken);
@@ -38,7 +39,7 @@ namespace Elsa.Services.Workflows
             string activityType,
             IBookmark bookmark,
             string? tenantId,
-            object? input = default,
+            WorkflowInput? input = default,
             string? contextId = default,
             CancellationToken cancellationToken = default)
         {
@@ -48,7 +49,7 @@ namespace Elsa.Services.Workflows
 
         public async Task<IEnumerable<RunWorkflowResult>> StartWorkflowsAsync(
             IEnumerable<TriggerFinderResult> results,
-            object? input = default,
+            WorkflowInput? input = default,
             string? contextId = default,
             CancellationToken cancellationToken = default)
         {
@@ -67,7 +68,7 @@ namespace Elsa.Services.Workflows
         public async Task<RunWorkflowResult> StartWorkflowAsync(
             IWorkflowBlueprint workflowBlueprint,
             string? activityId = default,
-            object? input = default,
+            WorkflowInput? input = default,
             string? correlationId = default,
             string? contextId = default,
             CancellationToken cancellationToken = default)
@@ -84,7 +85,7 @@ namespace Elsa.Services.Workflows
 
         public async Task<RunWorkflowResult> BuildAndStartWorkflowAsync<T>(
             string? activityId = default,
-            object? input = default,
+            WorkflowInput? input = default,
             string? correlationId = default,
             string? contextId = default,
             CancellationToken cancellationToken = default) where T : IWorkflow
@@ -96,7 +97,7 @@ namespace Elsa.Services.Workflows
         public async Task<RunWorkflowResult> BuildAndStartWorkflowAsync(
             IWorkflow workflow,
             string? activityId = default,
-            object? input = default,
+            WorkflowInput? input = default,
             string? correlationId = default,
             string? contextId = default,
             CancellationToken cancellationToken = default)

--- a/src/core/Elsa.Core/Services/Workflows/WorkflowTriggerInterruptor.cs
+++ b/src/core/Elsa.Core/Services/Workflows/WorkflowTriggerInterruptor.cs
@@ -27,13 +27,13 @@ namespace Elsa.Services.Workflows
             _bookmarkFinder = bookmarkFinder;
         }
 
-        public async Task<RunWorkflowResult> InterruptActivityAsync(WorkflowInstance workflowInstance, string activityId, object? input, CancellationToken cancellationToken)
+        public async Task<RunWorkflowResult> InterruptActivityAsync(WorkflowInstance workflowInstance, string activityId, WorkflowInput? input, CancellationToken cancellationToken)
         {
             var workflowBlueprint = await GetWorkflowBlueprintAsync(workflowInstance, cancellationToken);
             return await InterruptActivityAsync(workflowBlueprint!, workflowInstance, activityId, input, cancellationToken);
         }
 
-        public async Task<RunWorkflowResult> InterruptActivityAsync(IWorkflowBlueprint workflowBlueprint, WorkflowInstance workflowInstance, string activityId, object? input, CancellationToken cancellationToken)
+        public async Task<RunWorkflowResult> InterruptActivityAsync(IWorkflowBlueprint workflowBlueprint, WorkflowInstance workflowInstance, string activityId, WorkflowInput? input, CancellationToken cancellationToken)
         {
             if (workflowInstance.WorkflowStatus != WorkflowStatus.Suspended)
                 throw new WorkflowException("Cannot interrupt workflows that are not in the Suspended state.");
@@ -46,7 +46,7 @@ namespace Elsa.Services.Workflows
             return await _workflowRunner.RunWorkflowAsync(workflowBlueprint, workflowInstance, activityId, input, cancellationToken);
         }
 
-        public async Task<IEnumerable<RunWorkflowResult>> InterruptActivityTypeAsync(IWorkflowBlueprint workflowBlueprint, WorkflowInstance workflowInstance, string activityType, object? input, CancellationToken cancellationToken)
+        public async Task<IEnumerable<RunWorkflowResult>> InterruptActivityTypeAsync(IWorkflowBlueprint workflowBlueprint, WorkflowInstance workflowInstance, string activityType, WorkflowInput? input, CancellationToken cancellationToken)
         {
             var blockingActivities = workflowInstance.BlockingActivities.Where(x => x.ActivityType == activityType).ToList();
             var results = new List<RunWorkflowResult>();
@@ -60,19 +60,19 @@ namespace Elsa.Services.Workflows
             return results;
         }
 
-        public async Task<IEnumerable<RunWorkflowResult>> InterruptActivityTypeAsync(WorkflowInstance workflowInstance, string activityType, object? input, CancellationToken cancellationToken = default)
+        public async Task<IEnumerable<RunWorkflowResult>> InterruptActivityTypeAsync(WorkflowInstance workflowInstance, string activityType, WorkflowInput? input, CancellationToken cancellationToken = default)
         {
             var workflowBlueprint = await GetWorkflowBlueprintAsync(workflowInstance, cancellationToken);
             return await InterruptActivityTypeAsync(workflowBlueprint!, workflowInstance, activityType, input, cancellationToken);
         }
 
-        public async Task<IEnumerable<RunWorkflowResult>> InterruptActivityTypeAsync(string activityType, object? input, CancellationToken cancellationToken) =>
+        public async Task<IEnumerable<RunWorkflowResult>> InterruptActivityTypeAsync(string activityType, WorkflowInput? input, CancellationToken cancellationToken) =>
             await InterruptActivityTypeInternalAsync(activityType, input, cancellationToken).ToListAsync(cancellationToken);
 
         private async Task<IWorkflowBlueprint?> GetWorkflowBlueprintAsync(WorkflowInstance workflowInstance, CancellationToken cancellationToken) =>
             await _workflowRegistry.GetAsync(workflowInstance.DefinitionId, workflowInstance.TenantId, VersionOptions.SpecificVersion(workflowInstance.Version), cancellationToken);
 
-        private async IAsyncEnumerable<RunWorkflowResult> InterruptActivityTypeInternalAsync(string activityType, object? input, [EnumeratorCancellation] CancellationToken cancellationToken)
+        private async IAsyncEnumerable<RunWorkflowResult> InterruptActivityTypeInternalAsync(string activityType, WorkflowInput? input, [EnumeratorCancellation] CancellationToken cancellationToken)
         {
             var bookmarks = await _bookmarkFinder.FindBookmarksAsync(activityType, Enumerable.Empty<IBookmark>(), null, null, cancellationToken);
             var workflowInstanceIds = bookmarks.Select(x => x.WorkflowInstanceId).Distinct().ToList();

--- a/src/core/Elsa.Core/StartupTasks/ContinueRunningWorkflows.cs
+++ b/src/core/Elsa.Core/StartupTasks/ContinueRunningWorkflows.cs
@@ -4,7 +4,9 @@ using System.Threading.Tasks;
 using Elsa.Models;
 using Elsa.Persistence;
 using Elsa.Persistence.Specifications.WorkflowInstances;
+using Elsa.Providers.WorkflowStorage;
 using Elsa.Services;
+using Elsa.Services.WorkflowStorage;
 using Microsoft.Extensions.Logging;
 using Open.Linq.AsyncExtensions;
 using IDistributedLockProvider = Elsa.Services.IDistributedLockProvider;
@@ -20,6 +22,7 @@ namespace Elsa.StartupTasks
         private readonly IWorkflowInstanceStore _workflowInstanceStore;
         private readonly IWorkflowInstanceDispatcher _workflowInstanceDispatcher;
         private readonly IDistributedLockProvider _distributedLockProvider;
+        private readonly IWorkflowStorageService _workflowStorageService;
         private readonly ElsaOptions _elsaOptions;
         private readonly ILogger _logger;
 
@@ -27,12 +30,14 @@ namespace Elsa.StartupTasks
             IWorkflowInstanceStore workflowInstanceStore,
             IWorkflowInstanceDispatcher workflowInstanceDispatcher,
             IDistributedLockProvider distributedLockProvider,
+            IWorkflowStorageService workflowStorageService,
             ElsaOptions elsaOptions,
             ILogger<ContinueRunningWorkflows> logger)
         {
             _workflowInstanceStore = workflowInstanceStore;
             _workflowInstanceDispatcher = workflowInstanceDispatcher;
             _distributedLockProvider = distributedLockProvider;
+            _workflowStorageService = workflowStorageService;
             _elsaOptions = elsaOptions;
             _logger = logger;
         }
@@ -46,6 +51,38 @@ namespace Elsa.StartupTasks
             if (handle == null)
                 return;
 
+            await ResumeIdleWorkflows(cancellationToken);
+            await ResumeRunningWorkflowsAsync(cancellationToken);
+        }
+
+        private async Task ResumeIdleWorkflows(CancellationToken cancellationToken)
+        {
+            var instances = await _workflowInstanceStore.FindManyAsync(new WorkflowStatusSpecification(WorkflowStatus.Idle), cancellationToken: cancellationToken).ToList();
+
+            if (instances.Any())
+                _logger.LogInformation("Found {WorkflowInstanceCount} workflows with status 'Idle'. Resuming each one of them", instances.Count);
+            else
+                _logger.LogInformation("Found no workflows with status 'Id'. Nothing to resume");
+
+            foreach (var instance in instances)
+            {
+                await using var correlationLockHandle = await _distributedLockProvider.AcquireLockAsync(instance.CorrelationId, _elsaOptions.DistributedLockTimeout, cancellationToken);
+
+                if (correlationLockHandle == null)
+                {
+                    _logger.LogWarning("Failed to acquire lock on correlation {CorrelationId} for workflow instance {WorkflowInstanceId}", instance.CorrelationId, instance.Id);
+                    continue;
+                }
+
+                _logger.LogInformation("Resuming {WorkflowInstanceId}", instance.Id);
+
+                var input = await _workflowStorageService.LoadAsync(default, new WorkflowStorageContext(instance, instance.DefinitionId), nameof(WorkflowInstance.Input), cancellationToken);
+                await _workflowInstanceDispatcher.DispatchAsync(new ExecuteWorkflowInstanceRequest(instance.Id, Input: input), cancellationToken);
+            }
+        }
+
+        private async Task ResumeRunningWorkflowsAsync(CancellationToken cancellationToken)
+        {
             var instances = await _workflowInstanceStore.FindManyAsync(new WorkflowStatusSpecification(WorkflowStatus.Running), cancellationToken: cancellationToken).ToList();
 
             if (instances.Any())
@@ -56,8 +93,8 @@ namespace Elsa.StartupTasks
             foreach (var instance in instances)
             {
                 await using var correlationLockHandle = await _distributedLockProvider.AcquireLockAsync(instance.CorrelationId, _elsaOptions.DistributedLockTimeout, cancellationToken);
-                
-                if(handle == null)
+
+                if (correlationLockHandle == null)
                 {
                     _logger.LogWarning("Failed to acquire lock on correlation {CorrelationId} for workflow instance {WorkflowInstanceId}", instance.CorrelationId, instance.Id);
                     continue;
@@ -73,7 +110,7 @@ namespace Elsa.StartupTasks
                         _logger.LogWarning(
                             "Workflow '{WorkflowInstanceId}' was in the Running state, but has no scheduled activities not has a currently executing one. However, it does have blocking activities, so switching to Suspended status",
                             instance.Id);
-                        
+
                         instance.WorkflowStatus = WorkflowStatus.Suspended;
                         await _workflowInstanceStore.SaveAsync(instance, cancellationToken);
                         continue;
@@ -84,8 +121,8 @@ namespace Elsa.StartupTasks
                 }
 
                 var scheduledActivity = instance.CurrentActivity ?? instance.ScheduledActivities.Peek();
-
-                await _workflowInstanceDispatcher.DispatchAsync(new ExecuteWorkflowInstanceRequest(instance.Id, scheduledActivity.ActivityId), cancellationToken);
+                var input = await _workflowStorageService.LoadAsync(default, new WorkflowStorageContext(instance, instance.DefinitionId), nameof(WorkflowInstance.Input), cancellationToken);
+                await _workflowInstanceDispatcher.DispatchAsync(new ExecuteWorkflowInstanceRequest(instance.Id, scheduledActivity.ActivityId, input), cancellationToken);
             }
         }
     }

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/Configuration/WorkflowInstanceConfiguration.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/Configuration/WorkflowInstanceConfiguration.cs
@@ -13,6 +13,7 @@ namespace Elsa.Persistence.EntityFramework.Core.Configuration
             builder.Property(x => x.FinishedAt).HasConversion(ValueConverters.InstantConverter);
             builder.Property(x => x.CancelledAt).HasConversion(ValueConverters.InstantConverter);
             builder.Property(x => x.FaultedAt).HasConversion(ValueConverters.InstantConverter);
+            builder.Ignore(x => x.Input);
             builder.Ignore(x => x.Output);
             builder.Ignore(x => x.ActivityData);
             builder.Ignore(x => x.BlockingActivities);

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/Stores/EntityFrameworkWorkflowInstanceStore.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/Stores/EntityFrameworkWorkflowInstanceStore.cs
@@ -58,6 +58,7 @@ namespace Elsa.Persistence.EntityFramework.Core.Stores
         {
             var data = new
             {
+                entity.Input,
                 entity.Output,
                 entity.Variables,
                 entity.ActivityData,
@@ -77,6 +78,7 @@ namespace Elsa.Persistence.EntityFramework.Core.Stores
         {
             var data = new
             {
+                entity.Input,
                 entity.Output,
                 entity.Variables,
                 entity.ActivityData,
@@ -92,6 +94,7 @@ namespace Elsa.Persistence.EntityFramework.Core.Stores
             if (!string.IsNullOrWhiteSpace(json))
                 data = JsonConvert.DeserializeAnonymousType(json, data, DefaultContentSerializer.CreateDefaultJsonSerializationSettings())!;
 
+            entity.Input = data.Input;
             entity.Output = data.Output;
             entity.Variables = data.Variables;
             entity.ActivityData = data.ActivityData;

--- a/src/persistence/Elsa.Persistence.YesSql/Documents/WorkflowInstanceDocument.cs
+++ b/src/persistence/Elsa.Persistence.YesSql/Documents/WorkflowInstanceDocument.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using Elsa.Comparers;
 using Elsa.Models;
+using Elsa.Services.Models;
 using NodaTime;
 
 namespace Elsa.Persistence.YesSql.Documents
@@ -24,7 +25,9 @@ namespace Elsa.Persistence.YesSql.Documents
         public Instant? CancelledAt { get; set; }
         public Instant? FaultedAt { get; set; }
         public Variables Variables { get; set; } = new();
-        public object? Output { get; set; }
+        public object? InputData { get; set; }
+        public WorkflowInputReference? Input { get; set; }
+        public WorkflowOutputReference? Output { get; set; }
         public IDictionary<string, object> ActivityData { get; set; } = new Dictionary<string, object>();
 
         public HashSet<BlockingActivity> BlockingActivities

--- a/src/samples/console/Elsa.Samples.UserTaskConsole/Program.cs
+++ b/src/samples/console/Elsa.Samples.UserTaskConsole/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Elsa.Models;
 
 namespace Elsa.Samples.UserTaskConsole
 {
@@ -44,7 +45,7 @@ namespace Elsa.Samples.UserTaskConsole
             Console.WriteLine($"What action will you take? Choose one of: {string.Join(", ", availableActions)}");
             var userAction = Console.ReadLine();
             var currentActivityId = workflowInstance.BlockingActivities.Select(i => i.ActivityId).First();
-            await workflowTriggerInterruptor.InterruptActivityAsync(workflowInstance, currentActivityId, userAction);
+            await workflowTriggerInterruptor.InterruptActivityAsync(workflowInstance, currentActivityId, new WorkflowInput(userAction));
         }
     }
 }

--- a/src/samples/server/Elsa.Samples.Server.Host/SlowActivity.cs
+++ b/src/samples/server/Elsa.Samples.Server.Host/SlowActivity.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Elsa.ActivityResults;
+using Elsa.Services.Models;
+using Activity = Elsa.Services.Activity;
+
+namespace Elsa.Samples.Server.Host
+{
+    public class SlowActivity : Activity
+    {
+        protected override async ValueTask<IActivityExecutionResult> OnExecuteAsync(ActivityExecutionContext context)
+        {
+            Trace.WriteLine($"Starting my slow task.. {context.WorkflowInstance.Id}.{context.ActivityId}.  {DateTime.Now.TimeOfDay}");
+            
+            await Task.Delay(10000);
+
+            Trace.WriteLine($"Phew, I finished!  {context.WorkflowInstance.Id}. {context.ActivityId}.  {DateTime.Now.TimeOfDay}");
+
+            return Done();
+        }
+    }
+}

--- a/src/samples/server/Elsa.Samples.Server.Host/SlowActivityWorkflow.cs
+++ b/src/samples/server/Elsa.Samples.Server.Host/SlowActivityWorkflow.cs
@@ -1,0 +1,22 @@
+using Elsa.Activities.Console;
+using Elsa.Builders;
+
+namespace Elsa.Samples.Server.Host
+{
+    public class SlowActivityWorkflow : IWorkflow
+    {
+        public void Build(IWorkflowBuilder builder)
+        {
+            // builder
+            //     .WithPersistenceBehavior(Models.WorkflowPersistenceBehavior.WorkflowPassCompleted)
+            //     .WriteLine(x => "foo") // dummy activity to coerce persistence
+            //     .Then<SlowActivity>(x => x.WithId("number1")) // If the process is stopped during this activity, number1 will be resumed
+            //     .Then<SlowActivity>(x => x.WithId("number2"));
+
+            builder
+                .WithPersistenceBehavior(Models.WorkflowPersistenceBehavior.WorkflowPassCompleted)
+                .StartWith<SlowActivity>(x => x.WithId("number1")) // When the process is killed during this activity no runnable tasks are found
+                .Then<SlowActivity>(x => x.WithId("number2"));
+        }
+    }
+}

--- a/src/server/Elsa.Server.Api/Endpoints/WorkflowInstances/Models.cs
+++ b/src/server/Elsa.Server.Api/Endpoints/WorkflowInstances/Models.cs
@@ -38,11 +38,11 @@ namespace Elsa.Server.Api.Endpoints.WorkflowInstances
     {
     }
     
-    public record ExecuteWorkflowInstanceRequestModel(string? ActivityId, object? Input);
+    public record ExecuteWorkflowInstanceRequestModel(string? ActivityId, WorkflowInput? Input);
 
     public record ExecuteWorkflowInstanceResponseModel(bool Executed, string? ActivityId, WorkflowInstance? WorkflowInstance);
 
-    public record DispatchWorkflowInstanceRequestModel(string? ActivityId, object? Input);
+    public record DispatchWorkflowInstanceRequestModel(string? ActivityId, WorkflowInput? Input);
 
     public record DispatchWorkflowInstanceResponseModel();
 }

--- a/src/server/Elsa.Server.Api/Endpoints/Workflows/Dispatch.cs
+++ b/src/server/Elsa.Server.Api/Endpoints/Workflows/Dispatch.cs
@@ -36,7 +36,7 @@ namespace Elsa.Server.Api.Endpoints.Workflows
         public async Task<IActionResult> Handle(string workflowDefinitionId, DispatchWorkflowDefinitionRequestModel request, CancellationToken cancellationToken = default)
         {
             var tenantId = await _tenantAccessor.GetTenantIdAsync(cancellationToken);
-            var startableWorkflow = await _workflowLaunchpad.CollectStartableWorkflowAsync(workflowDefinitionId, request.ActivityId, request.CorrelationId, request.ContextId, tenantId, cancellationToken);
+            var startableWorkflow = await _workflowLaunchpad.FindStartableWorkflowAsync(workflowDefinitionId, request.ActivityId, request.CorrelationId, request.ContextId, tenantId, cancellationToken);
 
             if (startableWorkflow == null)
                 return NotFound();

--- a/src/server/Elsa.Server.Api/Endpoints/Workflows/Execute.cs
+++ b/src/server/Elsa.Server.Api/Endpoints/Workflows/Execute.cs
@@ -36,7 +36,7 @@ namespace Elsa.Server.Api.Endpoints.Workflows
         public async Task<IActionResult> Handle(string workflowDefinitionId, ExecuteWorkflowDefinitionRequestModel request, CancellationToken cancellationToken = default)
         {
             var tenantId = await _tenantAccessor.GetTenantIdAsync(cancellationToken);
-            var startableWorkflow = await _workflowLaunchpad.CollectStartableWorkflowAsync(workflowDefinitionId, request.ActivityId, request.CorrelationId, request.ContextId, tenantId, cancellationToken);
+            var startableWorkflow = await _workflowLaunchpad.FindStartableWorkflowAsync(workflowDefinitionId, request.ActivityId, request.CorrelationId, request.ContextId, tenantId, cancellationToken);
 
             if (startableWorkflow == null)
                 return NotFound();

--- a/src/server/Elsa.Server.Api/Endpoints/Workflows/Models.cs
+++ b/src/server/Elsa.Server.Api/Endpoints/Workflows/Models.cs
@@ -1,24 +1,25 @@
 using System.Collections.Generic;
 using Elsa.Models;
+using Elsa.Services;
 using Elsa.Services.Bookmarks;
 using Elsa.Services.Models;
 
 namespace Elsa.Server.Api.Endpoints.Workflows
 {
-    public record ExecuteWorkflowDefinitionRequestModel(string? ActivityId, string? CorrelationId, string? ContextId, object? Input);
+    public record ExecuteWorkflowDefinitionRequestModel(string? ActivityId, string? CorrelationId, string? ContextId, WorkflowInput? Input);
 
     public record ExecuteWorkflowDefinitionResponseModel(bool Executed, string? ActivityId, WorkflowInstance? WorkflowInstance);
 
-    public record DispatchWorkflowDefinitionRequestModel(string? ActivityId, string? CorrelationId, string? ContextId, object? Input);
+    public record DispatchWorkflowDefinitionRequestModel(string? ActivityId, string? CorrelationId, string? ContextId, WorkflowInput? Input);
 
     public record DispatchWorkflowDefinitionResponseModel(string WorkflowInstanceId, string? ActivityId);
     
     public record TriggeredWorkflowModel(string WorkflowInstanceId, string? ActivityId);
 
-    public record DispatchTriggerWorkflowsRequestModel(string ActivityType, IBookmark? Bookmark, IBookmark? Trigger, string? CorrelationId, string? WorkflowInstanceId, string? ContextId, object? Input);
+    public record DispatchTriggerWorkflowsRequestModel(string ActivityType, IBookmark? Bookmark, IBookmark? Trigger, string? CorrelationId, string? WorkflowInstanceId, string? ContextId, WorkflowInput? Input);
 
     public record DispatchTriggerWorkflowsResponseModel(ICollection<CollectedWorkflow> PendingWorkflows);
-    public record TriggerWorkflowsRequestModel(string ActivityType, IBookmark? Bookmark, string? CorrelationId, string? WorkflowInstanceId, string? ContextId, object? Input, bool Dispatch);
+    public record TriggerWorkflowsRequestModel(string ActivityType, IBookmark? Bookmark, string? CorrelationId, string? WorkflowInstanceId, string? ContextId, WorkflowInput? Input, bool Dispatch);
 
     public record TriggerWorkflowsResponseModel(ICollection<TriggeredWorkflowModel> TriggeredWorkflows);
 }

--- a/src/server/Elsa.Server.Api/Endpoints/Workflows/Trigger.cs
+++ b/src/server/Elsa.Server.Api/Endpoints/Workflows/Trigger.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Elsa.Server.Api.ActionFilters;
 using Elsa.Services;
+using Elsa.Services.Models;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Open.Linq.AsyncExtensions;
@@ -38,7 +39,7 @@ namespace Elsa.Server.Api.Endpoints.Workflows
         public async Task<IActionResult> Handle(TriggerWorkflowsRequestModel request, CancellationToken cancellationToken = default)
         {
             var tenantId = await _tenantAccessor.GetTenantIdAsync(cancellationToken);
-            var context = new CollectWorkflowsContext(request.ActivityType, request.Bookmark, request.CorrelationId, request.WorkflowInstanceId, request.ContextId, tenantId);
+            var context = new WorkflowsQuery(request.ActivityType, request.Bookmark, request.CorrelationId, request.WorkflowInstanceId, request.ContextId, tenantId);
             ICollection<TriggeredWorkflowModel> triggeredWorkflows;
 
             if (request.Dispatch)

--- a/src/server/Elsa.Server.Hangfire/Jobs/CorrelatedWorkflowDefinitionJob.cs
+++ b/src/server/Elsa.Server.Hangfire/Jobs/CorrelatedWorkflowDefinitionJob.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
 using Elsa.Services;
+using Elsa.Services.Models;
 
 namespace Elsa.Server.Hangfire.Jobs
 {
@@ -9,7 +10,7 @@ namespace Elsa.Server.Hangfire.Jobs
         private readonly IWorkflowLaunchpad _workflowLaunchpad;
         public CorrelatedWorkflowDefinitionJob(IWorkflowLaunchpad workflowLaunchpad) => _workflowLaunchpad = workflowLaunchpad;
 
-        public async Task ExecuteAsync(TriggerWorkflowsRequest request, CancellationToken cancellationToken = default) => await _workflowLaunchpad.CollectAndExecuteWorkflowsAsync(new CollectWorkflowsContext(
+        public async Task ExecuteAsync(TriggerWorkflowsRequest request, CancellationToken cancellationToken = default) => await _workflowLaunchpad.CollectAndExecuteWorkflowsAsync(new WorkflowsQuery(
                 request.ActivityType,
                 request.Bookmark,
                 request.CorrelationId,

--- a/src/server/Elsa.Server.Hangfire/Jobs/WorkflowDefinitionJob.cs
+++ b/src/server/Elsa.Server.Hangfire/Jobs/WorkflowDefinitionJob.cs
@@ -10,6 +10,6 @@ namespace Elsa.Server.Hangfire.Jobs
         public WorkflowDefinitionJob(IWorkflowLaunchpad launchpad) => _launchpad = launchpad;
 
         public async Task ExecuteAsync(ExecuteWorkflowDefinitionRequest request, CancellationToken cancellationToken = default) =>
-            await _launchpad.CollectAndExecuteStartableWorkflowAsync(request.WorkflowDefinitionId, request.ActivityId, request.CorrelationId, request.ContextId, request.Input, request.TenantId, cancellationToken);
+            await _launchpad.FindAndExecuteStartableWorkflowAsync(request.WorkflowDefinitionId, request.ActivityId, request.CorrelationId, request.ContextId, request.Input, request.TenantId, cancellationToken);
     }
 }

--- a/src/server/Elsa.Server.Orleans/Grains/CorrelatedWorkflowDefinitionGrain.cs
+++ b/src/server/Elsa.Server.Orleans/Grains/CorrelatedWorkflowDefinitionGrain.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Elsa.Server.Orleans.Grains.Contracts;
 using Elsa.Services;
+using Elsa.Services.Models;
 using Orleans;
 using Orleans.Concurrency;
 
@@ -13,7 +14,7 @@ namespace Elsa.Server.Orleans.Grains
         private readonly IWorkflowLaunchpad _workflowLaunchpad;
         public CorrelatedWorkflowDefinitionGrain(IWorkflowLaunchpad workflowLaunchpad) => _workflowLaunchpad = workflowLaunchpad;
 
-        public async Task ExecutedCorrelatedWorkflowAsync(TriggerWorkflowsRequest request, CancellationToken cancellationToken = default) => await _workflowLaunchpad.CollectAndExecuteWorkflowsAsync(new CollectWorkflowsContext(
+        public async Task ExecutedCorrelatedWorkflowAsync(TriggerWorkflowsRequest request, CancellationToken cancellationToken = default) => await _workflowLaunchpad.CollectAndExecuteWorkflowsAsync(new WorkflowsQuery(
                 request.ActivityType,
                 request.Bookmark,
                 request.CorrelationId,

--- a/src/server/Elsa.Server.Orleans/Grains/WorkflowDefinitionGrain.cs
+++ b/src/server/Elsa.Server.Orleans/Grains/WorkflowDefinitionGrain.cs
@@ -14,6 +14,6 @@ namespace Elsa.Server.Orleans.Grains
         public WorkflowDefinitionGrain(IWorkflowLaunchpad workflowLaunchpad) => _workflowLaunchpad = workflowLaunchpad;
 
         public async Task ExecuteWorkflowAsync(ExecuteWorkflowDefinitionRequest request, CancellationToken cancellationToken = default) =>
-            await _workflowLaunchpad.CollectAndExecuteStartableWorkflowAsync(request.WorkflowDefinitionId, request.ActivityId, request.CorrelationId, request.ContextId, request.Input, request.TenantId, cancellationToken);
+            await _workflowLaunchpad.FindAndExecuteStartableWorkflowAsync(request.WorkflowDefinitionId, request.ActivityId, request.CorrelationId, request.ContextId, request.Input, request.TenantId, cancellationToken);
     }
 }

--- a/test/integration/Elsa.Core.IntegrationTests/Workflows/ForkJoinWorkflowTests.cs
+++ b/test/integration/Elsa.Core.IntegrationTests/Workflows/ForkJoinWorkflowTests.cs
@@ -97,7 +97,7 @@ namespace Elsa.Core.IntegrationTests.Workflows
             var receiveSignal = receiveSignalActivities.Single(activity => workflowBlueprintWrapper.GetActivity<SignalReceived>(activity.ActivityBlueprint.Id)!.EvaluatePropertyValueAsync(x => x.Signal).GetAwaiter().GetResult() == signal);
             
             var triggeredSignal = new Signal(signal);
-            var result = await WorkflowRunner.RunWorkflowAsync(workflowBlueprint, workflowInstance, receiveSignal.ActivityBlueprint.Id, triggeredSignal);
+            var result = await WorkflowRunner.RunWorkflowAsync(workflowBlueprint, workflowInstance, receiveSignal.ActivityBlueprint.Id, new WorkflowInput(triggeredSignal));
             return result.WorkflowInstance!;
         }
     }

--- a/test/shared/Elsa.Testing.Shared/AutoFixture/SpecimenBuilders/MockBookmarkProvidersSpecimenBuilder.cs
+++ b/test/shared/Elsa.Testing.Shared/AutoFixture/SpecimenBuilders/MockBookmarkProvidersSpecimenBuilder.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using AutoFixture.Kernel;
+using Elsa.Services;
 using Elsa.Services.Bookmarks;
 using Moq;
 


### PR DESCRIPTION
This PR refactors workflow input to be persistable, which allows workflows that didn't complete a workflow pass to be resumed automatically by the `ContinueRunningWorkflows` startup task **and also provide its initial input**.

This fixes #1182 and closes #1267