### PR TITLE
Native JSON variable handling

### DIFF
--- a/src/server/Elsa.Server.Api/Converters/VariablesConverter.cs
+++ b/src/server/Elsa.Server.Api/Converters/VariablesConverter.cs
@@ -1,11 +1,7 @@
 using System;
-using System.Collections.Generic;
-using System.Dynamic;
-using System.Linq;
 using Elsa.Models;
 using Elsa.Serialization;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace Elsa.Server.Api.Converters;
 

--- a/src/server/Elsa.Server.Api/Endpoints/WorkflowDefinitions/Save.cs
+++ b/src/server/Elsa.Server.Api/Endpoints/WorkflowDefinitions/Save.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Dynamic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -10,7 +9,6 @@ using Elsa.Server.Api.Swagger.Examples;
 using Elsa.Services;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Newtonsoft.Json.Linq;
 using Swashbuckle.AspNetCore.Annotations;
 using Swashbuckle.AspNetCore.Filters;
 


### PR DESCRIPTION
This PR updates the way workflow variables are passed into Jint by converting them from `JObject` to `ExpandoObject` and back again when variables are updated using the `setVariable` JS function.

This solves the issue where you wouldn't be able to predefine  workflow variables without specifying a type as outlined in #2668.