### PR TITLE
Manage & revert workflow definitions versions through UI

### DIFF
--- a/src/core/Elsa.Abstractions/Models/WorkflowDefinition.cs
+++ b/src/core/Elsa.Abstractions/Models/WorkflowDefinition.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using NodaTime;
 
 namespace Elsa.Models
 {
@@ -35,6 +36,11 @@ namespace Elsa.Models
         /// Allows for applications to store an application-specific, queryable value to associate with the workflow.
         /// </summary>
         public string? Tag { get; set; }
+
+        /// <summary>
+        /// The timestamp this workflow definition was created.
+        /// </summary>
+        public Instant CreatedAt { get; set; }
 
         public ICollection<ActivityDefinition> Activities { get; set; }
         public ICollection<ConnectionDefinition> Connections { get; set; }

--- a/src/core/Elsa.Abstractions/Services/Workflows/IWorkflowPublisher.cs
+++ b/src/core/Elsa.Abstractions/Services/Workflows/IWorkflowPublisher.cs
@@ -11,9 +11,15 @@ namespace Elsa.Services
         Task<WorkflowDefinition> PublishAsync(WorkflowDefinition workflowDefinition, CancellationToken cancellationToken = default);
         Task<WorkflowDefinition?> RetractAsync(string workflowDefinitionId, CancellationToken cancellationToken = default);
         Task<WorkflowDefinition> RetractAsync(WorkflowDefinition workflowDefinition, CancellationToken cancellationToken = default);
-        Task<WorkflowDefinition?> GetDraftAsync(string workflowDefinitionId, CancellationToken cancellationToken= default);
+        Task<WorkflowDefinition?> GetDraftAsync(string workflowDefinitionId, VersionOptions? versionOptions = default, CancellationToken cancellationToken = default);
         Task<WorkflowDefinition> SaveDraftAsync(WorkflowDefinition workflowDefinition, CancellationToken cancellationToken = default);
         Task DeleteAsync(string workflowDefinitionId, CancellationToken cancellationToken = default);
         Task DeleteAsync(WorkflowDefinition workflowDefinition, CancellationToken cancellationToken = default);
+    }
+
+    public static class WorkflowPublisherExtensions
+    {
+        public static Task<WorkflowDefinition?> GetDraftAsync(this IWorkflowPublisher workflowPublisher, string workflowDefinitionId, CancellationToken cancellationToken = default) =>
+            workflowPublisher.GetDraftAsync(workflowDefinitionId, VersionOptions.Latest, cancellationToken);
     }
 }

--- a/src/core/Elsa.Abstractions/Services/Workflows/IWorkflowPublisher.cs
+++ b/src/core/Elsa.Abstractions/Services/Workflows/IWorkflowPublisher.cs
@@ -13,7 +13,15 @@ namespace Elsa.Services
         Task<WorkflowDefinition> RetractAsync(WorkflowDefinition workflowDefinition, CancellationToken cancellationToken = default);
         Task<WorkflowDefinition?> GetDraftAsync(string workflowDefinitionId, VersionOptions? versionOptions = default, CancellationToken cancellationToken = default);
         Task<WorkflowDefinition> SaveDraftAsync(WorkflowDefinition workflowDefinition, CancellationToken cancellationToken = default);
-        Task DeleteAsync(string workflowDefinitionId, CancellationToken cancellationToken = default);
+        
+        /// <summary>
+        /// Delete the specified workflow version or versions.
+        /// </summary>
+        Task DeleteAsync(string workflowDefinitionId, VersionOptions versionOptions, CancellationToken cancellationToken = default);
+        
+        /// <summary>
+        /// Delete a specific workflow version.
+        /// </summary>
         Task DeleteAsync(WorkflowDefinition workflowDefinition, CancellationToken cancellationToken = default);
     }
 

--- a/src/designer/elsa-workflows-studio/src/components.d.ts
+++ b/src/designer/elsa-workflows-studio/src/components.d.ts
@@ -5,7 +5,7 @@
  * It contains typing information for all components that exist in this project.
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
-import { ActivityDefinitionProperty, ActivityDescriptor, ActivityModel, ActivityPropertyDescriptor, ElsaStudio, IntellisenseContext, OrderBy, SelectListItem, VersionOptions, WorkflowBlueprint, WorkflowDefinition, WorkflowExecutionLogRecord, WorkflowFault, WorkflowInstance, WorkflowModel, WorkflowStatus } from "./models";
+import { ActivityDefinitionProperty, ActivityDescriptor, ActivityModel, ActivityPropertyDescriptor, ElsaStudio, IntellisenseContext, OrderBy, SelectListItem, VersionOptions, WorkflowBlueprint, WorkflowDefinition, WorkflowDefinitionVersion, WorkflowExecutionLogRecord, WorkflowFault, WorkflowInstance, WorkflowModel, WorkflowStatus } from "./models";
 import { LocationSegments, MatchResults, RouterHistory } from "@stencil/router";
 import { MenuItem } from "./components/controls/elsa-context-menu/models";
 import { VNode } from "@stencil/core";
@@ -1070,6 +1070,7 @@ declare namespace LocalJSX {
     interface ElsaToastNotification {
     }
     interface ElsaVersionHistoryPanel {
+        "onVersionSelected"?: (event: CustomEvent<WorkflowDefinitionVersion>) => void;
         "serverUrl"?: string;
         "workflowDefinition"?: WorkflowDefinition;
     }
@@ -1158,6 +1159,7 @@ declare namespace LocalJSX {
         "onExportClicked"?: (event: CustomEvent<any>) => void;
         "onImportClicked"?: (event: CustomEvent<File>) => void;
         "onPublishClicked"?: (event: CustomEvent<any>) => void;
+        "onRevertClicked"?: (event: CustomEvent<any>) => void;
         "onUnPublishClicked"?: (event: CustomEvent<any>) => void;
         "publishing"?: boolean;
         "workflowDefinition"?: WorkflowDefinition;

--- a/src/designer/elsa-workflows-studio/src/components.d.ts
+++ b/src/designer/elsa-workflows-studio/src/components.d.ts
@@ -1070,6 +1070,8 @@ declare namespace LocalJSX {
     interface ElsaToastNotification {
     }
     interface ElsaVersionHistoryPanel {
+        "onDeleteVersionClicked"?: (event: CustomEvent<WorkflowDefinitionVersion>) => void;
+        "onRevertVersionClicked"?: (event: CustomEvent<WorkflowDefinitionVersion>) => void;
         "onVersionSelected"?: (event: CustomEvent<WorkflowDefinitionVersion>) => void;
         "serverUrl"?: string;
         "workflowDefinition"?: WorkflowDefinition;

--- a/src/designer/elsa-workflows-studio/src/components.d.ts
+++ b/src/designer/elsa-workflows-studio/src/components.d.ts
@@ -260,6 +260,10 @@ export namespace Components {
         "hide": () => Promise<void>;
         "show": (options: ToastNotificationOptions) => Promise<void>;
     }
+    interface ElsaVersionHistoryPanel {
+        "serverUrl": string;
+        "workflowDefinition": WorkflowDefinition;
+    }
     interface ElsaWebhookDefinitionEditorNotifications {
     }
     interface ElsaWebhookDefinitionEditorScreen {
@@ -636,6 +640,12 @@ declare global {
         prototype: HTMLElsaToastNotificationElement;
         new (): HTMLElsaToastNotificationElement;
     };
+    interface HTMLElsaVersionHistoryPanelElement extends Components.ElsaVersionHistoryPanel, HTMLStencilElement {
+    }
+    var HTMLElsaVersionHistoryPanelElement: {
+        prototype: HTMLElsaVersionHistoryPanelElement;
+        new (): HTMLElsaVersionHistoryPanelElement;
+    };
     interface HTMLElsaWebhookDefinitionEditorNotificationsElement extends Components.ElsaWebhookDefinitionEditorNotifications, HTMLStencilElement {
     }
     var HTMLElsaWebhookDefinitionEditorNotificationsElement: {
@@ -789,6 +799,7 @@ declare global {
         "elsa-tab-content": HTMLElsaTabContentElement;
         "elsa-tab-header": HTMLElsaTabHeaderElement;
         "elsa-toast-notification": HTMLElsaToastNotificationElement;
+        "elsa-version-history-panel": HTMLElsaVersionHistoryPanelElement;
         "elsa-webhook-definition-editor-notifications": HTMLElsaWebhookDefinitionEditorNotificationsElement;
         "elsa-webhook-definition-editor-screen": HTMLElsaWebhookDefinitionEditorScreenElement;
         "elsa-webhook-definitions-list-screen": HTMLElsaWebhookDefinitionsListScreenElement;
@@ -1058,6 +1069,10 @@ declare namespace LocalJSX {
     }
     interface ElsaToastNotification {
     }
+    interface ElsaVersionHistoryPanel {
+        "serverUrl"?: string;
+        "workflowDefinition"?: WorkflowDefinition;
+    }
     interface ElsaWebhookDefinitionEditorNotifications {
     }
     interface ElsaWebhookDefinitionEditorScreen {
@@ -1208,6 +1223,7 @@ declare namespace LocalJSX {
         "elsa-tab-content": ElsaTabContent;
         "elsa-tab-header": ElsaTabHeader;
         "elsa-toast-notification": ElsaToastNotification;
+        "elsa-version-history-panel": ElsaVersionHistoryPanel;
         "elsa-webhook-definition-editor-notifications": ElsaWebhookDefinitionEditorNotifications;
         "elsa-webhook-definition-editor-screen": ElsaWebhookDefinitionEditorScreen;
         "elsa-webhook-definitions-list-screen": ElsaWebhookDefinitionsListScreen;
@@ -1276,6 +1292,7 @@ declare module "@stencil/core" {
             "elsa-tab-content": LocalJSX.ElsaTabContent & JSXBase.HTMLAttributes<HTMLElsaTabContentElement>;
             "elsa-tab-header": LocalJSX.ElsaTabHeader & JSXBase.HTMLAttributes<HTMLElsaTabHeaderElement>;
             "elsa-toast-notification": LocalJSX.ElsaToastNotification & JSXBase.HTMLAttributes<HTMLElsaToastNotificationElement>;
+            "elsa-version-history-panel": LocalJSX.ElsaVersionHistoryPanel & JSXBase.HTMLAttributes<HTMLElsaVersionHistoryPanelElement>;
             "elsa-webhook-definition-editor-notifications": LocalJSX.ElsaWebhookDefinitionEditorNotifications & JSXBase.HTMLAttributes<HTMLElsaWebhookDefinitionEditorNotificationsElement>;
             "elsa-webhook-definition-editor-screen": LocalJSX.ElsaWebhookDefinitionEditorScreen & JSXBase.HTMLAttributes<HTMLElsaWebhookDefinitionEditorScreenElement>;
             "elsa-webhook-definitions-list-screen": LocalJSX.ElsaWebhookDefinitionsListScreen & JSXBase.HTMLAttributes<HTMLElsaWebhookDefinitionsListScreenElement>;

--- a/src/designer/elsa-workflows-studio/src/components/icons/delete-icon.tsx
+++ b/src/designer/elsa-workflows-studio/src/components/icons/delete-icon.tsx
@@ -1,0 +1,13 @@
+﻿import {h} from "@stencil/core";
+
+export const DeleteIcon = props =>
+  (
+    `<svg class="elsa-h-5 elsa-w-5 elsa-text-gray-500" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+        <path stroke="none" d="M0 0h24v24H0z"/>
+        <line x1="4" y1="7" x2="20" y2="7"/>
+        <line x1="10" y1="11" x2="10" y2="17"/>
+        <line x1="14" y1="11" x2="14" y2="17"/>
+        <path d="M5 7l1 12a2 2 0 0 0 2 2h8a2 2 0 0 0 2 -2l1 -12"/>
+        <path d="M9 7v-3a1 1 0 0 1 1 -1h4a1 1 0 0 1 1 1v3"/>
+      </svg>`
+  );

--- a/src/designer/elsa-workflows-studio/src/components/screens/workflow-definition-editor/elsa-version-history-panel/elsa-version-history-panel.tsx
+++ b/src/designer/elsa-workflows-studio/src/components/screens/workflow-definition-editor/elsa-version-history-panel/elsa-version-history-panel.tsx
@@ -40,8 +40,14 @@ export class ElsaVersionHistoryPanel {
     this.versionSelected.emit(version);
   };
 
-  onDeleteVersionClick = (e: Event, version: WorkflowDefinitionVersion) => {
+  onDeleteVersionClick = async (e: Event, version: WorkflowDefinitionVersion) => {
     e.preventDefault();
+
+    const result = await this.confirmDialog.show('Delete Version', 'Are you sure you wish to permanently delete this version? This operation cannot be undone.');
+
+    if (!result)
+      return;
+
     this.deleteVersionClicked.emit(version);
   };
 

--- a/src/designer/elsa-workflows-studio/src/components/screens/workflow-definition-editor/elsa-version-history-panel/elsa-version-history-panel.tsx
+++ b/src/designer/elsa-workflows-studio/src/components/screens/workflow-definition-editor/elsa-version-history-panel/elsa-version-history-panel.tsx
@@ -81,10 +81,11 @@ export class ElsaVersionHistoryPanel {
                           const createdAt = moment(v.createdAt);
                           const isSelected = selectedVersion == v.version;
                           const rowCssClass = isSelected ? 'elsa-bg-gray-100' : undefined;
+                          const canDeleteOrRevert = !v.isLatest && !v.isPublished;
 
                           const published = v.isPublished ? (
                             <div title="Published">
-                              <svg class="elsa-h-6 elsa-w-6 elsa-text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                              <svg class="elsa-h-6 elsa-w-6 elsa-text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
                               </svg>
                             </div>
@@ -103,13 +104,25 @@ export class ElsaVersionHistoryPanel {
                           );
 
                           const revertIcon = (
-                            <svg class="h-6 w-6 text-gray-500" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                            <svg class="elsa-h-6 elsa-w-6 elsa-text-gray-500" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
                               <path stroke="none" d="M0 0h24v24H0z"/>
                               <path d="M9 11l-4 4l4 4m-4 -4h11a4 4 0 0 0 0 -8h-1"/>
                             </svg>
                           );
 
-                          const contextMenuItems: Array<MenuItem> = [{
+                          const viewIcon = (
+                            <svg class="elsa-h-6 w-6 elsa-text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
+                              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/>
+                            </svg>
+
+                          );
+
+                          let contextMenuItems: Array<MenuItem> = [{
+                            text: 'View',
+                            icon: viewIcon,
+                            clickHandler: e => this.onViewVersionClick(e, v)
+                          }, {
                             text: 'Delete',
                             icon: deleteIcon,
                             clickHandler: e => this.onDeleteVersionClick(e, v)
@@ -135,7 +148,7 @@ export class ElsaVersionHistoryPanel {
                                 </button>
                               </td>
                               <td>
-                                <elsa-context-menu menuItems={contextMenuItems}/>
+                                {!v.isPublished && !v.isPublished ? <elsa-context-menu menuItems={contextMenuItems}/> : undefined}
                               </td>
                             </tr>
                           );

--- a/src/designer/elsa-workflows-studio/src/components/screens/workflow-definition-editor/elsa-version-history-panel/elsa-version-history-panel.tsx
+++ b/src/designer/elsa-workflows-studio/src/components/screens/workflow-definition-editor/elsa-version-history-panel/elsa-version-history-panel.tsx
@@ -61,9 +61,9 @@ export class ElsaVersionHistoryPanel {
           <div class="elsa-text-sm elsa-font-medium">
 
             <div class="elsa-mt-2 elsa-flex elsa-flex-col">
-              <div class="elsa-overflow-x-auto">
+              <div class="">
                 <div class="elsa-inline-block elsa-min-w-full elsa-py-2 elsa-align-middle">
-                  <div class="elsa-overflow-hidden elsa-shadow-sm elsa-ring-1 elsa-ring-black elsa-ring-opacity-5 md:elsa-rounded-lg">
+                  <div class="elsa-shadow-sm elsa-ring-1 elsa-ring-black elsa-ring-opacity-5 md:elsa-rounded-lg">
                     <table class="elsa-min-w-full elsa-divide-y elsa-divide-gray-300">
                       <thead class="elsa-bg-gray-50">
                       <tr>
@@ -148,7 +148,7 @@ export class ElsaVersionHistoryPanel {
                                 </button>
                               </td>
                               <td>
-                                {!v.isPublished && !v.isPublished ? <elsa-context-menu menuItems={contextMenuItems}/> : undefined}
+                                {v.isPublished || v.isPublished ? undefined : <elsa-context-menu menuItems={contextMenuItems}/>}
                               </td>
                             </tr>
                           );

--- a/src/designer/elsa-workflows-studio/src/components/screens/workflow-definition-editor/elsa-version-history-panel/elsa-version-history-panel.tsx
+++ b/src/designer/elsa-workflows-studio/src/components/screens/workflow-definition-editor/elsa-version-history-panel/elsa-version-history-panel.tsx
@@ -1,6 +1,8 @@
-import {Component, h, Host, Prop} from '@stencil/core';
-import {WorkflowDefinition} from "../../../../models";
+import {Component, h, Host, Prop, State, Event, EventEmitter, Watch} from '@stencil/core';
+import {WorkflowDefinition, WorkflowDefinitionVersion} from "../../../../models";
 import Tunnel from "../../../../data/dashboard";
+import {createElsaClient} from "../../../../services";
+import moment from "moment";
 
 @Component({
   tag: 'elsa-version-history-panel',
@@ -10,10 +12,35 @@ export class ElsaVersionHistoryPanel {
 
   @Prop() workflowDefinition: WorkflowDefinition;
   @Prop() serverUrl: string;
+  @Event() versionSelected: EventEmitter<WorkflowDefinitionVersion>;
+  @State() versions: Array<WorkflowDefinitionVersion> = [];
 
   confirmDialog: HTMLElsaConfirmDialogElement;
 
+  @Watch('workflowDefinition')
+  async onWorkflowDefinitionChanged(value: WorkflowDefinition) {
+    await this.loadVersions();
+  }
+
+  async componentWillLoad() {
+    await this.loadVersions();
+  }
+
+  loadVersions = async () => {
+    const client = await createElsaClient(this.serverUrl);
+    const workflowDefinitionId = this.workflowDefinition.definitionId;
+    this.versions = await client.workflowDefinitionsApi.getVersionHistory(workflowDefinitionId);
+  }
+
+  onViewVersionClick = (e: Event, version: WorkflowDefinitionVersion) => {
+    e.preventDefault();
+    this.versionSelected.emit(version);
+  };
+
   render() {
+
+    const versions = this.versions;
+    const selectedVersion = this.workflowDefinition.version;
 
     return (
       <Host>
@@ -29,21 +56,39 @@ export class ElsaVersionHistoryPanel {
                       <tr>
                         <th scope="col" class="elsa-py-3.5 elsa-pl-4 elsa-pr-3 elsa-text-left elsa-text-sm elsa-font-semibold elsa-text-gray-900 sm:elsa-pl-6 lg:elsa-pl-8">Version</th>
                         <th scope="col" class="elsa-px-3 elsa-py-3.5 elsa-text-left elsa-text-sm elsa-font-semibold elsa-text-gray-900">Created</th>
+                        <th scope="col" class="elsa-px-3 elsa-py-3.5 elsa-text-left elsa-text-sm elsa-font-semibold elsa-text-gray-900">Published</th>
                         <th scope="col" class="elsa-relative elsa-py-3.5 elsa-pl-3 elsa-pr-4 sm:elsa-pr-6 lg:elsa-pr-8">
                           <span class="elsa-sr-only">View</span>
                         </th>
                       </tr>
                       </thead>
                       <tbody class="elsa-divide-y elsa-divide-gray-200 elsa-bg-white">
-                      {[0, 0, 0, 0, 0].map(v => (
-                          <tr>
-                            <td class="elsa-whitespace-nowrap elsa-py-4 elsa-pl-4 elsa-pr-3 elsa-text-sm elsa-font-medium elsa-text-gray-900 sm:elsa-pl-6 lg:elsa-pl-8">8</td>
-                            <td class="elsa-whitespace-nowrap elsa-px-3 elsa-py-4 elsa-text-sm elsa-text-gray-500">10-12-2020 13:20</td>
-                            <td class="elsa-relative elsa-whitespace-nowrap elsa-py-4 elsa-pl-3 elsa-pr-4 elsa-text-right elsa-text-sm elsa-font-medium sm:elsa-pr-6 lg:elsa-pr-8">
-                              <a href="#" class="elsa-text-blue-600 hover:elsa-text-blue-900">View<span class="elsa-sr-only">, 8</span></a>
-                            </td>
-                          </tr>
-                        )
+                      {versions.map(v => {
+                          const createdAt = moment(v.createdAt);
+                          const isSelected = selectedVersion == v.version;
+                          const rowCssClass = isSelected ? 'elsa-bg-gray-100' : undefined;
+
+                          const published = v.isPublished ? (
+                            <svg class="elsa-h-6 elsa-w-6 elsa-text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
+                            </svg>
+
+                          ) : undefined;
+
+                          return (
+                            <tr class={rowCssClass}>
+                              <td class="elsa-whitespace-nowrap elsa-py-4 elsa-pl-4 elsa-pr-3 elsa-text-sm elsa-font-medium elsa-text-gray-900 sm:elsa-pl-6 lg:elsa-pl-8">{v.version}</td>
+                              <td class="elsa-whitespace-nowrap elsa-px-3 elsa-py-4 elsa-text-sm elsa-text-gray-500">{createdAt.format('DD-MM-YYYY HH:mm:ss')}</td>
+                              <td class="elsa-whitespace-nowrap elsa-px-3 elsa-py-4 elsa-text-sm elsa-text-gray-500">{published}</td>
+                              <td class="elsa-relative elsa-whitespace-nowrap elsa-py-4 elsa-pl-3 elsa-pr-4 elsa-text-right elsa-text-sm elsa-font-medium sm:elsa-pr-6 lg:elsa-pr-8">
+                                {!isSelected
+                                  ? <a onClick={e => this.onViewVersionClick(e, v)} href="#" class="elsa-text-blue-600 hover:elsa-text-blue-900">View<span class="elsa-sr-only">, {v.version}</span></a>
+                                  : undefined
+                                }
+                              </td>
+                            </tr>
+                          );
+                        }
                       )}
 
                       </tbody>

--- a/src/designer/elsa-workflows-studio/src/components/screens/workflow-definition-editor/elsa-version-history-panel/elsa-version-history-panel.tsx
+++ b/src/designer/elsa-workflows-studio/src/components/screens/workflow-definition-editor/elsa-version-history-panel/elsa-version-history-panel.tsx
@@ -1,0 +1,65 @@
+import {Component, h, Host, Prop} from '@stencil/core';
+import {WorkflowDefinition} from "../../../../models";
+import Tunnel from "../../../../data/dashboard";
+
+@Component({
+  tag: 'elsa-version-history-panel',
+  shadow: false
+})
+export class ElsaVersionHistoryPanel {
+
+  @Prop() workflowDefinition: WorkflowDefinition;
+  @Prop() serverUrl: string;
+
+  confirmDialog: HTMLElsaConfirmDialogElement;
+
+  render() {
+
+    return (
+      <Host>
+        <dl class="elsa-border-gray-200 elsa-divide-y elsa-divide-gray-200">
+          <div class="elsa-text-sm elsa-font-medium">
+
+            <div class="elsa-mt-2 elsa-flex elsa-flex-col">
+              <div class="elsa-overflow-x-auto">
+                <div class="elsa-inline-block elsa-min-w-full elsa-py-2 elsa-align-middle">
+                  <div class="elsa-overflow-hidden elsa-shadow-sm elsa-ring-1 elsa-ring-black elsa-ring-opacity-5 md:elsa-rounded-lg">
+                    <table class="elsa-min-w-full elsa-divide-y elsa-divide-gray-300">
+                      <thead class="elsa-bg-gray-50">
+                      <tr>
+                        <th scope="col" class="elsa-py-3.5 elsa-pl-4 elsa-pr-3 elsa-text-left elsa-text-sm elsa-font-semibold elsa-text-gray-900 sm:elsa-pl-6 lg:elsa-pl-8">Version</th>
+                        <th scope="col" class="elsa-px-3 elsa-py-3.5 elsa-text-left elsa-text-sm elsa-font-semibold elsa-text-gray-900">Created</th>
+                        <th scope="col" class="elsa-relative elsa-py-3.5 elsa-pl-3 elsa-pr-4 sm:elsa-pr-6 lg:elsa-pr-8">
+                          <span class="elsa-sr-only">View</span>
+                        </th>
+                      </tr>
+                      </thead>
+                      <tbody class="elsa-divide-y elsa-divide-gray-200 elsa-bg-white">
+                      {[0, 0, 0, 0, 0].map(v => (
+                          <tr>
+                            <td class="elsa-whitespace-nowrap elsa-py-4 elsa-pl-4 elsa-pr-3 elsa-text-sm elsa-font-medium elsa-text-gray-900 sm:elsa-pl-6 lg:elsa-pl-8">8</td>
+                            <td class="elsa-whitespace-nowrap elsa-px-3 elsa-py-4 elsa-text-sm elsa-text-gray-500">10-12-2020 13:20</td>
+                            <td class="elsa-relative elsa-whitespace-nowrap elsa-py-4 elsa-pl-3 elsa-pr-4 elsa-text-right elsa-text-sm elsa-font-medium sm:elsa-pr-6 lg:elsa-pr-8">
+                              <a href="#" class="elsa-text-blue-600 hover:elsa-text-blue-900">View<span class="elsa-sr-only">, 8</span></a>
+                            </td>
+                          </tr>
+                        )
+                      )}
+
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+
+          </div>
+        </dl>
+        <elsa-confirm-dialog ref={el => this.confirmDialog = el}/>
+      </Host>
+    );
+  }
+}
+
+Tunnel.injectProps(ElsaVersionHistoryPanel, ['serverUrl']);

--- a/src/designer/elsa-workflows-studio/src/components/screens/workflow-definition-editor/elsa-version-history-panel/elsa-version-history-panel.tsx
+++ b/src/designer/elsa-workflows-studio/src/components/screens/workflow-definition-editor/elsa-version-history-panel/elsa-version-history-panel.tsx
@@ -3,6 +3,7 @@ import {WorkflowDefinition, WorkflowDefinitionVersion} from "../../../../models"
 import Tunnel from "../../../../data/dashboard";
 import {createElsaClient} from "../../../../services";
 import moment from "moment";
+import {MenuItem} from "../../../controls/elsa-context-menu/models";
 
 @Component({
   tag: 'elsa-version-history-panel',
@@ -13,6 +14,8 @@ export class ElsaVersionHistoryPanel {
   @Prop() workflowDefinition: WorkflowDefinition;
   @Prop() serverUrl: string;
   @Event() versionSelected: EventEmitter<WorkflowDefinitionVersion>;
+  @Event() deleteVersionClicked: EventEmitter<WorkflowDefinitionVersion>;
+  @Event() revertVersionClicked: EventEmitter<WorkflowDefinitionVersion>;
   @State() versions: Array<WorkflowDefinitionVersion> = [];
 
   confirmDialog: HTMLElsaConfirmDialogElement;
@@ -37,6 +40,16 @@ export class ElsaVersionHistoryPanel {
     this.versionSelected.emit(version);
   };
 
+  onDeleteVersionClick = (e: Event, version: WorkflowDefinitionVersion) => {
+    e.preventDefault();
+    this.deleteVersionClicked.emit(version);
+  };
+
+  onRevertVersionClick = (e: Event, version: WorkflowDefinitionVersion) => {
+    e.preventDefault();
+    this.revertVersionClicked.emit(version);
+  };
+
   render() {
 
     const versions = this.versions;
@@ -54,12 +67,13 @@ export class ElsaVersionHistoryPanel {
                     <table class="elsa-min-w-full elsa-divide-y elsa-divide-gray-300">
                       <thead class="elsa-bg-gray-50">
                       <tr>
-                        <th scope="col" class="elsa-py-3.5 elsa-pl-4 elsa-pr-3 elsa-text-left elsa-text-sm elsa-font-semibold elsa-text-gray-900 sm:elsa-pl-6 lg:elsa-pl-8">Version</th>
+                        <th scope="col" class="elsa-px-3 elsa-py-3.5 elsa-text-left elsa-text-sm elsa-font-semibold elsa-text-gray-900"/>
+                        <th scope="col" class="elsa-py-3.5 elsa-pl-2 elsa-pr-3 elsa-text-left elsa-text-sm elsa-font-semibold elsa-text-gray-900">Version</th>
                         <th scope="col" class="elsa-px-3 elsa-py-3.5 elsa-text-left elsa-text-sm elsa-font-semibold elsa-text-gray-900">Created</th>
-                        <th scope="col" class="elsa-px-3 elsa-py-3.5 elsa-text-left elsa-text-sm elsa-font-semibold elsa-text-gray-900">Published</th>
                         <th scope="col" class="elsa-relative elsa-py-3.5 elsa-pl-3 elsa-pr-4 sm:elsa-pr-6 lg:elsa-pr-8">
                           <span class="elsa-sr-only">View</span>
                         </th>
+                        <th scope="col" class="elsa-relative elsa-py-3.5 elsa-pr-4 sm:elsa-pr-6 lg:elsa-pr-8"/>
                       </tr>
                       </thead>
                       <tbody class="elsa-divide-y elsa-divide-gray-200 elsa-bg-white">
@@ -69,22 +83,59 @@ export class ElsaVersionHistoryPanel {
                           const rowCssClass = isSelected ? 'elsa-bg-gray-100' : undefined;
 
                           const published = v.isPublished ? (
-                            <svg class="elsa-h-6 elsa-w-6 elsa-text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
-                            </svg>
+                            <div title="Published">
+                              <svg class="elsa-h-6 elsa-w-6 elsa-text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
+                              </svg>
+                            </div>
 
                           ) : undefined;
 
+                          const deleteIcon = (
+                            <svg class="elsa-h-5 elsa-w-5 elsa-text-gray-500" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                              <path stroke="none" d="M0 0h24v24H0z"/>
+                              <line x1="4" y1="7" x2="20" y2="7"/>
+                              <line x1="10" y1="11" x2="10" y2="17"/>
+                              <line x1="14" y1="11" x2="14" y2="17"/>
+                              <path d="M5 7l1 12a2 2 0 0 0 2 2h8a2 2 0 0 0 2 -2l1 -12"/>
+                              <path d="M9 7v-3a1 1 0 0 1 1 -1h4a1 1 0 0 1 1 1v3"/>
+                            </svg>
+                          );
+
+                          const revertIcon = (
+                            <svg class="h-6 w-6 text-gray-500" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+                              <path stroke="none" d="M0 0h24v24H0z"/>
+                              <path d="M9 11l-4 4l4 4m-4 -4h11a4 4 0 0 0 0 -8h-1"/>
+                            </svg>
+                          );
+
+                          const contextMenuItems: Array<MenuItem> = [{
+                            text: 'Delete',
+                            icon: deleteIcon,
+                            clickHandler: e => this.onDeleteVersionClick(e, v)
+                          },
+                            {
+                              text: 'Revert',
+                              icon: revertIcon,
+                              clickHandler: e => this.onRevertVersionClick(e, v)
+                            }];
+
                           return (
                             <tr class={rowCssClass}>
-                              <td class="elsa-whitespace-nowrap elsa-py-4 elsa-pl-4 elsa-pr-3 elsa-text-sm elsa-font-medium elsa-text-gray-900 sm:elsa-pl-6 lg:elsa-pl-8">{v.version}</td>
-                              <td class="elsa-whitespace-nowrap elsa-px-3 elsa-py-4 elsa-text-sm elsa-text-gray-500">{createdAt.format('DD-MM-YYYY HH:mm:ss')}</td>
                               <td class="elsa-whitespace-nowrap elsa-px-3 elsa-py-4 elsa-text-sm elsa-text-gray-500">{published}</td>
+                              <td class="elsa-whitespace-nowrap elsa-py-4 elsa-pl-2 elsa-pr-3 elsa-text-sm elsa-font-medium elsa-text-gray-900">{v.version}</td>
+                              <td class="elsa-whitespace-nowrap elsa-px-3 elsa-py-4 elsa-text-sm elsa-text-gray-500">{createdAt.format('DD-MM-YYYY HH:mm:ss')}</td>
                               <td class="elsa-relative elsa-whitespace-nowrap elsa-py-4 elsa-pl-3 elsa-pr-4 elsa-text-right elsa-text-sm elsa-font-medium sm:elsa-pr-6 lg:elsa-pr-8">
-                                {!isSelected
-                                  ? <a onClick={e => this.onViewVersionClick(e, v)} href="#" class="elsa-text-blue-600 hover:elsa-text-blue-900">View<span class="elsa-sr-only">, {v.version}</span></a>
-                                  : undefined
-                                }
+                                <button onClick={e => this.onViewVersionClick(e, v)}
+                                        type="button"
+                                        disabled={isSelected}
+                                        class="elsa-inline-flex elsa-items-center elsa-rounded-md elsa-border elsa-border-gray-300 elsa-bg-white elsa-px-3 elsa-py-2 elsa-text-sm elsa-font-medium elsa-leading-4 elsa-text-gray-700 elsa-shadow-sm hover:elsa-bg-gray-50 focus:elsa-outline-none focus:elsa-ring-2 focus:elsa-ring-blue-500 focus:elsa-ring-offset-2 disabled:elsa-cursor-not-allowed disabled:elsa-opacity-30">
+                                  View
+                                  <span class="elsa-sr-only">, {v.version}</span>
+                                </button>
+                              </td>
+                              <td>
+                                <elsa-context-menu menuItems={contextMenuItems}/>
                               </td>
                             </tr>
                           );

--- a/src/designer/elsa-workflows-studio/src/components/screens/workflow-definition-editor/elsa-workflow-definition-editor-screen/elsa-workflow-definition-editor-screen.tsx
+++ b/src/designer/elsa-workflows-studio/src/components/screens/workflow-definition-editor/elsa-workflow-definition-editor-screen/elsa-workflow-definition-editor-screen.tsx
@@ -10,7 +10,7 @@ import {
   ConnectionModel,
   EventTypes,
   VersionOptions,
-  WorkflowDefinition,
+  WorkflowDefinition, WorkflowDefinitionVersion,
   WorkflowInstance,
   WorkflowModel,
   WorkflowPersistenceBehavior,
@@ -37,6 +37,7 @@ import {i18n} from "i18next";
 import {loadTranslations} from "../../../i18n/i18n-loader";
 import {resources} from "./localizations";
 import * as collection from 'lodash/collection';
+import {tr} from "cronstrue/dist/i18n/locales/tr";
 
 @Component({
   tag: 'elsa-workflow-definition-editor-screen',
@@ -63,6 +64,8 @@ export class ElsaWorkflowDefinitionEditorScreen {
   @State() saved: boolean;
   @State() importing: boolean;
   @State() imported: boolean;
+  @State() reverting: boolean;
+  @State() reverted: boolean;
   @State() networkError: string;
   @State() selectedActivityId?: string;
   @State() workflowDesignerMode: WorkflowDesignerMode;
@@ -285,11 +288,13 @@ export class ElsaWorkflowDefinitionEditorScreen {
     await eventBus.emit(EventTypes.WorkflowPublished, this, this.workflowDefinition);
   }
 
-  async unPublishWorkflow() {
-    this.unPublishing = true;
-    await this.unpublishWorkflow();
-    this.unPublishing = false;
+  async unpublishWorkflow() {
+    await this.unpublishWorkflowInternal();
     await eventBus.emit(EventTypes.WorkflowRetracted, this, this.workflowDefinition);
+  }
+
+  async revertWorkflow(){
+    await this.revertWorkflowInternal();
   }
 
   async saveWorkflow(publish?: boolean) {
@@ -365,7 +370,7 @@ export class ElsaWorkflowDefinitionEditorScreen {
     }
   }
 
-  async unpublishWorkflow() {
+  async unpublishWorkflowInternal() {
     const client = await createElsaClient(this.serverUrl);
     const workflowDefinitionId = this.workflowDefinition.definitionId;
     this.unPublishing = true;
@@ -379,6 +384,26 @@ export class ElsaWorkflowDefinitionEditorScreen {
       console.error(e);
       this.unPublishing = false;
       this.unPublished = false;
+      this.networkError = e.message;
+      setTimeout(() => this.networkError = null, 2000);
+    }
+  }
+
+  async revertWorkflowInternal(){
+    const client = await createElsaClient(this.serverUrl);
+    const workflowDefinitionId = this.workflowDefinition.definitionId;
+    const version = this.workflowDefinition.version;
+    this.reverting = true;
+
+    try {
+      this.workflowDefinition = await client.workflowDefinitionsApi.revert(workflowDefinitionId, version);
+      this.reverting = false;
+      this.reverted = true
+      setTimeout(() => this.reverted = false, 500);
+    } catch (e) {
+      console.error(e);
+      this.reverting = false;
+      this.reverted = false;
       this.networkError = e.message;
       setTimeout(() => this.networkError = null, 2000);
     }
@@ -453,7 +478,11 @@ export class ElsaWorkflowDefinitionEditorScreen {
   }
 
   async onUnPublishClicked() {
-    await this.unPublishWorkflow();
+    await this.unpublishWorkflow();
+  }
+
+  async onRevertClicked(){
+    await this.revertWorkflow();
   }
 
   async onExportClicked() {
@@ -1050,6 +1079,7 @@ export class ElsaWorkflowDefinitionEditorScreen {
       workflowDefinition={this.workflowDefinition}
       onPublishClicked={() => this.onPublishClicked()}
       onUnPublishClicked={() => this.onUnPublishClicked()}
+      onRevertClicked={() => this.onRevertClicked()}
       onExportClicked={() => this.onExportClicked()}
       onImportClicked={e => this.onImportClicked(e.detail)}
       culture={this.culture}
@@ -1067,17 +1097,20 @@ export class ElsaWorkflowDefinitionEditorScreen {
   }
 
   private renderPanel() {
+
+    const workflowDefinition = this.workflowDefinition;
+
     return (
       <elsa-flyout-panel expandButtonPosition={3}>
         <elsa-tab-header tab="general" slot="header">General</elsa-tab-header>
         <elsa-tab-content tab="general" slot="content">
           <elsa-workflow-properties-panel
-            workflowDefinition={this.workflowDefinition}
+            workflowDefinition={workflowDefinition}
           />
         </elsa-tab-content>
         {this.renderTestPanel()}
         {this.renderDesignerPanel()}
-        {this.renderVersionHistoryPanel()}
+        {this.renderVersionHistoryPanel(workflowDefinition)}
       </elsa-flyout-panel>
     );
   }
@@ -1115,12 +1148,12 @@ export class ElsaWorkflowDefinitionEditorScreen {
     }
   }
 
-  private renderVersionHistoryPanel = () => {
+  private renderVersionHistoryPanel = (workflowDefinition: WorkflowDefinition) => {
 
     return [
       <elsa-tab-header tab="versionHistory" slot="header">Version History</elsa-tab-header>,
       <elsa-tab-content tab="versionHistory" slot="content">
-        <elsa-version-history-panel />
+        <elsa-version-history-panel workflowDefinition={workflowDefinition} onVersionSelected={e => this.onVersionSelected(e)}/>
       </elsa-tab-content>
     ];
   }
@@ -1146,6 +1179,13 @@ export class ElsaWorkflowDefinitionEditorScreen {
       }
     }
   }
+
+  onVersionSelected = async (e: CustomEvent<WorkflowDefinitionVersion>) => {
+    const client = await createElsaClient(this.serverUrl);
+    const version = e.detail;
+    const workflowDefinition = await client.workflowDefinitionsApi.getByDefinitionAndVersion(version.definitionId, {version: version.version});
+    this.updateWorkflowDefinition(workflowDefinition);
+  };
 }
 
 injectHistory(ElsaWorkflowDefinitionEditorScreen);

--- a/src/designer/elsa-workflows-studio/src/components/screens/workflow-definition-editor/elsa-workflow-definition-editor-screen/elsa-workflow-definition-editor-screen.tsx
+++ b/src/designer/elsa-workflows-studio/src/components/screens/workflow-definition-editor/elsa-workflow-definition-editor-screen/elsa-workflow-definition-editor-screen.tsx
@@ -1077,6 +1077,7 @@ export class ElsaWorkflowDefinitionEditorScreen {
         </elsa-tab-content>
         {this.renderTestPanel()}
         {this.renderDesignerPanel()}
+        {this.renderVersionHistoryPanel()}
       </elsa-flyout-panel>
     );
   }
@@ -1112,6 +1113,16 @@ export class ElsaWorkflowDefinitionEditorScreen {
         </elsa-tab-content>
       ];
     }
+  }
+
+  private renderVersionHistoryPanel = () => {
+
+    return [
+      <elsa-tab-header tab="versionHistory" slot="header">Version History</elsa-tab-header>,
+      <elsa-tab-content tab="versionHistory" slot="content">
+        <elsa-version-history-panel />
+      </elsa-tab-content>
+    ];
   }
 
   handleFeatureChange = (e: CustomEvent<string>) => {

--- a/src/designer/elsa-workflows-studio/src/components/screens/workflow-definition-editor/elsa-workflow-definition-editor-screen/elsa-workflow-definition-editor-screen.tsx
+++ b/src/designer/elsa-workflows-studio/src/components/screens/workflow-definition-editor/elsa-workflow-definition-editor-screen/elsa-workflow-definition-editor-screen.tsx
@@ -293,7 +293,7 @@ export class ElsaWorkflowDefinitionEditorScreen {
     await eventBus.emit(EventTypes.WorkflowRetracted, this, this.workflowDefinition);
   }
 
-  async revertWorkflow(){
+  async revertWorkflow() {
     await this.revertWorkflowInternal();
   }
 
@@ -389,7 +389,7 @@ export class ElsaWorkflowDefinitionEditorScreen {
     }
   }
 
-  async revertWorkflowInternal(){
+  async revertWorkflowInternal() {
     const client = await createElsaClient(this.serverUrl);
     const workflowDefinitionId = this.workflowDefinition.definitionId;
     const version = this.workflowDefinition.version;
@@ -481,7 +481,7 @@ export class ElsaWorkflowDefinitionEditorScreen {
     await this.unpublishWorkflow();
   }
 
-  async onRevertClicked(){
+  async onRevertClicked() {
     await this.revertWorkflow();
   }
 
@@ -1153,7 +1153,11 @@ export class ElsaWorkflowDefinitionEditorScreen {
     return [
       <elsa-tab-header tab="versionHistory" slot="header">Version History</elsa-tab-header>,
       <elsa-tab-content tab="versionHistory" slot="content">
-        <elsa-version-history-panel workflowDefinition={workflowDefinition} onVersionSelected={e => this.onVersionSelected(e)}/>
+        <elsa-version-history-panel
+          workflowDefinition={workflowDefinition}
+          onVersionSelected={e => this.onVersionSelected(e)}
+          onDeleteVersionClicked={e => this.onDeleteVersionClicked(e)}
+          onRevertVersionClicked={e => this.onRevertVersionClicked(e)}/>
       </elsa-tab-content>
     ];
   }
@@ -1184,6 +1188,20 @@ export class ElsaWorkflowDefinitionEditorScreen {
     const client = await createElsaClient(this.serverUrl);
     const version = e.detail;
     const workflowDefinition = await client.workflowDefinitionsApi.getByDefinitionAndVersion(version.definitionId, {version: version.version});
+    this.updateWorkflowDefinition(workflowDefinition);
+  };
+
+  onDeleteVersionClicked = async (e: CustomEvent<WorkflowDefinitionVersion>) => {
+    const client = await createElsaClient(this.serverUrl);
+    const version = e.detail;
+    await client.workflowDefinitionsApi.delete(version.definitionId, {version: version.version});
+    this.updateWorkflowDefinition({...this.workflowDefinition}); // Force a rerender.
+  };
+
+  onRevertVersionClicked = async (e: CustomEvent<WorkflowDefinitionVersion>) => {
+    const client = await createElsaClient(this.serverUrl);
+    const version = e.detail;
+    const workflowDefinition = await client.workflowDefinitionsApi.revert(version.definitionId, version.version);
     this.updateWorkflowDefinition(workflowDefinition);
   };
 }

--- a/src/designer/elsa-workflows-studio/src/components/screens/workflow-definition-editor/elsa-workflow-publish-button/elsa-workflow-publish-button.tsx
+++ b/src/designer/elsa-workflows-studio/src/components/screens/workflow-definition-editor/elsa-workflow-publish-button/elsa-workflow-publish-button.tsx
@@ -17,6 +17,7 @@ export class ElsaWorkflowPublishButton {
   @Prop() culture: string;
   @Event({bubbles: true}) publishClicked: EventEmitter;
   @Event({bubbles: true}) unPublishClicked: EventEmitter;
+  @Event({bubbles: true}) revertClicked: EventEmitter;
   @Event({bubbles: true}) exportClicked: EventEmitter;
   @Event({bubbles: true}) importClicked: EventEmitter<File>;
 
@@ -25,12 +26,12 @@ export class ElsaWorkflowPublishButton {
   fileInput: HTMLInputElement;
   element: HTMLElement;
 
-  async componentWillLoad(){
+  async componentWillLoad() {
     this.i18next = await loadTranslations(this.culture, resources);
   }
 
   @Listen('click', {target: 'window'})
-  onWindowClicked(event: Event){
+  onWindowClicked(event: Event) {
     const target = event.target as HTMLElement;
 
     if (!this.element.contains(target))
@@ -47,24 +48,31 @@ export class ElsaWorkflowPublishButton {
     toggle(this.menu);
   }
 
-  onPublishClick() {
+  onPublishClick = (e: Event) => {
+    e.preventDefault();
     this.publishClicked.emit();
     leave(this.menu);
   }
 
-  onUnPublishClick(e: Event) {
+  onUnPublishClick = (e: Event) => {
     e.preventDefault();
     this.unPublishClicked.emit();
     leave(this.menu);
   }
 
-  async onExportClick(e: Event) {
+  onRevertClick = (e: Event) => {
+    e.preventDefault();
+    this.revertClicked.emit();
+    leave(this.menu);
+  }
+
+  onExportClick = async (e: Event) => {
     e.preventDefault();
     this.exportClicked.emit();
     leave(this.menu);
   }
 
-  async onImportClick(e: Event) {
+  onImportClick = async (e: Event) => {
     e.preventDefault();
     this.fileInput.value = null;
     this.fileInput.click();
@@ -72,8 +80,7 @@ export class ElsaWorkflowPublishButton {
     leave(this.menu);
   }
 
-  async onFileInputChange(e: Event)
-  {
+  async onFileInputChange(e: Event) {
     const files = this.fileInput.files;
 
     if (files.length == 0) {
@@ -85,11 +92,12 @@ export class ElsaWorkflowPublishButton {
 
   render() {
     const t = this.t;
+    const isPublished = this.workflowDefinition.isPublished;
 
     return (
       <Host class="elsa-block" ref={el => this.element = el}>
         <span class="elsa-relative elsa-z-0 elsa-inline-flex elsa-shadow-sm elsa-rounded-md">
-          {this.publishing ? this.renderPublishingButton() : this.renderPublishButton()}
+          {this.renderMainButton()}
           <span class="-elsa-ml-px elsa-relative elsa-block">
             <button onClick={() => this.toggleMenu()} id="option-menu" type="button"
                     class="elsa-relative elsa-inline-flex elsa-items-center elsa-px-2 elsa-py-2 elsa-rounded-r-md elsa-border elsa-border-gray-300 elsa-bg-white elsa-text-sm elsa-font-medium elsa-text-gray-500 hover:elsa-bg-gray-50 focus:elsa-z-10 focus:elsa-outline-none focus:elsa-ring-1 focus:elsa-ring-blue-500 focus:elsa-border-blue-500">
@@ -117,31 +125,89 @@ export class ElsaWorkflowPublishButton {
                     {t('Import')}
                   </a>
                 </div>
-
-                {this.renderUnpublishButton()}
-
               </div>
             </div>
           </span>
         </span>
-        <input type="file" class="hidden" onChange={e => this.onFileInputChange(e)} ref={el => this.fileInput = el} />
+        <input type="file" class="hidden" onChange={e => this.onFileInputChange(e)} ref={el => this.fileInput = el}/>
       </Host>
     );
   }
 
-  renderPublishButton() {
+  renderMainButton = () => {
+    const workflowDefinition = this.workflowDefinition;
+    const isPublished = workflowDefinition.isPublished;
+
+    if (isPublished)
+      return this.publishing ? this.renderUnpublishingButton() : this.renderUnpublishButton();
+    else
+      return this.publishing ? this.renderPublishingButton() : this.renderPublishButton();
+  }
+
+  renderPublishButton = () => {
+    const workflowDefinition = this.workflowDefinition;
+    const isLatest = workflowDefinition.isLatest;
+    const version = workflowDefinition.version;
+
+    if (isLatest)
+      return this.renderButton('Publish', this.onPublishClick);
+
+    return this.renderButton(`Revert version ${version}`, this.onRevertClick);
+  }
+
+  renderPublishingButton() {
+    const workflowDefinition = this.workflowDefinition;
+    const isLatest = workflowDefinition.isLatest;
+    const version = workflowDefinition.version;
+    const text = isLatest ? 'Publishing' : `Publishing version ${version}`;
+
+    return this.renderLoadingButton(text);
+  }
+
+  renderUnpublishButton = () => {
+    return this.renderButton('Unpublish', e => this.onUnPublishClick(e));
+  };
+
+  renderPublishMenuItem = () => {
+    return this.renderMenuItem('Publish', this.onPublishClick);
+  };
+
+  renderUnpublishMenuItem = () => {
+    return this.renderMenuItem('Unpublish', this.onUnPublishClick);
+  };
+
+  renderMenuItem = (text: string, handler: (e: Event) => any) => {
+    if (!this.workflowDefinition.isPublished)
+      return undefined;
+
+    const t = this.t;
+
+    return (
+      <div class="elsa-py-1" role="none">
+        <a href="#" onClick={e => handler(e)} class="elsa-block elsa-px-4 elsa-py-2 elsa-text-sm elsa-text-gray-700 hover:elsa-bg-gray-100 hover:elsa-text-gray-900" role="menuitem">
+          {t(text)}
+        </a>
+      </div>
+    );
+  };
+
+  renderUnpublishingButton = () => {
+    return this.renderLoadingButton('Unpublishing');
+  };
+
+  renderButton = (text: string, handler: (e: Event) => any) => {
     const t = this.t;
 
     return (
       <button type="button"
-              onClick={() => this.onPublishClick()}
+              onClick={e => handler(e)}
               class="elsa-relative elsa-inline-flex elsa-items-center elsa-px-4 elsa-py-2 elsa-rounded-l-md elsa-border elsa-border-gray-300 elsa-bg-white elsa-text-sm elsa-font-medium elsa-text-gray-700 hover:elsa-bg-gray-50 focus:elsa-z-10 focus:elsa-outline-none focus:elsa-ring-1 focus:elsa-ring-blue-500 focus:elsa-border-blue-500">
-
-        {t('Publish')}
+        {text}
       </button>);
   }
 
-  renderPublishingButton() {
+
+  renderLoadingButton(text: string) {
     const t = this.t;
 
     return (
@@ -153,23 +219,8 @@ export class ElsaWorkflowPublishButton {
           <circle class="elsa-opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
           <path class="elsa-opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"/>
         </svg>
-        {t('Publishing')}
+        {t(text)}
       </button>);
-  }
-
-  renderUnpublishButton() {
-    if (!this.workflowDefinition.isPublished)
-      return undefined;
-
-    const t = this.t;
-
-    return (
-      <div class="elsa-py-1" role="none">
-        <a href="#" onClick={e => this.onUnPublishClick(e)} class="elsa-block elsa-px-4 elsa-py-2 elsa-text-sm elsa-text-gray-700 hover:elsa-bg-gray-100 hover:elsa-text-gray-900" role="menuitem">
-          {t('Unpublish')}
-        </a>
-      </div>
-    );
   }
 }
 

--- a/src/designer/elsa-workflows-studio/src/components/screens/workflow-definition-list/elsa-workflow-definitions-screen/elsa-workflow-definitions-list-screen.tsx
+++ b/src/designer/elsa-workflows-studio/src/components/screens/workflow-definition-list/elsa-workflow-definitions-screen/elsa-workflow-definitions-list-screen.tsx
@@ -61,13 +61,13 @@ export class ElsaWorkflowDefinitionsListScreen {
     this.currentPageSize = Math.max(Math.min(this.currentPageSize, ElsaWorkflowDefinitionsListScreen.MAX_PAGE_SIZE), ElsaWorkflowDefinitionsListScreen.MIN_PAGE_SIZE);
   }
 
-  async onPublishClick (e: Event, workflowDefinition: WorkflowDefinitionSummary) {
+  async onPublishClick(e: Event, workflowDefinition: WorkflowDefinitionSummary) {
     const elsaClient = await this.createClient();
     await elsaClient.workflowDefinitionsApi.publish(workflowDefinition.definitionId);
     await this.loadWorkflowDefinitions();
   }
 
-  async onUnPublishClick (e: Event, workflowDefinition: WorkflowDefinitionSummary) {
+  async onUnPublishClick(e: Event, workflowDefinition: WorkflowDefinitionSummary) {
     const elsaClient = await this.createClient();
     await elsaClient.workflowDefinitionsApi.retract(workflowDefinition.definitionId);
     await this.loadWorkflowDefinitions();
@@ -81,7 +81,7 @@ export class ElsaWorkflowDefinitionsListScreen {
       return;
 
     const elsaClient = await this.createClient();
-    await elsaClient.workflowDefinitionsApi.delete(workflowDefinition.definitionId);
+    await elsaClient.workflowDefinitionsApi.delete(workflowDefinition.definitionId, {allVersions: true});
     await this.loadWorkflowDefinitions();
   }
 
@@ -181,13 +181,13 @@ export class ElsaWorkflowDefinitionsListScreen {
 
               const publishIcon = (
                 <svg xmlns="http://www.w3.org/2000/svg" class="elsa-h-5 elsa-w-5 elsa-text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"/>
                 </svg>
               );
 
               const unPublishIcon = (
                 <svg xmlns="http://www.w3.org/2000/svg" class="elsa-h-5 elsa-w-5 elsa-text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" />
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636"/>
                 </svg>
               );
 
@@ -210,7 +210,11 @@ export class ElsaWorkflowDefinitionsListScreen {
                   <td class="elsa-pr-6">
                     <elsa-context-menu history={this.history} menuItems={[
                       {text: i18next.t('Edit'), anchorUrl: editUrl, icon: editIcon},
-                      isPublished ? {text: i18next.t('Unpublish'), clickHandler: e => this.onUnPublishClick(e, workflowDefinition), icon: unPublishIcon} : {text: i18next.t('Publish'), clickHandler: e => this.onPublishClick(e, workflowDefinition), icon: publishIcon},
+                      isPublished ? {text: i18next.t('Unpublish'), clickHandler: e => this.onUnPublishClick(e, workflowDefinition), icon: unPublishIcon} : {
+                        text: i18next.t('Publish'),
+                        clickHandler: e => this.onPublishClick(e, workflowDefinition),
+                        icon: publishIcon
+                      },
                       {text: i18next.t('Delete'), clickHandler: e => this.onDeleteClick(e, workflowDefinition), icon: deleteIcon}
                     ]}/>
                   </td>

--- a/src/designer/elsa-workflows-studio/src/components/screens/workflow-definition-list/elsa-workflow-definitions-screen/elsa-workflow-definitions-list-screen.tsx
+++ b/src/designer/elsa-workflows-studio/src/components/screens/workflow-definition-list/elsa-workflow-definitions-screen/elsa-workflow-definitions-list-screen.tsx
@@ -30,16 +30,16 @@ export class ElsaWorkflowDefinitionsListScreen {
   @State() currentPageSize: number = ElsaWorkflowDefinitionsListScreen.DEFAULT_PAGE_SIZE;
   private i18next: i18n;
   private confirmDialog: HTMLElsaConfirmDialogElement;
-  private unlistenRouteChanged: () => void;
+  private clearRouteChangedListeners: () => void;
 
   connectedCallback() {
     if (!!this.history)
-      this.unlistenRouteChanged = this.history.listen(e => this.routeChanged(e));
+      this.clearRouteChangedListeners = this.history.listen(e => this.routeChanged(e));
   }
 
   disconnectedCallback() {
-    if (!!this.unlistenRouteChanged)
-      this.unlistenRouteChanged();
+    if (!!this.clearRouteChangedListeners)
+      this.clearRouteChangedListeners();
   }
 
   async componentWillLoad() {

--- a/src/designer/elsa-workflows-studio/src/globals/tailwind.css
+++ b/src/designer/elsa-workflows-studio/src/globals/tailwind.css
@@ -2561,6 +2561,16 @@ select {
   margin-bottom: 1rem;
 }
 
+.elsa-my-2 {
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.elsa-mx-4 {
+  margin-left: 1rem;
+  margin-right: 1rem;
+}
+
 .-elsa-ml-1 {
   margin-left: -0.25rem;
 }
@@ -3120,14 +3130,14 @@ select {
   border-color: rgb(229 231 235 / var(--tw-divide-opacity));
 }
 
-.elsa-divide-gray-50 > :not([hidden]) ~ :not([hidden]) {
-  --tw-divide-opacity: 1;
-  border-color: rgb(249 250 251 / var(--tw-divide-opacity));
-}
-
 .elsa-divide-gray-300 > :not([hidden]) ~ :not([hidden]) {
   --tw-divide-opacity: 1;
   border-color: rgb(209 213 219 / var(--tw-divide-opacity));
+}
+
+.elsa-divide-gray-50 > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-opacity: 1;
+  border-color: rgb(249 250 251 / var(--tw-divide-opacity));
 }
 
 .elsa-divide-gray-400 > :not([hidden]) ~ :not([hidden]) {
@@ -8096,6 +8106,11 @@ select {
   padding-right: 2rem;
 }
 
+.elsa-py-3\.5 {
+  padding-top: 0.875rem;
+  padding-bottom: 0.875rem;
+}
+
 .elsa-pr-8 {
   padding-right: 2rem;
 }
@@ -8176,16 +8191,20 @@ select {
   padding-left: 2.5rem;
 }
 
+.elsa-pl-4 {
+  padding-left: 1rem;
+}
+
+.elsa-pr-3 {
+  padding-right: 0.75rem;
+}
+
 .elsa-pr-6 {
   padding-right: 1.5rem;
 }
 
 .elsa-pl-8 {
   padding-left: 2rem;
-}
-
-.elsa-pr-3 {
-  padding-right: 0.75rem;
 }
 
 .elsa-pb-10 {
@@ -8247,6 +8266,10 @@ select {
 
 .elsa-font-extrabold {
   font-weight: 800;
+}
+
+.elsa-font-semibold {
+  font-weight: 600;
 }
 
 .elsa-uppercase {
@@ -8389,6 +8412,11 @@ select {
 .elsa-text-gray-600 {
   --tw-text-opacity: 1;
   color: rgb(75 85 99 / var(--tw-text-opacity));
+}
+
+.elsa-text-indigo-600 {
+  --tw-text-opacity: 1;
+  color: rgb(79 70 229 / var(--tw-text-opacity));
 }
 
 .elsa-text-red-500 {
@@ -12146,6 +12174,11 @@ svg.jtk-connector.jtk-hover path {
   color: rgb(55 65 81 / var(--tw-text-opacity));
 }
 
+.hover\:elsa-text-indigo-900:hover {
+  --tw-text-opacity: 1;
+  color: rgb(49 46 129 / var(--tw-text-opacity));
+}
+
 .hover\:elsa-text-gray-600:hover {
   --tw-text-opacity: 1;
   color: rgb(75 85 99 / var(--tw-text-opacity));
@@ -12324,6 +12357,11 @@ svg.jtk-connector.jtk-hover path {
   .sm\:elsa-mx-auto {
     margin-left: auto;
     margin-right: auto;
+  }
+
+  .sm\:elsa-mx-6 {
+    margin-left: 1.5rem;
+    margin-right: 1.5rem;
   }
 
   .sm\:elsa-mt-0 {
@@ -12543,6 +12581,14 @@ svg.jtk-connector.jtk-hover path {
     padding-right: 0px;
   }
 
+  .sm\:elsa-pl-6 {
+    padding-left: 1.5rem;
+  }
+
+  .sm\:elsa-pr-6 {
+    padding-right: 1.5rem;
+  }
+
   .sm\:elsa-text-left {
     text-align: left;
   }
@@ -12598,6 +12644,10 @@ svg.jtk-connector.jtk-hover path {
 
   .md\:elsa-max-w-2xl {
     max-width: 42rem;
+  }
+
+  .md\:elsa-rounded-lg {
+    border-radius: 0.5rem;
   }
 }
 
@@ -12661,6 +12711,14 @@ svg.jtk-connector.jtk-hover path {
   .lg\:elsa-px-0 {
     padding-left: 0px;
     padding-right: 0px;
+  }
+
+  .lg\:elsa-pl-8 {
+    padding-left: 2rem;
+  }
+
+  .lg\:elsa-pr-8 {
+    padding-right: 2rem;
   }
 
   .lg\:elsa-pl-2 {

--- a/src/designer/elsa-workflows-studio/src/globals/tailwind.css
+++ b/src/designer/elsa-workflows-studio/src/globals/tailwind.css
@@ -6258,11 +6258,6 @@ select {
   background-color: rgb(219 234 254 / var(--tw-bg-opacity));
 }
 
-.elsa-bg-gray-300 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(209 213 219 / var(--tw-bg-opacity));
-}
-
 .elsa-bg-green-500 {
   --tw-bg-opacity: 1;
   background-color: rgb(34 197 94 / var(--tw-bg-opacity));
@@ -6271,6 +6266,11 @@ select {
 .elsa-bg-gray-200 {
   --tw-bg-opacity: 1;
   background-color: rgb(229 231 235 / var(--tw-bg-opacity));
+}
+
+.elsa-bg-gray-300 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(209 213 219 / var(--tw-bg-opacity));
 }
 
 .elsa-bg-gray-400 {
@@ -12159,11 +12159,6 @@ svg.jtk-connector.jtk-hover path {
   color: rgb(55 65 81 / var(--tw-text-opacity));
 }
 
-.hover\:elsa-text-blue-900:hover {
-  --tw-text-opacity: 1;
-  color: rgb(30 58 138 / var(--tw-text-opacity));
-}
-
 .hover\:elsa-text-gray-600:hover {
   --tw-text-opacity: 1;
   color: rgb(75 85 99 / var(--tw-text-opacity));
@@ -12314,6 +12309,10 @@ svg.jtk-connector.jtk-hover path {
 
 .disabled\:elsa-opacity-50:disabled {
   opacity: 0.5;
+}
+
+.disabled\:elsa-opacity-30:disabled {
+  opacity: 0.3;
 }
 
 @media (min-width: 640px) {

--- a/src/designer/elsa-workflows-studio/src/globals/tailwind.css
+++ b/src/designer/elsa-workflows-studio/src/globals/tailwind.css
@@ -2561,16 +2561,6 @@ select {
   margin-bottom: 1rem;
 }
 
-.elsa-my-2 {
-  margin-top: 0.5rem;
-  margin-bottom: 0.5rem;
-}
-
-.elsa-mx-4 {
-  margin-left: 1rem;
-  margin-right: 1rem;
-}
-
 .-elsa-ml-1 {
   margin-left: -0.25rem;
 }
@@ -6268,6 +6258,11 @@ select {
   background-color: rgb(219 234 254 / var(--tw-bg-opacity));
 }
 
+.elsa-bg-gray-300 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(209 213 219 / var(--tw-bg-opacity));
+}
+
 .elsa-bg-green-500 {
   --tw-bg-opacity: 1;
   background-color: rgb(34 197 94 / var(--tw-bg-opacity));
@@ -6276,11 +6271,6 @@ select {
 .elsa-bg-gray-200 {
   --tw-bg-opacity: 1;
   background-color: rgb(229 231 235 / var(--tw-bg-opacity));
-}
-
-.elsa-bg-gray-300 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(209 213 219 / var(--tw-bg-opacity));
 }
 
 .elsa-bg-gray-400 {
@@ -8412,11 +8402,6 @@ select {
 .elsa-text-gray-600 {
   --tw-text-opacity: 1;
   color: rgb(75 85 99 / var(--tw-text-opacity));
-}
-
-.elsa-text-indigo-600 {
-  --tw-text-opacity: 1;
-  color: rgb(79 70 229 / var(--tw-text-opacity));
 }
 
 .elsa-text-red-500 {
@@ -12174,9 +12159,9 @@ svg.jtk-connector.jtk-hover path {
   color: rgb(55 65 81 / var(--tw-text-opacity));
 }
 
-.hover\:elsa-text-indigo-900:hover {
+.hover\:elsa-text-blue-900:hover {
   --tw-text-opacity: 1;
-  color: rgb(49 46 129 / var(--tw-text-opacity));
+  color: rgb(30 58 138 / var(--tw-text-opacity));
 }
 
 .hover\:elsa-text-gray-600:hover {
@@ -12357,11 +12342,6 @@ svg.jtk-connector.jtk-hover path {
   .sm\:elsa-mx-auto {
     margin-left: auto;
     margin-right: auto;
-  }
-
-  .sm\:elsa-mx-6 {
-    margin-left: 1.5rem;
-    margin-right: 1.5rem;
   }
 
   .sm\:elsa-mt-0 {

--- a/src/designer/elsa-workflows-studio/src/models/domain.ts
+++ b/src/designer/elsa-workflows-studio/src/models/domain.ts
@@ -41,6 +41,7 @@ export interface WorkflowDefinitionVersion {
   id: string;
   definitionId: string;
   version: number;
+  isLatest: boolean;
   isPublished: boolean;
   createdAt: Date;
 }

--- a/src/designer/elsa-workflows-studio/src/models/domain.ts
+++ b/src/designer/elsa-workflows-studio/src/models/domain.ts
@@ -37,6 +37,14 @@ export interface WorkflowDefinitionSummary {
   tag?: string;
 }
 
+export interface WorkflowDefinitionVersion {
+  id: string;
+  definitionId: string;
+  version: number;
+  isPublished: boolean;
+  createdAt: Date;
+}
+
 export interface ActivityBlueprint {
   id: string;
   name?: string;

--- a/src/designer/elsa-workflows-studio/src/services/elsa-client.ts
+++ b/src/designer/elsa-workflows-studio/src/services/elsa-client.ts
@@ -16,7 +16,7 @@ import {
   WorkflowBlueprintSummary,
   WorkflowContextOptions,
   WorkflowDefinition,
-  WorkflowDefinitionSummary,
+  WorkflowDefinitionSummary, WorkflowDefinitionVersion,
   WorkflowExecutionLogRecord,
   WorkflowInstance,
   WorkflowInstanceSummary,
@@ -82,6 +82,10 @@ export const createElsaClient = async function (serverUrl: string): Promise<Elsa
         const response = await httpClient.get<ListModel<WorkflowDefinitionSummary>>(`v1/workflow-definitions?ids=${ids.join(',')}&version=${versionOptionsString}`);
         return response.data.items;
       },
+      getVersionHistory: async (definitionId: string): Promise<Array<WorkflowDefinitionVersion>> => {
+        const response = await httpClient.get<ListModel<WorkflowDefinitionVersion>>(`v1/workflow-definitions/${definitionId}/history`);
+        return response.data.items;
+      },
       getByDefinitionAndVersion: async (definitionId: string, versionOptions: VersionOptions) => {
         const versionOptionsString = getVersionOptionsString(versionOptions);
         const response = await httpClient.get<WorkflowDefinition>(`v1/workflow-definitions/${definitionId}/${versionOptionsString}`);
@@ -100,6 +104,10 @@ export const createElsaClient = async function (serverUrl: string): Promise<Elsa
       },
       publish: async workflowDefinitionId => {
         const response = await httpClient.post<WorkflowDefinition>(`v1/workflow-definitions/${workflowDefinitionId}/publish`);
+        return response.data;
+      },
+      revert: async (workflowDefinitionId, version) => {
+        const response = await httpClient.post<WorkflowDefinition>(`v1/workflow-definitions/${workflowDefinitionId}/revert/${version}`);
         return response.data;
       },
       export: async (workflowDefinitionId, versionOptions): Promise<ExportWorkflowResponse> => {
@@ -339,6 +347,8 @@ export interface WorkflowDefinitionsApi {
 
   getMany(ids: Array<string>, versionOptions?: VersionOptions): Promise<Array<WorkflowDefinitionSummary>>;
 
+  getVersionHistory(id: string): Promise<Array<WorkflowDefinitionVersion>>;
+
   getByDefinitionAndVersion(definitionId: string, versionOptions: VersionOptions): Promise<WorkflowDefinition>;
 
   save(request: SaveWorkflowDefinitionRequest): Promise<WorkflowDefinition>;
@@ -348,6 +358,7 @@ export interface WorkflowDefinitionsApi {
   retract(workflowDefinitionId: string): Promise<WorkflowDefinition>;
 
   publish(workflowDefinitionId: string): Promise<WorkflowDefinition>;
+  revert(workflowDefinitionId: string, version: number): Promise<WorkflowDefinition>;
 
   export(workflowDefinitionId: string, versionOptions: VersionOptions): Promise<ExportWorkflowResponse>;
 

--- a/src/designer/elsa-workflows-studio/src/services/elsa-client.ts
+++ b/src/designer/elsa-workflows-studio/src/services/elsa-client.ts
@@ -95,8 +95,16 @@ export const createElsaClient = async function (serverUrl: string): Promise<Elsa
         const response = await httpClient.post<WorkflowDefinition>('v1/workflow-definitions', request);
         return response.data;
       },
-      delete: async definitionId => {
-        await httpClient.delete(`v1/workflow-definitions/${definitionId}`);
+      delete: async (definitionId, versionOptions?: VersionOptions) => {
+
+        let path = `v1/workflow-definitions/${definitionId}`;
+
+        if (!!versionOptions) {
+          const versionOptionsString = getVersionOptionsString(versionOptions);
+          path = `${path}/${versionOptionsString}`;
+        }
+
+        await httpClient.delete(path);
       },
       retract: async workflowDefinitionId => {
         const response = await httpClient.post<WorkflowDefinition>(`v1/workflow-definitions/${workflowDefinitionId}/retract`);
@@ -138,8 +146,8 @@ export const createElsaClient = async function (serverUrl: string): Promise<Elsa
     },
     workflowTestApi: {
       execute: async (request) => {
-          const response = await httpClient.post<WorkflowTestExecuteResponse>(`v1/workflow-test/execute`, request);
-          return response.data;
+        const response = await httpClient.post<WorkflowTestExecuteResponse>(`v1/workflow-test/execute`, request);
+        return response.data;
       },
       restartFromActivity: async (request) => {
         await httpClient.post<void>(`v1/workflow-test/restartFromActivity`, request);
@@ -232,7 +240,7 @@ export const createElsaClient = async function (serverUrl: string): Promise<Elsa
         await httpClient.delete(`v1/workflow-instances/${id}`);
       },
       retry: async id => {
-        await httpClient.post(`v1/workflow-instances/${id}/retry`, { runImmediately: false });
+        await httpClient.post(`v1/workflow-instances/${id}/retry`, {runImmediately: false});
       },
       bulkCancel: async request => {
         const response = await httpClient.post(`v1/workflow-instances/bulk/cancel`, request);
@@ -353,11 +361,12 @@ export interface WorkflowDefinitionsApi {
 
   save(request: SaveWorkflowDefinitionRequest): Promise<WorkflowDefinition>;
 
-  delete(definitionId: string): Promise<void>;
+  delete(definitionId: string, versionOptions: VersionOptions): Promise<void>;
 
   retract(workflowDefinitionId: string): Promise<WorkflowDefinition>;
 
   publish(workflowDefinitionId: string): Promise<WorkflowDefinition>;
+
   revert(workflowDefinitionId: string, version: number): Promise<WorkflowDefinition>;
 
   export(workflowDefinitionId: string, versionOptions: VersionOptions): Promise<ExportWorkflowResponse>;
@@ -495,7 +504,7 @@ export interface WorkflowTestStopRequest {
   workflowInstanceId: string
 }
 
-export interface WorkflowTestExecuteResponse{
+export interface WorkflowTestExecuteResponse {
   isSuccess: boolean,
   isAnotherInstanceRunning: boolean
 }

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/Configuration/WorkflowDefinitionConfiguration.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/Configuration/WorkflowDefinitionConfiguration.cs
@@ -15,6 +15,7 @@ namespace Elsa.Persistence.EntityFramework.Core.Configuration
             builder.Ignore(x => x.ContextOptions);
             builder.Ignore(x => x.Channel);
             builder.Property<string>("Data");
+            builder.Property(x => x.CreatedAt).HasConversion(ValueConverters.InstantConverter);
             builder.HasIndex(x => new {x.DefinitionId, x.Version}).HasDatabaseName($"IX_{nameof(WorkflowDefinition)}_{nameof(WorkflowDefinition.DefinitionId)}_{nameof(WorkflowDefinition.VersionId)}").IsUnique();
             builder.HasIndex(x => x.TenantId).HasDatabaseName($"IX_{nameof(WorkflowDefinition)}_{nameof(WorkflowDefinition.TenantId)}");
             builder.HasIndex(x => x.Version).HasDatabaseName($"IX_{nameof(WorkflowDefinition)}_{nameof(WorkflowDefinition.Version)}");

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/create-migrations-280.cmd
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/create-migrations-280.cmd
@@ -1,0 +1,19 @@
+REM MySql
+cd ../Elsa.Persistence.EntityFramework.MySql
+dotnet ef migrations add Update28 -- "Server=localhost;Port=3306;Database=elsa;User=root;Password=password;" "8.0.22"
+
+REM PostgreSql
+cd ../Elsa.Persistence.EntityFramework.PostgreSql
+dotnet ef migrations add Update28 -- "Server=localhost;Port=3306;Database=elsa;User=root;Password=password;" "8.0.22"
+
+REM Sqlite
+cd ../Elsa.Persistence.EntityFramework.Sqlite
+dotnet ef migrations add Update28
+
+REM SqlServer
+cd ../Elsa.Persistence.EntityFramework.SqlServer
+dotnet ef migrations add Update28 -- "{connection string}"
+
+REM Oracle
+cd ../Elsa.Persistence.EntityFramework.Oracle
+dotnet ef migrations add Update28 -- "{connection string}"

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.MySql/Migrations/20220512203646_Update28.Designer.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.MySql/Migrations/20220512203646_Update28.Designer.cs
@@ -3,58 +3,58 @@ using System;
 using Elsa.Persistence.EntityFramework.Core;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
-using Oracle.EntityFrameworkCore.Metadata;
 
-namespace Elsa.Persistence.EntityFramework.Oracle.Migrations
+namespace Elsa.Persistence.EntityFramework.MySql.Migrations
 {
     [DbContext(typeof(ElsaContext))]
-    partial class ElsaContextModelSnapshot : ModelSnapshot
+    [Migration("20220512203646_Update28")]
+    partial class Update28
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
                 .HasDefaultSchema("Elsa")
-                .HasAnnotation("Relational:MaxIdentifierLength", 128)
-                .HasAnnotation("ProductVersion", "5.0.10")
-                .HasAnnotation("Oracle:ValueGenerationStrategy", OracleValueGenerationStrategy.IdentityColumn);
+                .HasAnnotation("Relational:MaxIdentifierLength", 64)
+                .HasAnnotation("ProductVersion", "5.0.10");
 
             modelBuilder.Entity("Elsa.Models.Bookmark", b =>
                 {
                     b.Property<string>("Id")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<string>("ActivityId")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<string>("ActivityType")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<string>("CorrelationId")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<string>("Hash")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<string>("Model")
                         .IsRequired()
-                        .HasColumnType("NCLOB");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("ModelType")
                         .IsRequired()
-                        .HasColumnType("NCLOB");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("TenantId")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<string>("WorkflowInstanceId")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("varchar(255)");
 
                     b.HasKey("Id");
 
@@ -88,34 +88,34 @@ namespace Elsa.Persistence.EntityFramework.Oracle.Migrations
             modelBuilder.Entity("Elsa.Models.Trigger", b =>
                 {
                     b.Property<string>("Id")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<string>("ActivityId")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<string>("ActivityType")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<string>("Hash")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<string>("Model")
                         .IsRequired()
-                        .HasColumnType("NCLOB");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("ModelType")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(2000)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("TenantId")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<string>("WorkflowDefinitionId")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("varchar(255)");
 
                     b.HasKey("Id");
 
@@ -146,50 +146,50 @@ namespace Elsa.Persistence.EntityFramework.Oracle.Migrations
             modelBuilder.Entity("Elsa.Models.WorkflowDefinition", b =>
                 {
                     b.Property<string>("Id")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<DateTimeOffset>("CreatedAt")
-                        .HasColumnType("TIMESTAMP(7) WITH TIME ZONE");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("Data")
-                        .HasColumnType("NCLOB");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("DefinitionId")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<bool>("DeleteCompletedInstances")
-                        .HasColumnType("NUMBER(1)");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("Description")
-                        .HasColumnType("NCLOB");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("DisplayName")
-                        .HasColumnType("NCLOB");
+                        .HasColumnType("longtext");
 
                     b.Property<bool>("IsLatest")
-                        .HasColumnType("NUMBER(1)");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("IsPublished")
-                        .HasColumnType("NUMBER(1)");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("IsSingleton")
-                        .HasColumnType("NUMBER(1)");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("Name")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<int>("PersistenceBehavior")
-                        .HasColumnType("NUMBER(10)");
+                        .HasColumnType("int");
 
                     b.Property<string>("Tag")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<string>("TenantId")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<int>("Version")
-                        .HasColumnType("NUMBER(10)");
+                        .HasColumnType("int");
 
                     b.HasKey("Id");
 
@@ -221,37 +221,37 @@ namespace Elsa.Persistence.EntityFramework.Oracle.Migrations
             modelBuilder.Entity("Elsa.Models.WorkflowExecutionLogRecord", b =>
                 {
                     b.Property<string>("Id")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<string>("ActivityId")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<string>("ActivityType")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<string>("Data")
-                        .HasColumnType("NCLOB");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("EventName")
-                        .HasColumnType("NCLOB");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("Message")
-                        .HasColumnType("NCLOB");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("Source")
-                        .HasColumnType("NCLOB");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("TenantId")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<DateTimeOffset>("Timestamp")
-                        .HasColumnType("TIMESTAMP(7) WITH TIME ZONE");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("WorkflowInstanceId")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("varchar(255)");
 
                     b.HasKey("Id");
 
@@ -276,58 +276,58 @@ namespace Elsa.Persistence.EntityFramework.Oracle.Migrations
             modelBuilder.Entity("Elsa.Models.WorkflowInstance", b =>
                 {
                     b.Property<string>("Id")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<DateTimeOffset?>("CancelledAt")
-                        .HasColumnType("TIMESTAMP(7) WITH TIME ZONE");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("ContextId")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<string>("ContextType")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<string>("CorrelationId")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<DateTimeOffset>("CreatedAt")
-                        .HasColumnType("TIMESTAMP(7) WITH TIME ZONE");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("Data")
-                        .HasColumnType("NCLOB");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("DefinitionId")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<string>("DefinitionVersionId")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<DateTimeOffset?>("FaultedAt")
-                        .HasColumnType("TIMESTAMP(7) WITH TIME ZONE");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<DateTimeOffset?>("FinishedAt")
-                        .HasColumnType("TIMESTAMP(7) WITH TIME ZONE");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("LastExecutedActivityId")
-                        .HasColumnType("NCLOB");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTimeOffset?>("LastExecutedAt")
-                        .HasColumnType("TIMESTAMP(7) WITH TIME ZONE");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("Name")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<string>("TenantId")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<int>("Version")
-                        .HasColumnType("NUMBER(10)");
+                        .HasColumnType("int");
 
                     b.Property<int>("WorkflowStatus")
-                        .HasColumnType("NUMBER(10)");
+                        .HasColumnType("int");
 
                     b.HasKey("Id");
 

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.MySql/Migrations/20220512203646_Update28.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.MySql/Migrations/20220512203646_Update28.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Elsa.Persistence.EntityFramework.MySql.Migrations
+{
+    public partial class Update28 : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "CreatedAt",
+                schema: "Elsa",
+                table: "WorkflowDefinitions",
+                type: "datetime(6)",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CreatedAt",
+                schema: "Elsa",
+                table: "WorkflowDefinitions");
+        }
+    }
+}

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.MySql/Migrations/ElsaContextModelSnapshot.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.MySql/Migrations/ElsaContextModelSnapshot.cs
@@ -146,6 +146,9 @@ namespace Elsa.Persistence.EntityFramework.MySql.Migrations
                     b.Property<string>("Id")
                         .HasColumnType("varchar(255)");
 
+                    b.Property<DateTimeOffset>("CreatedAt")
+                        .HasColumnType("datetime(6)");
+
                     b.Property<string>("Data")
                         .HasColumnType("longtext");
 

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Oracle/Migrations/20220512203705_Update28.Designer.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Oracle/Migrations/20220512203705_Update28.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Elsa.Persistence.EntityFramework.Core;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Oracle.EntityFrameworkCore.Metadata;
 
 namespace Elsa.Persistence.EntityFramework.Oracle.Migrations
 {
     [DbContext(typeof(ElsaContext))]
-    partial class ElsaContextModelSnapshot : ModelSnapshot
+    [Migration("20220512203705_Update28")]
+    partial class Update28
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Oracle/Migrations/20220512203705_Update28.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Oracle/Migrations/20220512203705_Update28.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Elsa.Persistence.EntityFramework.Oracle.Migrations
+{
+    public partial class Update28 : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "CreatedAt",
+                schema: "Elsa",
+                table: "WorkflowDefinitions",
+                type: "TIMESTAMP(7) WITH TIME ZONE",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CreatedAt",
+                schema: "Elsa",
+                table: "WorkflowDefinitions");
+        }
+    }
+}

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.PostgreSql/Migrations/20220512203651_Update28.Designer.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.PostgreSql/Migrations/20220512203651_Update28.Designer.cs
@@ -3,58 +3,60 @@ using System;
 using Elsa.Persistence.EntityFramework.Core;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
-using Oracle.EntityFrameworkCore.Metadata;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
-namespace Elsa.Persistence.EntityFramework.Oracle.Migrations
+namespace Elsa.Persistence.EntityFramework.PostgreSql.Migrations
 {
     [DbContext(typeof(ElsaContext))]
-    partial class ElsaContextModelSnapshot : ModelSnapshot
+    [Migration("20220512203651_Update28")]
+    partial class Update28
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
                 .HasDefaultSchema("Elsa")
-                .HasAnnotation("Relational:MaxIdentifierLength", 128)
+                .HasAnnotation("Relational:MaxIdentifierLength", 63)
                 .HasAnnotation("ProductVersion", "5.0.10")
-                .HasAnnotation("Oracle:ValueGenerationStrategy", OracleValueGenerationStrategy.IdentityColumn);
+                .HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
 
             modelBuilder.Entity("Elsa.Models.Bookmark", b =>
                 {
                     b.Property<string>("Id")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("text");
 
                     b.Property<string>("ActivityId")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("text");
 
                     b.Property<string>("ActivityType")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("text");
 
                     b.Property<string>("CorrelationId")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("text");
 
                     b.Property<string>("Hash")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("text");
 
                     b.Property<string>("Model")
                         .IsRequired()
-                        .HasColumnType("NCLOB");
+                        .HasColumnType("text");
 
                     b.Property<string>("ModelType")
                         .IsRequired()
-                        .HasColumnType("NCLOB");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("text");
 
                     b.Property<string>("WorkflowInstanceId")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("text");
 
                     b.HasKey("Id");
 
@@ -88,34 +90,34 @@ namespace Elsa.Persistence.EntityFramework.Oracle.Migrations
             modelBuilder.Entity("Elsa.Models.Trigger", b =>
                 {
                     b.Property<string>("Id")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("text");
 
                     b.Property<string>("ActivityId")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("text");
 
                     b.Property<string>("ActivityType")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("text");
 
                     b.Property<string>("Hash")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("text");
 
                     b.Property<string>("Model")
                         .IsRequired()
-                        .HasColumnType("NCLOB");
+                        .HasColumnType("text");
 
                     b.Property<string>("ModelType")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(2000)");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("text");
 
                     b.Property<string>("WorkflowDefinitionId")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("text");
 
                     b.HasKey("Id");
 
@@ -146,50 +148,50 @@ namespace Elsa.Persistence.EntityFramework.Oracle.Migrations
             modelBuilder.Entity("Elsa.Models.WorkflowDefinition", b =>
                 {
                     b.Property<string>("Id")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("text");
 
                     b.Property<DateTimeOffset>("CreatedAt")
-                        .HasColumnType("TIMESTAMP(7) WITH TIME ZONE");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Data")
-                        .HasColumnType("NCLOB");
+                        .HasColumnType("text");
 
                     b.Property<string>("DefinitionId")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("text");
 
                     b.Property<bool>("DeleteCompletedInstances")
-                        .HasColumnType("NUMBER(1)");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("Description")
-                        .HasColumnType("NCLOB");
+                        .HasColumnType("text");
 
                     b.Property<string>("DisplayName")
-                        .HasColumnType("NCLOB");
+                        .HasColumnType("text");
 
                     b.Property<bool>("IsLatest")
-                        .HasColumnType("NUMBER(1)");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("IsPublished")
-                        .HasColumnType("NUMBER(1)");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("IsSingleton")
-                        .HasColumnType("NUMBER(1)");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("Name")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("text");
 
                     b.Property<int>("PersistenceBehavior")
-                        .HasColumnType("NUMBER(10)");
+                        .HasColumnType("integer");
 
                     b.Property<string>("Tag")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("text");
 
                     b.Property<int>("Version")
-                        .HasColumnType("NUMBER(10)");
+                        .HasColumnType("integer");
 
                     b.HasKey("Id");
 
@@ -221,37 +223,37 @@ namespace Elsa.Persistence.EntityFramework.Oracle.Migrations
             modelBuilder.Entity("Elsa.Models.WorkflowExecutionLogRecord", b =>
                 {
                     b.Property<string>("Id")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("text");
 
                     b.Property<string>("ActivityId")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("text");
 
                     b.Property<string>("ActivityType")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("text");
 
                     b.Property<string>("Data")
-                        .HasColumnType("NCLOB");
+                        .HasColumnType("text");
 
                     b.Property<string>("EventName")
-                        .HasColumnType("NCLOB");
+                        .HasColumnType("text");
 
                     b.Property<string>("Message")
-                        .HasColumnType("NCLOB");
+                        .HasColumnType("text");
 
                     b.Property<string>("Source")
-                        .HasColumnType("NCLOB");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("text");
 
                     b.Property<DateTimeOffset>("Timestamp")
-                        .HasColumnType("TIMESTAMP(7) WITH TIME ZONE");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("WorkflowInstanceId")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("text");
 
                     b.HasKey("Id");
 
@@ -276,58 +278,58 @@ namespace Elsa.Persistence.EntityFramework.Oracle.Migrations
             modelBuilder.Entity("Elsa.Models.WorkflowInstance", b =>
                 {
                     b.Property<string>("Id")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("text");
 
                     b.Property<DateTimeOffset?>("CancelledAt")
-                        .HasColumnType("TIMESTAMP(7) WITH TIME ZONE");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("ContextId")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("text");
 
                     b.Property<string>("ContextType")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("text");
 
                     b.Property<string>("CorrelationId")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("text");
 
                     b.Property<DateTimeOffset>("CreatedAt")
-                        .HasColumnType("TIMESTAMP(7) WITH TIME ZONE");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Data")
-                        .HasColumnType("NCLOB");
+                        .HasColumnType("text");
 
                     b.Property<string>("DefinitionId")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("text");
 
                     b.Property<string>("DefinitionVersionId")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("text");
 
                     b.Property<DateTimeOffset?>("FaultedAt")
-                        .HasColumnType("TIMESTAMP(7) WITH TIME ZONE");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTimeOffset?>("FinishedAt")
-                        .HasColumnType("TIMESTAMP(7) WITH TIME ZONE");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("LastExecutedActivityId")
-                        .HasColumnType("NCLOB");
+                        .HasColumnType("text");
 
                     b.Property<DateTimeOffset?>("LastExecutedAt")
-                        .HasColumnType("TIMESTAMP(7) WITH TIME ZONE");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Name")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("text");
 
                     b.Property<string>("TenantId")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("text");
 
                     b.Property<int>("Version")
-                        .HasColumnType("NUMBER(10)");
+                        .HasColumnType("integer");
 
                     b.Property<int>("WorkflowStatus")
-                        .HasColumnType("NUMBER(10)");
+                        .HasColumnType("integer");
 
                     b.HasKey("Id");
 

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.PostgreSql/Migrations/20220512203651_Update28.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.PostgreSql/Migrations/20220512203651_Update28.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Elsa.Persistence.EntityFramework.PostgreSql.Migrations
+{
+    public partial class Update28 : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "CreatedAt",
+                schema: "Elsa",
+                table: "WorkflowDefinitions",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CreatedAt",
+                schema: "Elsa",
+                table: "WorkflowDefinitions");
+        }
+    }
+}

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.PostgreSql/Migrations/ElsaContextModelSnapshot.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.PostgreSql/Migrations/ElsaContextModelSnapshot.cs
@@ -148,6 +148,9 @@ namespace Elsa.Persistence.EntityFramework.PostgreSql.Migrations
                     b.Property<string>("Id")
                         .HasColumnType("text");
 
+                    b.Property<DateTimeOffset>("CreatedAt")
+                        .HasColumnType("timestamp with time zone");
+
                     b.Property<string>("Data")
                         .HasColumnType("text");
 

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.SqlServer/Migrations/20220512203701_Update28.Designer.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.SqlServer/Migrations/20220512203701_Update28.Designer.cs
@@ -3,58 +3,60 @@ using System;
 using Elsa.Persistence.EntityFramework.Core;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
-using Oracle.EntityFrameworkCore.Metadata;
 
-namespace Elsa.Persistence.EntityFramework.Oracle.Migrations
+namespace Elsa.Persistence.EntityFramework.SqlServer.Migrations
 {
     [DbContext(typeof(ElsaContext))]
-    partial class ElsaContextModelSnapshot : ModelSnapshot
+    [Migration("20220512203701_Update28")]
+    partial class Update28
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
                 .HasDefaultSchema("Elsa")
                 .HasAnnotation("Relational:MaxIdentifierLength", 128)
                 .HasAnnotation("ProductVersion", "5.0.10")
-                .HasAnnotation("Oracle:ValueGenerationStrategy", OracleValueGenerationStrategy.IdentityColumn);
+                .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
             modelBuilder.Entity("Elsa.Models.Bookmark", b =>
                 {
                     b.Property<string>("Id")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("ActivityId")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("ActivityType")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("CorrelationId")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("Hash")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("Model")
                         .IsRequired()
-                        .HasColumnType("NCLOB");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("ModelType")
                         .IsRequired()
-                        .HasColumnType("NCLOB");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("TenantId")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("WorkflowInstanceId")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("nvarchar(450)");
 
                     b.HasKey("Id");
 
@@ -88,34 +90,34 @@ namespace Elsa.Persistence.EntityFramework.Oracle.Migrations
             modelBuilder.Entity("Elsa.Models.Trigger", b =>
                 {
                     b.Property<string>("Id")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("ActivityId")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("ActivityType")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("Hash")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("Model")
                         .IsRequired()
-                        .HasColumnType("NCLOB");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("ModelType")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(2000)");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("TenantId")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("WorkflowDefinitionId")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("nvarchar(450)");
 
                     b.HasKey("Id");
 
@@ -146,50 +148,50 @@ namespace Elsa.Persistence.EntityFramework.Oracle.Migrations
             modelBuilder.Entity("Elsa.Models.WorkflowDefinition", b =>
                 {
                     b.Property<string>("Id")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<DateTimeOffset>("CreatedAt")
-                        .HasColumnType("TIMESTAMP(7) WITH TIME ZONE");
+                        .HasColumnType("datetimeoffset");
 
                     b.Property<string>("Data")
-                        .HasColumnType("NCLOB");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("DefinitionId")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<bool>("DeleteCompletedInstances")
-                        .HasColumnType("NUMBER(1)");
+                        .HasColumnType("bit");
 
                     b.Property<string>("Description")
-                        .HasColumnType("NCLOB");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("DisplayName")
-                        .HasColumnType("NCLOB");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<bool>("IsLatest")
-                        .HasColumnType("NUMBER(1)");
+                        .HasColumnType("bit");
 
                     b.Property<bool>("IsPublished")
-                        .HasColumnType("NUMBER(1)");
+                        .HasColumnType("bit");
 
                     b.Property<bool>("IsSingleton")
-                        .HasColumnType("NUMBER(1)");
+                        .HasColumnType("bit");
 
                     b.Property<string>("Name")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<int>("PersistenceBehavior")
-                        .HasColumnType("NUMBER(10)");
+                        .HasColumnType("int");
 
                     b.Property<string>("Tag")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("TenantId")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<int>("Version")
-                        .HasColumnType("NUMBER(10)");
+                        .HasColumnType("int");
 
                     b.HasKey("Id");
 
@@ -221,37 +223,37 @@ namespace Elsa.Persistence.EntityFramework.Oracle.Migrations
             modelBuilder.Entity("Elsa.Models.WorkflowExecutionLogRecord", b =>
                 {
                     b.Property<string>("Id")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("ActivityId")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("ActivityType")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("Data")
-                        .HasColumnType("NCLOB");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("EventName")
-                        .HasColumnType("NCLOB");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Message")
-                        .HasColumnType("NCLOB");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Source")
-                        .HasColumnType("NCLOB");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("TenantId")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<DateTimeOffset>("Timestamp")
-                        .HasColumnType("TIMESTAMP(7) WITH TIME ZONE");
+                        .HasColumnType("datetimeoffset");
 
                     b.Property<string>("WorkflowInstanceId")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("nvarchar(450)");
 
                     b.HasKey("Id");
 
@@ -276,58 +278,58 @@ namespace Elsa.Persistence.EntityFramework.Oracle.Migrations
             modelBuilder.Entity("Elsa.Models.WorkflowInstance", b =>
                 {
                     b.Property<string>("Id")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<DateTimeOffset?>("CancelledAt")
-                        .HasColumnType("TIMESTAMP(7) WITH TIME ZONE");
+                        .HasColumnType("datetimeoffset");
 
                     b.Property<string>("ContextId")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("ContextType")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("CorrelationId")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<DateTimeOffset>("CreatedAt")
-                        .HasColumnType("TIMESTAMP(7) WITH TIME ZONE");
+                        .HasColumnType("datetimeoffset");
 
                     b.Property<string>("Data")
-                        .HasColumnType("NCLOB");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("DefinitionId")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("DefinitionVersionId")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<DateTimeOffset?>("FaultedAt")
-                        .HasColumnType("TIMESTAMP(7) WITH TIME ZONE");
+                        .HasColumnType("datetimeoffset");
 
                     b.Property<DateTimeOffset?>("FinishedAt")
-                        .HasColumnType("TIMESTAMP(7) WITH TIME ZONE");
+                        .HasColumnType("datetimeoffset");
 
                     b.Property<string>("LastExecutedActivityId")
-                        .HasColumnType("NCLOB");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<DateTimeOffset?>("LastExecutedAt")
-                        .HasColumnType("TIMESTAMP(7) WITH TIME ZONE");
+                        .HasColumnType("datetimeoffset");
 
                     b.Property<string>("Name")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("TenantId")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<int>("Version")
-                        .HasColumnType("NUMBER(10)");
+                        .HasColumnType("int");
 
                     b.Property<int>("WorkflowStatus")
-                        .HasColumnType("NUMBER(10)");
+                        .HasColumnType("int");
 
                     b.HasKey("Id");
 

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.SqlServer/Migrations/20220512203701_Update28.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.SqlServer/Migrations/20220512203701_Update28.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Elsa.Persistence.EntityFramework.SqlServer.Migrations
+{
+    public partial class Update28 : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "CreatedAt",
+                schema: "Elsa",
+                table: "WorkflowDefinitions",
+                type: "datetimeoffset",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CreatedAt",
+                schema: "Elsa",
+                table: "WorkflowDefinitions");
+        }
+    }
+}

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.SqlServer/Migrations/ElsaContextModelSnapshot.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.SqlServer/Migrations/ElsaContextModelSnapshot.cs
@@ -148,6 +148,9 @@ namespace Elsa.Persistence.EntityFramework.SqlServer.Migrations
                     b.Property<string>("Id")
                         .HasColumnType("nvarchar(450)");
 
+                    b.Property<DateTimeOffset>("CreatedAt")
+                        .HasColumnType("datetimeoffset");
+
                     b.Property<string>("Data")
                         .HasColumnType("nvarchar(max)");
 

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Sqlite/Migrations/20220512203656_Update28.Designer.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Sqlite/Migrations/20220512203656_Update28.Designer.cs
@@ -3,58 +3,57 @@ using System;
 using Elsa.Persistence.EntityFramework.Core;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
-using Oracle.EntityFrameworkCore.Metadata;
 
-namespace Elsa.Persistence.EntityFramework.Oracle.Migrations
+namespace Elsa.Persistence.EntityFramework.Sqlite.Migrations
 {
     [DbContext(typeof(ElsaContext))]
-    partial class ElsaContextModelSnapshot : ModelSnapshot
+    [Migration("20220512203656_Update28")]
+    partial class Update28
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
                 .HasDefaultSchema("Elsa")
-                .HasAnnotation("Relational:MaxIdentifierLength", 128)
-                .HasAnnotation("ProductVersion", "5.0.10")
-                .HasAnnotation("Oracle:ValueGenerationStrategy", OracleValueGenerationStrategy.IdentityColumn);
+                .HasAnnotation("ProductVersion", "5.0.10");
 
             modelBuilder.Entity("Elsa.Models.Bookmark", b =>
                 {
                     b.Property<string>("Id")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ActivityId")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ActivityType")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("CorrelationId")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Hash")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Model")
                         .IsRequired()
-                        .HasColumnType("NCLOB");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ModelType")
                         .IsRequired()
-                        .HasColumnType("NCLOB");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TenantId")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("WorkflowInstanceId")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -88,34 +87,34 @@ namespace Elsa.Persistence.EntityFramework.Oracle.Migrations
             modelBuilder.Entity("Elsa.Models.Trigger", b =>
                 {
                     b.Property<string>("Id")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ActivityId")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ActivityType")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Hash")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Model")
                         .IsRequired()
-                        .HasColumnType("NCLOB");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ModelType")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(2000)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TenantId")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("WorkflowDefinitionId")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -146,50 +145,50 @@ namespace Elsa.Persistence.EntityFramework.Oracle.Migrations
             modelBuilder.Entity("Elsa.Models.WorkflowDefinition", b =>
                 {
                     b.Property<string>("Id")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("TEXT");
 
-                    b.Property<DateTimeOffset>("CreatedAt")
-                        .HasColumnType("TIMESTAMP(7) WITH TIME ZONE");
+                    b.Property<DateTime>("CreatedAt")
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Data")
-                        .HasColumnType("NCLOB");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("DefinitionId")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("DeleteCompletedInstances")
-                        .HasColumnType("NUMBER(1)");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Description")
-                        .HasColumnType("NCLOB");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("DisplayName")
-                        .HasColumnType("NCLOB");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("IsLatest")
-                        .HasColumnType("NUMBER(1)");
+                        .HasColumnType("INTEGER");
 
                     b.Property<bool>("IsPublished")
-                        .HasColumnType("NUMBER(1)");
+                        .HasColumnType("INTEGER");
 
                     b.Property<bool>("IsSingleton")
-                        .HasColumnType("NUMBER(1)");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Name")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("PersistenceBehavior")
-                        .HasColumnType("NUMBER(10)");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Tag")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TenantId")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("Version")
-                        .HasColumnType("NUMBER(10)");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("Id");
 
@@ -221,37 +220,37 @@ namespace Elsa.Persistence.EntityFramework.Oracle.Migrations
             modelBuilder.Entity("Elsa.Models.WorkflowExecutionLogRecord", b =>
                 {
                     b.Property<string>("Id")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ActivityId")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ActivityType")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Data")
-                        .HasColumnType("NCLOB");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("EventName")
-                        .HasColumnType("NCLOB");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Message")
-                        .HasColumnType("NCLOB");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Source")
-                        .HasColumnType("NCLOB");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TenantId")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("TEXT");
 
-                    b.Property<DateTimeOffset>("Timestamp")
-                        .HasColumnType("TIMESTAMP(7) WITH TIME ZONE");
+                    b.Property<DateTime>("Timestamp")
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("WorkflowInstanceId")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -276,58 +275,58 @@ namespace Elsa.Persistence.EntityFramework.Oracle.Migrations
             modelBuilder.Entity("Elsa.Models.WorkflowInstance", b =>
                 {
                     b.Property<string>("Id")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("TEXT");
 
-                    b.Property<DateTimeOffset?>("CancelledAt")
-                        .HasColumnType("TIMESTAMP(7) WITH TIME ZONE");
+                    b.Property<DateTime?>("CancelledAt")
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ContextId")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("ContextType")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("CorrelationId")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("TEXT");
 
-                    b.Property<DateTimeOffset>("CreatedAt")
-                        .HasColumnType("TIMESTAMP(7) WITH TIME ZONE");
+                    b.Property<DateTime>("CreatedAt")
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Data")
-                        .HasColumnType("NCLOB");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("DefinitionId")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("DefinitionVersionId")
                         .IsRequired()
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("TEXT");
 
-                    b.Property<DateTimeOffset?>("FaultedAt")
-                        .HasColumnType("TIMESTAMP(7) WITH TIME ZONE");
+                    b.Property<DateTime?>("FaultedAt")
+                        .HasColumnType("TEXT");
 
-                    b.Property<DateTimeOffset?>("FinishedAt")
-                        .HasColumnType("TIMESTAMP(7) WITH TIME ZONE");
+                    b.Property<DateTime?>("FinishedAt")
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("LastExecutedActivityId")
-                        .HasColumnType("NCLOB");
+                        .HasColumnType("TEXT");
 
-                    b.Property<DateTimeOffset?>("LastExecutedAt")
-                        .HasColumnType("TIMESTAMP(7) WITH TIME ZONE");
+                    b.Property<DateTime?>("LastExecutedAt")
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Name")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TenantId")
-                        .HasColumnType("NVARCHAR2(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("Version")
-                        .HasColumnType("NUMBER(10)");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("WorkflowStatus")
-                        .HasColumnType("NUMBER(10)");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("Id");
 

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Sqlite/Migrations/20220512203656_Update28.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Sqlite/Migrations/20220512203656_Update28.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Elsa.Persistence.EntityFramework.Sqlite.Migrations
+{
+    public partial class Update28 : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "CreatedAt",
+                schema: "Elsa",
+                table: "WorkflowDefinitions",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CreatedAt",
+                schema: "Elsa",
+                table: "WorkflowDefinitions");
+        }
+    }
+}

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Sqlite/Migrations/ElsaContextModelSnapshot.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Sqlite/Migrations/ElsaContextModelSnapshot.cs
@@ -145,6 +145,9 @@ namespace Elsa.Persistence.EntityFramework.Sqlite.Migrations
                     b.Property<string>("Id")
                         .HasColumnType("TEXT");
 
+                    b.Property<DateTime>("CreatedAt")
+                        .HasColumnType("TEXT");
+
                     b.Property<string>("Data")
                         .HasColumnType("TEXT");
 

--- a/src/server/Elsa.Server.Api/Endpoints/WorkflowDefinitions/Delete.cs
+++ b/src/server/Elsa.Server.Api/Endpoints/WorkflowDefinitions/Delete.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
+using Elsa.Models;
 using Elsa.Services;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -9,7 +10,8 @@ namespace Elsa.Server.Api.Endpoints.WorkflowDefinitions
 {
     [ApiController]
     [ApiVersion("1")]
-    [Route("v{apiVersion:apiVersion}/workflow-definitions/{id}")]
+    [Route("v{apiVersion:apiVersion}/workflow-definitions/{definitionId}")]
+    [Route("v{apiVersion:apiVersion}/workflow-definitions/{definitionId}/{versionOptions}")]
     [Produces("application/json")]
     public class Delete : ControllerBase
     {
@@ -24,9 +26,13 @@ namespace Elsa.Server.Api.Endpoints.WorkflowDefinitions
             OperationId = "WorkflowDefinitions.Delete",
             Tags = new[] { "WorkflowDefinitions" })
         ]
-        public async Task<IActionResult> Handle(string id, CancellationToken cancellationToken)
+        public async Task<IActionResult> Handle(string definitionId, VersionOptions? versionOptions = default, CancellationToken cancellationToken = default)
         {
-            await _workflowPublisher.DeleteAsync(id, cancellationToken);
+            if (versionOptions == null)
+                await _workflowPublisher.DeleteAsync(definitionId, VersionOptions.All, cancellationToken);
+            else
+                await _workflowPublisher.DeleteAsync(definitionId, versionOptions.Value, cancellationToken);
+
             return Accepted();
         }
     }

--- a/src/server/Elsa.Server.Api/Endpoints/WorkflowDefinitions/GetByDefinitionAndVersion.cs
+++ b/src/server/Elsa.Server.Api/Endpoints/WorkflowDefinitions/GetByDefinitionAndVersion.cs
@@ -1,7 +1,9 @@
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Elsa.Models;
 using Elsa.Persistence;
+using Elsa.Persistence.Specifications;
 using Elsa.Persistence.Specifications.WorkflowDefinitions;
 using Elsa.Server.Api.Helpers;
 using Elsa.Server.Api.Swagger.Examples;
@@ -34,6 +36,11 @@ namespace Elsa.Server.Api.Endpoints.WorkflowDefinitions
         public async Task<IActionResult> Handle(string workflowDefinitionId, VersionOptions versionOptions, CancellationToken cancellationToken = default)
         {
             var workflowDefinition = await _workflowDefinitionStore.FindAsync(new WorkflowDefinitionIdSpecification(workflowDefinitionId, versionOptions), cancellationToken);
+
+            if (workflowDefinition == null && versionOptions.IsLatest)
+                workflowDefinition = (await _workflowDefinitionStore.FindManyAsync(new WorkflowDefinitionIdSpecification(workflowDefinitionId, VersionOptions.All),
+                    new OrderBy<WorkflowDefinition>(x => x.Version, SortDirection.Descending), new Paging(0, 1), cancellationToken)).FirstOrDefault();
+
             return workflowDefinition == null ? NotFound() : Json(workflowDefinition, SerializationHelper.GetSettingsForWorkflowDefinition());
         }
     }

--- a/src/server/Elsa.Server.Api/Endpoints/WorkflowDefinitions/History.cs
+++ b/src/server/Elsa.Server.Api/Endpoints/WorkflowDefinitions/History.cs
@@ -43,7 +43,7 @@ namespace Elsa.Server.Api.Endpoints.WorkflowDefinitions
             OperationId = "WorkflowDefinitions.History",
             Tags = new[] { "WorkflowDefinitions" })
         ]
-        public async Task<ActionResult<PagedList<WorkflowDefinitionSummaryModel>>> Handle(string definitionId, CancellationToken cancellationToken = default)
+        public async Task<IActionResult> Handle(string definitionId, CancellationToken cancellationToken = default)
         {
             var tenantId = await _tenantAccessor.GetTenantIdAsync(cancellationToken);
             var specification = GetSpecification(definitionId).And(new TenantSpecification<WorkflowDefinition>(tenantId));
@@ -52,7 +52,7 @@ namespace Elsa.Server.Api.Endpoints.WorkflowDefinitions
 
             var model = new
             {
-                Versions = versionModels
+                Items = versionModels
             };
 
             return Json(model, SerializationHelper.GetSettingsForWorkflowDefinition());

--- a/src/server/Elsa.Server.Api/Endpoints/WorkflowDefinitions/History.cs
+++ b/src/server/Elsa.Server.Api/Endpoints/WorkflowDefinitions/History.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using AutoMapper;
+using Elsa.Models;
+using Elsa.Persistence;
+using Elsa.Persistence.Specifications;
+using Elsa.Persistence.Specifications.WorkflowDefinitions;
+using Elsa.Server.Api.Helpers;
+using Elsa.Server.Api.Models;
+using Elsa.Server.Api.Swagger.Examples;
+using Elsa.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
+using Swashbuckle.AspNetCore.Filters;
+
+namespace Elsa.Server.Api.Endpoints.WorkflowDefinitions
+{
+    [ApiController]
+    [ApiVersion("1")]
+    [Route("v{apiVersion:apiVersion}/workflow-definitions/{definitionId}/history")]
+    [Produces("application/json")]
+    public class History : Controller
+    {
+        private readonly IWorkflowDefinitionStore _workflowDefinitionStore;
+        private readonly IMapper _mapper;
+        private readonly ITenantAccessor _tenantAccessor;
+
+        public History(IWorkflowDefinitionStore workflowDefinitionStore, IMapper mapper, ITenantAccessor tenantAccessor)
+        {
+            _workflowDefinitionStore = workflowDefinitionStore;
+            _mapper = mapper;
+            _tenantAccessor = tenantAccessor;
+        }
+
+        [HttpGet]
+        [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(ICollection<WorkflowDefinitionVersionModel>))]
+        [SwaggerOperation(
+            Summary = "Returns a list of workflow definition versions.",
+            Description = "Returns a list of workflow definition versions.",
+            OperationId = "WorkflowDefinitions.History",
+            Tags = new[] { "WorkflowDefinitions" })
+        ]
+        public async Task<ActionResult<PagedList<WorkflowDefinitionSummaryModel>>> Handle(string definitionId, CancellationToken cancellationToken = default)
+        {
+            var tenantId = await _tenantAccessor.GetTenantIdAsync(cancellationToken);
+            var specification = GetSpecification(definitionId).And(new TenantSpecification<WorkflowDefinition>(tenantId));
+            var definitions = await _workflowDefinitionStore.FindManyAsync(specification, new OrderBy<WorkflowDefinition>(x => x.Version, SortDirection.Descending), cancellationToken: cancellationToken);
+            var versionModels = _mapper.Map<IList<WorkflowDefinitionVersionModel>>(definitions);
+
+            var model = new
+            {
+                Versions = versionModels
+            };
+
+            return Json(model, SerializationHelper.GetSettingsForWorkflowDefinition());
+        }
+
+        private Specification<WorkflowDefinition> GetSpecification(string definitionId) => new WorkflowDefinitionIdSpecification(definitionId, VersionOptions.All);
+    }
+}

--- a/src/server/Elsa.Server.Api/Endpoints/WorkflowDefinitions/Models.cs
+++ b/src/server/Elsa.Server.Api/Endpoints/WorkflowDefinitions/Models.cs
@@ -17,4 +17,4 @@ public record WorkflowDefinitionSummaryModel(
     bool IsLatest,
     Variables CustomAttributes);
     
-public record WorkflowDefinitionVersionModel(string DefinitionId, int Version, Instant CreatedAt);
+public record WorkflowDefinitionVersionModel(string Id, string DefinitionId, int Version, bool IsPublished, Instant CreatedAt);

--- a/src/server/Elsa.Server.Api/Endpoints/WorkflowDefinitions/Models.cs
+++ b/src/server/Elsa.Server.Api/Endpoints/WorkflowDefinitions/Models.cs
@@ -1,18 +1,20 @@
 using Elsa.Models;
+using NodaTime;
 
-namespace Elsa.Server.Api.Endpoints.WorkflowDefinitions
-{
-    public record WorkflowDefinitionSummaryModel(
-        string Id,
-        string DefinitionId,
-        string? TenantId,
-        string? Name,
-        string? DisplayName,
-        string? Description,
-        int Version,
-        bool IsSingleton,
-        WorkflowPersistenceBehavior PersistenceBehavior,
-        bool IsPublished,
-        bool IsLatest,
-		Variables CustomAttributes);
-}
+namespace Elsa.Server.Api.Endpoints.WorkflowDefinitions;
+
+public record WorkflowDefinitionSummaryModel(
+    string Id,
+    string DefinitionId,
+    string? TenantId,
+    string? Name,
+    string? DisplayName,
+    string? Description,
+    int Version,
+    bool IsSingleton,
+    WorkflowPersistenceBehavior PersistenceBehavior,
+    bool IsPublished,
+    bool IsLatest,
+    Variables CustomAttributes);
+    
+public record WorkflowDefinitionVersionModel(string DefinitionId, int Version, Instant CreatedAt);

--- a/src/server/Elsa.Server.Api/Endpoints/WorkflowDefinitions/Models.cs
+++ b/src/server/Elsa.Server.Api/Endpoints/WorkflowDefinitions/Models.cs
@@ -17,4 +17,4 @@ public record WorkflowDefinitionSummaryModel(
     bool IsLatest,
     Variables CustomAttributes);
     
-public record WorkflowDefinitionVersionModel(string Id, string DefinitionId, int Version, bool IsPublished, Instant CreatedAt);
+public record WorkflowDefinitionVersionModel(string Id, string DefinitionId, int Version, bool IsLatest, bool IsPublished, Instant CreatedAt);

--- a/src/server/Elsa.Server.Api/Endpoints/WorkflowDefinitions/Revert.cs
+++ b/src/server/Elsa.Server.Api/Endpoints/WorkflowDefinitions/Revert.cs
@@ -1,0 +1,48 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Elsa.Models;
+using Elsa.Server.Api.Helpers;
+using Elsa.Server.Api.Swagger.Examples;
+using Elsa.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
+using Swashbuckle.AspNetCore.Filters;
+
+namespace Elsa.Server.Api.Endpoints.WorkflowDefinitions
+{
+    [ApiController]
+    [ApiVersion("1")]
+    [Route("v{apiVersion:apiVersion}/workflow-definitions/{definitionId}/revert/{version}")]
+    [Produces("application/json")]
+    public class Revert : ControllerBase
+    {
+        private readonly IWorkflowPublisher _workflowPublisher;
+        public Revert(IWorkflowPublisher workflowPublisher) => _workflowPublisher = workflowPublisher;
+
+        [HttpPost]
+        [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(WorkflowDefinition))]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [SwaggerResponseExample(StatusCodes.Status200OK, typeof(WorkflowDefinitionExample))]
+        [SwaggerOperation(
+            Summary = "Reverts a workflow definition to the specified version and returns it as a new draft.",
+            Description = "Reverts a workflow definition to the specified version and returns it as a new draft.",
+            OperationId = "WorkflowDefinitions.Revert",
+            Tags = new[] { "WorkflowDefinitions" })
+        ]
+        public async Task<ActionResult<WorkflowDefinition>> Handle(string definitionId, int version, ApiVersion apiVersion, CancellationToken cancellationToken)
+        {
+            // Create a draft based on the specified version.
+            var draft = await _workflowPublisher.GetDraftAsync(definitionId, VersionOptions.SpecificVersion(version), cancellationToken);
+
+            if (draft == null)
+                return NotFound();
+
+            // Save the draft.
+            await _workflowPublisher.SaveDraftAsync(draft, cancellationToken);
+
+            return AcceptedAtAction("Handle", "GetByVersionId", new { versionId = draft.Id, apiVersion = apiVersion.ToString() }, draft)
+                .ConfigureForWorkflowDefinition();
+        }
+    }
+}

--- a/src/server/Elsa.Server.Api/Mapping/AutoMapperProfile.cs
+++ b/src/server/Elsa.Server.Api/Mapping/AutoMapperProfile.cs
@@ -18,6 +18,7 @@ namespace Elsa.Server.Api.Mapping
             CreateMap<IConnection, ConnectionModel?>().ConvertUsing<ConnectionConverter>();
             CreateMap<WorkflowInstance, WorkflowInstanceSummaryModel>();
             CreateMap<WorkflowDefinition, WorkflowDefinitionSummaryModel>();
+            CreateMap<WorkflowDefinition, WorkflowDefinitionVersionModel>();
         }
     }
 }


### PR DESCRIPTION
This PR adds a tab to the workflow definition editor panel that lets the user view older versions of the workflow definition, revert back to them and permanently delete them.

Example video:

[![Alt text](https://img.youtube.com/vi/O10MUh8SD14/0.jpg)](https://www.youtube.com/watch?v=O10MUh8SD14)

Closes #2572 and #1311