### PR TITLE
Bump Automapper Version to 11

### DIFF
--- a/src/activities/webhooks/Elsa.Webhooks.Persistence.YesSql/Elsa.Webhooks.Persistence.YesSql.csproj
+++ b/src/activities/webhooks/Elsa.Webhooks.Persistence.YesSql/Elsa.Webhooks.Persistence.YesSql.csproj
@@ -13,7 +13,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AutoMapper" Version="10.1.1" />
+        <PackageReference Include="AutoMapper" Version="11.0.1" />
         <PackageReference Include="YesSql.Core" Version="3.0.7" />
         <PackageReference Include="YesSql.Provider.Sqlite" Version="3.0.7" />
     </ItemGroup>

--- a/src/core/Elsa.Core/Elsa.Core.csproj
+++ b/src/core/Elsa.Core/Elsa.Core.csproj
@@ -15,8 +15,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AutoMapper" Version="10.1.1" />
-        <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
+        <PackageReference Include="AutoMapper" Version="11.0.1" />
+        <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
         <PackageReference Include="DistributedLock.Core" Version="1.0.4" />
         <PackageReference Include="DistributedLock.FileSystem" Version="1.0.1" />
         <PackageReference Include="Humanizer.Core" Version="2.13.14" />

--- a/src/core/Elsa.Core/Extensions/PrimitiveExtensions.cs
+++ b/src/core/Elsa.Core/Extensions/PrimitiveExtensions.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Reflection;
+
+namespace Elsa 
+{
+    public static class PrimitiveExtensions 
+    {
+        public static Type GetTypeOfNullable(this Type type)
+        {
+            return type.GetTypeInfo().GenericTypeArguments[0];
+        }
+    }
+}


### PR DESCRIPTION
This PR updates Elsa to use Automapper Version 11 as the latest supported version