### PR TITLE
Masstransit changed logic to check missing context for providers

### DIFF
--- a/src/activities/Elsa.Activities.MassTransit/Activities/MassTransitBusActivity.cs
+++ b/src/activities/Elsa.Activities.MassTransit/Activities/MassTransitBusActivity.cs
@@ -1,6 +1,7 @@
 using System;
 using Elsa.Services;
 using MassTransit;
+using MassTransit.Context;
 
 // ReSharper disable once CheckNamespace
 namespace Elsa.Activities.MassTransit
@@ -24,7 +25,7 @@ namespace Elsa.Activities.MassTransit
         /// the conversation and correlation id.
         /// </remarks>
         protected IPublishEndpoint PublishEndpoint =>
-            _consumeContext ?? (IPublishEndpoint)_bus;
+            _consumeContext != MissingConsumeContext.Instance ? _consumeContext : _bus;
 
         /// <summary>
         /// Gets the send endpoint provider to use.
@@ -34,7 +35,6 @@ namespace Elsa.Activities.MassTransit
         /// the conversation and correlation id.
         /// </remarks>
         protected ISendEndpointProvider SendEndpointProvider =>
-            _consumeContext ?? (ISendEndpointProvider)_bus;
-
+            _consumeContext != MissingConsumeContext.Instance ? _consumeContext : _bus;
     }
 }


### PR DESCRIPTION
Version: 2.3
Hi, I think that MassTransitBusActivity  has incorrect logic :

```
      protected IPublishEndpoint PublishEndpoint =>
            _consumeContext ?? (IPublishEndpoint)_bus;

        /// <summary>
        /// Gets the send endpoint provider to use.
        /// </summary>
        /// <remarks>
        /// Will use the current scopes consume context if one exists to maintain
        /// the conversation and correlation id.
        /// </remarks>
        protected ISendEndpointProvider SendEndpointProvider =>
            _consumeContext ?? (ISendEndpointProvider)_bus;
```

when I try to send a message then consumeContext has not null and exist next:
![image](https://user-images.githubusercontent.com/21295107/136799985-6f319f33-da74-4bd2-8729-06d55e63e545.png)

maybe in new version masstransit consume context can't be null 
![image](https://user-images.githubusercontent.com/21295107/136803948-4f1135df-be9b-44b3-a661-9480da6ad6f0.png)
