### PR TITLE
Extension Methods for Rebus Activities

### DIFF
--- a/src/activities/Elsa.Activities.Rebus/Extensions/PublishRebusMessageExtensions.cs
+++ b/src/activities/Elsa.Activities.Rebus/Extensions/PublishRebusMessageExtensions.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Elsa.Builders;
+using Elsa.Services.Models;
+
+// ReSharper disable once CheckNamespace
+namespace Elsa.Activities.Rebus
+{
+    public static class PublishRebusMessageExtensions
+    {
+        // With Message
+        public static ISetupActivity<PublishRebusMessage> WithMessage(this ISetupActivity<PublishRebusMessage> activity, Func<ActivityExecutionContext, ValueTask<object>> value) => activity.Set(x => x.Message, value!);
+
+        public static ISetupActivity<PublishRebusMessage> WithMessage(this ISetupActivity<PublishRebusMessage> activity, Func<ValueTask<object>> value) => activity.Set(x => x.Message, value!);
+
+        public static ISetupActivity<PublishRebusMessage> WithMessage(this ISetupActivity<PublishRebusMessage> activity, Func<object> value) => activity.Set(x => x.Message, value!);
+
+        public static ISetupActivity<PublishRebusMessage> WithMessage(this ISetupActivity<PublishRebusMessage> activity, Func<ActivityExecutionContext, object> value) => activity.Set(x => x.Message, value!);
+
+        public static ISetupActivity<PublishRebusMessage> WithMessage(this ISetupActivity<PublishRebusMessage> activity, object value) => activity.Set(x => x.Message, value!);
+
+        // With Headers
+        public static ISetupActivity<PublishRebusMessage> WithHeaders(this ISetupActivity<PublishRebusMessage> activity, Func<ActivityExecutionContext, ValueTask<IDictionary<string, string>>> value) => activity.Set(x => x.Headers, value!);
+
+        public static ISetupActivity<PublishRebusMessage> WithHeaders(this ISetupActivity<PublishRebusMessage> activity, Func<ValueTask<IDictionary<string, string>>> value) => activity.Set(x => x.Headers, value!);
+
+        public static ISetupActivity<PublishRebusMessage> WithHeaders(this ISetupActivity<PublishRebusMessage> activity, Func<IDictionary<string, string>> value) => activity.Set(x => x.Headers, value!);
+
+        public static ISetupActivity<PublishRebusMessage> WithHeaders(this ISetupActivity<PublishRebusMessage> activity, Func<ActivityExecutionContext, IDictionary<string, string>> value) => activity.Set(x => x.Headers, value!);
+
+        public static ISetupActivity<PublishRebusMessage> WithHeaders(this ISetupActivity<PublishRebusMessage> activity, IDictionary<string, string> value) => activity.Set(x => x.Headers, value!);
+    }
+}

--- a/src/activities/Elsa.Activities.Rebus/Extensions/RebusMessageReceivedExtensions.cs
+++ b/src/activities/Elsa.Activities.Rebus/Extensions/RebusMessageReceivedExtensions.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Threading.Tasks;
+using Elsa.Builders;
+using Elsa.Services.Models;
+
+// ReSharper disable once CheckNamespace
+namespace Elsa.Activities.Rebus
+{
+    public static class RebusMessageReceivedExtensions
+    {
+        public static ISetupActivity<RebusMessageReceived> WithMessageType(this ISetupActivity<RebusMessageReceived> activity, Func<ActivityExecutionContext, ValueTask<Type>> value) => activity.Set(x => x.MessageType, value!);
+
+        public static ISetupActivity<RebusMessageReceived> WithMessageType(this ISetupActivity<RebusMessageReceived> activity, Func<ValueTask<Type>> value) => activity.Set(x => x.MessageType, value!);
+
+        public static ISetupActivity<RebusMessageReceived> WithMessageType(this ISetupActivity<RebusMessageReceived> activity, Func<Type> value) => activity.Set(x => x.MessageType, value!);
+
+        public static ISetupActivity<RebusMessageReceived> WithMessageType(this ISetupActivity<RebusMessageReceived> activity, Func<ActivityExecutionContext, Type> value) => activity.Set(x => x.MessageType, value!);
+
+        public static ISetupActivity<RebusMessageReceived> WithMessageType(this ISetupActivity<RebusMessageReceived> activity, Type value) => activity.Set(x => x.MessageType, value!);
+    }
+}

--- a/src/activities/Elsa.Activities.Rebus/Extensions/SendRebusMessageExtensions.cs
+++ b/src/activities/Elsa.Activities.Rebus/Extensions/SendRebusMessageExtensions.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Elsa.Builders;
+using Elsa.Services.Models;
+
+// ReSharper disable once CheckNamespace
+namespace Elsa.Activities.Rebus
+{
+    public static class SendRebusMessageExtensions
+    {
+        // With Message
+        public static ISetupActivity<SendRebusMessage> WithMessage(this ISetupActivity<SendRebusMessage> activity, Func<ActivityExecutionContext, ValueTask<object>> value) => activity.Set(x => x.Message, value!);
+
+        public static ISetupActivity<SendRebusMessage> WithMessage(this ISetupActivity<SendRebusMessage> activity, Func<ValueTask<object>> value) => activity.Set(x => x.Message, value!);
+
+        public static ISetupActivity<SendRebusMessage> WithMessage(this ISetupActivity<SendRebusMessage> activity, Func<object> value) => activity.Set(x => x.Message, value!);
+
+        public static ISetupActivity<SendRebusMessage> WithMessage(this ISetupActivity<SendRebusMessage> activity, Func<ActivityExecutionContext, object> value) => activity.Set(x => x.Message, value!);
+
+        public static ISetupActivity<SendRebusMessage> WithMessage(this ISetupActivity<SendRebusMessage> activity, object value) => activity.Set(x => x.Message, value!);
+
+        // With Headers
+        public static ISetupActivity<SendRebusMessage> WithHeaders(this ISetupActivity<SendRebusMessage> activity, Func<ActivityExecutionContext, ValueTask<IDictionary<string, string>>> value) => activity.Set(x => x.Headers, value!);
+
+        public static ISetupActivity<SendRebusMessage> WithHeaders(this ISetupActivity<SendRebusMessage> activity, Func<ValueTask<IDictionary<string, string>>> value) => activity.Set(x => x.Headers, value!);
+
+        public static ISetupActivity<SendRebusMessage> WithHeaders(this ISetupActivity<SendRebusMessage> activity, Func<IDictionary<string, string>> value) => activity.Set(x => x.Headers, value!);
+
+        public static ISetupActivity<SendRebusMessage> WithHeaders(this ISetupActivity<SendRebusMessage> activity, Func<ActivityExecutionContext, IDictionary<string, string>> value) => activity.Set(x => x.Headers, value!);
+
+        public static ISetupActivity<SendRebusMessage> WithHeaders(this ISetupActivity<SendRebusMessage> activity, IDictionary<string, string> value) => activity.Set(x => x.Headers, value!);
+    }
+}


### PR DESCRIPTION
This pull request is to add convenience Extension Methods for setting properties on Rebus Activities, following the 'with*' naming convention. The Extension methods included are:

- `WithMessage` & `WithHeaders` (for _SendRebusMessage_ & _PublishRebusMessage_ Activites)
- `WithMessageType` (_RebusMessageReceived_ Activity)