### PR TITLE
Fix Composite Activity Timing/Occurrence and measurement in UI Journal

### DIFF
--- a/src/designer/elsa-workflows-studio/src/components/screens/workflow-instance-viewer/elsa-workflow-instance-journal/elsa-workflow-instance-journal.tsx
+++ b/src/designer/elsa-workflows-studio/src/components/screens/workflow-instance-viewer/elsa-workflow-instance-journal/elsa-workflow-instance-journal.tsx
@@ -152,7 +152,14 @@ export class ElsaWorkflowInstanceJournal {
     const selectedRecordId = this.selectedRecordId;
 
     const renderRecord = (record: WorkflowExecutionLogRecord, index: number) => {
-      const prevItem = allItems[allItems.indexOf(items[index]) - 1];
+      var prevItemReverseIndex = allItems
+        .slice(0, allItems.indexOf(items[index]))
+        .reverse()
+        .findIndex((e)=>{
+          return (e.activityId == record.activityId);
+        });
+
+      const prevItem = allItems[allItems.indexOf(items[index]) - (prevItemReverseIndex+1)];
       const currentTimestamp = moment(record.timestamp);
       const prevTimestamp = moment(prevItem.timestamp);
       const deltaTime = moment.duration(currentTimestamp.diff(prevTimestamp));


### PR DESCRIPTION
This PR aims to fix the composite Activity Timing/Occurrence in the stats. (refer to #2871 )

Because the use of Composite activity create two activities before/after the child activities, the statistics are wrong : 
- occurrence are x2
- Timing doesn't reflect the duration of all the child activities.

The proposal is to filter the fired events for Composite activity to be sure to fire only :
- the beginning of the first composite activity
- the end of the last composite activity

With this remark, we can see that begin/end are not necessary in a straightforward sequence, so UI journal for composite activity also need to be updated (front). --> about this remark, maybe this information should be taken from the stats api? 