### PR TITLE
Fixes #2417

### DIFF
--- a/src/designer/elsa-workflows-studio/src/components/controls/elsa-monaco/elsa-monaco.tsx
+++ b/src/designer/elsa-workflows-studio/src/components/controls/elsa-monaco/elsa-monaco.tsx
@@ -85,8 +85,7 @@ export class ElsaMonaco {
       monaco.languages.typescript.javascriptDefaults.setCompilerOptions({
         target: monaco.languages.typescript.ScriptTarget.ES2020,
         lib: [],
-        allowNonTsExtensions: true,
-        allowJs: true
+        allowNonTsExtensions: true
       });
 
       monaco.languages.typescript.javascriptDefaults.setEagerModelSync(true);


### PR DESCRIPTION
Removing allowJs option does not seem to be having any negative sides and it fixes the issue when properties form already entered expression always appear in intellisense (e.g. for "return test.prop." intellisense will suggest both "test" and "prop" as valid options even when they are not).