### PR TITLE
Workflow Testing UI Improvement

### DIFF
--- a/src/designer/elsa-workflows-studio/src/components/designers/tree/elsa-designer-tree/elsa-designer-tree.tsx
+++ b/src/designer/elsa-workflows-studio/src/components/designers/tree/elsa-designer-tree/elsa-designer-tree.tsx
@@ -957,10 +957,10 @@ export class ElsaWorkflowDesigner {
       <Host class="workflow-canvas elsa-flex-1 elsa-flex" ref={el => (this.el = el)}>
         {this.mode == WorkflowDesignerMode.Test ?
           <div>
-            <div id="left" style={{border:`4px solid orange`, position:`fixed`, zIndex:`10`, height: `calc(100vh - 64px)`, width:`4px`, top:`64`, bottom:`0`, left:`0`}}/>
-            <div id="right" style={{border:`4px solid orange`, position:`fixed`, zIndex:`10`, height: `calc(100vh - 64px)`, width:`4px`, top:`64`, bottom:`0`, right:`0`}}/>
-            <div id="top" style={{border:`4px solid orange`, position:`fixed`, zIndex:`10`, height:`4px`, left:`0`, right:`0`, top:`30`}}/>
-            <div id="bottom" style={{border:`4px solid orange`, position:`fixed`, zIndex:`10`, height:`4px`, left:`0`, right:`0`, bottom:`0`}}/>
+            <div id="left" style={{border:`4px solid orange`, position:`fixed`, height: `calc(100vh - 64px)`, width:`4px`, top:`64`, bottom:`0`, left:`0`}}/>
+            <div id="right" style={{border:`4px solid orange`, position:`fixed`, height: `calc(100vh - 64px)`, width:`4px`, top:`64`, bottom:`0`, right:`0`}}/>
+            <div id="top" style={{border:`4px solid orange`, position:`fixed`, height:`4px`, left:`0`, right:`0`, top:`30`}}/>
+            <div id="bottom" style={{border:`4px solid orange`, position:`fixed`, height:`4px`, left:`0`, right:`0`, bottom:`0`}}/>
           </div>
           :
           undefined

--- a/src/designer/elsa-workflows-studio/src/components/screens/workflow-definition-editor/elsa-workflow-test-panel/localizations.ts
+++ b/src/designer/elsa-workflows-studio/src/components/screens/workflow-definition-editor/elsa-workflow-test-panel/localizations.ts
@@ -4,7 +4,9 @@ export const resources = {
       'ExecuteWorkflow': 'Execute Workflow',
       'StopWorkflow': 'Stop Workflow',
       'EntryEndpoint': 'Entry Endpoint',
-      'Status': 'Status'
+      'Status': 'Status',
+      'RestartInstanceConfirmationModel.Title': 'Workflow Is Already Running',
+      'RestartInstanceConfirmationModel.Message': 'Seems like there is another instance of this workflow already running. Would you like to stop it and start a new one?'
     }
   },
   'zh-CN': {
@@ -12,7 +14,9 @@ export const resources = {
       'ExecuteWorkflow': '执行工作流程',
       'StopWorkflow': '停止工作流程',
       'EntryEndpoint': '输入端点',
-      'Status': '状态'
+      'Status': '状态',
+      'RestartInstanceConfirmationModel.Title': '工作流已经在运行',
+      'RestartInstanceConfirmationModel.Message': '此工作流的另一个实例似乎已在运行。你想停止它并开始一个新的吗？'
     }
   },
   'nl-NL': {
@@ -20,7 +24,9 @@ export const resources = {
       'ExecuteWorkflow': 'Werkstroom uitvoeren',
       'StopWorkflow': 'Werkstroom stoppen',
       'EntryEndpoint': 'Invoer eindpunt',
-      'Status': 'Toestand'
+      'Status': 'Toestand',
+      'RestartInstanceConfirmationModel.Title': 'Werkstroom Is Al Actief',
+      'RestartInstanceConfirmationModel.Message': 'Het lijkt erop dat er al een ander exemplaar van deze workflow actief is. Wil je het stoppen en een nieuwe beginnen?'
     }
   }
 };

--- a/src/designer/elsa-workflows-studio/src/services/elsa-client.ts
+++ b/src/designer/elsa-workflows-studio/src/services/elsa-client.ts
@@ -129,7 +129,8 @@ export const createElsaClient = async function (serverUrl: string): Promise<Elsa
     },
     workflowTestApi: {
       execute: async (request) => {
-        await httpClient.post<void>(`v1/workflow-test/execute`, request);
+          const response = await httpClient.post<WorkflowTestExecuteResponse>(`v1/workflow-test/execute`, request);
+          return response.data;
       },
       restartFromActivity: async (request) => {
         await httpClient.post<void>(`v1/workflow-test/restartFromActivity`, request);
@@ -347,7 +348,7 @@ export interface WorkflowDefinitionsApi {
 
 export interface WorkflowTestApi {
 
-  execute(request: WorkflowTestExecuteRequest): Promise<void>;
+  execute(request: WorkflowTestExecuteRequest): Promise<WorkflowTestExecuteResponse>;
 
   restartFromActivity(request: WorkflowTestRestartFromActivityRequest): Promise<void>;
 
@@ -461,6 +462,11 @@ export interface WorkflowTestRestartFromActivityRequest {
 
 export interface WorkflowTestStopRequest {
   workflowInstanceId: string
+}
+
+export interface WorkflowTestExecuteResponse{
+  isSuccess: boolean,
+  isAnotherInstanceRunning: boolean
 }
 
 export interface ExportWorkflowResponse {

--- a/src/modules/workflowtesting/Elsa.WorkflowTesting.Api/Endpoints/Execute.cs
+++ b/src/modules/workflowtesting/Elsa.WorkflowTesting.Api/Endpoints/Execute.cs
@@ -26,8 +26,7 @@ namespace Elsa.WorkflowTesting.Api.Endpoints
 
         [HttpPost]
         [ElsaJsonFormatter]
-        [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(WorkflowTestExecuteRequest))]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(WorkflowTestExecuteResponse))]
         [SwaggerOperation(
             Summary = "Executes the specified workflow definition version in test mode.",
             Description = "Executes the specified workflow definition version in test mode.",
@@ -41,7 +40,7 @@ namespace Elsa.WorkflowTesting.Api.Endpoints
             var startableWorkflow = await _workflowLaunchpad.FindStartableWorkflowAsync(request.WorkflowDefinitionId, request.Version, default, testCorrelation, default, tenantId, cancellationToken);
 
             if (startableWorkflow == null)
-                return NotFound();
+                return Ok(new WorkflowTestExecuteResponse { IsSuccess = false, IsAnotherInstanceRunning = true });
 
             startableWorkflow.WorkflowInstance.SetMetadata("isTest", true);
             startableWorkflow.WorkflowInstance.SetMetadata("signalRConnectionId", request.SignalRConnectionId);
@@ -51,7 +50,7 @@ namespace Elsa.WorkflowTesting.Api.Endpoints
             if (Response.HasStarted)
                 return new EmptyResult();
 
-            return Ok();
+            return Ok(new WorkflowTestExecuteResponse { IsSuccess = true });
         }
     }
 }

--- a/src/modules/workflowtesting/Elsa.WorkflowTesting.Api/Models/WorkflowTestExecuteResponse.cs
+++ b/src/modules/workflowtesting/Elsa.WorkflowTesting.Api/Models/WorkflowTestExecuteResponse.cs
@@ -1,0 +1,8 @@
+namespace Elsa.WorkflowTesting.Api.Models
+{
+    public class WorkflowTestExecuteResponse
+    {
+        public bool IsSuccess { get; set; }
+        public bool IsAnotherInstanceRunning { get; set; }
+    }
+}


### PR DESCRIPTION
Currently, when workflow is executed from test panel and there is already an instance of this workflow running (typical scenario - execute workflow with blocking activity and refresh the page) - there is no feedback telling user what exactly is going on. Developer tools will display 404 error, but that tells very little as well.

I've added confirmation modal for this scenario, that is asking if user wants to stop current instance and start a new one.