### PR TITLE
Mongo dependency registration missing for Triggers

### DIFF
--- a/src/persistence/Elsa.Persistence.MongoDb/Extensions/ServiceCollectionExtensions.cs
+++ b/src/persistence/Elsa.Persistence.MongoDb/Extensions/ServiceCollectionExtensions.cs
@@ -44,6 +44,7 @@ namespace Elsa.Persistence.MongoDb
                 .AddSingleton(sp => sp.GetRequiredService<TDbContext>().WorkflowInstances)
                 .AddSingleton(sp => sp.GetRequiredService<TDbContext>().WorkflowExecutionLog)
                 .AddSingleton(sp => sp.GetRequiredService<TDbContext>().Bookmarks)
+                .AddSingleton(sp => sp.GetRequiredService<TDbContext>().Triggers);
                 .AddStartupTask<DatabaseInitializer>();
 
             elsa


### PR DESCRIPTION
Added missing .AddSingleton(sp => sp.GetRequiredService<TDbContext>().Triggers);