### PR TITLE
Ensure the front-end HttpClient is only created once

### DIFF
--- a/src/designer/elsa-workflows-studio/src/services/elsa-client.ts
+++ b/src/designer/elsa-workflows-studio/src/services/elsa-client.ts
@@ -35,15 +35,13 @@ export const createHttpClient = async function (baseAddress: string): Promise<Ax
   const config: AxiosRequestConfig = {
     baseURL: baseAddress
   };
+  _httpClient = axios.create(config);
+  const service = new Service(_httpClient);
 
   await eventBus.emit(EventTypes.HttpClientConfigCreated, this, {config});
+  await eventBus.emit(EventTypes.HttpClientCreated, this, {service, _httpClient});
 
-  const httpClient = axios.create(config);
-  const service = new Service(httpClient);
-
-  await eventBus.emit(EventTypes.HttpClientCreated, this, {service, httpClient});
-
-  return _httpClient = httpClient;
+  return _httpClient;
 }
 
 export const createElsaClient = async function (serverUrl: string): Promise<ElsaClient> {


### PR DESCRIPTION
In the `createHttpClient` function, assigning the `HttpClient` singleton after awaiting other operations allows a quick succession of calls to `#createHttpClient` to instantiate multiple `HttpClient` instances and overwrite the singleton instance.

Performing creation and assignment of the `HttpClient` before any asynchronous operations ensures that sequential invocations of `#createHttpClient` operate on the same `HttpClient` instance.

The sequence of operations is _roughly_ as follows:

![HttpClient Singleton Assignment](https://user-images.githubusercontent.com/6382057/155942485-2e67ba7c-779e-4e57-998f-5805db213989.png)

Currently, creation of the `HttpClient` instance takes place in step `A1` and `A2`. Assignment take place in steps `B1` and `B2`.

This causes the `HttpClient` singleton to be overwritten when `createElsaClient` is invoked before a previous execution has completed.

Moving assignment of the `HttpClient` singleton to step `A1`, before invoking any asynchronous tasts, causes the same instance to be used in step `A2`.

This PR addresses #2789 