### PR TITLE
Flush activity execution log

### DIFF
--- a/src/core/Elsa.Abstractions/Models/WorkflowPersistenceBehavior.cs
+++ b/src/core/Elsa.Abstractions/Models/WorkflowPersistenceBehavior.cs
@@ -15,12 +15,7 @@ namespace Elsa.Models
         /// Workflow instances are persisted after the workflow completed a burst of execution.
         /// </summary>
         WorkflowBurst,
-
-        /// <summary>
-        /// Workflow instances are persisted after the workflow executed an activity.
-        /// </summary>
-        WorkflowPassCompleted,
-
+        
         /// <summary>
         /// Workflow instances are persisted after each activity that executed.
         /// </summary>

--- a/src/core/Elsa.Abstractions/Services/Workflows/IWorkflowExecutionLog.cs
+++ b/src/core/Elsa.Abstractions/Services/Workflows/IWorkflowExecutionLog.cs
@@ -9,6 +9,6 @@ namespace Elsa.Services
     public interface IWorkflowExecutionLog
     {
         Task AddEntryAsync(string workflowInstanceId, string activityId, string activityType, string eventName, string? message, string? tenantId, string? source, JObject? data, CancellationToken cancellationToken = default);
-        Task<WorkflowExecutionLogRecord?> FindEntryAsync(ISpecification<WorkflowExecutionLogRecord> specification, CancellationToken cancellationToken = default);
+        Task FlushAsync(CancellationToken cancellationToken = default);
     }
 }

--- a/src/core/Elsa.Core/Handlers/FlushWorkflowExecutionLog.cs
+++ b/src/core/Elsa.Core/Handlers/FlushWorkflowExecutionLog.cs
@@ -1,0 +1,15 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Elsa.Events;
+using Elsa.Services;
+using MediatR;
+
+namespace Elsa.Handlers
+{
+    public class FlushWorkflowExecutionLog : INotificationHandler<WorkflowInstanceSaved>
+    {
+        private readonly IWorkflowExecutionLog _workflowExecutionLog;
+        public FlushWorkflowExecutionLog(IWorkflowExecutionLog workflowExecutionLog) => _workflowExecutionLog = workflowExecutionLog;
+        public async Task Handle(WorkflowInstanceSaved notification, CancellationToken cancellationToken) => await _workflowExecutionLog.FlushAsync(cancellationToken);
+    }
+}

--- a/src/core/Elsa.Core/Handlers/PersistWorkflow.cs
+++ b/src/core/Elsa.Core/Handlers/PersistWorkflow.cs
@@ -9,11 +9,8 @@ using Microsoft.Extensions.Logging;
 namespace Elsa.Handlers
 {
     public class PersistWorkflow :
-        INotificationHandler<WorkflowExecuted>,
-        INotificationHandler<WorkflowSuspended>,
         INotificationHandler<WorkflowFaulted>,
         INotificationHandler<WorkflowExecutionPassCompleted>,
-        INotificationHandler<WorkflowExecutionBurstCompleted>,
         INotificationHandler<WorkflowExecutionFinished>,
         INotificationHandler<WorkflowInputUpdated>
     {
@@ -26,35 +23,11 @@ namespace Elsa.Handlers
             _logger = logger;
         }
 
-        public async Task Handle(WorkflowSuspended notification, CancellationToken cancellationToken)
-        {
-            var behavior = notification.WorkflowExecutionContext.WorkflowBlueprint.PersistenceBehavior;
-            
-            if (behavior == WorkflowPersistenceBehavior.Suspended)
-                await SaveWorkflowAsync(notification.WorkflowExecutionContext.WorkflowInstance, cancellationToken);
-        }
-
-        public async Task Handle(WorkflowExecutionBurstCompleted notification, CancellationToken cancellationToken)
-        {
-            var behavior = notification.WorkflowExecutionContext.WorkflowBlueprint.PersistenceBehavior;
-            
-            if (behavior == WorkflowPersistenceBehavior.WorkflowBurst)
-                await SaveWorkflowAsync(notification.WorkflowExecutionContext.WorkflowInstance, cancellationToken);
-        }
-
         public async Task Handle(WorkflowExecutionPassCompleted notification, CancellationToken cancellationToken)
         {
             var behavior = notification.WorkflowExecutionContext.WorkflowBlueprint.PersistenceBehavior;
 
-            if (behavior == WorkflowPersistenceBehavior.WorkflowPassCompleted || behavior == WorkflowPersistenceBehavior.ActivityExecuted || notification.ActivityExecutionContext.ActivityBlueprint.PersistWorkflow)
-                await SaveWorkflowAsync(notification.WorkflowExecutionContext.WorkflowInstance, cancellationToken);
-        }
-
-        public async Task Handle(WorkflowExecuted notification, CancellationToken cancellationToken)
-        {
-            var behavior = notification.WorkflowExecutionContext.WorkflowBlueprint.PersistenceBehavior;
-
-            if (behavior == WorkflowPersistenceBehavior.WorkflowPassCompleted || behavior == WorkflowPersistenceBehavior.WorkflowBurst)
+            if (behavior == WorkflowPersistenceBehavior.ActivityExecuted || notification.ActivityExecutionContext.ActivityBlueprint.PersistWorkflow)
                 await SaveWorkflowAsync(notification.WorkflowExecutionContext.WorkflowInstance, cancellationToken);
         }
 

--- a/src/core/Elsa.Core/Services/Workflows/WorkflowExecutionLog.cs
+++ b/src/core/Elsa.Core/Services/Workflows/WorkflowExecutionLog.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Elsa.Models;
 using Elsa.Persistence;
@@ -13,6 +14,7 @@ namespace Elsa.Services.Workflows
         private readonly IWorkflowExecutionLogStore _store;
         private readonly IIdGenerator _idGenerator;
         private readonly IClock _clock;
+        private readonly ICollection<WorkflowExecutionLogRecord> _records = new List<WorkflowExecutionLogRecord>();
 
         public WorkflowExecutionLog(IWorkflowExecutionLogStore store, IIdGenerator idGenerator, IClock clock)
         {
@@ -20,13 +22,20 @@ namespace Elsa.Services.Workflows
             _idGenerator = idGenerator;
             _clock = clock;
         }
-        
-        public async Task AddEntryAsync(string workflowInstanceId, string activityId, string activityType, string eventName, string? message, string? tenantId, string? source, JObject? data, CancellationToken cancellationToken = default)
+
+        public Task AddEntryAsync(string workflowInstanceId, string activityId, string activityType, string eventName, string? message, string? tenantId, string? source, JObject? data, CancellationToken cancellationToken = default)
         {
             var id = _idGenerator.Generate();
             var timeStamp = _clock.GetCurrentInstant();
             var record = new WorkflowExecutionLogRecord(id, tenantId, workflowInstanceId, activityId, activityType, timeStamp, eventName, message, source, data);
-            await _store.SaveAsync(record, cancellationToken);
+            _records.Add(record);
+            return Task.CompletedTask;
+        }
+
+        public async Task FlushAsync(CancellationToken cancellationToken = default)
+        {
+            await _store.AddManyAsync(_records, cancellationToken);
+            _records.Clear();
         }
 
         public Task<WorkflowExecutionLogRecord?> FindEntryAsync(ISpecification<WorkflowExecutionLogRecord> specification, CancellationToken cancellationToken = default) => _store.FindAsync(specification, cancellationToken);

--- a/src/designer/elsa-workflows-studio/src/components/designers/tree/elsa-designer-tree/elsa-designer-tree.tsx
+++ b/src/designer/elsa-workflows-studio/src/components/designers/tree/elsa-designer-tree/elsa-designer-tree.tsx
@@ -70,7 +70,7 @@ export class ElsaWorkflowDesigner {
   handleConnectionContextMenuChange(state: ActivityContextMenuState) {
     this.connectionContextMenuState = state;
     this.connectionContextMenuButtonClicked.emit(state);
-  }  
+  }
 
   @Watch('model')
   handleModelChanged(newValue: WorkflowModel) {
@@ -108,17 +108,17 @@ export class ElsaWorkflowDesigner {
   @Method()
   async showActivityEditor(activity: ActivityModel, animate: boolean) {
     this.showActivityEditorInternal(activity, animate);
-  }   
-
-  @Listen('keydown', { target: 'document' })
-  async handleKeyDown(event: KeyboardEvent){    
-    if((event.ctrlKey || event.metaKey) && event.key === 'c') {
-      await this.copyActivitiesToClipboard();
-    }
-    if((event.ctrlKey || event.metaKey) && event.key === 'v') {
-      await this.pasteActivitiesFromClipboard();
-    }
   }
+
+  // @Listen('keydown', { target: 'document' })
+  // async handleKeyDown(event: KeyboardEvent){
+  //   if((event.ctrlKey || event.metaKey) && event.key === 'c') {
+  //     await this.copyActivitiesToClipboard();
+  //   }
+  //   if((event.ctrlKey || event.metaKey) && event.key === 'v') {
+  //     await this.pasteActivitiesFromClipboard();
+  //   }
+  // }
 
   async copyActivitiesToClipboard()
   {
@@ -133,7 +133,7 @@ export class ElsaWorkflowDesigner {
 
     let copiedActivities: Array<ActivityModel> = [];
 
-    await navigator.clipboard.readText().then(data => { 
+    await navigator.clipboard.readText().then(data => {
       copiedActivities = JSON.parse(data);
     });
 
@@ -158,10 +158,10 @@ export class ElsaWorkflowDesigner {
 
     for (const key in copiedActivities) {
       this.addingActivity = true;
-      copiedActivities[key].activityId = uuid();    
+      copiedActivities[key].activityId = uuid();
 
       eventBus.emit(EventTypes.UpdateActivity, this, copiedActivities[key]);
-      
+
       this.parentActivityId = copiedActivities[key].activityId;
       this.parentActivityOutcome = copiedActivities[key].outcomes[0];
     }
@@ -174,7 +174,7 @@ export class ElsaWorkflowDesigner {
 
   checkClipboardPermissions()
   {
-    navigator.permissions.query({ name: "clipboard-read" }).then((result) => { 
+    navigator.permissions.query({ name: "clipboard-read" }).then((result) => {
       if (result.state == 'denied')
         eventBus.emit(EventTypes.ClipboardPermissionDenied, this);
     });
@@ -184,7 +184,7 @@ export class ElsaWorkflowDesigner {
     eventBus.on(EventTypes.ActivityPicked, this.onActivityPicked);
     eventBus.on(EventTypes.UpdateActivity, this.onUpdateActivity);
     eventBus.on(EventTypes.PasteActivity, this.onPasteActivity);
-    
+
   }
 
   disconnectedCallback() {
@@ -584,7 +584,7 @@ export class ElsaWorkflowDesigner {
     activityModel.outcomes[0] = this.parentActivityOutcome;
     this.selectedActivities[activityModel.activityId] = activityModel;
     this.pasteActivitiesFromClipboard();
-  };  
+  };
 
   tryRerenderTree(waitTime?: number, attempt?: number) {
     const maxTries = 3;
@@ -645,7 +645,7 @@ export class ElsaWorkflowDesigner {
           e.preventDefault();
           e.stopPropagation();
           this.parentActivityId = node.activity.activityId;
-          this.parentActivityOutcome = node.outcome;          
+          this.parentActivityOutcome = node.outcome;
           this.handleConnectionContextMenuChange({x: e.clientX, y: e.clientY, shown: true, activity: node.activity});
         });
       });
@@ -700,7 +700,7 @@ export class ElsaWorkflowDesigner {
               this.activitySelected.emit(activity);
             }
           }
-          // When clicking an activity:          
+          // When clicking an activity:
           else
           {
             if (!!this.selectedActivities[activityId])

--- a/src/designer/elsa-workflows-studio/src/components/screens/workflow-definition-editor/elsa-workflow-settings-modal/elsa-workflow-settings-modal.tsx
+++ b/src/designer/elsa-workflows-studio/src/components/screens/workflow-definition-editor/elsa-workflow-settings-modal/elsa-workflow-settings-modal.tsx
@@ -1,7 +1,14 @@
 import {Component, Event, Host, Prop, State, Watch, h} from '@stencil/core';
 import {eventBus} from "../../../../services/event-bus";
 import {Map} from "../../../../utils/utils";
-import {EventTypes, Variables, WorkflowContextFidelity, WorkflowContextOptions, WorkflowDefinition, WorkflowPersistenceBehavior} from "../../../../models";
+import {
+  EventTypes,
+  Variables,
+  WorkflowContextFidelity,
+  WorkflowContextOptions,
+  WorkflowDefinition,
+  WorkflowPersistenceBehavior
+} from "../../../../models";
 import {MonacoValueChangedArgs} from "../../../controls/elsa-monaco/elsa-monaco";
 import {MarkerSeverity} from "monaco-editor";
 import {checkBox, FormContext, selectField, SelectOption, textArea, textInput} from "../../../../utils/forms";
@@ -97,7 +104,8 @@ export class ElsaWorkflowDefinitionSettingsModal {
                     {tabs.map(tab => {
                       const isSelected = tab === selectedTab;
                       const cssClass = isSelected ? selectedClass : inactiveClass;
-                      return <a href="#" onClick={e => this.onTabClick(e, tab)} class={`${cssClass} elsa-whitespace-nowrap elsa-py-4 elsa-px-1 elsa-border-b-2 elsa-font-medium elsa-text-sm`}>{tab}</a>;
+                      return <a href="#" onClick={e => this.onTabClick(e, tab)}
+                                class={`${cssClass} elsa-whitespace-nowrap elsa-py-4 elsa-px-1 elsa-border-b-2 elsa-font-medium elsa-text-sm`}>{tab}</a>;
                     })}
                   </nav>
                 </div>
@@ -161,7 +169,10 @@ export class ElsaWorkflowDefinitionSettingsModal {
   renderAdvancedTab() {
     const workflowDefinition = this.workflowDefinitionInternal;
     const formContext = this.formContext;
-    const workflowChannelOptions: Array<SelectOption> = [{text: '', value: null}, ...this.workflowChannels.map(x => ({text: x, value: x}))];
+    const workflowChannelOptions: Array<SelectOption> = [{
+      text: '',
+      value: null
+    }, ...this.workflowChannels.map(x => ({text: x, value: x}))];
 
     const persistenceBehaviorOptions: Array<SelectOption> = [{
       text: 'Suspended',
@@ -169,9 +180,6 @@ export class ElsaWorkflowDefinitionSettingsModal {
     }, {
       text: 'Workflow Burst',
       value: 'WorkflowBurst'
-    }, {
-      text: 'Workflow Pass Completed',
-      value: 'WorkflowPassCompleted'
     }, {
       text: 'Activity Executed',
       value: 'ActivityExecuted'
@@ -199,7 +207,8 @@ export class ElsaWorkflowDefinitionSettingsModal {
     return (
       <div class="elsa-flex elsa-px-8">
         <div class="elsa-space-y-8 elsa-w-full elsa-h-30">
-          <elsa-monaco value={value} language={language} editor-height="30em" onValueChanged={e => this.onMonacoValueChanged(e.detail)} ref={el => this.monacoEditor = el}/>
+          <elsa-monaco value={value} language={language} editor-height="30em"
+                       onValueChanged={e => this.onMonacoValueChanged(e.detail)} ref={el => this.monacoEditor = el}/>
         </div>
       </div>
     );

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/Stores/EntityFrameworkStore.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/Stores/EntityFrameworkStore.cs
@@ -80,6 +80,9 @@ namespace Elsa.Persistence.EntityFramework.Core.Stores
         {
             var list = entities.ToList();
 
+            if (!list.Any())
+                return;
+
             await DoWork(async dbContext =>
             {
                 var dbSet = dbContext.Set<T>();

--- a/src/scripting/Elsa.Scripting.JavaScript/Handlers/ConfigureJavaScriptEngine.cs
+++ b/src/scripting/Elsa.Scripting.JavaScript/Handlers/ConfigureJavaScriptEngine.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Elsa.Persistence;
 using Elsa.Persistence.Specifications;
 using Elsa.Persistence.Specifications.WorkflowExecutionLogRecords;
 using Elsa.Providers.WorkflowStorage;
@@ -169,9 +170,9 @@ namespace Elsa.Scripting.JavaScript.Handlers
         
         private static async Task<string?> FindExecutedActivityByTypeAsync(ActivityExecutionContext activityExecutionContext, string activityTypeName, CancellationToken cancellationToken)
         {
-            var log = activityExecutionContext.GetService<IWorkflowExecutionLog>();
+            var log = activityExecutionContext.GetService<IWorkflowExecutionLogStore>();
             var specification = new WorkflowInstanceIdSpecification(activityExecutionContext.WorkflowInstance.Id).And(new ActivityTypeSpecification(activityTypeName));
-            var entry = await log.FindEntryAsync(specification, cancellationToken);
+            var entry = await log.FindAsync(specification, cancellationToken);
 
             return entry?.ActivityId;
         }

--- a/test/integration/Elsa.Core.IntegrationTests/Persistence/InMemory/InMemoryStoreIntegrationTests.cs
+++ b/test/integration/Elsa.Core.IntegrationTests/Persistence/InMemory/InMemoryStoreIntegrationTests.cs
@@ -54,16 +54,6 @@ namespace Elsa.Core.IntegrationTests.Persistence.InMemory
             var host = await hostBuilder.StartAsync();
         }
 
-        [Theory(DisplayName = "A persistable-on-workflow-pass-completed workflow instance should be persisted-to and readable-from an in-memory store after being run"), AutoMoqData]
-        public async Task APersistableOnWorkflowPassCompletedWorkflowInstanceShouldBeRoundTrippable([WithPersistableWorkflow] ElsaHostBuilderBuilder hostBuilderBuilder)
-        {
-            var hostBuilder = hostBuilderBuilder.GetHostBuilder();
-            hostBuilder.ConfigureServices((ctx, services) => {
-                services.AddHostedService<HostedWorkflowRunner<PersistableWorkflow.OnWorkflowPassCompleted>>();
-            });
-            var host = await hostBuilder.StartAsync();
-        }
-
         class HostedWorkflowRunner<TWorkflow> : IHostedService where TWorkflow : PersistableWorkflow
         {
             readonly IBuildsAndStartsWorkflow _workflowRunner;

--- a/test/integration/Elsa.Core.IntegrationTests/Workflows/ForkJoinWorkflowTests.cs
+++ b/test/integration/Elsa.Core.IntegrationTests/Workflows/ForkJoinWorkflowTests.cs
@@ -29,7 +29,7 @@ namespace Elsa.Core.IntegrationTests.Workflows
             async Task<bool> GetActivityHasExecutedAsync(string name)
             {
                 var activity = workflowBlueprint.Activities.First(x => x.Name == name);
-                var entry = await WorkflowExecutionLog.FindEntryAsync(new ActivityIdSpecification(activity.Id));
+                var entry = await WorkflowExecutionLogStore.FindAsync(new ActivityIdSpecification(activity.Id));
                 return entry != null;
             }
             
@@ -71,7 +71,7 @@ namespace Elsa.Core.IntegrationTests.Workflows
             async Task<bool> GetActivityHasExecutedAsync(string name)
             {
                 var activity = workflowBlueprint!.Activities.First(x => x.Name == name);
-                var entry = await WorkflowExecutionLog.FindEntryAsync(new ActivityIdSpecification(activity.Id));
+                var entry = await WorkflowExecutionLogStore.FindAsync(new ActivityIdSpecification(activity.Id));
                 return entry != null;
             }
             

--- a/test/integration/Elsa.Core.IntegrationTests/Workflows/PersistableWorkflow.cs
+++ b/test/integration/Elsa.Core.IntegrationTests/Workflows/PersistableWorkflow.cs
@@ -46,14 +46,5 @@ namespace Elsa.Core.IntegrationTests.Workflows
                 base.Build(builder);
             }
         }
-
-        public class OnWorkflowPassCompleted : PersistableWorkflow
-        {
-            public override void Build(IWorkflowBuilder builder)
-            {
-                builder.WithPersistenceBehavior(WorkflowPersistenceBehavior.WorkflowPassCompleted);
-                base.Build(builder);
-            }
-        }
     }
 }

--- a/test/shared/Elsa.Testing.Shared/Unit/WorkflowsUnitTestBase.cs
+++ b/test/shared/Elsa.Testing.Shared/Unit/WorkflowsUnitTestBase.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using Elsa.Builders;
+using Elsa.Persistence;
 using Elsa.Services;
 using Elsa.Services.Bookmarks;
 using Elsa.Services.WorkflowStorage;
@@ -36,6 +37,7 @@ namespace Elsa.Testing.Shared.Unit
             WorkflowRegistry = ServiceScope.ServiceProvider.GetRequiredService<IWorkflowRegistry>();
             BookmarkFinder = ServiceScope.ServiceProvider.GetRequiredService<IBookmarkFinder>();
             WorkflowExecutionLog = ServiceScope.ServiceProvider.GetRequiredService<IWorkflowExecutionLog>();
+            WorkflowExecutionLogStore = ServiceScope.ServiceProvider.GetRequiredService<IWorkflowExecutionLogStore>();
             WorkflowStorageService = ServiceScope.ServiceProvider.GetRequiredService<IWorkflowStorageService>();
         }
 
@@ -47,6 +49,7 @@ namespace Elsa.Testing.Shared.Unit
         protected IStartsWorkflow WorkflowStarter { get; }
         protected IResumesWorkflow WorkflowResumer { get; }
         protected IWorkflowExecutionLog WorkflowExecutionLog { get; }
+        protected IWorkflowExecutionLogStore WorkflowExecutionLogStore { get; }
         protected IWorkflowBlueprintMaterializer WorkflowBlueprintMaterializer { get; }
         protected IWorkflowBuilder WorkflowBuilder { get; }
         protected IWorkflowRegistry WorkflowRegistry { get; }


### PR DESCRIPTION
This PR reduces the number of database commits that happen during the execution of a workflow in the following ways:

- Activity execution log records are now only committed at the same time the workflow instance is persisted (as opposed to writing execution log records as soon as they are created).
- The `PersistWorkflow` handler now handles less notifications to achieve a more sane number of times the workflow instance is being written.

Closed #1410