### PR TITLE
Compensation

### DIFF
--- a/Elsa.sln
+++ b/Elsa.sln
@@ -403,6 +403,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.DataMasking.Core", "sr
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Activities.Http.OpenApi", "src\activities\Elsa.Activities.Http.OpenApi\Elsa.Activities.Http.OpenApi.csproj", "{F9731DF7-CEB1-4B9B-8838-803275E301E4}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Samples.CompensationConsole", "src\samples\console\Elsa.Samples.CompensationConsole\Elsa.Samples.CompensationConsole.csproj", "{962653DD-BFE7-4DDB-9B3D-5AC8C222F43F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -965,6 +967,10 @@ Global
 		{F9731DF7-CEB1-4B9B-8838-803275E301E4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F9731DF7-CEB1-4B9B-8838-803275E301E4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F9731DF7-CEB1-4B9B-8838-803275E301E4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{962653DD-BFE7-4DDB-9B3D-5AC8C222F43F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{962653DD-BFE7-4DDB-9B3D-5AC8C222F43F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{962653DD-BFE7-4DDB-9B3D-5AC8C222F43F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{962653DD-BFE7-4DDB-9B3D-5AC8C222F43F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1146,6 +1152,7 @@ Global
 		{2C75C427-94D8-4F20-821C-20582BDB865B} = {69BB424A-AAA3-415C-9651-9F4349CA3AC5}
 		{1208F7DC-1CFF-48B4-A7A8-1F7EFD12CA89} = {2C75C427-94D8-4F20-821C-20582BDB865B}
 		{F9731DF7-CEB1-4B9B-8838-803275E301E4} = {B43B546E-23F3-46E8-ACB7-D04F05CDA180}
+		{962653DD-BFE7-4DDB-9B3D-5AC8C222F43F} = {FC9F520F-BA51-4AD2-BFEE-EF787798E734}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8B0975FD-7050-48B0-88C5-48C33378E158}

--- a/Elsa.sln.DotSettings
+++ b/Elsa.sln.DotSettings
@@ -13,6 +13,7 @@
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Autofixture/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Compensable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Configurer/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Interruptor/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=localizer/@EntryIndexedValue">True</s:Boolean>

--- a/src/core/Elsa.Abstractions/Events/WorkflowFaulting.cs
+++ b/src/core/Elsa.Abstractions/Events/WorkflowFaulting.cs
@@ -1,0 +1,14 @@
+using Elsa.Services;
+using Elsa.Services.Models;
+
+namespace Elsa.Events;
+
+/// <summary>
+/// Published when a workflow transitioned into the Faulted state but execution is still inside the worker loop.
+/// </summary>
+public class WorkflowFaulting : ActivityNotification
+{
+    public WorkflowFaulting(ActivityExecutionContext activityExecutionContext, IActivity activity) : base(activityExecutionContext, activity)
+    {
+    }
+}

--- a/src/core/Elsa.Abstractions/OutcomeNames.cs
+++ b/src/core/Elsa.Abstractions/OutcomeNames.cs
@@ -8,5 +8,9 @@ namespace Elsa
         public const string False = "False";
         public const string Iterate = "Iterate";
         public const string Default = "Default";
+        public const string Body = "Body";
+        public const string Compensate = "Compensate";
+        public const string Cancel = "Cancel";
+        public const string Confirm = "Confirm";
     }
 }

--- a/src/core/Elsa.Abstractions/Services/Compensation/ICompensationService.cs
+++ b/src/core/Elsa.Abstractions/Services/Compensation/ICompensationService.cs
@@ -14,4 +14,9 @@ public interface ICompensationService
     /// Invokes the specified compensation activity.
     /// </summary>
     void Compensate(ActivityExecutionContext activityExecutionContext, string compensableActivityId, Exception? exception = default, string? message = default);
+    
+    /// <summary>
+    /// Confirms the specified compensation activity.
+    /// </summary>
+    void Confirm(ActivityExecutionContext activityExecutionContext, string compensableActivityId);
 }

--- a/src/core/Elsa.Abstractions/Services/Compensation/ICompensationService.cs
+++ b/src/core/Elsa.Abstractions/Services/Compensation/ICompensationService.cs
@@ -1,0 +1,17 @@
+using System;
+using Elsa.Services.Models;
+
+namespace Elsa.Services.Compensation;
+
+public interface ICompensationService
+{
+    /// <summary>
+    /// Attempts to invoke any compensation activity in the inbound trajectory of the faulting activity.
+    /// </summary>
+    void Compensate(ActivityExecutionContext activityExecutionContext, Exception? exception = default, string? message = default);
+    
+    /// <summary>
+    /// Invokes the specified compensation activity.
+    /// </summary>
+    void Compensate(ActivityExecutionContext activityExecutionContext, string compensableActivityId, Exception? exception = default, string? message = default);
+}

--- a/src/core/Elsa.Abstractions/Services/Models/WorkflowExecutionContext.cs
+++ b/src/core/Elsa.Abstractions/Services/Models/WorkflowExecutionContext.cs
@@ -53,6 +53,11 @@ namespace Elsa.Services.Models
         /// </summary>
         public Variables TransientState { get; set; } = new();
 
+        /// <summary>
+        /// The current exception, if any.
+        /// </summary>
+        public Exception? Exception { get; private set; }
+
         public void ScheduleActivities(IEnumerable<string> activityIds, object? input = null)
         {
             foreach (var activityId in activityIds)
@@ -183,6 +188,7 @@ namespace Elsa.Services.Models
             WorkflowInstance.WorkflowStatus = WorkflowStatus.Faulted;
             WorkflowInstance.FaultedAt = clock.GetCurrentInstant();
             WorkflowInstance.Fault = new WorkflowFault(SimpleException.FromException(exception), message, activityId, activityInput, resuming);
+            Exception = exception;
         }
 
         public void Cancel(Exception? exception, string message, string? activityId, object? activityInput, bool resuming)

--- a/src/core/Elsa.Abstractions/Services/Models/WorkflowExecutionContext.cs
+++ b/src/core/Elsa.Abstractions/Services/Models/WorkflowExecutionContext.cs
@@ -33,7 +33,7 @@ namespace Elsa.Services.Models
             IsFirstPass = true;
             Serializer = serviceProvider.GetRequiredService<JsonSerializer>();
             Mediator = serviceProvider.GetRequiredService<IMediator>();
-            
+
             // This is a service that needs to be bound to the same lifetime scope as the workflow execution context.
             WorkflowExecutionLog = ActivatorUtilities.CreateInstance<WorkflowExecutionLog>(serviceProvider);
         }
@@ -117,7 +117,7 @@ namespace Elsa.Services.Models
         public T? GetVariable<T>() => GetVariable<T>(typeof(T).Name);
         public T? GetVariable<T>(string name) => GetMergedVariables().Get<T>(name);
         public bool HasVariable(string name) => GetMergedVariables().Has(name);
-        
+
         /// <summary>
         /// Gets a variable from across all scopes, starting with the current scope, going up each scope until the requested variable is found.
         /// </summary>
@@ -127,7 +127,7 @@ namespace Elsa.Services.Models
             var mergedVariables = GetMergedVariables();
             return mergedVariables.Get(name);
         }
-        
+
         /// <summary>
         /// Gets all variables merged across all scopes.
         /// </summary>
@@ -185,6 +185,14 @@ namespace Elsa.Services.Models
             WorkflowInstance.Fault = new WorkflowFault(SimpleException.FromException(exception), message, activityId, activityInput, resuming);
         }
 
+        public void Cancel(Exception? exception, string message, string? activityId, object? activityInput, bool resuming)
+        {
+            var clock = ServiceProvider.GetRequiredService<IClock>();
+            WorkflowInstance.WorkflowStatus = WorkflowStatus.Cancelled;
+            WorkflowInstance.CancelledAt = clock.GetCurrentInstant();
+            WorkflowInstance.Fault = new WorkflowFault(SimpleException.FromException(exception), message, activityId, activityInput, resuming);
+        }
+
         public async Task CompleteAsync()
         {
             // Remove all blocking activities.
@@ -196,7 +204,23 @@ namespace Elsa.Services.Models
                 await EvictScopeAsync(scope);
 
             WorkflowInstance.Scopes = new SimpleStack<ActivityScope>();
-            WorkflowInstance.WorkflowStatus = WorkflowStatus.Finished;
+            var now = ServiceProvider.GetRequiredService<IClock>().GetCurrentInstant();
+
+            if(WorkflowInstance.GetMetadata("Compensated") as bool? == true)
+            {
+                WorkflowInstance.WorkflowStatus = WorkflowStatus.Cancelled;
+                WorkflowInstance.CancelledAt = now;
+            }
+            if(WorkflowInstance.Fault != null)
+            {
+                WorkflowInstance.WorkflowStatus = WorkflowStatus.Faulted;
+                WorkflowInstance.FaultedAt = now;
+            }
+            else
+            {
+                WorkflowInstance.WorkflowStatus = WorkflowStatus.Finished;
+                WorkflowInstance.FinishedAt = now;
+            }
         }
 
         public IActivityBlueprint? GetActivityBlueprintById(string id) => WorkflowBlueprint.Activities.FirstOrDefault(x => x.Id == id);
@@ -208,32 +232,33 @@ namespace Elsa.Services.Models
 
             if (activityBlueprint == null)
                 throw new Exception($"No activity found with name {activityName}");
-            
+
             return await GetActivityPropertyAsync(activityBlueprint, propertyName, cancellationToken);
         }
 
-        public async ValueTask<T?> GetNamedActivityPropertyAsync<T>(string activityName, string propertyName, CancellationToken cancellationToken = default) => (T?) await GetNamedActivityPropertyAsync(activityName, propertyName, cancellationToken);
-        
+        public async ValueTask<T?> GetNamedActivityPropertyAsync<T>(string activityName, string propertyName, CancellationToken cancellationToken = default) =>
+            (T?)await GetNamedActivityPropertyAsync(activityName, propertyName, cancellationToken);
+
         public async Task<T?> GetNamedActivityPropertyAsync<TActivity, T>(string activityName, Expression<Func<TActivity, T>> propertyExpression, CancellationToken cancellationToken = default) where TActivity : IActivity
         {
-            var expression = (MemberExpression) propertyExpression.Body;
+            var expression = (MemberExpression)propertyExpression.Body;
             string propertyName = expression.Member.Name;
             return await GetNamedActivityPropertyAsync<T>(activityName, propertyName, cancellationToken);
         }
-        
+
         public async Task<T?> GetActivityPropertyAsync<TActivity, T>(string activityId, Expression<Func<TActivity, T>> propertyExpression, CancellationToken cancellationToken = default) where TActivity : IActivity
         {
-            var expression = (MemberExpression) propertyExpression.Body;
+            var expression = (MemberExpression)propertyExpression.Body;
             string propertyName = expression.Member.Name;
             return await GetActivityPropertyAsync<T>(activityId, propertyName, cancellationToken);
         }
-        
+
         public async Task<T?> GetActivityPropertyAsync<T>(string activityId, string propertyName, CancellationToken cancellationToken = default)
         {
             var activityBlueprint = GetActivityBlueprintById(activityId)!;
             return await GetActivityPropertyAsync<T>(activityBlueprint, propertyName, cancellationToken);
         }
-        
+
         public async Task<T?> GetActivityPropertyAsync<T>(IActivityBlueprint activityBlueprint, string propertyName, CancellationToken cancellationToken = default)
         {
             var value = await GetActivityPropertyAsync(activityBlueprint, propertyName, cancellationToken);
@@ -247,25 +272,25 @@ namespace Elsa.Services.Models
             var context = new WorkflowStorageContext(WorkflowInstance, activityBlueprint.Id);
             return await workflowStorageService.LoadAsync(storageProviderName, context, propertyName, cancellationToken);
         }
-        
+
         public void SetWorkflowContext(object? value) => WorkflowContext = value;
         public object? GetWorkflowContext() => WorkflowContext;
-        public T GetWorkflowContext<T>() => (T) WorkflowContext!;
-        
+        public T GetWorkflowContext<T>() => (T)WorkflowContext!;
+
         public IDictionary<string, object?> GetActivityData(string activityId)
         {
             var activityData = WorkflowInstance.ActivityData;
             var state = activityData.ContainsKey(activityId) ? activityData[activityId] : default;
 
-            if (state != null) 
+            if (state != null)
                 return state;
-            
+
             state = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
             activityData[activityId] = state;
 
             return state;
         }
-        
+
         public void AddEntry(IActivityBlueprint activityBlueprint, string eventName, string? message, object? data) => AddEntry(activityBlueprint.Id, activityBlueprint.Type, eventName, message, data);
 
         public void AddEntry(string activityId, string activityType, string eventName, string? message, object? data)

--- a/src/core/Elsa.Core/Activities/Compensation/Compensable/Compensable.cs
+++ b/src/core/Elsa.Core/Activities/Compensation/Compensable/Compensable.cs
@@ -1,12 +1,16 @@
 using Elsa.ActivityResults;
 using Elsa.Attributes;
+using Elsa.Exceptions;
 using Elsa.Services;
 using Elsa.Services.Models;
 
 // ReSharper disable once CheckNamespace
 namespace Elsa.Activities.Compensation;
 
-[Activity(Category = "Compensation", Description = "Allow work that executed after this activity to be undone.", Outcomes = new[]{ OutcomeNames.Body, OutcomeNames.Compensate, OutcomeNames.Cancel, OutcomeNames.Confirm, OutcomeNames.Done })]
+[Activity(
+    Category = "Compensation", 
+    Description = "Allow work that executed after this activity to be undone.", 
+    Outcomes = new[] { OutcomeNames.Body, OutcomeNames.Compensate, OutcomeNames.Cancel, OutcomeNames.Confirm, OutcomeNames.Done })]
 public class Compensable : Activity
 {
     public bool EnteredScope
@@ -14,32 +18,47 @@ public class Compensable : Activity
         get => GetState<bool>();
         set => SetState(value);
     }
-    
+
     public bool Entered
     {
         get => GetState<bool>();
         set => SetState(value);
     }
-    
+
     public bool Compensating
     {
         get => GetState<bool>();
         set => SetState(value);
     }
-    
+
     public bool Cancelling
     {
         get => GetState<bool>();
         set => SetState(value);
     }
-    
+
+    public bool Confirming
+    {
+        get => GetState<bool>();
+        set => SetState(value);
+    }
+
+    public bool Confirmed
+    {
+        get => GetState<bool>();
+        set => SetState(value);
+    }
+
     protected override IActivityExecutionResult OnExecute(ActivityExecutionContext context)
     {
         if (Compensating)
         {
+            if (Confirmed)
+                throw new WorkflowException("Cannot compensate a confirmed compensable activity");
+
             if (EnteredScope)
             {
-                if(!Cancelling)
+                if (!Cancelling)
                 {
                     Cancelling = true;
                     return Outcome(OutcomeNames.Cancel);
@@ -51,17 +70,33 @@ public class Compensable : Activity
 
             return Outcome(OutcomeNames.Compensate);
         }
-        
+
         if (!context.WorkflowInstance.Scopes.Contains(x => x.ActivityId == Id))
         {
             if (!EnteredScope)
             {
                 context.CreateScope();
                 EnteredScope = true;
+
+                if (Confirming)
+                    if (Confirmed)
+                        throw new WorkflowException("Cannot confirm an already-confirmed compensable activity");
+                    else
+                        return Outcome(OutcomeNames.Confirm);
             }
             else
             {
                 EnteredScope = false;
+
+                if (Confirming)
+                {
+                    Confirmed = true;
+                    Confirming = false;
+                    
+                    // This activity is done.
+                    return Noop();
+                }
+
                 return Done();
             }
         }

--- a/src/core/Elsa.Core/Activities/Compensation/Compensable/Compensable.cs
+++ b/src/core/Elsa.Core/Activities/Compensation/Compensable/Compensable.cs
@@ -1,0 +1,55 @@
+using Elsa.ActivityResults;
+using Elsa.Attributes;
+using Elsa.Services;
+using Elsa.Services.Models;
+
+namespace Elsa.Activities.Compensation.Compensable;
+
+[Activity(Category = "Compensation", Description = "Allow work that executed after this activity to be undone.", Outcomes = new[]{ OutcomeNames.Body, OutcomeNames.Compensate, OutcomeNames.Cancel, OutcomeNames.Confirm, OutcomeNames.Done })]
+public class Compensable : Activity
+{
+    public bool EnteredScope
+    {
+        get => GetState<bool>();
+        set => SetState(value);
+    }
+    
+    public bool Entered
+    {
+        get => GetState<bool>();
+        set => SetState(value);
+    }
+    
+    public bool Compensating
+    {
+        get => GetState<bool>();
+        set => SetState(value);
+    }
+    
+    protected override IActivityExecutionResult OnExecute(ActivityExecutionContext context)
+    {
+        if (Compensating)
+        {
+            EnteredScope = false;
+            return Outcome(OutcomeNames.Compensate);
+        }
+        
+        if (!context.WorkflowInstance.Scopes.Contains(x => x.ActivityId == Id))
+        {
+            if (!EnteredScope)
+            {
+                context.CreateScope();
+                EnteredScope = true;
+            }
+            else
+            {
+                EnteredScope = false;
+                context.JournalData.Add("Unwinding", true);
+                return Done();
+            }
+        }
+
+        Entered = true;
+        return Outcome(OutcomeNames.Body);
+    }
+}

--- a/src/core/Elsa.Core/Activities/Compensation/Compensate/Compensate.cs
+++ b/src/core/Elsa.Core/Activities/Compensation/Compensate/Compensate.cs
@@ -5,7 +5,8 @@ using Elsa.Expressions;
 using Elsa.Services;
 using Elsa.Services.Models;
 
-namespace Elsa.Activities.Compensation.Compensate;
+// ReSharper disable once CheckNamespace
+namespace Elsa.Activities.Compensation;
 
 [Activity(Category = "Compensation", Description = "Invoke a specific compensable activity.", Outcomes = new[] { OutcomeNames.Done })]
 public class Compensate : Activity

--- a/src/core/Elsa.Core/Activities/Compensation/Compensate/Compensate.cs
+++ b/src/core/Elsa.Core/Activities/Compensation/Compensate/Compensate.cs
@@ -1,0 +1,38 @@
+using Elsa.ActivityResults;
+using Elsa.Attributes;
+using Elsa.Exceptions;
+using Elsa.Expressions;
+using Elsa.Services;
+using Elsa.Services.Models;
+
+namespace Elsa.Activities.Compensation.Compensate;
+
+[Activity(Category = "Compensation", Description = "Invoke a specific compensable activity.", Outcomes = new[] { OutcomeNames.Done })]
+public class Compensate : Activity
+{
+    /// <summary>
+    /// The name of the <see cref="Compensable"/> activity to invoke.
+    /// </summary>
+    [ActivityInput(Hint = "The name of the compensable activity to invoke.", SupportedSyntaxes = new[]{ SyntaxNames.Liquid, SyntaxNames.JavaScript })]
+    public string CompensableActivityName { get; set; } = default!;
+    
+    /// <summary>
+    /// Optional. The message to store as the reason for compensation.
+    /// </summary>
+    [ActivityInput(Hint = "Optional. The message to store as the reason for compensation.", SupportedSyntaxes = new[]{ SyntaxNames.Liquid, SyntaxNames.JavaScript })]
+    public string? Message { get; set; }
+
+    protected override IActivityExecutionResult OnExecute(ActivityExecutionContext context)
+    {
+        if (string.IsNullOrWhiteSpace(CompensableActivityName))
+            throw new WorkflowException("No name specified");
+        
+        var message = Message ?? "Compensating";
+        var compensableActivity = context.WorkflowExecutionContext.GetActivityBlueprintByName(CompensableActivityName);
+        
+        if(compensableActivity == null)
+            throw new WorkflowException($"No activity with name {CompensableActivityName} could be found");
+
+        return new CompensateResult(message, compensableActivityId: compensableActivity.Id);
+    }
+}

--- a/src/core/Elsa.Core/Activities/Compensation/Compensate/CompensateExtensions.cs
+++ b/src/core/Elsa.Core/Activities/Compensation/Compensate/CompensateExtensions.cs
@@ -3,7 +3,8 @@ using System.Threading.Tasks;
 using Elsa.Builders;
 using Elsa.Services.Models;
 
-namespace Elsa.Activities.Compensation.Compensate;
+// ReSharper disable once CheckNamespace
+namespace Elsa.Activities.Compensation;
 
 public static class CompensateExtensions
 {

--- a/src/core/Elsa.Core/Activities/Compensation/Compensate/CompensateExtensions.cs
+++ b/src/core/Elsa.Core/Activities/Compensation/Compensate/CompensateExtensions.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Threading.Tasks;
+using Elsa.Builders;
+using Elsa.Services.Models;
+
+namespace Elsa.Activities.Compensation.Compensate;
+
+public static class CompensateExtensions
+{
+    // CompensableActivityName
+    public static ISetupActivity<Compensate> WithCompensableActivityName(this ISetupActivity<Compensate> activity, Func<ActivityExecutionContext, ValueTask<string?>> value) => activity.Set(x => x.CompensableActivityName, value);
+    public static ISetupActivity<Compensate> WithCompensableActivityName(this ISetupActivity<Compensate> activity, Func<ValueTask<string?>> value) => activity.Set(x => x.CompensableActivityName, value);
+    public static ISetupActivity<Compensate> WithCompensableActivityName(this ISetupActivity<Compensate> activity, Func<ActivityExecutionContext, string?> value) => activity.Set(x => x.CompensableActivityName, value);
+    public static ISetupActivity<Compensate> WithCompensableActivityName(this ISetupActivity<Compensate> activity, Func<string?> value) => activity.Set(x => x.CompensableActivityName, value);
+    public static ISetupActivity<Compensate> WithCompensableActivityName(this ISetupActivity<Compensate> activity, string? value) => activity.Set(x => x.CompensableActivityName, value);
+    
+    // Message
+    public static ISetupActivity<Compensate> WithMessage(this ISetupActivity<Compensate> activity, Func<ActivityExecutionContext, ValueTask<string?>> value) => activity.Set(x => x.Message, value);
+    public static ISetupActivity<Compensate> WithMessage(this ISetupActivity<Compensate> activity, Func<ValueTask<string?>> value) => activity.Set(x => x.Message, value);
+    public static ISetupActivity<Compensate> WithMessage(this ISetupActivity<Compensate> activity, Func<ActivityExecutionContext, string?> value) => activity.Set(x => x.Message, value);
+    public static ISetupActivity<Compensate> WithMessage(this ISetupActivity<Compensate> activity, Func<string?> value) => activity.Set(x => x.Message, value);
+    public static ISetupActivity<Compensate> WithMessage(this ISetupActivity<Compensate> activity, string? value) => activity.Set(x => x.Message, value);
+}

--- a/src/core/Elsa.Core/Activities/Compensation/Confirm/Confirm.cs
+++ b/src/core/Elsa.Core/Activities/Compensation/Confirm/Confirm.cs
@@ -1,0 +1,32 @@
+using Elsa.ActivityResults;
+using Elsa.Attributes;
+using Elsa.Exceptions;
+using Elsa.Expressions;
+using Elsa.Services;
+using Elsa.Services.Models;
+
+// ReSharper disable once CheckNamespace
+namespace Elsa.Activities.Compensation;
+
+[Activity(Category = "Compensation", Description = "Confirm a specific compensable activity.", Outcomes = new[] { OutcomeNames.Done })]
+public class Confirm : Activity
+{
+    /// <summary>
+    /// The name of the <see cref="Compensable"/> activity to invoke.
+    /// </summary>
+    [ActivityInput(Hint = "The name of the compensable activity to confirm.", SupportedSyntaxes = new[]{ SyntaxNames.Liquid, SyntaxNames.JavaScript })]
+    public string CompensableActivityName { get; set; } = default!;
+    
+    protected override IActivityExecutionResult OnExecute(ActivityExecutionContext context)
+    {
+        if (string.IsNullOrWhiteSpace(CompensableActivityName))
+            throw new WorkflowException("No name specified");
+        
+        var compensableActivity = context.WorkflowExecutionContext.GetActivityBlueprintByName(CompensableActivityName);
+        
+        if(compensableActivity == null)
+            throw new WorkflowException($"No activity with name {CompensableActivityName} could be found");
+
+        return new ConfirmResult(compensableActivity.Id);
+    }
+}

--- a/src/core/Elsa.Core/Activities/Compensation/Confirm/ConfirmExtensions.cs
+++ b/src/core/Elsa.Core/Activities/Compensation/Confirm/ConfirmExtensions.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Threading.Tasks;
+using Elsa.Builders;
+using Elsa.Services.Models;
+
+// ReSharper disable once CheckNamespace
+namespace Elsa.Activities.Compensation;
+
+public static class ConfirmExtensions
+{
+    // CompensableActivityName
+    public static ISetupActivity<Confirm> WithCompensableActivityName(this ISetupActivity<Confirm> activity, Func<ActivityExecutionContext, ValueTask<string?>> value) => activity.Set(x => x.CompensableActivityName, value);
+    public static ISetupActivity<Confirm> WithCompensableActivityName(this ISetupActivity<Confirm> activity, Func<ValueTask<string?>> value) => activity.Set(x => x.CompensableActivityName, value);
+    public static ISetupActivity<Confirm> WithCompensableActivityName(this ISetupActivity<Confirm> activity, Func<ActivityExecutionContext, string?> value) => activity.Set(x => x.CompensableActivityName, value);
+    public static ISetupActivity<Confirm> WithCompensableActivityName(this ISetupActivity<Confirm> activity, Func<string?> value) => activity.Set(x => x.CompensableActivityName, value);
+    public static ISetupActivity<Confirm> WithCompensableActivityName(this ISetupActivity<Confirm> activity, string? value) => activity.Set(x => x.CompensableActivityName, value);
+}

--- a/src/core/Elsa.Core/Activities/Primitives/Fault/Fault.cs
+++ b/src/core/Elsa.Core/Activities/Primitives/Fault/Fault.cs
@@ -19,7 +19,7 @@ public class Fault : Activity
     protected override IActivityExecutionResult OnExecute(ActivityExecutionContext context)
     {
         var message = Message ?? "Custom fault";
-        
+        context.JournalData.Add("Error", message);
         return new FaultResult(message);
     }
 }

--- a/src/core/Elsa.Core/Activities/Primitives/Fault/Fault.cs
+++ b/src/core/Elsa.Core/Activities/Primitives/Fault/Fault.cs
@@ -1,0 +1,25 @@
+using Elsa.ActivityResults;
+using Elsa.Attributes;
+using Elsa.Expressions;
+using Elsa.Services;
+using Elsa.Services.Models;
+
+// ReSharper disable once CheckNamespace
+namespace Elsa.Activities.Primitives;
+
+[Activity(Category = "Primitives", Description = "Put the workflow in a faulted state.", Outcomes = new string[0])]
+public class Fault : Activity
+{
+    /// <summary>
+    /// Optional. The message to store as the reason for compensation.
+    /// </summary>
+    [ActivityInput(Hint = "Optional. The message to store as the reason for the fault.", SupportedSyntaxes = new[] { SyntaxNames.Liquid, SyntaxNames.JavaScript })]
+    public string? Message { get; set; }
+
+    protected override IActivityExecutionResult OnExecute(ActivityExecutionContext context)
+    {
+        var message = Message ?? "Custom fault";
+        
+        return new FaultResult(message);
+    }
+}

--- a/src/core/Elsa.Core/Activities/Primitives/Fault/Fault.cs
+++ b/src/core/Elsa.Core/Activities/Primitives/Fault/Fault.cs
@@ -11,7 +11,7 @@ namespace Elsa.Activities.Primitives;
 public class Fault : Activity
 {
     /// <summary>
-    /// Optional. The message to store as the reason for compensation.
+    /// Optional. The message to store as the reason for faulting.
     /// </summary>
     [ActivityInput(Hint = "Optional. The message to store as the reason for the fault.", SupportedSyntaxes = new[] { SyntaxNames.Liquid, SyntaxNames.JavaScript })]
     public string? Message { get; set; }

--- a/src/core/Elsa.Core/Activities/Primitives/Fault/FaultExtensions.cs
+++ b/src/core/Elsa.Core/Activities/Primitives/Fault/FaultExtensions.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Threading.Tasks;
+using Elsa.Builders;
+using Elsa.Services.Models;
+
+// ReSharper disable once CheckNamespace
+namespace Elsa.Activities.Primitives;
+
+public static class FaultExtensions
+{
+    // Message
+    public static ISetupActivity<Fault> WithMessage(this ISetupActivity<Fault> activity, Func<ActivityExecutionContext, ValueTask<string?>> value) => activity.Set(x => x.Message, value);
+    public static ISetupActivity<Fault> WithMessage(this ISetupActivity<Fault> activity, Func<ValueTask<string?>> value) => activity.Set(x => x.Message, value);
+    public static ISetupActivity<Fault> WithMessage(this ISetupActivity<Fault> activity, Func<ActivityExecutionContext, string?> value) => activity.Set(x => x.Message, value);
+    public static ISetupActivity<Fault> WithMessage(this ISetupActivity<Fault> activity, Func<string?> value) => activity.Set(x => x.Message, value);
+    public static ISetupActivity<Fault> WithMessage(this ISetupActivity<Fault> activity, string? value) => activity.Set(x => x.Message, value);
+}

--- a/src/core/Elsa.Core/ActivityResults/CompensateResult.cs
+++ b/src/core/Elsa.Core/ActivityResults/CompensateResult.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Linq;
-using Elsa.Activities.Compensation.Compensable;
-using Elsa.Exceptions;
+using Elsa.Services.Compensation;
 using Elsa.Services.Models;
 
 namespace Elsa.ActivityResults;
@@ -31,66 +29,11 @@ public class CompensateResult : ActivityExecutionResult
     
     private void Compensate(ActivityExecutionContext activityExecutionContext)
     {
+        var compensationService = activityExecutionContext.GetService<ICompensationService>();
+        
         if (string.IsNullOrWhiteSpace(CompensableActivityId))
-            CompensateAutomatically(activityExecutionContext);
+            compensationService.Compensate(activityExecutionContext, Exception, Message);
         else
-            CompensateExplicitly(activityExecutionContext, CompensableActivityId);
-    }
-
-    private void CompensateExplicitly(ActivityExecutionContext activityExecutionContext, string compensableActivityId)
-    {
-        var faultingActivityId = activityExecutionContext.ActivityId;
-        var compensableActivity = activityExecutionContext.WorkflowExecutionContext.WorkflowBlueprint.GetActivity(compensableActivityId);
-
-        if (compensableActivity == null)
-            throw new WorkflowException($"No activity with ID {compensableActivityId} could be found");
-        
-        var activityData = activityExecutionContext.WorkflowInstance.ActivityData[compensableActivity.Id];
-        
-        // Prepare the state of the compensable activity.
-        activityData[nameof(Compensable.Compensating)] = true;
-
-        // Schedule the compensable activity.
-        activityExecutionContext.WorkflowExecutionContext.ScheduleActivity(compensableActivity.Id);
-        
-        activityExecutionContext.WorkflowInstance.SetMetadata("Compensated", true);
-        activityExecutionContext.WorkflowExecutionContext.Cancel(Exception, Message, faultingActivityId, activityExecutionContext.Input, activityExecutionContext.Resuming);
-    }
-
-    private void CompensateAutomatically(ActivityExecutionContext activityExecutionContext)
-    {
-        var faultingActivityId = activityExecutionContext.ActivityId;
-        var inboundPath = activityExecutionContext.WorkflowExecutionContext.GetInboundActivityPath(faultingActivityId).ToList();
-        var inboundCompensableActivities = activityExecutionContext.WorkflowExecutionContext.WorkflowBlueprint.GetActivities(inboundPath).Where(x => x.Type == nameof(Compensable)).ToList();
-        var hasCompensableActivities = false;
-
-        foreach (var compensableActivity in inboundCompensableActivities)
-        {
-            var activityData = activityExecutionContext.WorkflowInstance.ActivityData[compensableActivity.Id];
-
-            if (!activityData.TryGetValue(nameof(Compensable.Entered), out var entered))
-                continue;
-
-            if (entered as bool? != true)
-                continue;
-
-            hasCompensableActivities = true;
-            
-            // Prepare the state of the compensable activity.
-            activityData[nameof(Compensable.Compensating)] = true;
-
-            // Schedule the compensable activity.
-            activityExecutionContext.WorkflowExecutionContext.ScheduleActivity(compensableActivity.Id);
-        }
-
-        if (!hasCompensableActivities)
-        {
-            activityExecutionContext.WorkflowExecutionContext.Fault(Exception, Message, faultingActivityId, activityExecutionContext.Input, activityExecutionContext.Resuming);
-        }
-        else
-        {
-            activityExecutionContext.WorkflowInstance.SetMetadata("Compensated", true);
-            activityExecutionContext.WorkflowExecutionContext.Cancel(Exception, Message, faultingActivityId, activityExecutionContext.Input, activityExecutionContext.Resuming);
-        }
+            compensationService.Compensate(activityExecutionContext, CompensableActivityId, Exception, Message);
     }
 }

--- a/src/core/Elsa.Core/ActivityResults/CompensateResult.cs
+++ b/src/core/Elsa.Core/ActivityResults/CompensateResult.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Linq;
+using Elsa.Activities.Compensation.Compensable;
+using Elsa.Services.Models;
+
+namespace Elsa.ActivityResults;
+
+public class CompensateResult : ActivityExecutionResult
+{ 
+    public CompensateResult(string message, Exception? exception = default)
+    {
+        Message = message;
+        Exception = exception;
+    }
+
+    public string Message { get; }
+    public Exception? Exception { get; }
+
+    protected override void Execute(ActivityExecutionContext activityExecutionContext)
+    {
+        // If the workflow contains compensable activities, schedule these instead of throwing an exception.
+        Compensate(activityExecutionContext);
+    }
+    
+    private void Compensate(ActivityExecutionContext activityExecutionContext)
+    {
+        var faultingActivityId = activityExecutionContext.ActivityId;
+        var inboundPath = activityExecutionContext.WorkflowExecutionContext.GetInboundActivityPath(faultingActivityId).ToList();
+        var inboundCompensableActivities = activityExecutionContext.WorkflowExecutionContext.WorkflowBlueprint.GetActivities(inboundPath).Where(x => x.Type == nameof(Compensable)).ToList();
+        var hasCompensableActivities = false;
+
+        foreach (var compensableActivity in inboundCompensableActivities)
+        {
+            var activityData = activityExecutionContext.WorkflowInstance.ActivityData[compensableActivity.Id];
+
+            if (!activityData.TryGetValue(nameof(Compensable.Entered), out var entered))
+                continue;
+
+            if (entered as bool? != true)
+                continue;
+
+            hasCompensableActivities = true;
+            
+            // Prepare the state of the compensable activity.
+            activityData[nameof(Compensable.Compensating)] = true;
+
+            // Schedule the compensable activity.
+            activityExecutionContext.WorkflowExecutionContext.ScheduleActivity(compensableActivity.Id);
+        }
+
+        if (!hasCompensableActivities)
+        {
+            activityExecutionContext.WorkflowExecutionContext.Fault(Exception, Message, faultingActivityId, activityExecutionContext.Input, activityExecutionContext.Resuming);
+        }
+        else
+        {
+            activityExecutionContext.WorkflowInstance.SetMetadata("Compensated", true);
+            activityExecutionContext.WorkflowExecutionContext.Cancel(Exception, Message, faultingActivityId, activityExecutionContext.Input, activityExecutionContext.Resuming);
+        }
+    }
+}

--- a/src/core/Elsa.Core/ActivityResults/CompensateResult.cs
+++ b/src/core/Elsa.Core/ActivityResults/CompensateResult.cs
@@ -1,20 +1,27 @@
 using System;
 using System.Linq;
 using Elsa.Activities.Compensation.Compensable;
+using Elsa.Exceptions;
 using Elsa.Services.Models;
 
 namespace Elsa.ActivityResults;
 
 public class CompensateResult : ActivityExecutionResult
 { 
-    public CompensateResult(string message, Exception? exception = default)
+    public CompensateResult(string message, Exception? exception = default, string? compensableActivityId = default)
     {
         Message = message;
         Exception = exception;
+        CompensableActivityId = compensableActivityId;
     }
 
     public string Message { get; }
     public Exception? Exception { get; }
+    
+    /// <summary>
+    /// The ID of a specific compensable activity to invoke.
+    /// </summary>
+    public string? CompensableActivityId { get; }
 
     protected override void Execute(ActivityExecutionContext activityExecutionContext)
     {
@@ -23,6 +30,34 @@ public class CompensateResult : ActivityExecutionResult
     }
     
     private void Compensate(ActivityExecutionContext activityExecutionContext)
+    {
+        if (string.IsNullOrWhiteSpace(CompensableActivityId))
+            CompensateAutomatically(activityExecutionContext);
+        else
+            CompensateExplicitly(activityExecutionContext, CompensableActivityId);
+    }
+
+    private void CompensateExplicitly(ActivityExecutionContext activityExecutionContext, string compensableActivityId)
+    {
+        var faultingActivityId = activityExecutionContext.ActivityId;
+        var compensableActivity = activityExecutionContext.WorkflowExecutionContext.WorkflowBlueprint.GetActivity(compensableActivityId);
+
+        if (compensableActivity == null)
+            throw new WorkflowException($"No activity with ID {compensableActivityId} could be found");
+        
+        var activityData = activityExecutionContext.WorkflowInstance.ActivityData[compensableActivity.Id];
+        
+        // Prepare the state of the compensable activity.
+        activityData[nameof(Compensable.Compensating)] = true;
+
+        // Schedule the compensable activity.
+        activityExecutionContext.WorkflowExecutionContext.ScheduleActivity(compensableActivity.Id);
+        
+        activityExecutionContext.WorkflowInstance.SetMetadata("Compensated", true);
+        activityExecutionContext.WorkflowExecutionContext.Cancel(Exception, Message, faultingActivityId, activityExecutionContext.Input, activityExecutionContext.Resuming);
+    }
+
+    private void CompensateAutomatically(ActivityExecutionContext activityExecutionContext)
     {
         var faultingActivityId = activityExecutionContext.ActivityId;
         var inboundPath = activityExecutionContext.WorkflowExecutionContext.GetInboundActivityPath(faultingActivityId).ToList();

--- a/src/core/Elsa.Core/ActivityResults/ConfirmResult.cs
+++ b/src/core/Elsa.Core/ActivityResults/ConfirmResult.cs
@@ -1,0 +1,28 @@
+using Elsa.Services.Compensation;
+using Elsa.Services.Models;
+
+namespace Elsa.ActivityResults;
+
+public class ConfirmResult : ActivityExecutionResult
+{ 
+    public ConfirmResult(string compensableActivityId)
+    {
+        CompensableActivityId = compensableActivityId;
+    }
+    
+    /// <summary>
+    /// The ID of a specific compensable activity to invoke.
+    /// </summary>
+    public string CompensableActivityId { get; }
+
+    protected override void Execute(ActivityExecutionContext activityExecutionContext)
+    {
+        Confirm(activityExecutionContext);
+    }
+    
+    private void Confirm(ActivityExecutionContext activityExecutionContext)
+    {
+        var compensationService = activityExecutionContext.GetService<ICompensationService>();
+        compensationService.Confirm(activityExecutionContext, CompensableActivityId);
+    }
+}

--- a/src/core/Elsa.Core/Extensions/ElsaServiceCollectionExtensions.cs
+++ b/src/core/Elsa.Core/Extensions/ElsaServiceCollectionExtensions.cs
@@ -26,6 +26,7 @@ using Elsa.Serialization;
 using Elsa.Serialization.Converters;
 using Elsa.Services;
 using Elsa.Services.Bookmarks;
+using Elsa.Services.Compensation;
 using Elsa.Services.Dispatch.Consumers;
 using Elsa.Services.Locking;
 using Elsa.Services.Messaging;
@@ -182,6 +183,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 .AddTransient<IWorkflowBlueprintMaterializer, WorkflowBlueprintMaterializer>()
                 .AddSingleton<IWorkflowBlueprintReflector, WorkflowBlueprintReflector>()
                 .AddSingleton<IBackgroundWorker, BackgroundWorker>()
+                .AddSingleton<ICompensationService, CompensationService>()
                 .AddScoped<IWorkflowPublisher, WorkflowPublisher>()
                 .AddScoped<IWorkflowContextManager, WorkflowContextManager>()
                 .AddScoped<IActivityTypeService, ActivityTypeService>()

--- a/src/core/Elsa.Core/Handlers/CompensateWorkflow.cs
+++ b/src/core/Elsa.Core/Handlers/CompensateWorkflow.cs
@@ -1,0 +1,30 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Elsa.Activities.Compensation;
+using Elsa.Events;
+using Elsa.Services.Compensation;
+using MediatR;
+
+namespace Elsa.Handlers;
+
+/// <summary>
+/// Handles the <see cref="WorkflowFaulting"/> event by trying to compensate the workflow in case it contains <see cref="Compensable"/> activities.
+/// </summary>
+public class CompensateWorkflow : INotificationHandler<WorkflowFaulting>
+{
+    private readonly ICompensationService _compensationService;
+
+    public CompensateWorkflow(ICompensationService compensationService)
+    {
+        _compensationService = compensationService;
+    }
+
+    public Task Handle(WorkflowFaulting notification, CancellationToken cancellationToken)
+    {
+        var activityExecutionContext = notification.ActivityExecutionContext;
+        var exception = activityExecutionContext.WorkflowExecutionContext.Exception;
+        var message = activityExecutionContext.WorkflowInstance.Fault?.Message;
+        _compensationService.Compensate(notification.ActivityExecutionContext, exception, message);
+        return Task.CompletedTask;
+    }
+}

--- a/src/core/Elsa.Core/Services/Compensation/CompensationService.cs
+++ b/src/core/Elsa.Core/Services/Compensation/CompensationService.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Linq;
+using Elsa.Activities.Compensation;
+using Elsa.Exceptions;
+using Elsa.Services.Models;
+
+namespace Elsa.Services.Compensation;
+
+public class CompensationService : ICompensationService
+{
+    public void Compensate(ActivityExecutionContext activityExecutionContext, Exception? exception = default, string? message = default)
+    {
+        var faultingActivityId = activityExecutionContext.ActivityId;
+        var inboundPath = activityExecutionContext.WorkflowExecutionContext.GetInboundActivityPath(faultingActivityId).ToList();
+        var inboundCompensableActivities = activityExecutionContext.WorkflowExecutionContext.WorkflowBlueprint.GetActivities(inboundPath).Where(x => x.Type == nameof(Compensable)).ToList();
+        var hasCompensableActivities = false;
+
+        foreach (var compensableActivity in inboundCompensableActivities)
+        {
+            var activityData = activityExecutionContext.WorkflowInstance.ActivityData[compensableActivity.Id];
+
+            if (!activityData.TryGetValue(nameof(Compensable.Entered), out var entered))
+                continue;
+
+            if (entered as bool? != true)
+                continue;
+
+            hasCompensableActivities = true;
+
+            // Prepare the state of the compensable activity.
+            activityData[nameof(Compensable.Compensating)] = true;
+
+            // Schedule the compensable activity.
+            activityExecutionContext.WorkflowExecutionContext.ScheduleActivity(compensableActivity.Id);
+        }
+
+        message ??= "Faulting";
+
+        if (!hasCompensableActivities)
+            return;
+
+        activityExecutionContext.WorkflowInstance.SetMetadata("Compensated", true);
+        activityExecutionContext.WorkflowExecutionContext.Cancel(exception, message, faultingActivityId, activityExecutionContext.Input, activityExecutionContext.Resuming);
+    }
+
+    public void Compensate(ActivityExecutionContext activityExecutionContext, string compensableActivityId, Exception? exception = default, string? message = default)
+    {
+        var faultingActivityId = activityExecutionContext.ActivityId;
+        var compensableActivity = activityExecutionContext.WorkflowExecutionContext.WorkflowBlueprint.GetActivity(compensableActivityId);
+
+        if (compensableActivity == null)
+            throw new WorkflowException($"No activity with ID {compensableActivityId} could be found");
+
+        var activityData = activityExecutionContext.WorkflowInstance.ActivityData[compensableActivity.Id];
+
+        // Prepare the state of the compensable activity.
+        activityData[nameof(Compensable.Compensating)] = true;
+
+        // Schedule the compensable activity.
+        activityExecutionContext.WorkflowExecutionContext.ScheduleActivity(compensableActivity.Id);
+
+        message ??= "Faulting";
+        activityExecutionContext.WorkflowInstance.SetMetadata("Compensated", true);
+        activityExecutionContext.WorkflowExecutionContext.Cancel(exception, message, faultingActivityId, activityExecutionContext.Input, activityExecutionContext.Resuming);
+    }
+}

--- a/src/core/Elsa.Core/Services/Workflows/WorkflowRunner.cs
+++ b/src/core/Elsa.Core/Services/Workflows/WorkflowRunner.cs
@@ -289,7 +289,7 @@ namespace Elsa.Services.Workflows
                     using var executionScope = AmbientActivityExecutionContext.EnterScope(activityExecutionContext);
                     await _mediator.Publish(new ActivityActivating(activityExecutionContext), cancellationToken);
                     var activity = await activityType.ActivateAsync(activityExecutionContext);
-                    var CompositeScheduledValue = isComposite && (activity is CompositeActivity comp) && comp.IsScheduled;
+                    var compositeScheduledValue = isComposite && (activity is CompositeActivity { IsScheduled: true });
 
                     if (!burstStarted)
                     {
@@ -301,7 +301,7 @@ namespace Elsa.Services.Workflows
                         await _mediator.Publish(new ActivityResuming(activityExecutionContext, activity), cancellationToken);
                     
                     await CheckIfCompositeEventAsync(isComposite
-                        , !CompositeScheduledValue
+                        , !compositeScheduledValue
                         , new ActivityExecuting(activityExecutionContext, activity)
                         , _mediator
                         , cancellationToken);
@@ -312,7 +312,7 @@ namespace Elsa.Services.Workflows
                         return;
                     
                     await CheckIfCompositeEventAsync(isComposite
-                        , CompositeScheduledValue
+                        , compositeScheduledValue
                         , new ActivityExecuted(activityExecutionContext, activity)
                         , _mediator
                         , cancellationToken);
@@ -322,7 +322,7 @@ namespace Elsa.Services.Workflows
                     workflowExecutionContext.CompletePass();
                     workflowInstance.LastExecutedActivityId = currentActivityId;
                     await CheckIfCompositeEventAsync(isComposite
-                        , CompositeScheduledValue
+                        , compositeScheduledValue
                         , new ActivityExecutionResultExecuted(result, activityExecutionContext)
                         , _mediator
                         , cancellationToken);

--- a/src/samples/console/Elsa.Samples.CompensationConsole/Activities/CancelCreditCardCharges.cs
+++ b/src/samples/console/Elsa.Samples.CompensationConsole/Activities/CancelCreditCardCharges.cs
@@ -1,0 +1,13 @@
+using Elsa.ActivityResults;
+using Elsa.Services;
+
+namespace Elsa.Samples.CompensationConsole.Activities;
+
+public class CancelCreditCardCharges : Activity
+{
+    protected override IActivityExecutionResult OnExecute()
+    {
+        Console.WriteLine("Cancel credit card charges");
+        return Done();
+    }
+}

--- a/src/samples/console/Elsa.Samples.CompensationConsole/Activities/CancelCreditCardCharges.cs
+++ b/src/samples/console/Elsa.Samples.CompensationConsole/Activities/CancelCreditCardCharges.cs
@@ -7,7 +7,7 @@ public class CancelCreditCardCharges : Activity
 {
     protected override IActivityExecutionResult OnExecute()
     {
-        Console.WriteLine("Cancel credit card charges");
+        Console.WriteLine("Cancelling credit card charges");
         return Done();
     }
 }

--- a/src/samples/console/Elsa.Samples.CompensationConsole/Activities/CancelFlight.cs
+++ b/src/samples/console/Elsa.Samples.CompensationConsole/Activities/CancelFlight.cs
@@ -1,0 +1,13 @@
+using Elsa.ActivityResults;
+using Elsa.Services;
+
+namespace Elsa.Samples.CompensationConsole.Activities;
+
+public class CancelFlight : Activity
+{
+    protected override IActivityExecutionResult OnExecute()
+    {
+        Console.WriteLine("Cancelling flight");
+        return Done();
+    }
+}

--- a/src/samples/console/Elsa.Samples.CompensationConsole/Activities/ChargeCreditCard.cs
+++ b/src/samples/console/Elsa.Samples.CompensationConsole/Activities/ChargeCreditCard.cs
@@ -7,7 +7,7 @@ public class ChargeCreditCard : Activity
 {
     protected override IActivityExecutionResult OnExecute()
     {
-        Console.WriteLine("Charge credit card for flight");
+        Console.WriteLine("Charging credit card for flight");
         return Done();
     }
 }

--- a/src/samples/console/Elsa.Samples.CompensationConsole/Activities/ChargeCreditCard.cs
+++ b/src/samples/console/Elsa.Samples.CompensationConsole/Activities/ChargeCreditCard.cs
@@ -1,0 +1,13 @@
+using Elsa.ActivityResults;
+using Elsa.Services;
+
+namespace Elsa.Samples.CompensationConsole.Activities;
+
+public class ChargeCreditCard : Activity
+{
+    protected override IActivityExecutionResult OnExecute()
+    {
+        Console.WriteLine("Charge credit card for flight");
+        return Done();
+    }
+}

--- a/src/samples/console/Elsa.Samples.CompensationConsole/Activities/ConfirmFlight.cs
+++ b/src/samples/console/Elsa.Samples.CompensationConsole/Activities/ConfirmFlight.cs
@@ -1,0 +1,13 @@
+using Elsa.ActivityResults;
+using Elsa.Services;
+
+namespace Elsa.Samples.CompensationConsole.Activities;
+
+public class ConfirmFlight : Activity
+{
+    protected override IActivityExecutionResult OnExecute()
+    {
+        Console.WriteLine("Confirming flight");
+        return Done();
+    }
+}

--- a/src/samples/console/Elsa.Samples.CompensationConsole/Activities/ManagerApproval.cs
+++ b/src/samples/console/Elsa.Samples.CompensationConsole/Activities/ManagerApproval.cs
@@ -1,0 +1,13 @@
+using Elsa.ActivityResults;
+using Elsa.Services;
+
+namespace Elsa.Samples.CompensationConsole.Activities;
+
+public class ManagerApproval : Activity
+{
+    protected override IActivityExecutionResult OnExecute()
+    {
+        Console.WriteLine("Manager approval received");
+        return Done();
+    }
+}

--- a/src/samples/console/Elsa.Samples.CompensationConsole/Activities/PurchaseFlight.cs
+++ b/src/samples/console/Elsa.Samples.CompensationConsole/Activities/PurchaseFlight.cs
@@ -1,0 +1,13 @@
+using Elsa.ActivityResults;
+using Elsa.Services;
+
+namespace Elsa.Samples.CompensationConsole.Activities;
+
+public class PurchaseFlight : Activity
+{
+    protected override IActivityExecutionResult OnExecute()
+    {
+        Console.WriteLine("Ticket is purchased");
+        return Done();
+    }
+}

--- a/src/samples/console/Elsa.Samples.CompensationConsole/Activities/ReserveFlight.cs
+++ b/src/samples/console/Elsa.Samples.CompensationConsole/Activities/ReserveFlight.cs
@@ -1,0 +1,13 @@
+using Elsa.ActivityResults;
+using Elsa.Services;
+
+namespace Elsa.Samples.CompensationConsole.Activities;
+
+public class ReserveFlight : Activity
+{
+    protected override IActivityExecutionResult OnExecute()
+    {
+        Console.WriteLine("Reserving flight");
+        return Done();
+    }
+}

--- a/src/samples/console/Elsa.Samples.CompensationConsole/Activities/TakeFlight.cs
+++ b/src/samples/console/Elsa.Samples.CompensationConsole/Activities/TakeFlight.cs
@@ -1,0 +1,13 @@
+using Elsa.ActivityResults;
+using Elsa.Services;
+
+namespace Elsa.Samples.CompensationConsole.Activities;
+
+public class TakeFlight : Activity
+{
+    protected override IActivityExecutionResult OnExecute()
+    {
+        Console.WriteLine("Flight has been taken, no compensation possible");
+        return Done();
+    }
+}

--- a/src/samples/console/Elsa.Samples.CompensationConsole/Elsa.Samples.CompensationConsole.csproj
+++ b/src/samples/console/Elsa.Samples.CompensationConsole/Elsa.Samples.CompensationConsole.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\..\core\Elsa\Elsa.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/samples/console/Elsa.Samples.CompensationConsole/Program.cs
+++ b/src/samples/console/Elsa.Samples.CompensationConsole/Program.cs
@@ -1,0 +1,17 @@
+﻿using Elsa.Samples.CompensationConsole;
+using Elsa.Samples.CompensationConsole.Workflows;
+using Elsa.Services;
+using Microsoft.Extensions.DependencyInjection;
+
+// Create a service container with Elsa services.
+var services = new ServiceCollection()
+    .AddElsa(options => options
+        .AddActivitiesFrom<Program>()
+        .AddWorkflowsFrom<Program>())
+    .BuildServiceProvider();
+
+// Get a workflow runner.
+var workflowRunner = services.GetRequiredService<IBuildsAndStartsWorkflow>();
+
+// Run the workflow.
+await workflowRunner.BuildAndStartWorkflowAsync<CompensableWorkflow>();

--- a/src/samples/console/Elsa.Samples.CompensationConsole/Program.cs
+++ b/src/samples/console/Elsa.Samples.CompensationConsole/Program.cs
@@ -1,7 +1,7 @@
-﻿using Elsa.Samples.CompensationConsole;
-using Elsa.Samples.CompensationConsole.Workflows;
+﻿using Elsa.Samples.CompensationConsole.Workflows;
 using Elsa.Services;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 // Create a service container with Elsa services.
 var services = new ServiceCollection()
@@ -14,4 +14,8 @@ var services = new ServiceCollection()
 var workflowRunner = services.GetRequiredService<IBuildsAndStartsWorkflow>();
 
 // Run the workflow.
-await workflowRunner.BuildAndStartWorkflowAsync<CompensableWorkflow>();
+var result = await workflowRunner.BuildAndStartWorkflowAsync<CompensableWorkflow>();
+//var result = await workflowRunner.BuildAndStartWorkflowAsync<FaultingWorkflow>();
+
+var logger = services.GetRequiredService<ILogger<Program>>();
+logger.LogDebug("@{Result}", result);

--- a/src/samples/console/Elsa.Samples.CompensationConsole/Workflows/CompensableWorkflow.cs
+++ b/src/samples/console/Elsa.Samples.CompensationConsole/Workflows/CompensableWorkflow.cs
@@ -1,5 +1,5 @@
-using Elsa.Activities.Compensation.Compensable;
-using Elsa.Activities.Compensation.Compensate;
+using Elsa.Activities.Compensation;
+using Elsa.Activities.Primitives;
 using Elsa.Builders;
 using Elsa.Samples.CompensationConsole.Activities;
 
@@ -15,7 +15,11 @@ public class CompensableWorkflow : IWorkflow
         builder
             .StartWith<Compensable>(compensable =>
             {
-                compensable.When(OutcomeNames.Body).Then<ReserveFlight>();
+                compensable.When(OutcomeNames.Body)
+                    .Then<ChargeCreditCard>()
+                    .Then<Fault>(a => a.WithMessage("System error!"))
+                    .Then<ReserveFlight>();
+                compensable.When(OutcomeNames.Cancel).Then<CancelCreditCardCharges>();
                 compensable.When(OutcomeNames.Compensate).Then<CancelFlight>();
             }).WithName("Compensable1")
             

--- a/src/samples/console/Elsa.Samples.CompensationConsole/Workflows/CompensableWorkflow.cs
+++ b/src/samples/console/Elsa.Samples.CompensationConsole/Workflows/CompensableWorkflow.cs
@@ -1,0 +1,24 @@
+using Elsa.Activities.Compensation.Compensable;
+using Elsa.Builders;
+using Elsa.Samples.CompensationConsole.Activities;
+
+namespace Elsa.Samples.CompensationConsole.Workflows;
+
+/// <summary>
+/// A simple workflow that compensates for errors occuring during workflow execution. 
+/// </summary>
+public class CompensableWorkflow : IWorkflow
+{
+    public void Build(IWorkflowBuilder builder)
+    {
+        builder
+            .StartWith<Compensable>(compensable =>
+            {
+                compensable.When(OutcomeNames.Body).Then<ReserveFlight>();
+                compensable.When(OutcomeNames.Compensate).Then<CancelFlight>();
+            })
+            .Then(() => throw new Exception("Catastrophic failure!"))
+            .Then<ManagerApproval>()
+            .Then<PurchaseFlight>();
+    }
+}

--- a/src/samples/console/Elsa.Samples.CompensationConsole/Workflows/CompensableWorkflow.cs
+++ b/src/samples/console/Elsa.Samples.CompensationConsole/Workflows/CompensableWorkflow.cs
@@ -1,4 +1,5 @@
 using Elsa.Activities.Compensation;
+using Elsa.Activities.Primitives;
 using Elsa.Builders;
 using Elsa.Samples.CompensationConsole.Activities;
 
@@ -18,10 +19,17 @@ public class CompensableWorkflow : IWorkflow
                 compensable.When(OutcomeNames.Body)
                     .Then<ChargeCreditCard>()
                     .Then<ReserveFlight>();
-                compensable.When(OutcomeNames.Compensate).Then<CancelFlight>();
-                compensable.When(OutcomeNames.Confirm).Then<ConfirmFlight>();
+                
+                compensable.When(OutcomeNames.Compensate)
+                    .Then<CancelFlight>()
+                    .Then<CancelCreditCardCharges>();
+                
+                compensable.When(OutcomeNames.Confirm)
+                    .Then<ConfirmFlight>();
+                
             }).WithName("Compensable1")
             .Then<ManagerApproval>()
+            .Then<Fault>(a => a.WithMessage("Critical system error!"))
             .Then<PurchaseFlight>()
             .Then<TakeFlight>()
             .Then<Confirm>(a => a.WithCompensableActivityName("Compensable1"));

--- a/src/samples/console/Elsa.Samples.CompensationConsole/Workflows/CompensableWorkflow.cs
+++ b/src/samples/console/Elsa.Samples.CompensationConsole/Workflows/CompensableWorkflow.cs
@@ -1,4 +1,5 @@
 using Elsa.Activities.Compensation.Compensable;
+using Elsa.Activities.Compensation.Compensate;
 using Elsa.Builders;
 using Elsa.Samples.CompensationConsole.Activities;
 
@@ -16,8 +17,16 @@ public class CompensableWorkflow : IWorkflow
             {
                 compensable.When(OutcomeNames.Body).Then<ReserveFlight>();
                 compensable.When(OutcomeNames.Compensate).Then<CancelFlight>();
-            })
-            .Then(() => throw new Exception("Catastrophic failure!"))
+            }).WithName("Compensable1")
+            
+            // Throw an exception to trigger compensation: 
+            //.Then(() => throw new Exception("Catastrophic failure!"))
+            
+            // Or target a specific compensable activity to trigger compensation
+            .Then<Compensate>(a => a
+                .WithCompensableActivityName("Compensable1")
+                .WithMessage("I changed my mind!"))
+            
             .Then<ManagerApproval>()
             .Then<PurchaseFlight>();
     }

--- a/src/samples/console/Elsa.Samples.CompensationConsole/Workflows/FaultingWorkflow.cs
+++ b/src/samples/console/Elsa.Samples.CompensationConsole/Workflows/FaultingWorkflow.cs
@@ -1,0 +1,21 @@
+using Elsa.Activities.Primitives;
+using Elsa.Builders;
+using Elsa.Samples.CompensationConsole.Activities;
+
+namespace Elsa.Samples.CompensationConsole.Workflows;
+
+/// <summary>
+/// A simple workflow that uses the Fault activity to fault the workflow. 
+/// </summary>
+public class FaultingWorkflow : IWorkflow
+{
+    public void Build(IWorkflowBuilder builder)
+    {
+        builder
+            .Then<ChargeCreditCard>()
+            .Then<ReserveFlight>()
+            .Then<Fault>(a => a.WithMessage("System error!"))
+            .Then<ManagerApproval>()
+            .Then<PurchaseFlight>();
+    }
+}


### PR DESCRIPTION
This PR adds compensation primitives and services to enable workflow compensation.

The following is a sample workflow taken as an inspiration from the [WF Compensation documentation](https://docs.microsoft.com/en-us/previous-versions/dotnet/netframework-4.0/dd489432(v=vs.100)):

```csharp
public class CompensableWorkflow : IWorkflow
{
    public void Build(IWorkflowBuilder builder)
    {
        builder
            .StartWith<Compensable>(compensable =>
            {
                compensable.When(OutcomeNames.Body)
                    .Then<ChargeCreditCard>()
                    .Then<ReserveFlight>();
                
                compensable.When(OutcomeNames.Compensate)
                    .Then<CancelFlight>()
                    .Then<CancelCreditCardCharges>();
                
                compensable.When(OutcomeNames.Confirm)
                    .Then<ConfirmFlight>();
                
            }).WithName("Compensable1")
            .Then<ManagerApproval>()
            .Then<Fault>(a => a.WithMessage("Critical system error!"))
            .Then<PurchaseFlight>()
            .Then<TakeFlight>()
            .Then<Confirm>(a => a.WithCompensableActivityName("Compensable1"));
    }
}
```

Output:

```
Charging credit card for flight
Reserving flight
Manager approval received
Cancelling flight
Cancelling credit card charges
```

A similar example created with the designer:

![image](https://user-images.githubusercontent.com/938393/163465807-3bb2e099-f0c7-4fa8-b1bc-56bc831452d3.png)

Closes #2683 