### PR TITLE
Data masking

### DIFF
--- a/Elsa.sln
+++ b/Elsa.sln
@@ -397,6 +397,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.DataMasking.Core", "sr
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Samples.MaskPii", "src\samples\aspnet\Elsa.Samples.MaskPii\Elsa.Samples.MaskPii.csproj", "{B0B027B2-C1FF-4C16-AC84-806E3B5C5B22}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Server.Core", "src\server\Elsa.Server.Core\Elsa.Server.Core.csproj", "{7ED399F9-1770-4CCB-9B1A-FE4543E2944B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -947,6 +949,10 @@ Global
 		{B0B027B2-C1FF-4C16-AC84-806E3B5C5B22}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B0B027B2-C1FF-4C16-AC84-806E3B5C5B22}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B0B027B2-C1FF-4C16-AC84-806E3B5C5B22}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7ED399F9-1770-4CCB-9B1A-FE4543E2944B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7ED399F9-1770-4CCB-9B1A-FE4543E2944B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7ED399F9-1770-4CCB-9B1A-FE4543E2944B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7ED399F9-1770-4CCB-9B1A-FE4543E2944B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1125,6 +1131,7 @@ Global
 		{D8B4E6A7-0325-4FF1-A77C-AFE0998FDF93} = {69BB424A-AAA3-415C-9651-9F4349CA3AC5}
 		{6DAE28C7-A2A3-4165-96FA-041747A999CA} = {D8B4E6A7-0325-4FF1-A77C-AFE0998FDF93}
 		{B0B027B2-C1FF-4C16-AC84-806E3B5C5B22} = {22E75696-6FE9-436A-9097-EE21C603F818}
+		{7ED399F9-1770-4CCB-9B1A-FE4543E2944B} = {468E498C-59DB-4541-8D8A-0D89DE9083AB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8B0975FD-7050-48B0-88C5-48C33378E158}

--- a/Elsa.sln
+++ b/Elsa.sln
@@ -391,6 +391,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Samples.RebusErrorWork
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Samples.IfThenElse", "src\samples\console\Elsa.Samples.IfThenElse\Elsa.Samples.IfThenElse.csproj", "{9F430D18-B42E-4127-8B48-BE5122AEB21B}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "datamasking", "datamasking", "{D8B4E6A7-0325-4FF1-A77C-AFE0998FDF93}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.DataMasking.Core", "src\modules\datamasking\Elsa.DataMasking.Core\Elsa.DataMasking.Core.csproj", "{6DAE28C7-A2A3-4165-96FA-041747A999CA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Samples.MaskPii", "src\samples\aspnet\Elsa.Samples.MaskPii\Elsa.Samples.MaskPii.csproj", "{B0B027B2-C1FF-4C16-AC84-806E3B5C5B22}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -933,6 +939,14 @@ Global
 		{9F430D18-B42E-4127-8B48-BE5122AEB21B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9F430D18-B42E-4127-8B48-BE5122AEB21B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9F430D18-B42E-4127-8B48-BE5122AEB21B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6DAE28C7-A2A3-4165-96FA-041747A999CA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6DAE28C7-A2A3-4165-96FA-041747A999CA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6DAE28C7-A2A3-4165-96FA-041747A999CA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6DAE28C7-A2A3-4165-96FA-041747A999CA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B0B027B2-C1FF-4C16-AC84-806E3B5C5B22}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B0B027B2-C1FF-4C16-AC84-806E3B5C5B22}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B0B027B2-C1FF-4C16-AC84-806E3B5C5B22}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B0B027B2-C1FF-4C16-AC84-806E3B5C5B22}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1108,6 +1122,9 @@ Global
 		{A7253665-5F7A-4BCB-B78B-E2E897E90DE4} = {22E75696-6FE9-436A-9097-EE21C603F818}
 		{9422DD57-A244-43ED-B0B8-5ED7684278FE} = {E42743A0-FBDD-4150-9D53-6000496D9B87}
 		{9F430D18-B42E-4127-8B48-BE5122AEB21B} = {FC9F520F-BA51-4AD2-BFEE-EF787798E734}
+		{D8B4E6A7-0325-4FF1-A77C-AFE0998FDF93} = {69BB424A-AAA3-415C-9651-9F4349CA3AC5}
+		{6DAE28C7-A2A3-4165-96FA-041747A999CA} = {D8B4E6A7-0325-4FF1-A77C-AFE0998FDF93}
+		{B0B027B2-C1FF-4C16-AC84-806E3B5C5B22} = {22E75696-6FE9-436A-9097-EE21C603F818}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8B0975FD-7050-48B0-88C5-48C33378E158}

--- a/src/core/Elsa.Abstractions/Events/SavingWorkflowExecutionLog.cs
+++ b/src/core/Elsa.Abstractions/Events/SavingWorkflowExecutionLog.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using Elsa.Models;
+using Elsa.Services;
+using MediatR;
+
+namespace Elsa.Events;
+
+/// <summary>
+/// A domain event that is published when the <see cref="WorkflowExecutionLog"/> about to persist its collection of workflow execution log records.  
+/// </summary>
+public record SavingWorkflowExecutionLog(IReadOnlyCollection<WorkflowExecutionLogRecord> Records) : INotification;

--- a/src/core/Elsa.Abstractions/Providers/Workflows/IWorkflowProvider.cs
+++ b/src/core/Elsa.Abstractions/Providers/Workflows/IWorkflowProvider.cs
@@ -15,6 +15,7 @@ namespace Elsa.Providers.Workflows
         IAsyncEnumerable<IWorkflowBlueprint> ListAsync(VersionOptions versionOptions, int? skip = default, int? take = default, string? tenantId = default, CancellationToken cancellationToken = default);
         ValueTask<int> CountAsync(VersionOptions versionOptions, string? tenantId = default, CancellationToken cancellationToken = default);
         ValueTask<IWorkflowBlueprint?> FindAsync(string definitionId, VersionOptions versionOptions, string? tenantId = default, CancellationToken cancellationToken = default);
+        ValueTask<IWorkflowBlueprint?> FindByDefinitionVersionIdAsync(string definitionVersionId, string? tenantId = default, CancellationToken cancellationToken = default);
         ValueTask<IWorkflowBlueprint?> FindByNameAsync(string name, VersionOptions versionOptions, string? tenantId = default, CancellationToken cancellationToken = default);
         ValueTask<IWorkflowBlueprint?> FindByTagAsync(string tag, VersionOptions versionOptions, string? tenantId = default, CancellationToken cancellationToken = default);
         ValueTask<IEnumerable<IWorkflowBlueprint>> FindManyByDefinitionVersionIds(IEnumerable<string> definitionVersionIds, CancellationToken cancellationToken = default);

--- a/src/core/Elsa.Abstractions/Providers/Workflows/WorkflowProvider.cs
+++ b/src/core/Elsa.Abstractions/Providers/Workflows/WorkflowProvider.cs
@@ -12,6 +12,8 @@ namespace Elsa.Providers.Workflows
         public abstract ValueTask<int> CountAsync(VersionOptions versionOptions, string? tenantId = default, CancellationToken cancellationToken = default);
 
         public abstract ValueTask<IWorkflowBlueprint?> FindAsync(string definitionId, VersionOptions versionOptions, string? tenantId = default, CancellationToken cancellationToken = default);
+        public abstract ValueTask<IWorkflowBlueprint?> FindByDefinitionVersionIdAsync(string definitionVersionId, string? tenantId = default, CancellationToken cancellationToken = default);
+
         public abstract ValueTask<IWorkflowBlueprint?> FindByNameAsync(string name, VersionOptions versionOptions, string? tenantId = default, CancellationToken cancellationToken = default);
         public abstract ValueTask<IWorkflowBlueprint?> FindByTagAsync(string tag, VersionOptions versionOptions, string? tenantId = default, CancellationToken cancellationToken = default);
         public abstract ValueTask<IEnumerable<IWorkflowBlueprint>> FindManyByDefinitionVersionIds(IEnumerable<string> definitionVersionIds, CancellationToken cancellationToken = default);

--- a/src/core/Elsa.Abstractions/Services/Workflows/IWorkflowRegistry.cs
+++ b/src/core/Elsa.Abstractions/Services/Workflows/IWorkflowRegistry.cs
@@ -12,17 +12,22 @@ namespace Elsa.Services
     public interface IWorkflowRegistry
     {
         /// <summary>
-        /// Gets a single workflow blueprint with the specified ID for the specified tenant and version.
+        /// Finds a single workflow blueprint with the specified ID for the specified tenant and version.
         /// </summary>
         Task<IWorkflowBlueprint?> FindAsync(string definitionId, VersionOptions versionOptions, string? tenantId = default, CancellationToken cancellationToken = default);
         
         /// <summary>
-        /// Gets a single workflow blueprint with the specified name for the specified tenant and version.
+        /// Finds a single workflow blueprint with the specified version ID for the specified tenant.
+        /// </summary>
+        Task<IWorkflowBlueprint?> FindByDefinitionVersionIdAsync(string definitionVersionId, string? tenantId = default, CancellationToken cancellationToken = default);
+        
+        /// <summary>
+        /// Finds a single workflow blueprint with the specified name for the specified tenant and version.
         /// </summary>
         Task<IWorkflowBlueprint?> FindByNameAsync(string name, VersionOptions versionOptions, string? tenantId = default, CancellationToken cancellationToken = default);
         
         /// <summary>
-        /// Gets a single workflow blueprint with the specified tag for the specified tenant and version.
+        /// Finds a single workflow blueprint with the specified tag for the specified tenant and version.
         /// </summary>
         Task<IWorkflowBlueprint?> FindByTagAsync(string tag, VersionOptions versionOptions, string? tenantId = default, CancellationToken cancellationToken = default);
 

--- a/src/core/Elsa.Core/Decorators/CachingWorkflowRegistry.cs
+++ b/src/core/Elsa.Core/Decorators/CachingWorkflowRegistry.cs
@@ -32,6 +32,12 @@ namespace Elsa.Decorators
             return await FindInternalAsync(cacheKey, () => _workflowRegistry.FindAsync(definitionId, versionOptions, tenantId, cancellationToken), cancellationToken);
         }
 
+        public async Task<IWorkflowBlueprint?> FindByDefinitionVersionIdAsync(string definitionVersionId, string? tenantId = default, CancellationToken cancellationToken = default)
+        {
+            var cacheKey = $"{RootKey}:definition-version:id:{definitionVersionId}:{tenantId}";
+            return await FindInternalAsync(cacheKey, () => _workflowRegistry.FindByDefinitionVersionIdAsync(definitionVersionId, tenantId, cancellationToken), cancellationToken);
+        }
+
         public async Task<IWorkflowBlueprint?> FindByNameAsync(string name, VersionOptions versionOptions, string? tenantId = default, CancellationToken cancellationToken = default)
         {
             var cacheKey = $"{RootKey}:definition:name:{name}:{versionOptions}:{tenantId}";

--- a/src/core/Elsa.Core/Providers/Workflows/BlobStorageWorkflowProvider.cs
+++ b/src/core/Elsa.Core/Providers/Workflows/BlobStorageWorkflowProvider.cs
@@ -84,6 +84,16 @@ namespace Elsa.Providers.Workflows
             return await ListInternalAsync(cancellationToken).FirstOrDefaultAsync(predicate.Compile(), cancellationToken);
         }
 
+        public override async ValueTask<IWorkflowBlueprint?> FindByDefinitionVersionIdAsync(string definitionVersionId, string? tenantId = default, CancellationToken cancellationToken = default)
+        {
+            Expression<Func<IWorkflowBlueprint, bool>> predicate = x => x.VersionId == definitionVersionId;
+
+            if (!string.IsNullOrWhiteSpace(tenantId))
+                predicate = predicate.And(x => x.TenantId == tenantId);
+
+            return await ListInternalAsync(cancellationToken).FirstOrDefaultAsync(predicate.Compile(), cancellationToken);
+        }
+
         public override async ValueTask<IWorkflowBlueprint?> FindByNameAsync(string name, VersionOptions versionOptions, string? tenantId = default, CancellationToken cancellationToken = default)
         {
             Expression<Func<IWorkflowBlueprint, bool>> predicate = x => string.Equals(x.Name, name, StringComparison.OrdinalIgnoreCase) && x.WithVersion(versionOptions);

--- a/src/core/Elsa.Core/Providers/Workflows/DatabaseWorkflowProvider.cs
+++ b/src/core/Elsa.Core/Providers/Workflows/DatabaseWorkflowProvider.cs
@@ -73,6 +73,12 @@ namespace Elsa.Providers.Workflows
             return workflowDefinition == null ? null : await TryMaterializeBlueprintAsync(workflowDefinition, cancellationToken);
         }
 
+        public override async ValueTask<IWorkflowBlueprint?> FindByDefinitionVersionIdAsync(string definitionVersionId, string? tenantId = default, CancellationToken cancellationToken = default)
+        {
+            var workflowDefinition = await _workflowDefinitionStore.FindAsync(new WorkflowDefinitionVersionIdSpecification(definitionVersionId), cancellationToken);
+            return workflowDefinition == null ? null : await TryMaterializeBlueprintAsync(workflowDefinition, cancellationToken);
+        }
+
         public override async ValueTask<IWorkflowBlueprint?> FindByNameAsync(string name, VersionOptions versionOptions, string? tenantId = default, CancellationToken cancellationToken = default)
         {
             var workflowDefinition = await _workflowDefinitionStore.FindAsync(new WorkflowDefinitionNameSpecification(name, versionOptions), cancellationToken);

--- a/src/core/Elsa.Core/Providers/Workflows/ListWorkflowProvider.cs
+++ b/src/core/Elsa.Core/Providers/Workflows/ListWorkflowProvider.cs
@@ -54,6 +54,17 @@ public class ListWorkflowProvider : WorkflowProvider
         return new ValueTask<IWorkflowBlueprint?>(workflowBlueprint);
     }
 
+    public override ValueTask<IWorkflowBlueprint?> FindByDefinitionVersionIdAsync(string definitionVersionId, string? tenantId = default, CancellationToken cancellationToken = default)
+    {
+        var queryable = _workflowBlueprints.AsQueryable().Where(x => x.VersionId == definitionVersionId);
+
+        if (tenantId != null)
+            queryable = queryable.Where(x => x.TenantId == tenantId);
+
+        var workflowBlueprint = queryable.FirstOrDefault();
+        return new ValueTask<IWorkflowBlueprint?>(workflowBlueprint);
+    }
+
     public override ValueTask<IWorkflowBlueprint?> FindByNameAsync(string name, VersionOptions versionOptions, string? tenantId = default, CancellationToken cancellationToken = default)
     {
         var queryable = _workflowBlueprints.AsQueryable().Where(x => x.Name == name).WithVersion(versionOptions);

--- a/src/core/Elsa.Core/Providers/Workflows/ProgrammaticWorkflowProvider.cs
+++ b/src/core/Elsa.Core/Providers/Workflows/ProgrammaticWorkflowProvider.cs
@@ -36,6 +36,12 @@ namespace Elsa.Providers.Workflows
             return new ValueTask<IWorkflowBlueprint?>(workflowBlueprint);
         }
 
+        public override ValueTask<IWorkflowBlueprint?> FindByDefinitionVersionIdAsync(string definitionVersionId, string? tenantId = default, CancellationToken cancellationToken = default)
+        {
+            var workflowBlueprint = GetWorkflows().FirstOrDefault(x => x.VersionId == definitionVersionId);
+            return new ValueTask<IWorkflowBlueprint?>(workflowBlueprint);
+        }
+
         public override ValueTask<IWorkflowBlueprint?> FindByNameAsync(string name, VersionOptions versionOptions, string? tenantId = default, CancellationToken cancellationToken = default)
         {
             var workflowBlueprint = GetWorkflows().FirstOrDefault(x => string.Equals(x.Name, name, StringComparison.OrdinalIgnoreCase) && x.WithVersion(versionOptions));

--- a/src/core/Elsa.Core/Services/Workflows/WorkflowRegistry.cs
+++ b/src/core/Elsa.Core/Services/Workflows/WorkflowRegistry.cs
@@ -27,6 +27,9 @@ namespace Elsa.Services.Workflows
         public async Task<IWorkflowBlueprint?> FindAsync(string definitionId, VersionOptions versionOptions, string? tenantId = default, CancellationToken cancellationToken = default) =>
             await FindInternalAsync(provider => provider.FindAsync(definitionId, versionOptions, tenantId, cancellationToken), cancellationToken);
 
+        public async Task<IWorkflowBlueprint?> FindByDefinitionVersionIdAsync(string definitionVersionId, string? tenantId = default, CancellationToken cancellationToken = default) =>
+            await FindInternalAsync(provider => provider.FindByDefinitionVersionIdAsync(definitionVersionId, tenantId, cancellationToken), cancellationToken);
+
         public async Task<IWorkflowBlueprint?> FindByNameAsync(string name, VersionOptions versionOptions, string? tenantId = default, CancellationToken cancellationToken = default) =>
             await FindInternalAsync(provider => provider.FindByNameAsync(name, versionOptions, tenantId, cancellationToken), cancellationToken);
 

--- a/src/designer/elsa-workflows-studio/src/components/screens/workflow-instance-viewer/elsa-workflow-instance-journal/elsa-workflow-instance-journal.tsx
+++ b/src/designer/elsa-workflows-studio/src/components/screens/workflow-instance-viewer/elsa-workflow-instance-journal/elsa-workflow-instance-journal.tsx
@@ -350,7 +350,7 @@ export class ElsaWorkflowInstanceJournal {
     const activityModel = !!this.workflowModel && this.selectedActivityId ? this.workflowModel.activities.find(x => x.activityId === this.selectedActivityId) : null;
 
     if (!activityModel)
-      return <p>No activity selected</p>;
+      return <p class="elsa-mt-4">No activity selected</p>;
 
     // Hide expressions field from properties so that we only display the evaluated value.
     const model = {...activityModel, properties: activityModel.properties.map(x => ({name: x.name, value: x.value}))}

--- a/src/modules/datamasking/Elsa.DataMasking.Core/Abstractions/ActivityStateFilter.cs
+++ b/src/modules/datamasking/Elsa.DataMasking.Core/Abstractions/ActivityStateFilter.cs
@@ -1,0 +1,23 @@
+using System.Threading.Tasks;
+using Elsa.DataMasking.Core.Contracts;
+using Elsa.DataMasking.Core.Models;
+
+namespace Elsa.DataMasking.Core.Abstractions;
+
+/// <summary>
+/// A base class for activity state filters.
+/// </summary>
+public abstract class ActivityStateFilter : IActivityStateFilter
+{
+    async ValueTask IActivityStateFilter.ApplyAsync(ActivityStateFilterContext context) => await ApplyAsync(context);
+
+    protected virtual Task ApplyAsync(ActivityStateFilterContext context)
+    {
+        Apply(context);
+        return Task.CompletedTask;
+    }
+
+    protected virtual void Apply(ActivityStateFilterContext context)
+    {
+    }
+}

--- a/src/modules/datamasking/Elsa.DataMasking.Core/Abstractions/HttpEndpointWorkflowJournalFilter.cs
+++ b/src/modules/datamasking/Elsa.DataMasking.Core/Abstractions/HttpEndpointWorkflowJournalFilter.cs
@@ -1,0 +1,59 @@
+using System.Threading.Tasks;
+using Elsa.DataMasking.Core.Contracts;
+using Elsa.DataMasking.Core.Models;
+using Newtonsoft.Json.Linq;
+
+namespace Elsa.DataMasking.Core.Abstractions;
+
+/// <summary>
+/// A base class for workflow journal filters for HTTP Endpoints.
+/// </summary>
+public abstract class HttpEndpointWorkflowJournalFilter : IWorkflowJournalFilter
+{
+    protected virtual ValueTask ProcessInboundRequestAsync(WorkflowJournalFilterContext context, JToken inboundRequest)
+    {
+        ProcessInboundRequest(context, inboundRequest);
+        return new();
+    }
+
+    protected virtual void ProcessInboundRequest(WorkflowJournalFilterContext context, JToken inboundRequest)
+    {
+    }
+
+    protected virtual ValueTask<bool> GetSupportsPathAsync(WorkflowJournalFilterContext context, string path) => new(GetSupportsPath(context, path));
+    protected virtual bool GetSupportsPath(WorkflowJournalFilterContext context, string path) => true;
+    protected virtual ValueTask<JToken> ProcessBodyAsync(WorkflowJournalFilterContext context, JToken body) => new(ProcessBody(context, body));
+    protected virtual JToken ProcessBody(WorkflowJournalFilterContext context, JToken body) => body;
+    protected virtual ValueTask<JToken> ProcessRawBodyAsync(WorkflowJournalFilterContext context, JToken rawBody) => new(ProcessRawBody(context, rawBody));
+    protected virtual JToken ProcessRawBody(WorkflowJournalFilterContext context, JToken rawBody) => rawBody;
+    protected virtual ValueTask<JToken> ProcessHeadersAsync(WorkflowJournalFilterContext context, JToken headers) => new(ProcessHeaders(context, headers));
+    protected virtual JToken ProcessHeaders(WorkflowJournalFilterContext context, JToken headers) => headers;
+
+    async ValueTask IWorkflowJournalFilter.ApplyAsync(WorkflowJournalFilterContext context) => await ApplyAsync(context);
+
+    protected virtual async ValueTask ApplyAsync(WorkflowJournalFilterContext context)
+    {
+        // We're only interested in journal records related to the HttpEndpoint activity. 
+        if (context.Record.ActivityType != "HttpEndpoint")
+            return;
+
+        // The HTTP endpoint receives user passwords - we do not want to store these in the workflow journal!
+        var data = context.Record.Data;
+
+        if (data == null)
+            return;
+
+        if (!data.TryGetValue("Inbound Request", out var inboundRequest))
+            return;
+
+        var path = inboundRequest["path"]!.Value<string>()!;
+
+        if (!await GetSupportsPathAsync(context, path))
+            return;
+
+        await ProcessInboundRequestAsync(context, inboundRequest);
+        inboundRequest["body"] = await ProcessBodyAsync(context, inboundRequest["body"]!);
+        inboundRequest["rawBody"] = await ProcessRawBodyAsync(context, inboundRequest["rawBody"]!);
+        inboundRequest["headers"] = await ProcessHeadersAsync(context, inboundRequest["headers"]!);
+    }
+}

--- a/src/modules/datamasking/Elsa.DataMasking.Core/Abstractions/WorkflowJournalFilter.cs
+++ b/src/modules/datamasking/Elsa.DataMasking.Core/Abstractions/WorkflowJournalFilter.cs
@@ -1,0 +1,23 @@
+using System.Threading.Tasks;
+using Elsa.DataMasking.Core.Contracts;
+using Elsa.DataMasking.Core.Models;
+
+namespace Elsa.DataMasking.Core.Abstractions;
+
+/// <summary>
+/// A base class for workflow journal filters.
+/// </summary>
+public abstract class WorkflowJournalFilter : IWorkflowJournalFilter
+{
+    async ValueTask IWorkflowJournalFilter.ApplyAsync(WorkflowJournalFilterContext context) => await ApplyAsync(context);
+
+    protected virtual Task ApplyAsync(WorkflowJournalFilterContext context)
+    {
+        Apply(context);
+        return Task.CompletedTask;
+    }
+
+    protected virtual void Apply(WorkflowJournalFilterContext context)
+    {
+    }
+}

--- a/src/modules/datamasking/Elsa.DataMasking.Core/Contracts/IActivityStateFilter.cs
+++ b/src/modules/datamasking/Elsa.DataMasking.Core/Contracts/IActivityStateFilter.cs
@@ -1,0 +1,12 @@
+using System.Threading.Tasks;
+using Elsa.DataMasking.Core.Models;
+
+namespace Elsa.DataMasking.Core.Contracts;
+
+/// <summary>
+/// Implement this interface to filter or mask sensitive data that is about to be displayed in the workflow designer 
+/// </summary>
+public interface IActivityStateFilter
+{
+    ValueTask ApplyAsync(ActivityStateFilterContext context);
+}

--- a/src/modules/datamasking/Elsa.DataMasking.Core/Contracts/IWorkflowJournalFilter.cs
+++ b/src/modules/datamasking/Elsa.DataMasking.Core/Contracts/IWorkflowJournalFilter.cs
@@ -1,0 +1,12 @@
+﻿using System.Threading.Tasks;
+using Elsa.DataMasking.Core.Models;
+
+namespace Elsa.DataMasking.Core.Contracts;
+
+/// <summary>
+/// Implement this interface to filter or mask sensitive data that is about to be stored in the workflow journal. 
+/// </summary>
+public interface IWorkflowJournalFilter
+{
+    ValueTask ApplyAsync(WorkflowJournalFilterContext context);
+}

--- a/src/modules/datamasking/Elsa.DataMasking.Core/Elsa.DataMasking.Core.csproj
+++ b/src/modules/datamasking/Elsa.DataMasking.Core/Elsa.DataMasking.Core.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <Import Project="..\..\..\..\common.props" />
+    <Import Project="..\..\..\..\configureawait.props" />
+
+    <PropertyGroup>
+        <TargetFramework>netstandard2.1</TargetFramework>
+        <Description>
+            Elsa Data Masking is an optional part of Elsa Workflows that adds masking of recorded data to the system.
+        </Description>
+        <PackageTags>elsa, masking, redaction, gdpr, pii</PackageTags>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\core\Elsa.Core\Elsa.Core.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <Folder Include="Filters" />
+    </ItemGroup>
+
+</Project>

--- a/src/modules/datamasking/Elsa.DataMasking.Core/Elsa.DataMasking.Core.csproj
+++ b/src/modules/datamasking/Elsa.DataMasking.Core/Elsa.DataMasking.Core.csproj
@@ -18,10 +18,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\..\core\Elsa.Core\Elsa.Core.csproj" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <Folder Include="Filters" />
+        <ProjectReference Include="..\..\..\server\Elsa.Server.Core\Elsa.Server.Core.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/modules/datamasking/Elsa.DataMasking.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/modules/datamasking/Elsa.DataMasking.Core/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,12 @@
+using Elsa.DataMasking.Core.Handlers;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Elsa.DataMasking.Core.Extensions;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddDataMasking(this IServiceCollection services)
+    {
+        return services.AddNotificationHandlersFrom<ApplyWorkflowJournalFilters>();
+    }
+}

--- a/src/modules/datamasking/Elsa.DataMasking.Core/FodyWeavers.xml
+++ b/src/modules/datamasking/Elsa.DataMasking.Core/FodyWeavers.xml
@@ -1,0 +1,3 @@
+﻿<Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
+  <ConfigureAwait />
+</Weavers>

--- a/src/modules/datamasking/Elsa.DataMasking.Core/Handlers/ApplyActivityStateFilters.cs
+++ b/src/modules/datamasking/Elsa.DataMasking.Core/Handlers/ApplyActivityStateFilters.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Elsa.DataMasking.Core.Contracts;
+using Elsa.DataMasking.Core.Models;
+using Elsa.Server.Core.Events;
+using MediatR;
+
+namespace Elsa.DataMasking.Core.Handlers;
+
+public class ApplyActivityStateFilters : INotificationHandler<RequestingWorkflowInstance>
+{
+    private readonly IEnumerable<IActivityStateFilter> _filters;
+
+    public ApplyActivityStateFilters(IEnumerable<IActivityStateFilter> filters)
+    {
+        _filters = filters;
+    }
+    
+    public async Task Handle(RequestingWorkflowInstance notification, CancellationToken cancellationToken)
+    {
+        var workflowBlueprint = notification.WorkflowBlueprint;
+        var activityData = notification.WorkflowInstance.ActivityData;
+
+        foreach (var entry in activityData.Where(x => x.Key != workflowBlueprint.Id))
+        {
+            var activityId = entry.Key;
+            var activityBlueprint = workflowBlueprint.GetActivity(activityId)!;
+            var context = new ActivityStateFilterContext(entry.Value, activityBlueprint);
+
+            foreach (var filter in _filters) await filter.ApplyAsync(context);
+        }
+    }
+}

--- a/src/modules/datamasking/Elsa.DataMasking.Core/Handlers/ApplyWorkflowJournalFilters.cs
+++ b/src/modules/datamasking/Elsa.DataMasking.Core/Handlers/ApplyWorkflowJournalFilters.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Elsa.DataMasking.Core.Contracts;
+using Elsa.DataMasking.Core.Models;
+using Elsa.Events;
+using MediatR;
+
+namespace Elsa.DataMasking.Core.Handlers;
+
+public class ApplyWorkflowJournalFilters : INotificationHandler<SavingWorkflowExecutionLog>
+{
+    private readonly IEnumerable<IWorkflowJournalFilter> _filters;
+
+    public ApplyWorkflowJournalFilters(IEnumerable<IWorkflowJournalFilter> filters)
+    {
+        _filters = filters;
+    }
+    
+    public async Task Handle(SavingWorkflowExecutionLog notification, CancellationToken cancellationToken)
+    {
+        var records = notification.Records;
+
+        foreach (var filter in _filters)
+        {
+            foreach (var executionLogRecord in records)
+            {
+                var context = new WorkflowJournalFilterContext(executionLogRecord);
+                await filter.ApplyAsync(context);
+            }    
+        }
+        
+    }
+}

--- a/src/modules/datamasking/Elsa.DataMasking.Core/IsExternalInit.cs
+++ b/src/modules/datamasking/Elsa.DataMasking.Core/IsExternalInit.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel;
+
+// ReSharper disable once CheckNamespace
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// Reserved to be used by the compiler for tracking metadata.
+    /// This class should not be used by developers in source code.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    internal static class IsExternalInit
+    {
+    }
+}

--- a/src/modules/datamasking/Elsa.DataMasking.Core/Models/ActivityStateFilterContext.cs
+++ b/src/modules/datamasking/Elsa.DataMasking.Core/Models/ActivityStateFilterContext.cs
@@ -1,0 +1,7 @@
+using System.Collections.Generic;
+using Elsa.Models;
+using Elsa.Services.Models;
+
+namespace Elsa.DataMasking.Core.Models;
+
+public record ActivityStateFilterContext(IDictionary<string, object?> ActivityData, IActivityBlueprint ActivityBlueprint);

--- a/src/modules/datamasking/Elsa.DataMasking.Core/Models/HttpEndpointWorkflowJournalFilterContext.cs
+++ b/src/modules/datamasking/Elsa.DataMasking.Core/Models/HttpEndpointWorkflowJournalFilterContext.cs
@@ -1,0 +1,6 @@
+using Elsa.Models;
+using Newtonsoft.Json.Linq;
+
+namespace Elsa.DataMasking.Core.Models;
+
+public record HttpEndpointWorkflowJournalFilterContext(WorkflowExecutionLogRecord Record, JToken RequestModel, string Path, JToken Body, JToken RawBody) : WorkflowJournalFilterContext(Record);

--- a/src/modules/datamasking/Elsa.DataMasking.Core/Models/WorkflowJournalFilterContext.cs
+++ b/src/modules/datamasking/Elsa.DataMasking.Core/Models/WorkflowJournalFilterContext.cs
@@ -1,0 +1,6 @@
+using Elsa.Models;
+using Elsa.Services.Models;
+
+namespace Elsa.DataMasking.Core.Models;
+
+public record WorkflowJournalFilterContext(WorkflowExecutionLogRecord Record);

--- a/src/samples/aspnet/Elsa.Samples.MaskPii/Activities/StoreUser.cs
+++ b/src/samples/aspnet/Elsa.Samples.MaskPii/Activities/StoreUser.cs
@@ -1,6 +1,7 @@
 using Elsa.ActivityResults;
 using Elsa.Attributes;
 using Elsa.Builders;
+using Elsa.Expressions;
 using Elsa.Samples.MaskPii.Models;
 using Elsa.Services;
 using Elsa.Services.Models;
@@ -9,7 +10,7 @@ namespace Elsa.Samples.MaskPii.Activities;
 
 public class StoreUser : Activity
 {
-    [ActivityInput(Hint = "The user object to persist")]
+    [ActivityInput(Hint = "The user object to persist", SupportedSyntaxes = new[] { SyntaxNames.JavaScript, SyntaxNames.Liquid })]
     public User User { get; set; } = default!;
 
     protected override IActivityExecutionResult OnExecute()

--- a/src/samples/aspnet/Elsa.Samples.MaskPii/Activities/StoreUser.cs
+++ b/src/samples/aspnet/Elsa.Samples.MaskPii/Activities/StoreUser.cs
@@ -1,0 +1,25 @@
+using Elsa.ActivityResults;
+using Elsa.Attributes;
+using Elsa.Builders;
+using Elsa.Samples.MaskPii.Models;
+using Elsa.Services;
+using Elsa.Services.Models;
+
+namespace Elsa.Samples.MaskPii.Activities;
+
+public class StoreUser : Activity
+{
+    [ActivityInput(Hint = "The user object to persist")]
+    public User User { get; set; } = default!;
+
+    protected override IActivityExecutionResult OnExecute()
+    {
+        Console.WriteLine("Saving user {0}", User.Username);
+        return Done();
+    }
+}
+
+public static class StoreUserExtensions
+{
+    public static ISetupActivity<StoreUser> WithUser(this ISetupActivity<StoreUser> activity, Func<ActivityExecutionContext, User> value) => activity.Set(x => x.User, value);
+}

--- a/src/samples/aspnet/Elsa.Samples.MaskPii/Elsa.Samples.MaskPii.csproj
+++ b/src/samples/aspnet/Elsa.Samples.MaskPii/Elsa.Samples.MaskPii.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\..\activities\Elsa.Activities.Http\Elsa.Activities.Http.csproj" />
+      <ProjectReference Include="..\..\..\core\Elsa\Elsa.csproj" />
+      <ProjectReference Include="..\..\..\modules\datamasking\Elsa.DataMasking.Core\Elsa.DataMasking.Core.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/samples/aspnet/Elsa.Samples.MaskPii/Elsa.Samples.MaskPii.csproj
+++ b/src/samples/aspnet/Elsa.Samples.MaskPii/Elsa.Samples.MaskPii.csproj
@@ -10,6 +10,8 @@
       <ProjectReference Include="..\..\..\activities\Elsa.Activities.Http\Elsa.Activities.Http.csproj" />
       <ProjectReference Include="..\..\..\core\Elsa\Elsa.csproj" />
       <ProjectReference Include="..\..\..\modules\datamasking\Elsa.DataMasking.Core\Elsa.DataMasking.Core.csproj" />
+      <ProjectReference Include="..\..\..\persistence\Elsa.Persistence.EntityFramework\Elsa.Persistence.EntityFramework.Sqlite\Elsa.Persistence.EntityFramework.Sqlite.csproj" />
+      <ProjectReference Include="..\..\..\server\Elsa.Server.Api\Elsa.Server.Api.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/samples/aspnet/Elsa.Samples.MaskPii/Filters/RedactPasswordFilter.cs
+++ b/src/samples/aspnet/Elsa.Samples.MaskPii/Filters/RedactPasswordFilter.cs
@@ -1,0 +1,30 @@
+using Elsa.DataMasking.Core.Abstractions;
+using Elsa.DataMasking.Core.Models;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Elsa.Samples.MaskPii.Filters;
+
+/// <summary>
+/// Redacts user passwords received on HTTP Endpoint activities.
+/// </summary>
+public class RedactPasswordFilter : HttpEndpointWorkflowJournalFilter
+{
+    protected override bool GetSupportsPath(WorkflowJournalFilterContext context, string path) => path == "/workflows/users/signup";
+
+    protected override JToken ProcessBody(WorkflowJournalFilterContext context, JToken body)
+    {
+        body["password"] = JValue.CreateString("****");
+        return body;
+    }
+
+    protected override JToken ProcessRawBody(WorkflowJournalFilterContext context, JToken rawBody)
+    {
+        // Parse the raw body string so we can access its password field as well. 
+        var rawBodyModel = JObject.Parse(rawBody.Value<string>()!);
+        rawBodyModel["Password"] = JValue.CreateString("****");
+
+        // Update the rawBody field.
+        return rawBodyModel.ToString(Formatting.Indented);
+    }
+}

--- a/src/samples/aspnet/Elsa.Samples.MaskPii/Filters/RedactPasswordFromHttpRequestFilter.cs
+++ b/src/samples/aspnet/Elsa.Samples.MaskPii/Filters/RedactPasswordFromHttpRequestFilter.cs
@@ -8,7 +8,7 @@ namespace Elsa.Samples.MaskPii.Filters;
 /// <summary>
 /// Redacts user passwords received on HTTP Endpoint activities.
 /// </summary>
-public class RedactPasswordFilter : HttpEndpointWorkflowJournalFilter
+public class RedactPasswordFromHttpRequestFilter : HttpEndpointWorkflowJournalFilter
 {
     protected override bool GetSupportsPath(WorkflowJournalFilterContext context, string path) => path == "/workflows/users/signup";
 

--- a/src/samples/aspnet/Elsa.Samples.MaskPii/Filters/RedactPasswordFromStoreUserActivityFilter.cs
+++ b/src/samples/aspnet/Elsa.Samples.MaskPii/Filters/RedactPasswordFromStoreUserActivityFilter.cs
@@ -1,0 +1,18 @@
+using Elsa.DataMasking.Core.Abstractions;
+using Elsa.DataMasking.Core.Models;
+using Elsa.Samples.MaskPii.Activities;
+using Elsa.Samples.MaskPii.Models;
+
+namespace Elsa.Samples.MaskPii.Filters;
+
+public class RedactPasswordFromStoreUserActivityFilter : ActivityStateFilter
+{
+    protected override void Apply(ActivityStateFilterContext context)
+    {
+        // We're only interested in our StoreUser activity.
+        if (context.ActivityBlueprint.Type != nameof(StoreUser)) return;
+
+        // Redact the password field.
+        if (context.ActivityData["User"] is User user) context.ActivityData["User"] = user with { Password = "****" };
+    }
+}

--- a/src/samples/aspnet/Elsa.Samples.MaskPii/Models/User.cs
+++ b/src/samples/aspnet/Elsa.Samples.MaskPii/Models/User.cs
@@ -1,0 +1,3 @@
+namespace Elsa.Samples.MaskPii.Models;
+
+public record User(string Username, string Password);

--- a/src/samples/aspnet/Elsa.Samples.MaskPii/Program.cs
+++ b/src/samples/aspnet/Elsa.Samples.MaskPii/Program.cs
@@ -1,0 +1,33 @@
+using Elsa.DataMasking.Core.Contracts;
+using Elsa.DataMasking.Core.Extensions;
+using Elsa.Samples.MaskPii.Filters;
+
+var builder = WebApplication.CreateBuilder(args);
+var services = builder.Services;
+
+// Register a workflow journal filter that masks user passwords.
+services.AddSingleton<IWorkflowJournalFilter, RedactPasswordFilter>();
+
+// Register the "data masking" module.
+services.AddDataMasking();
+
+// Register Elsa services.
+services
+    .AddElsa(elsa => elsa
+        // Register HTTP activities.
+        .AddHttpActivities(options => options.BasePath = "/workflows")
+
+        // Register custom activities from this assembly.
+        .AddActivitiesFrom<Program>()
+
+        // Register workflows from this assembly.
+        .AddWorkflowsFrom<Program>());
+
+var app = builder.Build();
+
+// Install HTTP Endpoint middleware that invokes our workflows that use HTTP Endpoint activities. 
+app.UseHttpActivities();
+
+// Display a default welcome page in case nothing matches the HTTP request.
+app.UseWelcomePage();
+app.Run();

--- a/src/samples/aspnet/Elsa.Samples.MaskPii/Program.cs
+++ b/src/samples/aspnet/Elsa.Samples.MaskPii/Program.cs
@@ -1,19 +1,33 @@
 using Elsa.DataMasking.Core.Contracts;
 using Elsa.DataMasking.Core.Extensions;
+using Elsa.Persistence.EntityFramework.Core.Extensions;
+using Elsa.Persistence.EntityFramework.Sqlite;
 using Elsa.Samples.MaskPii.Filters;
 
 var builder = WebApplication.CreateBuilder(args);
 var services = builder.Services;
 
-// Register a workflow journal filter that masks user passwords.
-services.AddSingleton<IWorkflowJournalFilter, RedactPasswordFilter>();
-
 // Register the "data masking" module.
 services.AddDataMasking();
+
+// Register a workflow journal filter that masks user passwords.
+services.AddSingleton<IWorkflowJournalFilter, RedactPasswordFromHttpRequestFilter>();
+
+// Register an activity state filter that masks user passwords.
+services.AddSingleton<IActivityStateFilter, RedactPasswordFromStoreUserActivityFilter>();
+
+// Add API endpoints for workflow designer.
+services.AddElsaApiEndpoints();
+
+// Configure CORS.
+services.AddCors(cors => cors.AddDefaultPolicy(policy => policy.AllowAnyHeader().AllowAnyMethod().AllowAnyOrigin()));
 
 // Register Elsa services.
 services
     .AddElsa(elsa => elsa
+        // Use persistence
+        .UseEntityFrameworkPersistence(ef => ef.UseSqlite())
+
         // Register HTTP activities.
         .AddHttpActivities(options => options.BasePath = "/workflows")
 
@@ -21,12 +35,16 @@ services
         .AddActivitiesFrom<Program>()
 
         // Register workflows from this assembly.
-        .AddWorkflowsFrom<Program>());
+        .AddWorkflowsFrom<Program>()
+    );
 
 var app = builder.Build();
 
 // Install HTTP Endpoint middleware that invokes our workflows that use HTTP Endpoint activities. 
 app.UseHttpActivities();
+app.UseRouting();
+app.UseCors();
+app.UseEndpoints(endpoints => endpoints.MapControllers());
 
 // Display a default welcome page in case nothing matches the HTTP request.
 app.UseWelcomePage();

--- a/src/samples/aspnet/Elsa.Samples.MaskPii/Properties/launchSettings.json
+++ b/src/samples/aspnet/Elsa.Samples.MaskPii/Properties/launchSettings.json
@@ -1,0 +1,13 @@
+﻿{
+  "profiles": {
+    "Elsa.Samples.MaskPii": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:7134",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/samples/aspnet/Elsa.Samples.MaskPii/Workflows/UserRegistrationWorkflow.cs
+++ b/src/samples/aspnet/Elsa.Samples.MaskPii/Workflows/UserRegistrationWorkflow.cs
@@ -1,0 +1,25 @@
+using Elsa.Activities.Http;
+using Elsa.Activities.Http.Models;
+using Elsa.Builders;
+using Elsa.Samples.MaskPii.Activities;
+using Elsa.Samples.MaskPii.Models;
+
+namespace Elsa.Samples.MaskPii.Workflows;
+
+public class UserRegistrationWorkflow : IWorkflow
+{
+    public void Build(IWorkflowBuilder builder)
+    {
+        builder
+            // Build an endpoint that receives user credentials.
+            .HttpEndpoint(httpEndpoint => httpEndpoint
+                .WithPath("/users/signup")
+                .WithMethod(HttpMethods.Post)
+                .WithReadContent()
+                .WithTargetType<User>())
+
+            // Store the user in the database;
+            .Then<StoreUser>(storeUser => storeUser
+                .WithUser(context => context.GetInput<HttpRequestModel>()!.GetBody<User>()));
+    }
+}

--- a/src/samples/aspnet/Elsa.Samples.MaskPii/appsettings.json
+++ b/src/samples/aspnet/Elsa.Samples.MaskPii/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/src/samples/aspnet/Elsa.Samples.MaskPii/signup-user.http
+++ b/src/samples/aspnet/Elsa.Samples.MaskPii/signup-user.http
@@ -1,0 +1,9 @@
+POST https://localhost:7134/workflows/users/signup
+Content-Type: application/json
+
+{
+    "UserName": "lindsey91",
+    "Password": "This is actually quite a secure password!"
+}
+
+###

--- a/src/server/Elsa.Server.Api/Elsa.Server.Api.csproj
+++ b/src/server/Elsa.Server.Api/Elsa.Server.Api.csproj
@@ -16,7 +16,7 @@
     <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1'">
         <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.16" />
     </ItemGroup>
-    
+
     <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0'">
         <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.10" />
     </ItemGroup>
@@ -26,7 +26,7 @@
     </ItemGroup>
 
     <ItemGroup>
-            <FrameworkReference Include="Microsoft.AspNetCore.App" />
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.0.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
@@ -40,6 +40,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\core\Elsa\Elsa.csproj" />
+        <ProjectReference Include="..\Elsa.Server.Core\Elsa.Server.Core.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/server/Elsa.Server.Core/Elsa.Server.Core.csproj
+++ b/src/server/Elsa.Server.Core/Elsa.Server.Core.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <Import Project="..\..\..\common.props" />
+    <Import Project="..\..\..\configureawait.props" />
+    
+    <PropertyGroup>
+        <TargetFramework>netstandard2.1</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Description>
+            Elsa is a set of workflow libraries and tools that enable lean and mean workflowing capabilities in any .NET Core application.
+            This package provides core services and abstractions that other modules can consume in order to integrate with the Elsa API endpoints.
+        </Description>
+        <PackageTags>elsa, workflows, asp.net core</PackageTags>
+    </PropertyGroup>
+    
+    <ItemGroup>
+      <ProjectReference Include="..\..\core\Elsa.Abstractions\Elsa.Abstractions.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/server/Elsa.Server.Core/Events/RequestingWorkflowInstance.cs
+++ b/src/server/Elsa.Server.Core/Events/RequestingWorkflowInstance.cs
@@ -1,0 +1,10 @@
+using Elsa.Models;
+using Elsa.Services.Models;
+using MediatR;
+
+namespace Elsa.Server.Core.Events;
+
+/// <summary>
+/// A domain event that is published whenever a workflow instance is requested from an API endpoint. 
+/// </summary>
+public record RequestingWorkflowInstance(WorkflowInstance WorkflowInstance, IWorkflowBlueprint WorkflowBlueprint) : INotification;

--- a/src/server/Elsa.Server.Core/FodyWeavers.xml
+++ b/src/server/Elsa.Server.Core/FodyWeavers.xml
@@ -1,0 +1,3 @@
+﻿<Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
+  <ConfigureAwait />
+</Weavers>

--- a/src/server/Elsa.Server.Core/IsExternalInit.cs
+++ b/src/server/Elsa.Server.Core/IsExternalInit.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel;
+
+// ReSharper disable once CheckNamespace
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// Reserved to be used by the compiler for tracking metadata.
+    /// This class should not be used by developers in source code.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    internal static class IsExternalInit
+    {
+    }
+}


### PR DESCRIPTION
This PR adds a new "data masking" module that allows your application to redact sensitive information.
For example, when your workflow consists of an HTTP endpoint that receives user credentials, you may not want to store these credentials in the workflow journal.

With the data masking module, you can prevent this by implementing `IWorkflowJournalFilter` that provides write-access to workflow journal data in order to redact certain bits of data.

Additionally, you can implement `IActivityStateFilter` to redact potentially sensitive information from activity state being displayed in the workflow instance viewer.

For an example of both types of filters, checkout the `Elsa.Samples.MaskPii` sample project.

Closes #1587 and #2659 