### PR TITLE
Add scripting api to elsa client

### DIFF
--- a/src/clients/Elsa.Client/ElsaClient.cs
+++ b/src/clients/Elsa.Client/ElsaClient.cs
@@ -10,13 +10,15 @@ namespace Elsa.Client
             IWorkflowDefinitionsApi workflowDefinitions,
             IWorkflowRegistryApi workflowRegistry,
             IWorkflowInstancesApi workflowInstances,
-            IWebhookDefinitionsApi webhookDefinitions)
+            IWebhookDefinitionsApi webhookDefinitions,
+            IScriptingApi scriptingApi)
         {
             Activities = activities;
             WorkflowDefinitions = workflowDefinitions;
             WorkflowRegistry = workflowRegistry;
             WorkflowInstances = workflowInstances;
             WebhookDefinitions = webhookDefinitions;
+            Scripting = scriptingApi;
         }
 
         public IActivitiesApi Activities { get; }
@@ -24,5 +26,6 @@ namespace Elsa.Client
         public IWorkflowRegistryApi WorkflowRegistry { get; }
         public IWorkflowInstancesApi WorkflowInstances { get; }
         public IWebhookDefinitionsApi WebhookDefinitions { get; }
+        public IScriptingApi Scripting { get; }
     }
 }

--- a/src/clients/Elsa.Client/Extensions/ServiceCollectionExtensions.cs
+++ b/src/clients/Elsa.Client/Extensions/ServiceCollectionExtensions.cs
@@ -29,7 +29,8 @@ namespace Elsa.Client.Extensions
                 .AddApiClient<IWorkflowDefinitionsApi>(refitSettings, httpClientFactory)
                 .AddApiClient<IWorkflowRegistryApi>(refitSettings, httpClientFactory)
                 .AddApiClient<IWorkflowInstancesApi>(refitSettings, httpClientFactory)
-                .AddApiClient<IWebhookDefinitionsApi>(refitSettings, httpClientFactory);
+                .AddApiClient<IWebhookDefinitionsApi>(refitSettings, httpClientFactory)
+                .AddApiClient<IScriptingApi>(refitSettings, httpClientFactory);
 
             return services
                 .AddTransient<IElsaClient, ElsaClient>();

--- a/src/clients/Elsa.Client/IElsaClient.cs
+++ b/src/clients/Elsa.Client/IElsaClient.cs
@@ -10,5 +10,6 @@ namespace Elsa.Client
         IWorkflowRegistryApi WorkflowRegistry { get; }
         IWorkflowInstancesApi WorkflowInstances { get; }
         IWebhookDefinitionsApi WebhookDefinitions { get; }
+        IScriptingApi Scripting { get; }
     }
 }

--- a/src/clients/Elsa.Client/Services/IScriptingApi.cs
+++ b/src/clients/Elsa.Client/Services/IScriptingApi.cs
@@ -1,0 +1,13 @@
+﻿using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Refit;
+
+namespace Elsa.Client.Services
+{
+    public interface IScriptingApi
+    {
+        [Get("/v1/scripting/javascript/type-definitions/{workflowDefinitionId}")]
+        Task<HttpContent> GetTypeScriptDefinitionFileAsync(string workflowDefinitionId, CancellationToken cancellationToken = default);
+    }
+}


### PR DESCRIPTION
Exposes `/v1/scripting/javascript/type-definitions` endpoint through the client to allow consumers to easily access definition files. 