### PR TITLE
Optimize ForEach activity

### DIFF
--- a/src/core/Elsa.Core/Activities/ControlFlow/ForEach/ForEach.cs
+++ b/src/core/Elsa.Core/Activities/ControlFlow/ForEach/ForEach.cs
@@ -24,6 +24,8 @@ namespace Elsa.Activities.ControlFlow
             DefaultSyntax = SyntaxNames.Json,
             SupportedSyntaxes = new[] { SyntaxNames.Json, SyntaxNames.JavaScript, SyntaxNames.Liquid }
         )]
+        // Using IEnumerable here so the EnumerableResultConverter does not need to serialize/deserialize the collection instance - so to be able to return the instance as it is
+        // See here for further details: https://github.com/elsa-workflows/elsa-core/pull/2737
         public IEnumerable Items { get; set; } = new Collection<object>();
 
         [ActivityOutput] public object? Output { get; set; }

--- a/src/core/Elsa.Core/Activities/ControlFlow/ForEach/ForEach.cs
+++ b/src/core/Elsa.Core/Activities/ControlFlow/ForEach/ForEach.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+using System.Collections;
 using System.Collections.ObjectModel;
 using System.Linq;
 using Elsa.ActivityResults;
@@ -24,8 +24,8 @@ namespace Elsa.Activities.ControlFlow
             DefaultSyntax = SyntaxNames.Json,
             SupportedSyntaxes = new[] { SyntaxNames.Json, SyntaxNames.JavaScript, SyntaxNames.Liquid }
         )]
-        public ICollection<object> Items { get; set; } = new Collection<object>();
-        
+        public IEnumerable Items { get; set; } = new Collection<object>();
+
         [ActivityOutput] public object? Output { get; set; }
 
         private int? CurrentIndex
@@ -50,7 +50,7 @@ namespace Elsa.Activities.ControlFlow
                 return Done();
             }
 
-            var collection = Items.ToList();
+            var collection = Items.OfType<object>().ToList();
             var currentIndex = CurrentIndex ?? 0;
 
             if (currentIndex < collection.Count)
@@ -65,7 +65,7 @@ namespace Elsa.Activities.ControlFlow
                 Output = currentValue;
                 context.JournalData.Add("Current Index", currentIndex);
                 context.LogOutputProperty(this, nameof(Output), Output);
-                
+
                 return Outcome(OutcomeNames.Iterate, currentValue);
             }
 


### PR DESCRIPTION
This PR optimizes the ForEach Items property - to use IEnumerable type - this way any collection can be assigned - and there is no need that the EnumerableResultConverter needs to Serialize and Deserialize the collection - since desiredType.IsAssignableFrom(enumerable.GetType() gives True - and returns the enumarable as is.