### PR TITLE
Testing workflows with Timers

### DIFF
--- a/test/integration/Elsa.Core.IntegrationTests/Workflows/TimerWorkflow.cs
+++ b/test/integration/Elsa.Core.IntegrationTests/Workflows/TimerWorkflow.cs
@@ -1,0 +1,18 @@
+using Elsa.Activities.Console;
+using Elsa.Activities.Temporal;
+using Elsa.Builders;
+using NodaTime;
+
+namespace Elsa.Core.IntegrationTests.Workflows
+{
+    public class TimerWorkflow : IWorkflow
+    {
+        public void Build(IWorkflowBuilder builder)
+        {
+            builder
+                .WriteLine("Starting timer workflow test")
+                .Timer(Duration.FromSeconds(1))
+                .WriteLine("Finishing timer workflow test");
+        }
+    }
+}

--- a/test/integration/Elsa.Core.IntegrationTests/Workflows/TimerWorkflowTests.cs
+++ b/test/integration/Elsa.Core.IntegrationTests/Workflows/TimerWorkflowTests.cs
@@ -1,0 +1,75 @@
+using System.Threading.Tasks;
+using Elsa.Activities.Temporal;
+using Elsa.Activities.Temporal.Common.Services;
+using Elsa.Models;
+using Elsa.Services;
+using Elsa.Testing.Shared.Unit;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Moq;
+using NodaTime;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Elsa.Core.IntegrationTests.Workflows
+{
+    public class TimerWorkflowTests : WorkflowsUnitTestBase
+    {
+        private static readonly Mock<IWorkflowDefinitionScheduler> WorkflowDefinitionScheduler = new();
+        private static readonly Mock<IWorkflowInstanceScheduler> WorkflowInstanceScheduler = new ();
+        private static readonly Mock<IClock> Clock = new();
+
+        public TimerWorkflowTests(ITestOutputHelper testOutputHelper)
+            : base(
+                testOutputHelper,
+                services =>
+                {
+                    services.AddSingleton(WorkflowDefinitionScheduler.Object);
+                    services.AddSingleton(WorkflowInstanceScheduler.Object);
+                    services.Replace(new ServiceDescriptor(typeof(IClock), Clock.Object));
+                },
+                options =>
+                {
+                    options.AddCommonTemporalActivities();
+                    options.AddWorkflow<TimerWorkflow>();
+                }) { }
+
+        [Fact(DisplayName = "Runs timer workflow.")]
+        public async Task Test01()
+        {
+            var now = new Instant();
+            
+            Clock
+                .Setup(x => x.GetCurrentInstant())
+                .Returns(now);
+
+            var runWorkflowResult = await WorkflowBuilderAndStarter.BuildAndStartWorkflowAsync<TimerWorkflow>();
+            var workflowInstance = runWorkflowResult.WorkflowInstance!;
+
+            Assert.Equal(WorkflowStatus.Suspended, workflowInstance.WorkflowStatus);
+
+            var timerId = workflowInstance.LastExecutedActivityId!;
+
+            WorkflowInstanceScheduler
+                .Verify(x => x
+                    .ScheduleAsync(
+                        workflowInstance.Id,
+                        timerId,
+                        now.Plus(Duration.FromSeconds(1)),
+                        null,
+                        default));
+
+            var workflowResumer = ServiceProvider.GetRequiredService<IResumesWorkflow>();
+            await workflowResumer.ResumeWorkflowAsync(workflowInstance, timerId);
+            
+            Assert.Equal(WorkflowStatus.Finished, workflowInstance.WorkflowStatus);
+            
+            WorkflowInstanceScheduler
+                .Verify(x => x
+                    .UnscheduleAsync(
+                        workflowInstance.Id, 
+                        timerId!,
+                        default));
+        }
+    }
+}

--- a/test/shared/Elsa.Testing.Shared/Unit/WorkflowsUnitTestBase.cs
+++ b/test/shared/Elsa.Testing.Shared/Unit/WorkflowsUnitTestBase.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using Elsa.Builders;
+using Elsa.Options;
 using Elsa.Persistence;
 using Elsa.Services;
 using Elsa.Services.Bookmarks;
@@ -16,15 +17,22 @@ namespace Elsa.Testing.Shared.Unit
     {
         private readonly TemporaryFolder _tempFolder;
 
-        protected WorkflowsUnitTestBase(ITestOutputHelper testOutputHelper, Action<IServiceCollection>? configureServices = default)
+        protected WorkflowsUnitTestBase(
+            ITestOutputHelper testOutputHelper, 
+            Action<IServiceCollection>? configureServices = default,
+            Action<ElsaOptionsBuilder>? extraOptions = null)
         {
             _tempFolder = new TemporaryFolder();
             TestOutputHelper = testOutputHelper;
 
             var services = new ServiceCollection()
-                .AddElsa(options => options
-                    .AddConsoleActivities(Console.In, new XunitConsoleForwarder(testOutputHelper)));
-
+                .AddElsa(options =>
+                    {
+                        options.AddConsoleActivities(Console.In, new XunitConsoleForwarder(testOutputHelper));
+                        extraOptions?.Invoke(options);
+                    }
+                );
+            
             configureServices?.Invoke(services);
             ServiceProvider = services.BuildServiceProvider();
             ServiceScope = ServiceProvider.CreateScope();


### PR DESCRIPTION
I was investigating how to test workflows with Timers and realized that it would be much simpler to do if you had the ability to inject elsa options into WorkflowsUnitTestBase. I also added a test for a workflow with a timer to demonstrate how to use it