### PR TITLE
Refactor System.ComponentModel.Annotations dependencies.

### DIFF
--- a/src/activities/Elsa.Activities.BlobStorage/Elsa.Activities.BlobStorage.csproj
+++ b/src/activities/Elsa.Activities.BlobStorage/Elsa.Activities.BlobStorage.csproj
@@ -15,6 +15,7 @@
 
     <ItemGroup>
         <PackageReference Include="Storage.Net" Version="9.3.0" />
+        <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/activities/Elsa.Activities.File/Elsa.Activities.File.csproj
+++ b/src/activities/Elsa.Activities.File/Elsa.Activities.File.csproj
@@ -19,6 +19,10 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
+    </ItemGroup>
+
+    <ItemGroup>
         <ProjectReference Include="..\..\core\Elsa.Core\Elsa.Core.csproj" />
     </ItemGroup>
 

--- a/src/core/Elsa.Abstractions/Elsa.Abstractions.csproj
+++ b/src/core/Elsa.Abstractions/Elsa.Abstractions.csproj
@@ -26,7 +26,6 @@
         <PackageReference Include="NodaTime.Serialization.JsonNet" Version="3.0.0" />
         <PackageReference Include="Open.Linq.AsyncExtensions" Version="1.2.0" />
         <PackageReference Include="Rebus" Version="6.6.2" />
-        <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
         <PackageReference Include="System.Linq.Async" Version="5.1.0" />
         <PackageReference Include="System.Text.Json" Version="6.0.1" />
         <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />


### PR DESCRIPTION
### 📑 Summary 

As discussed in #3018.

### 🎯 Goals

Remove dependency from a preview version of a dependency: `System.ComponentModel.Annotations Version=6.0.0-preview.4.21253.7` and use the latest stable version `5.0.0`.

Remove from _Elsa.Abstractions_ project the dependency on `System.ComponentModel.Annotations` as it's own code does not depend on it.

Add `System.ComponentModel.Annotations Version=5.0.0` to the correct projects that depend on this package: _Elsa.Activities.File_ and _Elsa.Activities.BlobStorage_.

