### PR TITLE
Fixes #1601

### DIFF
--- a/src/designer/elsa-workflows-studio/src/components/controls/elsa-context-menu/elsa-context-menu.tsx
+++ b/src/designer/elsa-workflows-studio/src/components/controls/elsa-context-menu/elsa-context-menu.tsx
@@ -1,7 +1,6 @@
-import {Component, h, Prop} from '@stencil/core';
+import {Component, h, Listen, Prop} from '@stencil/core';
 import {RouterHistory} from "@stencil/router";
 import {leave, toggle} from 'el-transition'
-import {registerClickOutside} from "stencil-click-outside";
 import {MenuItem} from "./models";
 
 @Component({
@@ -14,12 +13,21 @@ export class ElsaContextMenu {
 
   navigate: (path: string) => void;
   contextMenu: HTMLElement;
+  element: HTMLElement;
 
   componentWillLoad() {
     if (!!this.history)
       this.navigate = this.history.push;
     else
       this.navigate = path => document.location.href = path;
+  }
+
+  @Listen('click', {target: 'window'})
+  onWindowClicked(event: Event){
+    const target = event.target as HTMLElement;
+
+    if (!this.element.contains(target))
+      this.closeContextMenu();
   }
 
   closeContextMenu() {
@@ -44,7 +52,7 @@ export class ElsaContextMenu {
 
   render() {
     return (
-      <div class="elsa-relative elsa-flex elsa-justify-end elsa-items-center" ref={el => registerClickOutside(this, el, this.closeContextMenu)}>
+      <div class="elsa-relative elsa-flex elsa-justify-end elsa-items-center" ref={el => this.element = el}>
         <button onClick={() => this.toggleMenu()} aria-has-popup="true" type="button"
                 class="elsa-w-8 elsa-h-8 elsa-inline-flex elsa-items-center elsa-justify-center elsa-text-gray-400 elsa-rounded-full elsa-bg-transparent hover:elsa-text-gray-500 focus:elsa-outline-none focus:elsa-text-gray-500 focus:elsa-bg-gray-100 elsa-transition elsa-ease-in-out elsa-duration-150">
           <svg class="elsa-w-5 elsa-h-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">

--- a/src/designer/elsa-workflows-studio/src/components/controls/elsa-dropdown-button/elsa-dropdown-button.tsx
+++ b/src/designer/elsa-workflows-studio/src/components/controls/elsa-dropdown-button/elsa-dropdown-button.tsx
@@ -1,6 +1,5 @@
-import {Component, Event, EventEmitter, h, Prop} from '@stencil/core';
+import {Component, Event, EventEmitter, Listen, h, Prop} from '@stencil/core';
 import {leave, toggle} from 'el-transition'
-import {registerClickOutside} from "stencil-click-outside";
 import {DropdownButtonItem, DropdownButtonOrigin} from "./models";
 
 @Component({
@@ -17,6 +16,15 @@ export class ElsaContextMenu {
     @Event() itemSelected: EventEmitter<DropdownButtonItem>
 
     contextMenu: HTMLElement;
+    element: HTMLElement;
+
+    @Listen('click', {target: 'window'})
+    onWindowClicked(event: Event){
+        const target = event.target as HTMLElement;
+
+        if (!this.element.contains(target))
+            this.closeContextMenu();
+    }
 
     closeContextMenu() {
         if (!!this.contextMenu)
@@ -46,7 +54,7 @@ export class ElsaContextMenu {
 
     render() {
         return (
-            <div class="elsa-relative" ref={el => registerClickOutside(this, el, this.closeContextMenu)}>
+            <div class="elsa-relative" ref={el => this.element = el}>
                 <button onClick={e => this.toggleMenu()} type="button"
                         class="elsa-w-full elsa-bg-white elsa-border elsa-border-gray-300 elsa-rounded-md elsa-shadow-sm elsa-px-4 elsa-py-2 elsa-inline-flex elsa-justify-center elsa-text-sm elsa-font-medium elsa-text-gray-700 hover:elsa-bg-gray-50 focus:elsa-outline-none focus:elsa-ring-2 focus:elsa-ring-offset-2 focus:elsa-ring-blue-500"
                         aria-haspopup="true" aria-expanded="false">

--- a/src/designer/elsa-workflows-studio/src/components/editors/elsa-multi-expression-editor/elsa-multi-expression-editor.tsx
+++ b/src/designer/elsa-workflows-studio/src/components/editors/elsa-multi-expression-editor/elsa-multi-expression-editor.tsx
@@ -1,6 +1,5 @@
-import {Component, Event, EventEmitter, h, Prop, State} from '@stencil/core';
+import {Component, Event, EventEmitter, Listen, h, Prop, State} from '@stencil/core';
 import {SyntaxNames} from "../../../models";
-import {registerClickOutside} from "stencil-click-outside";
 import {enter, leave, toggle} from 'el-transition'
 import {Map, mapSyntaxToLanguage} from "../../../utils/utils";
 
@@ -30,10 +29,19 @@ export class ElsaMultiExpressionEditor {
   contextMenu: HTMLElement;
   expressionEditor: HTMLElsaExpressionEditorElement;
   defaultSyntaxValue: string;
+  contextMenuWidget: HTMLElement;
 
   async componentWillLoad() {
     this.selectedSyntax = this.syntax;
     this.currentValue = this.expressions[this.selectedSyntax ? this.selectedSyntax : this.defaultSyntax];
+  }
+
+  @Listen('click', {target: 'window'})
+  onWindowClicked(event: Event){
+    const target = event.target as HTMLElement;
+
+    if (!this.contextMenuWidget.contains(target))
+      this.closeContextMenu();
   }
 
   toggleContextMenu() {
@@ -109,7 +117,7 @@ export class ElsaMultiExpressionEditor {
     const selectedSyntax = this.selectedSyntax;
     const advancedButtonClass = selectedSyntax ? 'elsa-text-blue-500' : 'elsa-text-gray-300'
 
-    return <div class="elsa-relative" ref={el => registerClickOutside(this, el, this.closeContextMenu)}>
+    return <div class="elsa-relative" ref={el => this.contextMenuWidget  = el}>
       <button type="button" class={`elsa-border-0 focus:elsa-outline-none elsa-text-sm ${advancedButtonClass}`} onClick={e => this.onSettingsClick(e)}>
         {!this.isReadOnly ? this.renderContextMenuButton() : ""}
       </button>

--- a/src/designer/elsa-workflows-studio/src/components/screens/workflow-definition-editor/elsa-workflow-definition-editor-screen/elsa-workflow-definition-editor-screen.tsx
+++ b/src/designer/elsa-workflows-studio/src/components/screens/workflow-definition-editor/elsa-workflow-definition-editor-screen/elsa-workflow-definition-editor-screen.tsx
@@ -21,7 +21,6 @@ import WorkflowEditorTunnel, {WorkflowEditorState} from '../../../../data/workfl
 import DashboardTunnel from "../../../../data/dashboard";
 import {downloadFromBlob} from "../../../../utils/download";
 import {ActivityContextMenuState, WorkflowDesignerMode} from "../../../designers/tree/elsa-designer-tree/models";
-import {registerClickOutside} from "stencil-click-outside";
 import {i18n} from "i18next";
 import {loadTranslations} from "../../../i18n/i18n-loader";
 import {resources} from "./localizations";
@@ -82,6 +81,9 @@ export class ElsaWorkflowDefinitionEditorScreen {
   designer: HTMLElsaDesignerTreeElement;
   configureComponentCustomButtonContext: ConfigureComponentCustomButtonContext = null;
   helpDialog: HTMLElsaModalDialogElement;
+  activityContextMenu: HTMLDivElement;
+  componentCustomButton: HTMLDivElement;
+  connectionContextMenu: HTMLDivElement;
 
   @Method()
   async getServerUrl(): Promise<string> {
@@ -164,6 +166,20 @@ export class ElsaWorkflowDefinitionEditorScreen {
   async workflowChangedHandler(event: CustomEvent<WorkflowModel>) {
     const workflowModel = event.detail;
     await this.saveWorkflowInternal(workflowModel);
+  }
+
+  @Listen('click', {target: 'window'})
+  onWindowClicked(event: Event){
+    const target = event.target as HTMLElement;
+
+    if (!this.componentCustomButton.contains(target))
+      this.handleContextMenuTestChange(0, 0, false, null)
+
+    if (!this.activityContextMenu.contains(target))
+      this.handleContextMenuChange({x: 0, y: 0, shown: false, activity: null, selectedActivities: {}})
+
+    if (!this.connectionContextMenu.contains(target))
+      this.handleConnectionContextMenuChange({x: 0, y: 0, shown: false, activity: null})    
   }
 
   async componentWillLoad() {
@@ -733,11 +749,8 @@ export class ElsaWorkflowDefinitionEditorScreen {
       data-transition-leave-end="elsa-transform elsa-opacity-0 elsa-scale-95"
       class={`${this.activityContextMenuTestState.shown ? '' : 'hidden'} elsa-absolute elsa-z-10 elsa-mt-3 elsa-px-2 elsa-w-screen elsa-max-w-xl sm:elsa-px-0`}
       style={{left: `${this.activityContextMenuTestState.x + 64}px`, top: `${this.activityContextMenuTestState.y - 256}px`}}
-      ref={el =>
-        registerClickOutside(this, el, () => {
-          this.handleContextMenuTestChange(0, 0, false, null);
-        })
-      }>
+      ref={el => this.componentCustomButton = el}
+    >
       <div class="elsa-rounded-lg elsa-shadow-lg elsa-ring-1 elsa-ring-black elsa-ring-opacity-5 elsa-overflow-hidden">
         {!!message ? renderMessage() : renderLoader()}
       </div>
@@ -758,11 +771,7 @@ export class ElsaWorkflowDefinitionEditorScreen {
       data-transition-leave-end="elsa-transform elsa-opacity-0 elsa-scale-95"
       class={`${this.activityContextMenuState.shown ? '' : 'hidden'} context-menu elsa-z-10 elsa-mx-3 elsa-w-48 elsa-mt-1 elsa-rounded-md elsa-shadow-lg elsa-fixed`}
       style={{left: `${this.activityContextMenuState.x}px`, top: `${this.activityContextMenuState.y}px`}}
-      ref={el =>
-        registerClickOutside(this, el, () => {
-          this.handleContextMenuChange({x: 0, y: 0, shown: false, activity: null, selectedActivities: {}});
-        })
-      }
+      ref={el => this.activityContextMenu = el }
     >
       <div class="elsa-rounded-md elsa-bg-white elsa-shadow-xs" role="menu" aria-orientation="vertical"
            aria-labelledby="pinned-project-options-menu-0">
@@ -801,11 +810,7 @@ export class ElsaWorkflowDefinitionEditorScreen {
       data-transition-leave-end="elsa-transform elsa-opacity-0 elsa-scale-95"
       class={`${this.connectionContextMenuState.shown ? '' : 'hidden'} context-menu elsa-z-10 elsa-mx-3 elsa-w-48 elsa-mt-1 elsa-rounded-md elsa-shadow-lg elsa-absolute`}
       style={{left: `${this.connectionContextMenuState.x}px`, top: `${this.connectionContextMenuState.y - 64}px`}}
-      ref={el =>
-        registerClickOutside(this, el, () => {
-          this.handleConnectionContextMenuChange({x: 0, y: 0, shown: false, activity: null});
-        })
-      }
+      ref={el => this.connectionContextMenu = el}
     >
       <div class="elsa-rounded-md elsa-bg-white elsa-shadow-xs" role="menu" aria-orientation="vertical"
            aria-labelledby="pinned-project-options-menu-0">

--- a/src/designer/elsa-workflows-studio/src/components/screens/workflow-definition-editor/elsa-workflow-publish-button/elsa-workflow-publish-button.tsx
+++ b/src/designer/elsa-workflows-studio/src/components/screens/workflow-definition-editor/elsa-workflow-publish-button/elsa-workflow-publish-button.tsx
@@ -1,6 +1,5 @@
-import {Component, Host, h, Prop, State, Event, EventEmitter, Watch} from '@stencil/core';
+import {Component, Event, EventEmitter, Host, h, Listen, Prop} from '@stencil/core';
 import {leave, toggle} from 'el-transition'
-import {registerClickOutside} from "stencil-click-outside";
 import {WorkflowDefinition} from "../../../../models";
 import Tunnel from '../../../../data/workflow-editor';
 import {i18n} from "i18next";
@@ -24,9 +23,18 @@ export class ElsaWorkflowPublishButton {
   i18next: i18n;
   menu: HTMLElement;
   fileInput: HTMLInputElement;
+  element: HTMLElement;
 
   async componentWillLoad(){
     this.i18next = await loadTranslations(this.culture, resources);
+  }
+
+  @Listen('click', {target: 'window'})
+  onWindowClicked(event: Event){
+    const target = event.target as HTMLElement;
+
+    if (!this.element.contains(target))
+      this.closeMenu();
   }
 
   t = (key: string) => this.i18next.t(key);
@@ -79,7 +87,7 @@ export class ElsaWorkflowPublishButton {
     const t = this.t;
 
     return (
-      <Host class="elsa-block" ref={el => registerClickOutside(this, el, this.closeMenu)}>
+      <Host class="elsa-block" ref={el => this.element = el}>
         <span class="elsa-relative elsa-z-0 elsa-inline-flex elsa-shadow-sm elsa-rounded-md">
           {this.publishing ? this.renderPublishingButton() : this.renderPublishButton()}
           <span class="-elsa-ml-px elsa-relative elsa-block">


### PR DESCRIPTION
After multiple (not very successful) attempts to mimic stencil-click-outside functionality I decided to replace it with **Listen** decorator.

Pros:

1. quick and easy to implement
2. reliable and bug-proof (I was getting quite inconsistent behavior when using window.addEventListener/window.removeEventListener)
3. **Listen** decorator is already build into stencil core

Cons:

1. doesn't look as pretty (need to check if click target is inside the element every time).