### PR TITLE
Update scripting client to use POST endpoint method

### DIFF
--- a/src/clients/Elsa.Client/Models/GetTypeScriptDefinitionFileRequest.cs
+++ b/src/clients/Elsa.Client/Models/GetTypeScriptDefinitionFileRequest.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace Elsa.Client.Models;
+
+[DataContract]
+public class GetTypeScriptDefinitionFileRequest
+{
+    public GetTypeScriptDefinitionFileRequest(string? activityTypeName, string? propertyName)
+    {
+        ActivityTypeName = activityTypeName;
+        PropertyName = propertyName;
+    }
+
+    [DataMember(Order = 1)] public string? ActivityTypeName { get; set; }
+    [DataMember(Order = 2)] public string? PropertyName { get; set; }
+}

--- a/src/clients/Elsa.Client/Services/IScriptingApi.cs
+++ b/src/clients/Elsa.Client/Services/IScriptingApi.cs
@@ -1,6 +1,7 @@
 ﻿using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Elsa.Client.Models;
 using Refit;
 
 namespace Elsa.Client.Services
@@ -8,6 +9,6 @@ namespace Elsa.Client.Services
     public interface IScriptingApi
     {
         [Post("/v1/scripting/javascript/type-definitions/{workflowDefinitionId}")]
-        Task<HttpContent> GetTypeScriptDefinitionFileAsync(string workflowDefinitionId, CancellationToken cancellationToken = default);
+        Task<HttpContent> GetTypeScriptDefinitionFileAsync(string workflowDefinitionId, [Body] GetTypeScriptDefinitionFileRequest? context, CancellationToken cancellationToken = default);
     }
 }

--- a/src/clients/Elsa.Client/Services/IScriptingApi.cs
+++ b/src/clients/Elsa.Client/Services/IScriptingApi.cs
@@ -7,7 +7,7 @@ namespace Elsa.Client.Services
 {
     public interface IScriptingApi
     {
-        [Get("/v1/scripting/javascript/type-definitions/{workflowDefinitionId}")]
+        [Post("/v1/scripting/javascript/type-definitions/{workflowDefinitionId}")]
         Task<HttpContent> GetTypeScriptDefinitionFileAsync(string workflowDefinitionId, CancellationToken cancellationToken = default);
     }
 }


### PR DESCRIPTION
Small fix to keep up to date with recent changes.

9f36d668 updated the JavaScript TypeDefinitions endpoint `Elsa.Server.Api/Endpoints/Scripting/JavaScript/TypeDefinitions/Get.cs` to use POST instead of GET. 

