### PR TITLE
return existing enumerable if it is assignable from the desiredtype

### DIFF
--- a/src/scripting/Elsa.Scripting.JavaScript/Services/EnumerableResultConverter.cs
+++ b/src/scripting/Elsa.Scripting.JavaScript/Services/EnumerableResultConverter.cs
@@ -9,7 +9,7 @@ namespace Elsa.Scripting.JavaScript.Services
     public class EnumerableResultConverter : IConvertsJintEvaluationResult, IConvertsEnumerableToObject
     {
         private readonly IConvertsJintEvaluationResult? _wrapped;
-        
+
         public EnumerableResultConverter(IConvertsJintEvaluationResult? wrapped) => _wrapped = wrapped;
 
         public object? ConvertToDesiredType(object? evaluationResult, Type desiredType)
@@ -25,6 +25,7 @@ namespace Elsa.Scripting.JavaScript.Services
             if (enumerable is string) return enumerable;
             if (enumerable is JObject) return enumerable;
             if (enumerable is byte[]) return enumerable;
+            if (enumerable != null && desiredType != null && desiredType.IsAssignableFrom(enumerable.GetType())) return enumerable;
 
             var destinationType = GetDestinationType(desiredType);
             var json = JsonConvert.SerializeObject(enumerable);


### PR DESCRIPTION
Hi,

like discussed on Discord - the EnumerableResultConverter corrently always tries to Serialize and Deserialize the Enumerable - even if the enumerable is assignable to the desired type. i added an check for desiredType.IsAssignableFrom(enumerable.GetType())) - and if so - return the existing enumerable instance!