### PR TITLE
Do not force Browsable of SubActivity to false if not defined.

### DIFF
--- a/src/core/Elsa.Core/Providers/ActivityTypes/TypeBasedActivityProvider.cs
+++ b/src/core/Elsa.Core/Providers/ActivityTypes/TypeBasedActivityProvider.cs
@@ -56,7 +56,7 @@ namespace Elsa.Providers.ActivityTypes
                 Type = activityType,
                 Description = info.Description,
                 DisplayName = info.DisplayName,
-                IsBrowsable =  activityType.GetCustomAttribute<BrowsableAttribute>()?.Browsable ?? true,
+                IsBrowsable =  activityType.GetCustomAttribute<BrowsableAttribute>(false)?.Browsable ?? true,
                 ActivateAsync = async context => await ActivateActivity(context, activityType),
                 DescribeAsync = async () => (await _describesActivityType.DescribeAsync(activityType, cancellationToken))!, 
                 CanExecuteAsync = async (context, instance) => await instance.CanExecuteAsync(context),


### PR DESCRIPTION

Allow Composite Activity or other subclass to not explicitly defined [Browsable(true)] if base class define [Browsable(false)]

refer to #2651 