### PR TITLE
do not create a new Scope - reuse workflowExecutionContext's scope

### DIFF
--- a/src/core/Elsa.Core/Elsa.Core.csproj
+++ b/src/core/Elsa.Core/Elsa.Core.csproj
@@ -42,7 +42,7 @@
         <PackageReference Include="Storage.Net" Version="9.3.0" />
         <PackageReference Include="System.Linq.Async" Version="5.0.0" />
         <PackageReference Include="System.Threading.Channels" Version="5.0.0" />
-        <PackageReference Include="Rebus.ServiceProvider" Version="6.4.1" />
+        <PackageReference Include="Rebus.ServiceProvider" Version="7.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/core/Elsa.Core/Services/Workflows/WorkflowRunner.cs
+++ b/src/core/Elsa.Core/Services/Workflows/WorkflowRunner.cs
@@ -204,10 +204,8 @@ namespace Elsa.Services.Workflows
 
         private async ValueTask<bool> CanExecuteAsync(WorkflowExecutionContext workflowExecutionContext, IActivityBlueprint activityBlueprint, bool resuming, CancellationToken cancellationToken)
         {
-            using var scope = _serviceScopeFactory.CreateScope();
-
             var activityExecutionContext = new ActivityExecutionContext(
-                scope.ServiceProvider,
+                workflowExecutionContext.ServiceProvider,
                 workflowExecutionContext,
                 activityBlueprint,
                 workflowExecutionContext.Input,


### PR DESCRIPTION
Like discussed on discord - reuse the workflowexecution scope - and do not create a new one