### PR TITLE
Fix EFCore.BulkExtensions does not support Oracle

### DIFF
--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/Extensions/OracleDatabaseFacadeExtensions.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/Extensions/OracleDatabaseFacadeExtensions.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.EntityFrameworkCore.Infrastructure;
+
+namespace Elsa.Persistence.EntityFramework.Core.Extensions
+{
+    internal static class OracleDatabaseFacadeExtensions
+    {
+        public static bool IsOracle(this DatabaseFacade database) => database.ProviderName == "Oracle.EntityFrameworkCore";
+    }
+}

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/Extensions/QueryableBulkExtensions.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/Extensions/QueryableBulkExtensions.cs
@@ -10,10 +10,11 @@ namespace Elsa.Persistence.EntityFramework.Core.Extensions
     {
         public static async Task<int> BatchDeleteWithWorkAroundAsync<T>(this IQueryable<T> queryable, DbContext elsaContext, CancellationToken cancellationToken = default) where T : class
         {
-            if (elsaContext.Database.IsPostgres() || elsaContext.Database.IsMySql())
+            if (elsaContext.Database.IsPostgres() || elsaContext.Database.IsMySql() || elsaContext.Database.IsOracle())
             {
                 // Need this workaround until https://github.com/borisdj/EFCore.BulkExtensions/issues/67
                 // and https://github.com/borisdj/EFCore.BulkExtensions/issues/553 is solved.
+                // Oracle also https://github.com/borisdj/EFCore.BulkExtensions/issues/375
                 var records = await queryable.ToListAsync(cancellationToken);
 
                 foreach (var @record in records) 


### PR DESCRIPTION
Similar to #1104, Oracle does not support bulk extension borisdj/EFCore.BulkExtensions#375.