### PR TITLE
fixes propertyDescriptor is potentially undefined

### DIFF
--- a/src/designer/elsa-workflows-studio/src/components/screens/workflow-blueprint-viewer/elsa-workflow-blueprint-viewer-screen/elsa-workflow-blueprint-viewer-screen.tsx
+++ b/src/designer/elsa-workflows-studio/src/components/screens/workflow-blueprint-viewer/elsa-workflow-blueprint-viewer-screen/elsa-workflow-blueprint-viewer-screen.tsx
@@ -110,7 +110,7 @@ export class ElsaWorkflowBlueprintViewerScreen {
     const activityDescriptor = activityDescriptors.find(x => x.type == source.type);
     const properties: Array<ActivityDefinitionProperty> = collection.map(source.inputProperties.data, (value, key) => {
       const propertyDescriptor = activityDescriptor.inputProperties.find(x => x.name == key);
-      const defaultSyntax = propertyDescriptor.defaultSyntax || SyntaxNames.Literal;
+      const defaultSyntax = propertyDescriptor?.defaultSyntax || SyntaxNames.Literal;
       const expressions = {};
       expressions[defaultSyntax] = value;
       return ({name: key, expressions: expressions, syntax: defaultSyntax});

--- a/src/designer/elsa-workflows-studio/src/components/screens/workflow-instance-viewer/elsa-workflow-instance-viewer-screen/elsa-workflow-instance-viewer-screen.tsx
+++ b/src/designer/elsa-workflows-studio/src/components/screens/workflow-instance-viewer/elsa-workflow-instance-viewer-screen/elsa-workflow-instance-viewer-screen.tsx
@@ -162,7 +162,7 @@ export class ElsaWorkflowInstanceViewerScreen {
 
     const properties: Array<ActivityDefinitionProperty> = collection.map(activityBlueprint.inputProperties.data, (value, key) => {
       const propertyDescriptor = activityDescriptor.inputProperties.find(x => x.name == key) || activityDescriptor.outputProperties.find(x => x.name == key);
-      const defaultSyntax = propertyDescriptor.defaultSyntax || SyntaxNames.Literal;
+      const defaultSyntax = propertyDescriptor?.defaultSyntax || SyntaxNames.Literal;
       const expressions = {};
       const v = activityData[key] || value;
       expressions[defaultSyntax] = v;

--- a/src/designer/elsa-workflows-studio/src/index.html
+++ b/src/designer/elsa-workflows-studio/src/index.html
@@ -127,7 +127,7 @@
       const propertyEditor = document.createElement('elsa-property-editor');
       const propertyDescriptor = activityDescriptor.inputProperties.find(x => x.name === 'Text');
       const propertyModel = getOrCreateProperty(activityModel, propertyDescriptor.name);
-      const defaultSyntax = propertyDescriptor.defaultSyntax || 'Literal';
+      const defaultSyntax = propertyDescriptor?.defaultSyntax || 'Literal';
       const currentValue = propertyModel.expressions[defaultSyntax] || '';
       const editorHtml = `<textarea class="focus:elsa-ring-blue-500 focus:elsa-border-blue-500 elsa-block elsa-w-full elsa-min-w-0 elsa-rounded-md sm:elsa-text-sm elsa-border-gray-300" rows="5">${currentValue}</textarea>`;
       const editorElement = htmlToElement(editorHtml);


### PR DESCRIPTION
We had an issue with one of our activities, where one of the props was marked as IsReadOnly, IsBrowsable.

```
 [ActivityInput(
          IsReadOnly = true,
           IsBrowsable = false
      )]
```

In that case, when trying to open the instance detail view in the client `proxyDescriptor` is undefined and therefore throws.

![image](https://user-images.githubusercontent.com/581644/137477773-b50c632c-db89-49d8-9809-2960414d6252.png)
