### PR TITLE
Remove triggers that have a malformed path

### DIFF
--- a/src/activities/Elsa.Activities.File/Services/FileSystemWatchersStarter.cs
+++ b/src/activities/Elsa.Activities.File/Services/FileSystemWatchersStarter.cs
@@ -118,14 +118,7 @@ namespace Elsa.Activities.File.Services
                 return;
 
             _logger.LogInformation("Creating directory {Path}", path);
-            try
-            {
-                Directory.CreateDirectory(path);
-            }
-            catch (ArgumentException ex)
-            {
-                _logger.LogError(ex, $"The path {path} is not valid.", path);
-            }
+            Directory.CreateDirectory(path);
         }
 
         #region Watcher delegates

--- a/src/activities/Elsa.Activities.File/Services/FileSystemWatchersStarter.cs
+++ b/src/activities/Elsa.Activities.File/Services/FileSystemWatchersStarter.cs
@@ -82,6 +82,9 @@ namespace Elsa.Activities.File.Services
             if (string.IsNullOrWhiteSpace(path))
                 throw new ArgumentException("File watcher path must not be null or empty");
 
+            if (!Uri.IsWellFormedUriString(path, UriKind.RelativeOrAbsolute))
+                throw new ArgumentException(nameof(path), $"Path {path} is not a well formed Uri");
+
             EnsurePathExists(path);
 
             var watcher = new FileSystemWatcher()
@@ -115,7 +118,14 @@ namespace Elsa.Activities.File.Services
                 return;
 
             _logger.LogInformation("Creating directory {Path}", path);
-            Directory.CreateDirectory(path);
+            try
+            {
+                Directory.CreateDirectory(path);
+            }
+            catch (ArgumentException ex)
+            {
+                _logger.LogError(ex, $"The path {path} is not valid.", path);
+            }
         }
 
         #region Watcher delegates

--- a/src/core/Elsa.Abstractions/Services/Triggers/ITriggerRemover.cs
+++ b/src/core/Elsa.Abstractions/Services/Triggers/ITriggerRemover.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Elsa.Models;
+
+namespace Elsa.Services
+{
+    public interface ITriggerRemover
+    {
+        Task RemoveTriggerAsync(Trigger trigger);
+    }
+}

--- a/src/core/Elsa.Core/Extensions/ElsaServiceCollectionExtensions.cs
+++ b/src/core/Elsa.Core/Extensions/ElsaServiceCollectionExtensions.cs
@@ -245,6 +245,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 .AddScoped<IGetsTriggersForWorkflowBlueprints, TriggersForBlueprintsProvider>()
                 .AddTransient<IGetsTriggersForActivityBlueprintAndWorkflow, TriggersForActivityBlueprintAndWorkflowProvider>()
                 .AddScoped<ITriggerFinder, TriggerFinder>()
+                .AddScoped<ITriggerRemover, TriggerRemover>()
                 .AddBookmarkProvider<SignalReceivedBookmarkProvider>()
                 .AddBookmarkProvider<RunWorkflowBookmarkProvider>();
 

--- a/src/core/Elsa.Core/Services/Triggers/TriggerRemover.cs
+++ b/src/core/Elsa.Core/Services/Triggers/TriggerRemover.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Elsa.Models;
+using Elsa.Persistence;
+
+namespace Elsa.Services.Triggers
+{
+    public class TriggerRemover: ITriggerRemover
+    {
+        private readonly ITriggerStore _triggerStore;
+
+        public TriggerRemover(ITriggerStore triggerStore)
+        {
+            _triggerStore = triggerStore;
+        }
+
+        public async Task RemoveTriggerAsync(Trigger trigger)
+        {
+            await _triggerStore.DeleteAsync(trigger);
+        }
+    }
+}


### PR DESCRIPTION
**Original Issue**

A malformed path would crash the program on startup because the `Directory.CreateDirectory` method would throw an unhandled exception. This is a bigger issue if the workflow is persistent since the trigger will get created but there isn't a way to remove it if something goes wrong. Meaning that if you use a `WatchDirectory` activity with an invalid path the project will fail to start until you change or remove the trigger in your database.

**How to create the original error**

I used the project `ElsaDashboard.Samples.AspNetCore.Monolith` in the samples directory for testing since it already has Elsa server setup with SQLite as the persistence provider.

I added file activities using `AddFileActivities()` in the Startup file and  I started up the project. I created a new workflow that only has one activity: a `WatchDirectory` activity and made the path `C:\Te|st`.

I am using Windows and this is an invalid path due to the `|`. If you are running something Unix based try `/test///directory`. The triple slashes should throw the same exception.

Publish this workflow and you will see a wave of exceptions fill the console. Now, shutdown the project and restart it. It will fail to start and cannot be restarted until you remove or change the trigger and the workflow definition in the SQLite database.

---

This PR is for two things:

1. Provide a service that allows a user to remove a trigger
2. Handles the IO or Argument exception thrown by the `Directory.CreateDirectory` method and removes the trigger that caused the exception.

---

**To Test**

Recreate the situation I described above using the `ElsaDashboard.Samples.AspNetCore.Monolith` project. This time though the exception will be logged to the console and the project can still be started. Meaning the user can edit the offending workflow from the UI.

I also tested this with the Builder API. This is the workflow I made:

```
public class WatchDirTest: IWorkflow
    {
        public void Build(IWorkflowBuilder builder)
        {
            builder 
                .WatchDirectory(setup => setup
                    .WithPath("C:\Te|st")
                    .WithPattern("*.txt"));
        }
    }
```

It will achieve the same result as when the designer is used. Even if you change the value of `WithPath` to something valid the trigger with the offending path is still there and the project will fail to start.