### PR TITLE
Change RunWorkflowInternalAsync to protected virtual

### DIFF
--- a/src/core/Elsa.Core/Services/Workflows/WorkflowRunner.cs
+++ b/src/core/Elsa.Core/Services/Workflows/WorkflowRunner.cs
@@ -69,8 +69,8 @@ namespace Elsa.Services.Workflows
             await workflowExecutionContext.WorkflowExecutionLog.FlushAsync(cancellationToken);
             return result;
         }
-        
-        private async Task<RunWorkflowResult> RunWorkflowInternalAsync(WorkflowExecutionContext workflowExecutionContext, string? activityId = default, CancellationToken cancellationToken = default)
+
+        protected virtual async Task<RunWorkflowResult> RunWorkflowInternalAsync(WorkflowExecutionContext workflowExecutionContext, string? activityId = default, CancellationToken cancellationToken = default)
         {
             var workflowInstance = workflowExecutionContext.WorkflowInstance;
 
@@ -175,7 +175,7 @@ namespace Elsa.Services.Workflows
             {
                 _logger.LogWarning(e, "Failed to run workflow {WorkflowInstanceId}", workflowExecutionContext.WorkflowInstance.Id);
                 workflowExecutionContext.Fault(e, activity.Id, null, false);
-                workflowExecutionContext.AddEntry(activity, "Faulted",  null, SimpleException.FromException(e));
+                workflowExecutionContext.AddEntry(activity, "Faulted", null, SimpleException.FromException(e));
             }
 
             return new RunWorkflowResult(workflowExecutionContext.WorkflowInstance, activity.Id, false);


### PR DESCRIPTION
Hi,

this is related to - https://github.com/elsa-workflows/elsa-core/issues/1645 - is it possible to change the method signature - this way i can inject my logic - and reuse the existing workflow runner code by inheriting.