### PR TITLE
add correlationId filter to instance view

### DIFF
--- a/src/designer/elsa-workflows-studio/src/components.d.ts
+++ b/src/designer/elsa-workflows-studio/src/components.d.ts
@@ -291,6 +291,7 @@ export namespace Components {
     }
     interface ElsaWorkflowInstanceListScreen {
         "basePath": string;
+        "correlationId"?: string;
         "culture": string;
         "getSelectedWorkflowInstanceIds": () => Promise<string[]>;
         "history"?: RouterHistory;
@@ -1008,6 +1009,7 @@ declare namespace LocalJSX {
     }
     interface ElsaWorkflowInstanceListScreen {
         "basePath"?: string;
+        "correlationId"?: string;
         "culture"?: string;
         "history"?: RouterHistory;
         "orderBy"?: OrderBy;

--- a/src/designer/elsa-workflows-studio/src/services/elsa-client.ts
+++ b/src/designer/elsa-workflows-studio/src/services/elsa-client.ts
@@ -137,11 +137,14 @@ export const createElsaClient = async function (serverUrl: string): Promise<Elsa
       }
     },
     workflowInstancesApi: {
-      list: async (page?: number, pageSize?: number, workflowDefinitionId?: string, workflowStatus?: WorkflowStatus, orderBy?: OrderBy, searchTerm?: string): Promise<PagedList<WorkflowInstanceSummary>> => {
+      list: async (page?: number, pageSize?: number, workflowDefinitionId?: string, workflowStatus?: WorkflowStatus, orderBy?: OrderBy, searchTerm?: string, correlationId?: string): Promise<PagedList<WorkflowInstanceSummary>> => {
         const queryString = {};
 
         if (!!workflowDefinitionId)
           queryString['workflow'] = workflowDefinitionId;
+
+        if (!!correlationId)
+          queryString['correlationId'] = correlationId;
 
         if (workflowStatus != null)
           queryString['status'] = workflowStatus;
@@ -292,7 +295,7 @@ export interface WorkflowRegistryApi {
 }
 
 export interface WorkflowInstancesApi {
-  list(page?: number, pageSize?: number, workflowDefinitionId?: string, workflowStatus?: WorkflowStatus, orderBy?: OrderBy, searchTerm?: string): Promise<PagedList<WorkflowInstanceSummary>>;
+  list(page?: number, pageSize?: number, workflowDefinitionId?: string, workflowStatus?: WorkflowStatus, orderBy?: OrderBy, searchTerm?: string, correlationId?: string): Promise<PagedList<WorkflowInstanceSummary>>;
 
   get(id: string): Promise<WorkflowInstance>;
 


### PR DESCRIPTION
Filtering by correlationId was added to the product https://github.com/elsa-workflows/elsa-core/issues/1151, but so far has not been exposed in the studio. This adds the ability to pass in correlationId as query string param in the instance view and deep link the correlationId column in the instance view.