### PR TITLE
#1598: Context Menu not disasppearing issue fixed

### DIFF
--- a/src/designer/elsa-workflows-studio/src/components/screens/workflow-definition-editor/elsa-workflow-definition-editor-screen/elsa-workflow-definition-editor-screen.tsx
+++ b/src/designer/elsa-workflows-studio/src/components/screens/workflow-definition-editor/elsa-workflow-definition-editor-screen/elsa-workflow-definition-editor-screen.tsx
@@ -746,7 +746,7 @@ export class ElsaWorkflowDefinitionEditorScreen {
 
   renderActivityContextMenu() {
     const t = this.t;
-    const selectedActivities = Object.keys(this.activityContextMenuState.selectedActivities);
+    const selectedActivities = Object.keys(this.activityContextMenuState.selectedActivities ?? {});
     const {activity} = this.activityContextMenuState;
 
     return <div


### PR DESCRIPTION
When there are no selected activities (.selectedActivities is undefined) it is defaulted  to empty object