### PR TITLE
Fixing the Azure Worker Processor

### DIFF
--- a/src/activities/Elsa.Activities.AzureServiceBus/Services/Worker.cs
+++ b/src/activities/Elsa.Activities.AzureServiceBus/Services/Worker.cs
@@ -49,7 +49,7 @@ namespace Elsa.Activities.AzureServiceBus.Services
                 MaxConcurrentCalls = options.Value.MaxConcurrentCalls
             };
 
-            _processor = subscription == null ? serviceBusClient.CreateProcessor(queueOrTopic, processorOptions) : serviceBusClient.CreateProcessor(queueOrTopic, subscription, processorOptions);
+            _processor = string.IsNullOrEmpty(subscription) ? serviceBusClient.CreateProcessor(queueOrTopic, processorOptions) : serviceBusClient.CreateProcessor(queueOrTopic, subscription, processorOptions);
             _processor.ProcessMessageAsync += OnMessageReceivedAsync;
             _processor.ProcessErrorAsync += OnErrorAsync;
         }


### PR DESCRIPTION
As the worker is created under WorkerManager.cs as per
```
worker = ActivatorUtilities.CreateInstance<Worker>(_serviceProvider, queueOrTopic, subscription ?? "", RemoveWorkerAsync);
```
The case of
```
subscription == null 
```
will never be fired and it will try to process a subscription with a empty name. This causes the Error event handler to be called which then disposes of the _processor early resulting in the following error.

System.ObjectDisposedException: The message processor is unable to continue and will stop processing; the host application has closed the connection to the Service Bus service. Object name: 'ServiceBusConnection'.

This pull request fixes this scenario where a queue is used, and not a topic/subscription model.

