### PR TITLE
Auto name activity

### DIFF
--- a/src/designer/elsa-workflows-designer/src/components.d.ts
+++ b/src/designer/elsa-workflows-designer/src/components.d.ts
@@ -168,11 +168,11 @@ export namespace Components {
         "activityDescriptors": Array<ActivityDescriptor>;
         "getCanvas": () => Promise<HTMLElsaCanvasElement>;
         "getWorkflow": () => Promise<WorkflowDefinition>;
-        "importWorkflow": (workflow: WorkflowDefinition, workflowInstance?: WorkflowInstance) => Promise<void>;
-        "importWorkflowMetadata": (workflow: WorkflowDefinition) => Promise<void>;
+        "importWorkflow": (workflowDefinition: WorkflowDefinition, workflowInstance?: WorkflowInstance) => Promise<void>;
         "monacoLibPath": string;
         "newWorkflow": () => Promise<void>;
         "registerActivityDrivers": (register: (registry: ActivityDriverRegistry) => void) => Promise<void>;
+        "updateWorkflowDefinition": (workflowDefinition: WorkflowDefinition) => Promise<void>;
     }
     interface ElsaWorkflowInstanceBrowser {
         "hide": () => Promise<void>;

--- a/src/designer/elsa-workflows-designer/src/components/activities/flowchart/flowchart.tsx
+++ b/src/designer/elsa-workflows-designer/src/components/activities/flowchart/flowchart.tsx
@@ -69,6 +69,7 @@ export class FlowchartComponent implements ContainerActivityComponent {
   public async addActivity(args: AddActivityArgs): Promise<void> {
     const graph = this.graph;
     const {descriptor, x, y} = args;
+    let id = args.id ?? uuid();
 
     // TODO: Figure out how to convert client coordinates to appropriate graph coordinates taking into account transformations.
     // See https://x6.antv.vision/en/docs/api/graph/coordinate for documentation.
@@ -78,13 +79,8 @@ export class FlowchartComponent implements ContainerActivityComponent {
     const sx = point.x;
     const sy = point.y;
 
-    console.debug({
-      client: {x, y},
-      local: {sx, sy},
-    });
-
     const activity: Activity = {
-      id: uuid(),
+      id: id,
       typeName: descriptor.activityType,
       applicationProperties: {},
       metadata: {

--- a/src/designer/elsa-workflows-designer/src/components/designer/canvas/canvas.tsx
+++ b/src/designer/elsa-workflows-designer/src/components/designer/canvas/canvas.tsx
@@ -4,6 +4,7 @@ import {Activity, ActivityDescriptor} from '../../../models';
 
 export interface AddActivityArgs {
   descriptor: ActivityDescriptor;
+  id?: string;
   x?: number;
   y?: number;
 }

--- a/src/designer/elsa-workflows-designer/src/components/designer/workflow-editor/workflow-editor.tsx
+++ b/src/designer/elsa-workflows-designer/src/components/designer/workflow-editor/workflow-editor.tsx
@@ -42,8 +42,6 @@ export class WorkflowEditor {
   private toolbox: HTMLElsaToolboxElement;
   private applyActivityChanges: (activity: Activity) => void;
   private deleteActivity: (activity: Activity) => void;
-  private applyTriggerChanges: (trigger: Trigger) => void;
-  private deleteTrigger: (trigger: Trigger) => void;
   private readonly emitActivityChangedDebounced: (e: ActivityPropertyChangedEventArgs) => void;
   private readonly saveChangesDebounced: () => void;
 

--- a/src/designer/elsa-workflows-designer/src/components/designer/workflow-editor/workflow-editor.tsx
+++ b/src/designer/elsa-workflows-designer/src/components/designer/workflow-editor/workflow-editor.tsx
@@ -25,6 +25,8 @@ import {WorkflowPropsUpdatedArgs} from "../workflow-properties-editor/workflow-p
 import {MonacoEditorSettings} from "../../../services/monaco-editor-settings";
 import {PluginRegistry} from "../../../services/plugin-registry";
 import {Flowchart} from "../../activities/flowchart/models";
+import {ActivityNode, flattenList, walkActivities} from "../../activities/flowchart/activity-walker";
+import {ActivityNameFormatter} from "../../../services/activity-name-formatter";
 
 export interface WorkflowUpdatedArgs {
   workflow: WorkflowDefinition;
@@ -37,6 +39,7 @@ export interface WorkflowUpdatedArgs {
 export class WorkflowEditor {
   private readonly pluginRegistry: PluginRegistry;
   private readonly eventBus: EventBus;
+  private readonly activityNameFormatter: ActivityNameFormatter;
   private canvas: HTMLElsaCanvasElement;
   private container: HTMLDivElement;
   private toolbox: HTMLElsaToolboxElement;
@@ -61,6 +64,7 @@ export class WorkflowEditor {
   constructor() {
     this.eventBus = Container.get(EventBus);
     this.pluginRegistry = Container.get(PluginRegistry);
+    this.activityNameFormatter = Container.get(ActivityNameFormatter);
     this.emitActivityChangedDebounced = debounce(this.emitActivityChanged, 100);
     this.saveChangesDebounced = debounce(this.saveChanges, 1000);
   }
@@ -126,15 +130,16 @@ export class WorkflowEditor {
   }
 
   @Method()
-  public async importWorkflow(workflow: WorkflowDefinition, workflowInstance?: WorkflowInstance): Promise<void> {
+  public async importWorkflow(workflowDefinition: WorkflowDefinition, workflowInstance?: WorkflowInstance): Promise<void> {
     this.workflowInstance = workflowInstance;
-    await this.importWorkflowMetadata(workflow);
-    await this.canvas.importGraph(workflow.root);
+    this.workflowDefinition = workflowDefinition;
+    await this.canvas.importGraph(workflowDefinition.root);
   }
 
+  // Updates the workflow definition without importing it into the designer.
   @Method()
-  public async importWorkflowMetadata(workflow: WorkflowDefinition): Promise<void> {
-    this.workflowDefinition = workflow;
+  public async updateWorkflowDefinition(workflowDefinition: WorkflowDefinition): Promise<void> {
+    this.workflowDefinition = workflowDefinition;
   }
 
   @Method()
@@ -240,6 +245,23 @@ export class WorkflowEditor {
     await this.updateLayout();
   }
 
+  private generateUniqueActivityName = async (activityDescriptor: ActivityDescriptor): Promise<string> => {
+    const activityType = activityDescriptor.activityType;
+    const workflowDefinition = await this.getWorkflowInternal();
+    const root = workflowDefinition.root;
+    const activityDescriptors = this.activityDescriptors;
+    const graph = walkActivities(root, activityDescriptors);
+    const activityNodes = flattenList(graph.children);
+    const activityCount = activityNodes.filter(x => x.activity.typeName == activityType).length;
+    let counter = activityCount + 1;
+    let newName = this.activityNameFormatter.format({activityDescriptor, count: counter, activityNodes});
+
+    while (!!activityNodes.find(x => x.activity.id == newName))
+      newName = this.activityNameFormatter.format({activityDescriptor, count: ++counter, activityNodes});
+
+    return newName;
+  };
+
   private onActivityPickerPanelStateChanged = async (e: PanelStateChangedArgs) => await this.updateContainerLayout('activity-picker-closed', e.expanded)
   private onActivityEditorPanelStateChanged = async (e: PanelStateChangedArgs) => await this.updateContainerLayout('object-editor-closed', e.expanded)
 
@@ -251,8 +273,13 @@ export class WorkflowEditor {
   private onDrop = async (e: DragEvent) => {
     const json = e.dataTransfer.getData('activity-descriptor');
     const activityDescriptor: ActivityDescriptor = JSON.parse(json);
+    const newName = await this.generateUniqueActivityName(activityDescriptor);
 
-    await this.canvas.addActivity({descriptor: activityDescriptor, x: e.offsetX, y: e.offsetY});
+    await this.canvas.addActivity({
+      descriptor: activityDescriptor,
+      id: newName,
+      x: e.offsetX,
+      y: e.offsetY});
   };
 
   private onActivityUpdated = (e: CustomEvent<ActivityUpdatedArgs>) => {

--- a/src/designer/elsa-workflows-designer/src/components/shell/studio/studio.tsx
+++ b/src/designer/elsa-workflows-designer/src/components/shell/studio/studio.tsx
@@ -184,7 +184,7 @@ export class Studio {
     };
 
     const updatedWorkflow = await this.elsaClient.workflowDefinitions.post(request);
-    await this.workflowEditorElement.importWorkflowMetadata(updatedWorkflow);
+    await this.workflowEditorElement.updateWorkflowDefinition(updatedWorkflow);
     return updatedWorkflow;
   }
 
@@ -194,7 +194,7 @@ export class Studio {
     };
 
     const updatedWorkflow = await this.elsaClient.workflowDefinitions.retract(request);
-    await this.workflowEditorElement.importWorkflowMetadata(updatedWorkflow);
+    await this.workflowEditorElement.updateWorkflowDefinition(updatedWorkflow);
     return updatedWorkflow;
   }
 }

--- a/src/designer/elsa-workflows-designer/src/index.html
+++ b/src/designer/elsa-workflows-designer/src/index.html
@@ -13,11 +13,27 @@
 <body>
 <!--Use the studio shell component to handle automatic interaction with the Elsa Server API-->
 <elsa-studio server="https://localhost:5001/elsa/api" monaco-lib-path="https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.31.1/min">
-    <elsa-workflow-toolbar></elsa-workflow-toolbar>
-    <div class="absolute inset-0" style="top: 64px;">
-      <elsa-workflow-editor></elsa-workflow-editor>
-    </div>
-<!--  <elsa-workflow-editor></elsa-workflow-editor>-->
+  <elsa-workflow-toolbar></elsa-workflow-toolbar>
+  <div class="absolute inset-0" style="top: 64px;">
+    <elsa-workflow-editor></elsa-workflow-editor>
+  </div>
+  <!--  <elsa-workflow-editor></elsa-workflow-editor>-->
 </elsa-studio>
+<script type="module">
+  // Integration demos.
+
+  // Import publicly exposed plugins, services and models to use in vanilla JavaScript.
+  import {Container, ActivityNameFormatter} from "/build/index.esm.js";
+
+  // Get a reference to the ActivityNameFormatter.
+  const activityNameFormatter = Container.get(ActivityNameFormatter);
+
+  // Install your preferred naming strategy:
+  activityNameFormatter.strategy = ActivityNameFormatter.CamelCaseStrategy;
+
+  // Or install a custom name formatter strategy.
+  //activityNameFormatter.strategy = context => `${context.activityDescriptor.activityType}_${context.count}`;
+
+</script>
 </body>
 </html>

--- a/src/designer/elsa-workflows-designer/src/index.ts
+++ b/src/designer/elsa-workflows-designer/src/index.ts
@@ -3,3 +3,5 @@ import 'reflect-metadata';
 export {Components, JSX} from './components';
 export {Container} from 'typedi';
 export {ElsaApiClientProvider, createElsaClient} from './services/elsa-api-client';
+export {stripActivityNameSpace} from './utils';
+export {PluginRegistry, ActivityNameFormatter} from './services';

--- a/src/designer/elsa-workflows-designer/src/services/activity-name-formatter.ts
+++ b/src/designer/elsa-workflows-designer/src/services/activity-name-formatter.ts
@@ -1,0 +1,30 @@
+import {Service} from 'typedi';
+import {camelCase, startCase, snakeCase, kebabCase} from 'lodash';
+import {ActivityDescriptor} from "../models";
+import {ActivityNode} from "../components/activities/flowchart/activity-walker";
+import {stripActivityNameSpace} from "../utils";
+
+export type ActivityNameStrategy = (context: ActivityNameFormatterContext) => string;
+
+export interface ActivityNameFormatterContext {
+  activityDescriptor: ActivityDescriptor;
+  count: number;
+  activityNodes: Array<ActivityNode>;
+}
+
+@Service()
+export class ActivityNameFormatter {
+
+  public static readonly DefaultStrategy: ActivityNameStrategy = context => `${stripActivityNameSpace(context.activityDescriptor.activityType)}${context.count}`;
+  public static readonly UnderscoreStrategy: ActivityNameStrategy = context => `${stripActivityNameSpace(context.activityDescriptor.activityType)}_${context.count}`;
+  public static readonly PascalCaseStrategy: ActivityNameStrategy = context => startCase(camelCase(ActivityNameFormatter.DefaultStrategy(context))).replace(/ /g, '');
+  public static readonly CamelCaseStrategy: ActivityNameStrategy = context => camelCase(ActivityNameFormatter.DefaultStrategy(context));
+  public static readonly SnakeCaseStrategy: ActivityNameStrategy = context => snakeCase(ActivityNameFormatter.DefaultStrategy(context));
+  public static readonly KebabCaseStrategy: ActivityNameStrategy = context => kebabCase(ActivityNameFormatter.DefaultStrategy(context));
+
+  public strategy: ActivityNameStrategy = ActivityNameFormatter.CamelCaseStrategy;
+
+  public format(context: ActivityNameFormatterContext): string {
+    return this.strategy(context);
+  }
+}

--- a/src/designer/elsa-workflows-designer/src/services/index.ts
+++ b/src/designer/elsa-workflows-designer/src/services/index.ts
@@ -7,3 +7,5 @@ export * from './event-bus';
 export * from './input-control-registry';
 export * from './input-driver-registry';
 export * from './server-settings';
+export * from './activity-name-formatter';
+export * from './plugin-registry';

--- a/src/designer/elsa-workflows-designer/src/utils/utils.ts
+++ b/src/designer/elsa-workflows-designer/src/utils/utils.ts
@@ -61,4 +61,9 @@ export const getInputPropertyValue = (inputContext: ActivityInputContext): Activ
   return inputContext.node[propName] as ActivityInput;
 };
 
-export const isNullOrWhitespace = ( input ) => !input || !input.trim();
+export const stripActivityNameSpace = (name: string): string => {
+  const lastDotIndex = name.lastIndexOf('.');
+  return lastDotIndex < 0 ? name : name.substr(lastDotIndex + 1);
+};
+
+export const isNullOrWhitespace = (input) => !input || !input.trim();


### PR DESCRIPTION
This PR adds a designer feature that will autogenerate activity names. Example:

![auto-name-activities-demo](https://user-images.githubusercontent.com/938393/168887593-524047cf-4ee2-481c-ad58-1379b0c58bff.gif)

The default naming strategy is *camel case**, but there are other ones available. This is the list out of the box:

- PascalCaseStrategy
- CamelCaseStrategy
- SnakeCaseStrategy
- KebabCaseStrategy

Additionally, custom strategies can be configured.

Here's an example demonstrating how to configure a strategy from the HTML page hosting the designer:

```html
<script type="module">
  // Import publicly exposed plugins, services and models to use in vanilla JavaScript.
  import {Container, ActivityNameFormatter} from "/build/index.esm.js"; // Use NPM package once released.

  // Get a reference to the ActivityNameFormatter.
  const activityNameFormatter = Container.get(ActivityNameFormatter); // Using service locator to get a reference to a service.

  // Install your preferred naming strategy:
  activityNameFormatter.strategy = ActivityNameFormatter.CamelCaseStrategy;

  // Or install a custom name formatter strategy (which is a simple function that receives a context and should return the resulting activity name as a string).
  //activityNameFormatter.strategy = context => `${context.activityDescriptor.activityType}_${context.count}`;

</script>
```

Closes #2874