### PR TITLE
Add new compare function to IBookmark

### DIFF
--- a/src/activities/Elsa.Activities.Entity/Bookmarks/EntityChangedBookmark.cs
+++ b/src/activities/Elsa.Activities.Entity/Bookmarks/EntityChangedBookmark.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Elsa.Attributes;
 using Elsa.Services;
 
 namespace Elsa.Activities.Entity.Bookmarks
@@ -13,8 +14,16 @@ namespace Elsa.Activities.Entity.Bookmarks
             Action = action;
         }
 
+        [ExcludeFromHash]
         public string? EntityName { get; }
         public EntityChangedAction? Action { get; }
+
+        public bool? Compare(IBookmark bookmark)
+        {
+            return bookmark is EntityChangedBookmark other 
+                && string.Equals(EntityName, other.EntityName, System.StringComparison.OrdinalIgnoreCase) 
+                && Action == other.Action;
+        }
     }
 
     public class EntityChangedWorkflowTriggerProvider : BookmarkProvider<EntityChangedBookmark, EntityChanged>

--- a/src/activities/Elsa.Activities.File/Bookmarks/FileSystemEventBookmark.cs
+++ b/src/activities/Elsa.Activities.File/Bookmarks/FileSystemEventBookmark.cs
@@ -1,4 +1,7 @@
+using Elsa.Attributes;
 using Elsa.Services;
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
@@ -19,13 +22,33 @@ namespace Elsa.Activities.File.Bookmarks
             Pattern = pattern;
         }
 
+        [ExcludeFromHash]
         public WatcherChangeTypes ChangeTypes { get; set; }
 
+        [ExcludeFromHash]
         public NotifyFilters NotifyFilters { get; set; }
 
+        [ExcludeFromHash]
         public string? Path { get; set; }
 
         public string? Pattern { get; set; }
+
+        public bool? Compare(IBookmark bookmark)
+        {
+            return bookmark is FileSystemEventBookmark other
+                && ComparePaths(Path, other.Path)
+                && ComparePaths(Pattern, other.Pattern)
+                && ((NotifyFilters & other.NotifyFilters) > 0)
+                && ((ChangeTypes & other.ChangeTypes) > 0);
+        }
+
+        private bool ComparePaths(string? left, string? right)
+        {
+            if (Environment.OSVersion.Platform == PlatformID.Unix)
+                return string.Equals(left, right);
+            else
+                return string.Equals(left, right, System.StringComparison.OrdinalIgnoreCase);
+        }
     }
 
     public class FileCreatedBookmarkProvider : BookmarkProvider<FileSystemEventBookmark, WatchDirectory>

--- a/src/core/Elsa.Abstractions/Services/Bookmarks/IBookmark.cs
+++ b/src/core/Elsa.Abstractions/Services/Bookmarks/IBookmark.cs
@@ -1,6 +1,12 @@
-﻿namespace Elsa.Services
+namespace Elsa.Services
 {
     public interface IBookmark
     {
+        /// <summary>
+        /// Compares this bookmark instance with another to check, if the values are equal for the function of the bookmark.
+        /// </summary>
+        /// <param name="bookmark"></param>
+        /// <returns><see langword="null"/> if default and no specific compare is done, false if not equal and true otherwise</returns>
+        bool? Compare(IBookmark bookmark) { return null; }
     }
 }


### PR DESCRIPTION
* so values that are excluded from hashing can still be checked before triggering a workflow
* implemented a default function for the new compare in the interface, so there is no need to implement it, if the hashing is enough
* add support for case-insensitive os platform for file system event
* fix case insensitivity for entity name for entity changed bookmark

Fixes #1624 