### PR TITLE
Fix build assets and run dashboard monolith

### DIFF
--- a/build-assets-and-run-dashboard-monolith.ps1
+++ b/build-assets-and-run-dashboard-monolith.ps1
@@ -1,3 +1,3 @@
 .\build-assets
-cd ../../../..
+cd ../../../../..
 .\run-dashboard-monolith

--- a/src/designer/elsa-workflows-studio/src/index.html
+++ b/src/designer/elsa-workflows-studio/src/index.html
@@ -14,7 +14,7 @@
 </head>
 <body>
 
-<elsa-studio-root server-url="https://localhost:11000" monaco-lib-path="build/assets/js/monaco-editor/min" culture="en-US">
+<elsa-studio-root server-url="https://localhost:15265" monaco-lib-path="build/assets/js/monaco-editor/min" culture="en-US">
   <!-- The root dashboard component -->
   <elsa-studio-dashboard></elsa-studio-dashboard>
 

--- a/src/samples/dashboard/aspnetcore/ElsaDashboard.Samples.AspNetCore.Monolith/appsettings.json
+++ b/src/samples/dashboard/aspnetcore/ElsaDashboard.Samples.AspNetCore.Monolith/appsettings.json
@@ -10,7 +10,7 @@
   "Elsa": {
     "Features": [],
     "Server": {
-      "BaseUrl": "https://localhost:11000",
+      "BaseUrl": "https://localhost:15265",
       "BasePath": "/workflows"
     }
   }


### PR DESCRIPTION
Hi!
First of all, thanks for this great project.
Second, this is my first pull request so if you feel there is anything I should do to improve, please let me know.

Now, to the actual pull request :)
I was playing with the dashboard (trying to translate it to italian, so expect another PR soon) and found some minor issues following the docs. I figured out I could try and fix them, so here we are.

With these changes you are able to run `build-assets-and-run-dashboard-monolith.ps1` and actually have a working dashboard you can play with. Before I faced following issues:
- `build-assets-and-run-dashboard-monolith.ps1`  was not compiling all the stuff needed to run, as a `cd` command was pointing to a wrong directory (fixed in [first commit](8768169))
- dashboard was loading but it was unable to pull data from the server (due to a wrong port used in configuration, fixed in [third commit](https://github.com/elsa-workflows/elsa-core/commit/f6a9cfe23fc166912a0e4b7965634770788e0ef0))

Please review my changes and let me know what you think.