### PR TITLE
update SqlClient and EFCore.BulkExtensions version

### DIFF
--- a/src/activities/Elsa.Activities.SQL/Elsa.Activities.Sql.csproj
+++ b/src/activities/Elsa.Activities.SQL/Elsa.Activities.Sql.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
     
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="4.1.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="2.1.4" />
   </ItemGroup>
 
     <ItemGroup>

--- a/src/activities/webhooks/Elsa.Webhooks.Persistence.EntityFramework.Core/Elsa.Webhooks.Persistence.EntityFramework.Core.csproj
+++ b/src/activities/webhooks/Elsa.Webhooks.Persistence.EntityFramework.Core/Elsa.Webhooks.Persistence.EntityFramework.Core.csproj
@@ -23,7 +23,7 @@
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0'">
-        <PackageReference Include="EFCore.BulkExtensions" Version="6.2.3" />
+        <PackageReference Include="EFCore.BulkExtensions" Version="6.2.9" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.1" />
     </ItemGroup>
 

--- a/src/modules/workflowsettings/Elsa.WorkflowSettings.Persistence.EntityFramework.Core/Elsa.WorkflowSettings.Persistence.EntityFramework.Core.csproj
+++ b/src/modules/workflowsettings/Elsa.WorkflowSettings.Persistence.EntityFramework.Core/Elsa.WorkflowSettings.Persistence.EntityFramework.Core.csproj
@@ -12,13 +12,18 @@
         <PackageTags>elsa, workflow settings, efcore</PackageTags>
     </PropertyGroup>
 
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1'">
+        <PackageReference Include="EFCore.BulkExtensions" Version="5.4.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.10" />
+    </ItemGroup>
+
     <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0'">
         <PackageReference Include="EFCore.BulkExtensions" Version="5.4.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.10" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0'">
-        <PackageReference Include="EFCore.BulkExtensions" Version="6.2.3" />
+        <PackageReference Include="EFCore.BulkExtensions" Version="6.2.9" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.1" />
     </ItemGroup>
 

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/Elsa.Persistence.EntityFramework.Core.csproj
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/Elsa.Persistence.EntityFramework.Core.csproj
@@ -18,7 +18,7 @@
     </ItemGroup>
     
     <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0'">
-        <PackageReference Include="EFCore.BulkExtensions" Version="6.2.3" />
+        <PackageReference Include="EFCore.BulkExtensions" Version="6.2.9" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.1" />
     </ItemGroup>
 


### PR DESCRIPTION
As discussed in https://github.com/elsa-workflows/elsa-core/pull/2841. `Microsoft.Data.SqlClient` v4 introduces breaking changes that affects Sql Server connections.

Both `EntitiyFramework.SqlServer` and newer versions of `EFCore.BulkExtensions` are targeting 2.1.4 as minimum version.

Users are free to choose a higher version by explicitly adding the reference.