### PR TITLE
add variables tab to instance view

### DIFF
--- a/src/designer/elsa-workflows-studio/src/components/screens/workflow-instance-viewer/elsa-workflow-instance-journal/elsa-workflow-instance-journal.tsx
+++ b/src/designer/elsa-workflows-studio/src/components/screens/workflow-instance-viewer/elsa-workflow-instance-journal/elsa-workflow-instance-journal.tsx
@@ -133,6 +133,12 @@ export class ElsaWorkflowInstanceJournal {
         <elsa-tab-content tab="activityState" slot="content">
           {this.renderActivityStateTab()}
         </elsa-tab-content>
+        <elsa-tab-header tab="variables" slot="header">
+          Variables
+        </elsa-tab-header>
+        <elsa-tab-content tab="variables" slot="content">
+          {this.renderVariablesTab()}
+        </elsa-tab-content>
       </elsa-flyout-panel>
     );
   }
@@ -410,5 +416,18 @@ export class ElsaWorkflowInstanceJournal {
         </div>
       </dl>
     )
+  };
+
+  renderVariablesTab = () => {
+    const { workflowInstance, workflowBlueprint } = this;
+    const { variables } = workflowInstance;
+    
+    return (
+      <dl class="elsa-border-b elsa-border-gray-200 elsa-divide-y elsa-divide-gray-200">
+        <div class="elsa-py-3 elsa-text-sm elsa-font-medium">
+          {variables?.data ? <pre>{JSON.stringify(variables?.data, null, 2)}</pre> : '-'}
+          </div>
+      </dl>
+    );
   };
 }


### PR DESCRIPTION
This adds a Variables Tab to the workflow instance viewer as discussed in https://github.com/elsa-workflows/elsa-core/issues/2413

### Short variables:

![image](https://user-images.githubusercontent.com/581644/139823659-1ad64817-9a8d-4683-8f97-387cb8153886.png)


### Long variables:

![image](https://user-images.githubusercontent.com/581644/139823688-4531d017-0581-40fa-b786-b0e4f7410c31.png)
