### PR TITLE
Add XML Code Comments For The HTTP Activities

### DIFF
--- a/src/activities/Elsa.Activities.Http/Activities/HttpEndpoint/HttpEndpoint.cs
+++ b/src/activities/Elsa.Activities.Http/Activities/HttpEndpoint/HttpEndpoint.cs
@@ -14,6 +14,9 @@ using Elsa.Services.Models;
 // ReSharper disable once CheckNamespace
 namespace Elsa.Activities.Http
 {
+    /// <summary>
+    /// Handle an incoming HTTP request.
+    /// </summary>
     [Trigger(
         Category = "HTTP",
         DisplayName = "HTTP Endpoint",
@@ -57,12 +60,19 @@ namespace Elsa.Activities.Http
         [ActivityInput(Category = PropertyCategories.Advanced)]
         public Type? TargetType { get; set; }
 
+        /// <summary>
+        /// Schema for the HTTP Request model. This is used for autocomplete when referencing the HTTP request body in the Workflow Designer.
+        /// You can use a tool like <see href="https://www.convertsimple.com/convert-json-to-json-schema/">Convert Simple's json to json schema converter</see> for schema generation.
+        /// </summary>
         [ActivityInput(
             Category = PropertyCategories.Advanced,
             UIHint = ActivityInputUIHints.CodeEditor,
             OptionsProvider = typeof(HttpEndpoint))]
         public string? Schema { get; set; }
 
+        /// <summary>
+        /// Allow authenticated requests only
+        /// </summary>
         [ActivityInput(
             Hint = "Check to allow authenticated requests only",
             SupportedSyntaxes = new[] { SyntaxNames.Literal, SyntaxNames.JavaScript, SyntaxNames.Liquid },
@@ -70,12 +80,19 @@ namespace Elsa.Activities.Http
         )]
         public bool Authorize { get; set; }
 
+        /// <summary>
+        /// Provide a policy to challenge the user with. If the policy fails, the request is forbidden.
+        /// </summary>
         [ActivityInput(
             Hint = "Provide a policy to evaluate. If the policy fails, the request is forbidden.",
             SupportedSyntaxes = new[] { SyntaxNames.Literal, SyntaxNames.JavaScript, SyntaxNames.Liquid },
             Category = "Security"
         )]
         public string? Policy { get; set; }
+
+        /// <summary>
+        /// The received HTTP request.
+        /// </summary>
 
         [ActivityOutput(Hint = "The received HTTP request.")]
         public HttpRequestModel? Output { get; set; }

--- a/src/activities/Elsa.Activities.Http/Activities/HttpEndpoint/HttpEndpointBuilderExtensions.cs
+++ b/src/activities/Elsa.Activities.Http/Activities/HttpEndpoint/HttpEndpointBuilderExtensions.cs
@@ -11,30 +11,121 @@ namespace Elsa.Activities.Http
 {
     public static class HttpEndpointBuilderExtensions
     {
+        /// <summary>
+        /// Creates an HTTP Endpoint activity
+        /// </summary>
+        /// <param name="setup">An <see cref="ISetupActivity"/> used to set the properties of the HTTP Endpoint Activity.</param>
+        /// <example>
+        /// <code>
+        /// builder
+        ///     .HttpEndpoint(setup => setup
+        ///         .WithPath("/path")
+        ///         .WithMethod(HttpMethods.Get));
+        /// </code>
+        /// </example>
+        /// <returns>The <see cref="IActivityBuilder"/> with the Http Endpoint activity built onto it.</returns>
+        /// <inheritdoc cref="BuilderExtensions.Then{T}(IBuilder, Action{ISetupActivity{T}}?, Action{IActivityBuilder}?, int, string?)"/>
         public static IActivityBuilder HttpEndpoint(this IBuilder builder, Action<ISetupActivity<HttpEndpoint>> setup, [CallerLineNumber] int lineNumber = default, [CallerFilePath] string? sourceFile = default) =>
             builder.Then(setup, null, lineNumber, sourceFile);
 
+        /// <param name="path">The path of the HTTP Endpoint. Allows caller to introduce the <see cref="ActivityExecutionContext"/> when deciding the endpoint's path.</param>
+        /// <example>
+        /// <code>
+        /// builder
+        ///     .HttpEndpoint(async context => context
+        ///         string? path = await context.GetNamedActivityPropertyAsync("PathGeneratorActivity", "SubPath", "");
+        ///         return "/path/" + path;
+        ///     });
+        /// </code>
+        /// </example>
+        /// <inheritdoc cref="HttpEndpoint(IBuilder, Action{ISetupActivity{HttpEndpoint}}, int, string?)"/>
         public static IActivityBuilder HttpEndpoint(this IBuilder builder, Func<ActivityExecutionContext, ValueTask<string>> path, [CallerLineNumber] int lineNumber = default, [CallerFilePath] string? sourceFile = default) =>
             builder.HttpEndpoint(setup => setup.WithPath(path).WithMethod(HttpMethods.Get), lineNumber, sourceFile);
 
+        /// <example>
+        /// <code>
+        /// <![CDATA[
+        /// builder
+        ///     .HttpEndpoint(context => 
+        ///         context.GetInput<string>());
+        /// ]]>
+        /// </code>
+        /// </example>
+        /// <inheritdoc cref="HttpEndpoint(IBuilder, Func{ActivityExecutionContext, ValueTask{string}}, int, string?)"/>
         public static IActivityBuilder HttpEndpoint(this IBuilder builder, Func<ActivityExecutionContext, string> path, [CallerLineNumber] int lineNumber = default, [CallerFilePath] string? sourceFile = default) =>
             builder.HttpEndpoint(setup => setup.WithPath(path).WithMethod(HttpMethods.Get), lineNumber, sourceFile);
 
+        /// <param name="path">The path of the HTTP Endpoint.</param>
+        /// <example>
+        /// <code>
+        /// builder
+        ///     .HttpEndpoint(async () => "/path");
+        /// </code>
+        /// </example>
+        /// <inheritdoc cref="HttpEndpoint(IBuilder, Func{ActivityExecutionContext, ValueTask{string}}, int, string?)"/>
         public static IActivityBuilder HttpEndpoint(this IBuilder builder, Func<ValueTask<string>> path, [CallerLineNumber] int lineNumber = default, [CallerFilePath] string? sourceFile = default) =>
             builder.HttpEndpoint(setup => setup.WithPath(path).WithMethod(HttpMethods.Get), lineNumber, sourceFile);
 
+
+        /// <example>
+        /// <code>
+        /// builder
+        ///     .HttpEndpoint(() => "/path");
+        /// </code>
+        /// </example>
+        /// <inheritdoc cref="HttpEndpoint(IBuilder, Func{ValueTask{string}}, int, string?)"/>
         public static IActivityBuilder HttpEndpoint(this IBuilder builder, Func<string> path, [CallerLineNumber] int lineNumber = default, [CallerFilePath] string? sourceFile = default) =>
             builder.HttpEndpoint(setup => setup.WithPath(path).WithMethod(HttpMethods.Get), lineNumber, sourceFile);
 
+        /// <example>
+        /// <code>
+        /// builder
+        ///     .HttpEndpoint("/path");
+        /// </code>
+        /// </example>
+        /// <inheritdoc cref="HttpEndpoint(IBuilder, Func{ValueTask{string}}, int, string?)"/>
         public static IActivityBuilder HttpEndpoint(this IBuilder builder, string path, [CallerLineNumber] int lineNumber = default, [CallerFilePath] string? sourceFile = default) =>
             builder.HttpEndpoint(setup => setup.WithPath(path).WithMethod(HttpMethods.Get), lineNumber, sourceFile);
 
+        /// <example>
+        /// <code>
+        /// <![CDATA[
+        /// builder
+        ///     .HttpEndpoint<RequestObject>(context => 
+        ///         context.GetInput<string>());
+        /// ]]>
+        /// </code>
+        /// </example>
+        /// <inheritdoc cref="HttpEndpoint(IBuilder, Func{ActivityExecutionContext, ValueTask{string}}, int, string?)"/>
         public static IActivityBuilder HttpEndpoint<T>(this IBuilder builder, Func<ActivityExecutionContext, string> path, [CallerLineNumber] int lineNumber = default, [CallerFilePath] string? sourceFile = default) =>
             builder.HttpEndpoint(activity => activity.WithPath(path).WithMethod(HttpMethods.Post).WithTargetType<T>(), lineNumber, sourceFile);
 
+        /// <summary>
+        /// Creates an HTTP Endpoint activity that parses the received request into type <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T">The type the received request should be parsed to.</typeparam>
+        /// <param name="path">The path of the HTTP Endpoint.</param>
+        /// <example>
+        /// <code>
+        /// <![CDATA[
+        /// builder
+        ///     .HttpEndpoint<RequestObject>(() => "/path");
+        /// ]]>
+        /// </code>
+        /// </example>
+        /// <inheritdoc cref="HttpEndpoint(IBuilder, Func{ValueTask{string}}, int, string?)"/>
         public static IActivityBuilder HttpEndpoint<T>(this IBuilder builder, Func<string> path, [CallerLineNumber] int lineNumber = default, [CallerFilePath] string? sourceFile = default) =>
             builder.HttpEndpoint(activity => activity.WithPath(path).WithMethod(HttpMethods.Post).WithTargetType<T>(), lineNumber, sourceFile);
 
+        /// <example>
+        /// <code>
+        /// <![CDATA[
+        /// builder
+        ///     .HttpEndpoint<RequestObject>("/path");
+        /// ]]>
+        /// </code>
+        /// </example>
+        /// <inheritdoc cref="HttpEndpoint{T}(IBuilder, Func{string}, int, string?)"/>
         public static IActivityBuilder HttpEndpoint<T>(this IBuilder builder, string path, [CallerLineNumber] int lineNumber = default, [CallerFilePath] string? sourceFile = default) =>
             builder.HttpEndpoint(activity => activity.WithPath(path).WithMethod(HttpMethods.Post).WithTargetType<T>(), lineNumber, sourceFile);
     }

--- a/src/activities/Elsa.Activities.Http/Activities/HttpEndpoint/HttpEndpointExtensions.cs
+++ b/src/activities/Elsa.Activities.Http/Activities/HttpEndpoint/HttpEndpointExtensions.cs
@@ -9,52 +9,150 @@ namespace Elsa.Activities.Http
 {
     public static class HttpEndpointExtensions
     {
+        /// <summary>
+        /// Specify the path of the HTTP Endpoint.
+        /// </summary>
+        /// <param name="path">The path of the <see cref="HttpEndpoint"/> Activity</param>
+        /// <returns>A <see cref="ISetupActivity"/> that can be used to further change properties of <see cref="HttpEndpoint"/></returns>
         public static ISetupActivity<HttpEndpoint> WithPath(this ISetupActivity<HttpEndpoint> activity, Func<ActivityExecutionContext, ValueTask<string>> path) => activity.Set(x => x.Path, path);
+
+        /// <inheritdoc cref="WithPath(ISetupActivity{HttpEndpoint}, Func{ActivityExecutionContext, ValueTask{string}})"/>
         public static ISetupActivity<HttpEndpoint> WithPath(this ISetupActivity<HttpEndpoint> activity, Func<ValueTask<string>> path) => activity.Set(x => x.Path, path);
+        
+        /// <inheritdoc cref="WithPath(ISetupActivity{HttpEndpoint}, Func{ActivityExecutionContext, ValueTask{string}})"/>
         public static ISetupActivity<HttpEndpoint> WithPath(this ISetupActivity<HttpEndpoint> activity, Func<ActivityExecutionContext, string> path) => activity.Set(x => x.Path, path);
+        
+        /// <inheritdoc cref="WithPath(ISetupActivity{HttpEndpoint}, Func{ActivityExecutionContext, ValueTask{string}})"/>
         public static ISetupActivity<HttpEndpoint> WithPath(this ISetupActivity<HttpEndpoint> activity, Func<string> path) => activity.Set(x => x.Path, path);
+        
+        /// <inheritdoc cref="WithPath(ISetupActivity{HttpEndpoint}, Func{ActivityExecutionContext, ValueTask{string}})"/>
         public static ISetupActivity<HttpEndpoint> WithPath(this ISetupActivity<HttpEndpoint> activity, string path) => activity.Set(x => x.Path, path);
 
+
+        /// <summary>
+        /// Specify the <see href="https://datatracker.ietf.org/doc/html/rfc7231#section-4.3">HTTP Verbs</see> that can be used to access this endpoint.
+        /// </summary>
+        /// <param name="value">A list of HTTP methods (GET, POST, PUT, PATCH, DELETE, etc.)</param>
+        /// <returns>A <see cref="ISetupActivity"/> that can be used to further change properties of <see cref="HttpEndpoint"/></returns>
         public static ISetupActivity<HttpEndpoint> WithMethods(this ISetupActivity<HttpEndpoint> activity, Func<ActivityExecutionContext, ValueTask<IEnumerable<string>>> value) =>
             activity.Set(x => x.Methods, async context => new HashSet<string>(await value(context)));
-
+        
+        /// <inheritdoc cref="WithMethods(ISetupActivity{HttpEndpoint}, Func{ActivityExecutionContext, ValueTask{IEnumerable{string}}})"/>
         public static ISetupActivity<HttpEndpoint> WithMethods(this ISetupActivity<HttpEndpoint> activity, Func<ValueTask<IEnumerable<string>>> value) => activity.Set(x => x.Methods, async () => await value());
-
+        
+        /// <inheritdoc cref="WithMethods(ISetupActivity{HttpEndpoint}, Func{ActivityExecutionContext, ValueTask{IEnumerable{string}}})"/>
         public static ISetupActivity<HttpEndpoint> WithMethods(this ISetupActivity<HttpEndpoint> activity, Func<ActivityExecutionContext, IEnumerable<string>> value) =>
             activity.Set(x => x.Methods, context => new HashSet<string>(value(context)));
-
+        
+        /// <inheritdoc cref="WithMethods(ISetupActivity{HttpEndpoint}, Func{ActivityExecutionContext, ValueTask{IEnumerable{string}}})"/>
         public static ISetupActivity<HttpEndpoint> WithMethods(this ISetupActivity<HttpEndpoint> activity, Func<IEnumerable<string>> value) => activity.Set(x => x.Methods, () => new HashSet<string>(value()));
+        
+        /// <inheritdoc cref="WithMethods(ISetupActivity{HttpEndpoint}, Func{ActivityExecutionContext, ValueTask{IEnumerable{string}}})"/>
         public static ISetupActivity<HttpEndpoint> WithMethods(this ISetupActivity<HttpEndpoint> activity, IEnumerable<string> value) => activity.Set(x => x.Methods, new HashSet<string>(value));
 
+        
+        /// <summary>
+        /// Specify the <see href="https://datatracker.ietf.org/doc/html/rfc7231#section-4.3">HTTP Verb</see> that can be used to access this endpoint.
+        /// </summary>
+        /// <param name="value">A single HTTP method (GET, POST, PUT, PATCH, DELETE, etc.)</param>
+        /// <returns>A <see cref="ISetupActivity"/> that can be used to further change properties of <see cref="HttpEndpoint"/></returns>
         public static ISetupActivity<HttpEndpoint> WithMethod(this ISetupActivity<HttpEndpoint> activity, Func<ActivityExecutionContext, ValueTask<string>> value) => activity.WithMethods(async context => new[] { await value(context) });
+        
+        /// <inheritdoc cref="WithMethod(ISetupActivity{HttpEndpoint}, Func{ActivityExecutionContext, ValueTask{string}})"/>
         public static ISetupActivity<HttpEndpoint> WithMethod(this ISetupActivity<HttpEndpoint> activity, Func<ValueTask<string>> value) => activity.WithMethods(async () => new[] { await value() });
+        
+        /// <inheritdoc cref="WithMethod(ISetupActivity{HttpEndpoint}, Func{ActivityExecutionContext, ValueTask{string}})"/>
         public static ISetupActivity<HttpEndpoint> WithMethod(this ISetupActivity<HttpEndpoint> activity, Func<ActivityExecutionContext, string> value) => activity.WithMethods(context => new[] { value(context) });
+        
+        /// <inheritdoc cref="WithMethod(ISetupActivity{HttpEndpoint}, Func{ActivityExecutionContext, ValueTask{string}})"/>
         public static ISetupActivity<HttpEndpoint> WithMethod(this ISetupActivity<HttpEndpoint> activity, Func<string> value) => activity.WithMethods(() => new[] { value() });
+        
+        /// <inheritdoc cref="WithMethod(ISetupActivity{HttpEndpoint}, Func{ActivityExecutionContext, ValueTask{string}})"/>
         public static ISetupActivity<HttpEndpoint> WithMethod(this ISetupActivity<HttpEndpoint> activity, string value) => activity.WithMethods(new[] { value });
 
+        
+        /// <summary>
+        /// Sets the value of <see cref="HttpActivity.ReadContent"/> which dictates whether the request content body should be read and stored as part of the HTTP request model.
+        /// </summary>
+        /// <param name="value">Whether the request content body should be read and stored as part of the HTTP request model.</param>
+        /// <returns>A <see cref="ISetupActivity"/> that can be used to further change properties of <see cref="HttpEndpoint"/></returns>
         public static ISetupActivity<HttpEndpoint> WithReadContent(this ISetupActivity<HttpEndpoint> activity, Func<ActivityExecutionContext, ValueTask<bool>> value) => activity.Set(x => x.ReadContent, value);
+        
+        /// <inheritdoc cref="WithReadContent(ISetupActivity{HttpEndpoint}, Func{ActivityExecutionContext, ValueTask{bool}})"/>
         public static ISetupActivity<HttpEndpoint> WithReadContent(this ISetupActivity<HttpEndpoint> activity, Func<ValueTask<bool>> value) => activity.Set(x => x.ReadContent, value);
+        
+        /// <inheritdoc cref="WithReadContent(ISetupActivity{HttpEndpoint}, Func{ActivityExecutionContext, ValueTask{bool}})"/>
         public static ISetupActivity<HttpEndpoint> WithReadContent(this ISetupActivity<HttpEndpoint> activity, Func<ActivityExecutionContext, bool> value) => activity.Set(x => x.ReadContent, value);
+        
+        /// <inheritdoc cref="WithReadContent(ISetupActivity{HttpEndpoint}, Func{ActivityExecutionContext, ValueTask{bool}})"/>
         public static ISetupActivity<HttpEndpoint> WithReadContent(this ISetupActivity<HttpEndpoint> activity, Func<bool> value) => activity.Set(x => x.ReadContent, value);
+        
+        /// <inheritdoc cref="WithReadContent(ISetupActivity{HttpEndpoint}, Func{ActivityExecutionContext, ValueTask{bool}})"/>
         public static ISetupActivity<HttpEndpoint> WithReadContent(this ISetupActivity<HttpEndpoint> activity, bool value = true) => activity.Set(x => x.ReadContent, value);
 
+        
+        /// <summary>
+        /// The <see cref="Type"/> to parse the received request content into if <seealso cref="HttpActivity.ReadContent"/> is set to true.
+        /// </summary>
+        /// <param name="value">The type to parse the request into.</param>
+        /// <returns>A <see cref="ISetupActivity"/> that can be used to further change properties of <see cref="HttpEndpoint"/></returns>
         public static ISetupActivity<HttpEndpoint> WithTargetType(this ISetupActivity<HttpEndpoint> activity, Func<ActivityExecutionContext, ValueTask<Type?>> value) => activity.Set(x => x.TargetType, value).WithReadContent();
+        
+        /// <inheritdoc cref="WithTargetType(ISetupActivity{HttpEndpoint}, Func{ActivityExecutionContext, ValueTask{Type?}})"/>
         public static ISetupActivity<HttpEndpoint> WithTargetType(this ISetupActivity<HttpEndpoint> activity, Func<ValueTask<Type?>> value) => activity.Set(x => x.TargetType, value).WithReadContent();
+        
+        /// <inheritdoc cref="WithTargetType(ISetupActivity{HttpEndpoint}, Func{ActivityExecutionContext, ValueTask{Type?}})"/>
         public static ISetupActivity<HttpEndpoint> WithTargetType(this ISetupActivity<HttpEndpoint> activity, Func<ActivityExecutionContext, Type?> value) => activity.Set(x => x.TargetType, value).WithReadContent();
+        
+        /// <inheritdoc cref="WithTargetType(ISetupActivity{HttpEndpoint}, Func{ActivityExecutionContext, ValueTask{Type?}})"/>
         public static ISetupActivity<HttpEndpoint> WithTargetType(this ISetupActivity<HttpEndpoint> activity, Func<Type?> value) => activity.Set(x => x.TargetType, value).WithReadContent();
+        
+        /// <inheritdoc cref="WithTargetType(ISetupActivity{HttpEndpoint}, Func{ActivityExecutionContext, ValueTask{Type?}})"/>
         public static ISetupActivity<HttpEndpoint> WithTargetType(this ISetupActivity<HttpEndpoint> activity, Type? value) => activity.Set(x => x.TargetType, value).WithReadContent();
+        
+        /// <inheritdoc cref="WithTargetType(ISetupActivity{HttpEndpoint}, Func{ActivityExecutionContext, ValueTask{Type?}})"/>
+        /// <typeparam name="T">The type to parse the request into.</typeparam>
         public static ISetupActivity<HttpEndpoint> WithTargetType<T>(this ISetupActivity<HttpEndpoint> activity) => activity.Set(x => x.TargetType, typeof(T)).WithReadContent();
+
         
+        /// <summary>
+        /// Sets whether or not this endpoint requires authorization to use.
+        /// </summary>
+        /// <param name="activity"></param>
+        /// <param name="value">Whether or not authorization is used.</param>
+        /// <returns>A <see cref="ISetupActivity"/> that can be used to further change properties of <see cref="HttpEndpoint"/></returns>
         public static ISetupActivity<HttpEndpoint> WithAuthorize(this ISetupActivity<HttpEndpoint> activity, Func<ActivityExecutionContext, ValueTask<bool>> value) => activity.Set(x => x.Authorize, value);
-        public static ISetupActivity<HttpEndpoint> WithAuthorize(this ISetupActivity<HttpEndpoint> activity, Func<ValueTask<bool>> value) => activity.Set(x => x.Authorize, value);
-        public static ISetupActivity<HttpEndpoint> WithAuthorize(this ISetupActivity<HttpEndpoint> activity, Func<ActivityExecutionContext, bool> value) => activity.Set(x => x.Authorize, value);
-        public static ISetupActivity<HttpEndpoint> WithAuthorize(this ISetupActivity<HttpEndpoint> activity, Func<bool> value) => activity.Set(x => x.Authorize, value);
-        public static ISetupActivity<HttpEndpoint> WithAuthorize(this ISetupActivity<HttpEndpoint> activity, bool value = true) => activity.Set(x => x.Authorize, value);
         
+        /// <inheritdoc cref="WithAuthorize(ISetupActivity{HttpEndpoint}, Func{ActivityExecutionContext, ValueTask{bool}})"/>
+        public static ISetupActivity<HttpEndpoint> WithAuthorize(this ISetupActivity<HttpEndpoint> activity, Func<ValueTask<bool>> value) => activity.Set(x => x.Authorize, value);
+        
+        /// <inheritdoc cref="WithAuthorize(ISetupActivity{HttpEndpoint}, Func{ActivityExecutionContext, ValueTask{bool}})"/>
+        public static ISetupActivity<HttpEndpoint> WithAuthorize(this ISetupActivity<HttpEndpoint> activity, Func<ActivityExecutionContext, bool> value) => activity.Set(x => x.Authorize, value);
+        
+        /// <inheritdoc cref="WithAuthorize(ISetupActivity{HttpEndpoint}, Func{ActivityExecutionContext, ValueTask{bool}})"/>
+        public static ISetupActivity<HttpEndpoint> WithAuthorize(this ISetupActivity<HttpEndpoint> activity, Func<bool> value) => activity.Set(x => x.Authorize, value);
+        
+        /// <inheritdoc cref="WithAuthorize(ISetupActivity{HttpEndpoint}, Func{ActivityExecutionContext, ValueTask{bool}})"/>
+        public static ISetupActivity<HttpEndpoint> WithAuthorize(this ISetupActivity<HttpEndpoint> activity, bool value = true) => activity.Set(x => x.Authorize, value);
+
+        
+        /// <summary>
+        /// Sets the policy name that is evaluated when a user calls the endpoint. If it fails then the request is forbidden
+        /// </summary>
+        /// <param name="value">The policy name that the user is challenged with.</param>
+        /// <returns>A <see cref="ISetupActivity"/> that can be used to further change properties of <see cref="HttpEndpoint"/></returns>
         public static ISetupActivity<HttpEndpoint> WithPolicy(this ISetupActivity<HttpEndpoint> activity, Func<ActivityExecutionContext, ValueTask<string?>> value) => activity.Set(x => x.Policy, value);
+        
+        /// <inheritdoc cref="WithPolicy(ISetupActivity{HttpEndpoint}, Func{ActivityExecutionContext, ValueTask{string?}})"/>
         public static ISetupActivity<HttpEndpoint> WithPolicy(this ISetupActivity<HttpEndpoint> activity, Func<ValueTask<string?>> value) => activity.Set(x => x.Policy, value);
+        
+        /// <inheritdoc cref="WithPolicy(ISetupActivity{HttpEndpoint}, Func{ActivityExecutionContext, ValueTask{string?}})"/>
         public static ISetupActivity<HttpEndpoint> WithPolicy(this ISetupActivity<HttpEndpoint> activity, Func<ActivityExecutionContext, string?> value) => activity.Set(x => x.Policy, value);
+        
+        /// <inheritdoc cref="WithPolicy(ISetupActivity{HttpEndpoint}, Func{ActivityExecutionContext, ValueTask{string?}})"/>
         public static ISetupActivity<HttpEndpoint> WithPolicy(this ISetupActivity<HttpEndpoint> activity, Func<string?> value) => activity.Set(x => x.Policy, value);
+        
+        /// <inheritdoc cref="WithPolicy(ISetupActivity{HttpEndpoint}, Func{ActivityExecutionContext, ValueTask{string?}})"/>
         public static ISetupActivity<HttpEndpoint> WithPolicy(this ISetupActivity<HttpEndpoint> activity, string? value) => activity.Set(x => x.Policy, value);
     }
 }

--- a/src/activities/Elsa.Activities.Http/Activities/Redirect/Redirect.cs
+++ b/src/activities/Elsa.Activities.Http/Activities/Redirect/Redirect.cs
@@ -29,9 +29,15 @@ namespace Elsa.Activities.Http
 
         private IStringLocalizer<Redirect> T { get; }
 
+        /// <summary>
+        /// The URL to redirect to (HTTP 302).
+        /// </summary>
         [ActivityInput(Hint = "The URL to redirect to (HTTP 302).", SupportedSyntaxes = new[] { SyntaxNames.JavaScript, SyntaxNames.Liquid })]
         public Uri Location { get; set; } = default!;
 
+        /// <summary>
+        /// Whether or not the redirect is permanent (HTTP 301).
+        /// </summary>
         [ActivityInput(Hint = "Whether or not the redirect is permanent (HTTP 301).", SupportedSyntaxes = new[] { SyntaxNames.Literal, SyntaxNames.JavaScript, SyntaxNames.Liquid })]
         public bool Permanent { get; set; }
 

--- a/src/activities/Elsa.Activities.Http/Activities/Redirect/RedirectBuilderExtensions.cs
+++ b/src/activities/Elsa.Activities.Http/Activities/Redirect/RedirectBuilderExtensions.cs
@@ -8,6 +8,13 @@ namespace Elsa.Activities.Http
 {
     public static class RedirectBuilderExtensions
     {
+        /// <summary>
+        /// Creates a Redirect activity.
+        /// </summary>
+        /// <param name="location">The URL to redirect the request to.</param>
+        /// <param name="permanent">Wether or not this redirect is permanent (301)</param>
+        /// <returns>The <see cref="IActivityBuilder"/> with the Redirect activity built onto it.</returns>
+        /// <inheritdoc cref="BuilderExtensions.Then{T}(IBuilder, Action{ISetupActivity{T}}?, Action{IActivityBuilder}?, int, string?)"/>
         public static IActivityBuilder Redirect(
             this IBuilder builder,
             Uri location,

--- a/src/activities/Elsa.Activities.Http/Activities/SendHttpRequest/SendHttpRequest.cs
+++ b/src/activities/Elsa.Activities.Http/Activities/SendHttpRequest/SendHttpRequest.cs
@@ -74,6 +74,9 @@ namespace Elsa.Activities.Http
             SupportedSyntaxes = new[] { SyntaxNames.JavaScript, SyntaxNames.Liquid }
         )]
         public string? ContentType { get; set; }
+        /// <summary>
+        /// The Authorization header value to send.
+        /// </summary>
 
         [ActivityInput(Hint = "The Authorization header value to send.", SupportedSyntaxes = new[] { SyntaxNames.JavaScript, SyntaxNames.Liquid }, Category = PropertyCategories.Advanced)]
         public string? Authorization { get; set; }
@@ -89,9 +92,15 @@ namespace Elsa.Activities.Http
         )]
         public HttpRequestHeaders RequestHeaders { get; set; } = new();
 
+        /// <summary>
+        /// Read the content of the response.
+        /// </summary>
         [ActivityInput(Hint = "Read the content of the response.", SupportedSyntaxes = new[] { SyntaxNames.Literal, SyntaxNames.JavaScript, SyntaxNames.Liquid })]
         public bool ReadContent { get; set; }
 
+        /// <summary>
+        /// The parser to use to parse the response content. Plain Text, JSON, .NET Type, Expando Object, JToken, File
+        /// </summary>
         [ActivityInput(
             Label = "Response Content Parser",
             Hint = "The parser to use to parse the response content.",
@@ -100,7 +109,10 @@ namespace Elsa.Activities.Http
             OptionsProvider = typeof(SendHttpRequest)
         )]
         public string? ResponseContentParserName { get; set; }
-        
+
+        /// <summary>
+        /// The assembly-qualified .NET type name to deserialize the received content into.
+        /// </summary>
         [ActivityInput(
             Label = "Response Content .NET Type",
             Hint = "The assembly-qualified .NET type name to deserialize the received content into.",
@@ -110,7 +122,8 @@ namespace Elsa.Activities.Http
         public Type? ResponseContentTargetType { get; set; }
 
         /// <summary>
-        /// A list of HTTP status codes this activity can handle.
+        /// A list of HTTP status codes this activity can handle. 
+        /// If the response's status code is in this list then an outcome with that status code is created. If it is not in this list then the outcome is <c>Unsupported Status Code</c>.
         /// </summary>
         [ActivityInput(
             Hint = "A list of possible HTTP status codes to handle.",
@@ -123,7 +136,14 @@ namespace Elsa.Activities.Http
         )]
         public ICollection<int>? SupportedStatusCodes { get; set; } = new HashSet<int>(new[] { 200 });
 
+        /// <summary>
+        /// The status code and headers of HTTP response.
+        /// </summary>
         [ActivityOutput] public HttpResponseModel? Response { get; set; }
+
+        /// <summary>
+        /// The content HTTP of the response formatted to <see cref="ResponseContentTargetType"/>
+        /// </summary>
         [ActivityOutput] public object? ResponseContent { get; set; }
 
         protected override async ValueTask<IActivityExecutionResult> OnExecuteAsync(ActivityExecutionContext context)

--- a/src/activities/Elsa.Activities.Http/Activities/SendHttpRequest/SendHttpRequestBuilderExtensions.cs
+++ b/src/activities/Elsa.Activities.Http/Activities/SendHttpRequest/SendHttpRequestBuilderExtensions.cs
@@ -11,6 +11,12 @@ namespace Elsa.Activities.Http;
 
 public static class SendHttpRequestBuilderExtensions
 {
+    /// <summary>
+    /// Creates an activity that sends an HTTP Request
+    /// </summary>
+    /// <param name="setup">Sets the properties of the SendHttpRequest activity</param>
+    /// <returns>The <see cref="IActivityBuilder"/> with the <see cref="Http.SendHttpRequest"/> activity built onto it.</returns>
+    /// <inheritdoc cref="BuilderExtensions.Then{T}(IBuilder, Action{ISetupActivity{T}}?, Action{IActivityBuilder}?, int, string?)"/>
     public static IActivityBuilder SendHttpRequest(
         this IActivityBuilder builder,
         Action<ISetupActivity<SendHttpRequest>> setup,
@@ -19,6 +25,15 @@ public static class SendHttpRequestBuilderExtensions
         [CallerFilePath] string? sourceFile = default) =>
         builder.Then(setup, activity, lineNumber, sourceFile);
 
+    /// <param name="url">Address of the resource.</param>
+    /// <param name="method">The <see href="https://datatracker.ietf.org/doc/html/rfc7231#section-4.3">HTTP Verb</see> to use for the request.</param>
+    /// <param name="content">The request body.</param>
+    /// <param name="contentType">The Content-Type header of the request.</param>
+    /// <param name="authorization">The Authorization header value of the request.</param>
+    /// <param name="requestHeaders">Additional headers of the request.</param>
+    /// <param name="readContent">Whether or not to read the content of the response.</param>
+    /// <param name="supportedStatusCodes">List of <see href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Status">status codes</see> that are supported.</param>
+    /// <inheritdoc cref="SendHttpRequest(IActivityBuilder, Action{ISetupActivity{SendHttpRequest}}, Action{IActivityBuilder}, int, string?)"/>
     public static IActivityBuilder SendHttpRequest(
         this IActivityBuilder builder,
         Func<ActivityExecutionContext, Uri?> url,
@@ -46,6 +61,7 @@ public static class SendHttpRequestBuilderExtensions
             lineNumber,
             sourceFile);
 
+    /// <inheritdoc cref="SendHttpRequest(IActivityBuilder, Func{ActivityExecutionContext, Uri?}, Func{ActivityExecutionContext, string?}, Func{ActivityExecutionContext, string?}, Func{ActivityExecutionContext, string?}, Func{ActivityExecutionContext, string?}, Func{ActivityExecutionContext, HttpRequestHeaders}, Func{ActivityExecutionContext, bool}, Func{ActivityExecutionContext, ICollection{int}}, Action{IActivityBuilder}?, int, string?)"/>
     public static IActivityBuilder SendHttpRequest(
         this IActivityBuilder builder,
         Func<Uri?> url,
@@ -73,6 +89,7 @@ public static class SendHttpRequestBuilderExtensions
             lineNumber,
             sourceFile);
 
+    /// <inheritdoc cref="SendHttpRequest(IActivityBuilder, Func{ActivityExecutionContext, Uri?}, Func{ActivityExecutionContext, string?}, Func{ActivityExecutionContext, string?}, Func{ActivityExecutionContext, string?}, Func{ActivityExecutionContext, string?}, Func{ActivityExecutionContext, HttpRequestHeaders}, Func{ActivityExecutionContext, bool}, Func{ActivityExecutionContext, ICollection{int}}, Action{IActivityBuilder}?, int, string?)"/>
     public static IActivityBuilder SendHttpRequest(
         this IActivityBuilder builder,
         Uri? url,

--- a/src/activities/Elsa.Activities.Http/Activities/SendHttpRequest/SendHttpRequestExtensions.cs
+++ b/src/activities/Elsa.Activities.Http/Activities/SendHttpRequest/SendHttpRequestExtensions.cs
@@ -10,97 +10,168 @@ namespace Elsa.Activities.Http
 {
     public static class SendHttpRequestExtensions
     {
+        /// <summary>
+        /// Specify the URL of the HTTP Request.
+        /// </summary>
+        /// <param name="url">The address of the resource.</param>
+        /// <returns>A <see cref="ISetupActivity"/> that can be used to further change properties of <see cref="SendHttpRequest"/></returns>
         public static ISetupActivity<Http.SendHttpRequest> WithUrl(this ISetupActivity<Http.SendHttpRequest> activity, Func<ActivityExecutionContext, ValueTask<Uri?>> url) => activity.Set(x => x.Url, url);
 
+        /// <inheritdoc cref="WithUrl(ISetupActivity{SendHttpRequest}, Func{ActivityExecutionContext, ValueTask{Uri?}})"/>
         public static ISetupActivity<Http.SendHttpRequest> WithUrl(this ISetupActivity<Http.SendHttpRequest> activity, Func<ValueTask<Uri?>> url) => activity.Set(x => x.Url, url);
 
+        /// <inheritdoc cref="WithUrl(ISetupActivity{SendHttpRequest}, Func{ActivityExecutionContext, ValueTask{Uri?}})"/>
         public static ISetupActivity<Http.SendHttpRequest> WithUrl(this ISetupActivity<Http.SendHttpRequest> activity, Func<ActivityExecutionContext, Uri?> url) => activity.Set(x => x.Url, url);
 
+        /// <inheritdoc cref="WithUrl(ISetupActivity{SendHttpRequest}, Func{ActivityExecutionContext, ValueTask{Uri?}})"/>
         public static ISetupActivity<Http.SendHttpRequest> WithUrl(this ISetupActivity<Http.SendHttpRequest> activity, Func<Uri?> url) => activity.Set(x => x.Url, url);
 
+        /// <inheritdoc cref="WithUrl(ISetupActivity{SendHttpRequest}, Func{ActivityExecutionContext, ValueTask{Uri?}})"/>
         public static ISetupActivity<Http.SendHttpRequest> WithUrl(this ISetupActivity<Http.SendHttpRequest> activity, Uri? url) => activity.Set(x => x.Url, url);
 
 
+        /// <summary>
+        /// Specify the method to use with the HTTP request.
+        /// </summary>
+        /// <param name="method">Set the HTTP method to use with the HTTP Request</param>
+        /// <returns>A <see cref="ISetupActivity"/> that can be used to further change properties of <see cref="SendHttpRequest"/></returns>
         public static ISetupActivity<Http.SendHttpRequest> WithMethod(this ISetupActivity<Http.SendHttpRequest> activity, Func<ActivityExecutionContext, ValueTask<string?>> method) => activity.Set(x => x.Method, method);
 
+        /// <inheritdoc cref="WithMethod(ISetupActivity{SendHttpRequest}, Func{ActivityExecutionContext, ValueTask{string?}})"/>
         public static ISetupActivity<Http.SendHttpRequest> WithMethod(this ISetupActivity<Http.SendHttpRequest> activity, Func<ValueTask<string?>> method) => activity.Set(x => x.Method, method);
 
+        /// <inheritdoc cref="WithMethod(ISetupActivity{SendHttpRequest}, Func{ActivityExecutionContext, ValueTask{string?}})"/>
         public static ISetupActivity<Http.SendHttpRequest> WithMethod(this ISetupActivity<Http.SendHttpRequest> activity, Func<ActivityExecutionContext, string?> method) => activity.Set(x => x.Method, method);
 
+        /// <inheritdoc cref="WithMethod(ISetupActivity{SendHttpRequest}, Func{ActivityExecutionContext, ValueTask{string?}})"/>
         public static ISetupActivity<Http.SendHttpRequest> WithMethod(this ISetupActivity<Http.SendHttpRequest> activity, Func<string?> method) => activity.Set(x => x.Method, method);
 
+        /// <inheritdoc cref="WithMethod(ISetupActivity{SendHttpRequest}, Func{ActivityExecutionContext, ValueTask{string?}})"/>
         public static ISetupActivity<Http.SendHttpRequest> WithMethod(this ISetupActivity<Http.SendHttpRequest> activity, string? method) => activity.Set(x => x.Method, method);
 
 
+        /// <summary>
+        /// Specify the content to send with the HTTP request.
+        /// </summary>
+        /// <param name="content">The content of the HTTP request</param>
+        /// <returns>A <see cref="ISetupActivity"/> that can be used to further change properties of <see cref="SendHttpRequest"/></returns>
         public static ISetupActivity<Http.SendHttpRequest> WithContent(this ISetupActivity<Http.SendHttpRequest> activity, Func<ActivityExecutionContext, ValueTask<string?>> content
             ) => activity.Set(x => x.Content, content);
 
+        /// <inheritdoc cref="WithContent(ISetupActivity{SendHttpRequest}, Func{ActivityExecutionContext, ValueTask{string?}})"/>
         public static ISetupActivity<Http.SendHttpRequest> WithContent(this ISetupActivity<Http.SendHttpRequest> activity, Func<ValueTask<string?>> content) => activity.Set(x => x.Content, content);
 
+        /// <inheritdoc cref="WithContent(ISetupActivity{SendHttpRequest}, Func{ActivityExecutionContext, ValueTask{string?}})"/>
         public static ISetupActivity<Http.SendHttpRequest> WithContent(this ISetupActivity<Http.SendHttpRequest> activity, Func<ActivityExecutionContext, string?> content) => activity.Set(x => x.Content, content);
 
+        /// <inheritdoc cref="WithContent(ISetupActivity{SendHttpRequest}, Func{ActivityExecutionContext, ValueTask{string?}})"/>
         public static ISetupActivity<Http.SendHttpRequest> WithContent(this ISetupActivity<Http.SendHttpRequest> activity, Func<string?> content) => activity.Set(x => x.Content, content);
 
+        /// <inheritdoc cref="WithContent(ISetupActivity{SendHttpRequest}, Func{ActivityExecutionContext, ValueTask{string?}})"/>
         public static ISetupActivity<Http.SendHttpRequest> WithContent(this ISetupActivity<Http.SendHttpRequest> activity, string? content) => activity.Set(x => x.Content, content);
 
 
+        /// <summary>
+        /// Specify the Content-Type header of the HTTP request.
+        /// </summary>
+        /// <param name="contentType">The value to set the Content-Type header to</param>
+        /// <returns>A <see cref="ISetupActivity"/> that can be used to further change properties of <see cref="SendHttpRequest"/></returns>
         public static ISetupActivity<Http.SendHttpRequest> WithContentType(this ISetupActivity<Http.SendHttpRequest> activity, Func<ActivityExecutionContext, ValueTask<string?>> contentType
             ) => activity.Set(x => x.ContentType, contentType);
 
+        /// <inheritdoc cref="WithContentType(ISetupActivity{SendHttpRequest}, Func{ActivityExecutionContext, ValueTask{string?}})"/>
         public static ISetupActivity<Http.SendHttpRequest> WithContentType(this ISetupActivity<Http.SendHttpRequest> activity, Func<ValueTask<string?>> contentType) => activity.Set(x => x.ContentType, contentType);
 
+        /// <inheritdoc cref="WithContentType(ISetupActivity{SendHttpRequest}, Func{ActivityExecutionContext, ValueTask{string?}})"/>
         public static ISetupActivity<Http.SendHttpRequest> WithContentType(this ISetupActivity<Http.SendHttpRequest> activity, Func<ActivityExecutionContext, string?> contentType) => activity.Set(x => x.ContentType, contentType);
 
+        /// <inheritdoc cref="WithContentType(ISetupActivity{SendHttpRequest}, Func{ActivityExecutionContext, ValueTask{string?}})"/>
         public static ISetupActivity<Http.SendHttpRequest> WithContentType(this ISetupActivity<Http.SendHttpRequest> activity, Func<string?> contentType) => activity.Set(x => x.ContentType, contentType);
 
+        /// <inheritdoc cref="WithContentType(ISetupActivity{SendHttpRequest}, Func{ActivityExecutionContext, ValueTask{string?}})"/>
         public static ISetupActivity<Http.SendHttpRequest> WithContentType(this ISetupActivity<Http.SendHttpRequest> activity, string? contentType) => activity.Set(x => x.ContentType, contentType);
 
 
+        /// <summary>
+        /// Specify the Authorization header of the HTTP request.
+        /// </summary>
+        /// <param name="authorization">The value of the Authorization header</param>
+        /// <returns>A <see cref="ISetupActivity"/> that can be used to further change properties of <see cref="SendHttpRequest"/></returns>
         public static ISetupActivity<Http.SendHttpRequest> WithAuthorization(this ISetupActivity<Http.SendHttpRequest> activity, Func<ActivityExecutionContext, ValueTask<string?>> authorization
             ) => activity.Set(x => x.Authorization, authorization);
 
+        /// <inheritdoc cref="WithAuthorization(ISetupActivity{SendHttpRequest}, Func{ActivityExecutionContext, ValueTask{string?}})"/>
         public static ISetupActivity<Http.SendHttpRequest> WithAuthorization(this ISetupActivity<Http.SendHttpRequest> activity, Func<ValueTask<string?>> authorization) => activity.Set(x => x.Authorization, authorization);
 
+        /// <inheritdoc cref="WithAuthorization(ISetupActivity{SendHttpRequest}, Func{ActivityExecutionContext, ValueTask{string?}})"/>
         public static ISetupActivity<Http.SendHttpRequest> WithAuthorization(this ISetupActivity<Http.SendHttpRequest> activity, Func<ActivityExecutionContext, string?> authorization) => activity.Set(x => x.Authorization, authorization);
 
+        /// <inheritdoc cref="WithAuthorization(ISetupActivity{SendHttpRequest}, Func{ActivityExecutionContext, ValueTask{string?}})"/>
         public static ISetupActivity<Http.SendHttpRequest> WithAuthorization(this ISetupActivity<Http.SendHttpRequest> activity, Func<string?> authorization) => activity.Set(x => x.Authorization, authorization);
 
+        /// <inheritdoc cref="WithAuthorization(ISetupActivity{SendHttpRequest}, Func{ActivityExecutionContext, ValueTask{string?}})"/>
         public static ISetupActivity<Http.SendHttpRequest> WithAuthorization(this ISetupActivity<Http.SendHttpRequest> activity, string? authorization) => activity.Set(x => x.Authorization, authorization);
 
-
+        /// <summary>
+        /// Set additional headers for the HTTP request.
+        /// </summary>
+        /// <param name="requestHeaders">A <see cref="Dictionary"/> of additional headers to send with the request.</param>
+        /// <returns>A <see cref="ISetupActivity"/> that can be used to further change properties of <see cref="SendHttpRequest"/></returns>
         public static ISetupActivity<Http.SendHttpRequest> WithRequestHeaders(this ISetupActivity<Http.SendHttpRequest> activity, Func<ActivityExecutionContext, ValueTask<HttpRequestHeaders?>> requestHeaders
             ) => activity.Set(x => x.RequestHeaders, requestHeaders);
 
+        /// <inheritdoc cref="WithRequestHeaders(ISetupActivity{SendHttpRequest}, Func{ActivityExecutionContext, ValueTask{HttpRequestHeaders?}})"/>
         public static ISetupActivity<Http.SendHttpRequest> WithRequestHeaders(this ISetupActivity<Http.SendHttpRequest> activity, Func<ValueTask<HttpRequestHeaders?>> requestHeaders) => activity.Set(x => x.RequestHeaders, requestHeaders);
 
+        /// <inheritdoc cref="WithRequestHeaders(ISetupActivity{SendHttpRequest}, Func{ActivityExecutionContext, ValueTask{HttpRequestHeaders?}})"/>
         public static ISetupActivity<Http.SendHttpRequest> WithRequestHeaders(this ISetupActivity<Http.SendHttpRequest> activity, Func<ActivityExecutionContext, HttpRequestHeaders?> requestHeaders) => activity.Set(x => x.RequestHeaders, requestHeaders);
 
+        /// <inheritdoc cref="WithRequestHeaders(ISetupActivity{SendHttpRequest}, Func{ActivityExecutionContext, ValueTask{HttpRequestHeaders?}})"/>
         public static ISetupActivity<Http.SendHttpRequest> WithRequestHeaders(this ISetupActivity<Http.SendHttpRequest> activity, Func<HttpRequestHeaders?> requestHeaders) => activity.Set(x => x.RequestHeaders, requestHeaders);
 
+        /// <inheritdoc cref="WithRequestHeaders(ISetupActivity{SendHttpRequest}, Func{ActivityExecutionContext, ValueTask{HttpRequestHeaders?}})"/>
         public static ISetupActivity<Http.SendHttpRequest> WithRequestHeaders(this ISetupActivity<Http.SendHttpRequest> activity, HttpRequestHeaders? requestHeaders) => activity.Set(x => x.RequestHeaders, requestHeaders);
 
 
+        /// <summary>
+        /// Sets whether or not to read the content of the HTTP response.
+        /// </summary>
+        /// <param name="readContent">Whether or not to read the content of the HTTP response.</param>
+        /// <returns>A <see cref="ISetupActivity"/> that can be used to further change properties of <see cref="SendHttpRequest"/></returns>
         public static ISetupActivity<Http.SendHttpRequest> WithReadContent(this ISetupActivity<Http.SendHttpRequest> activity, Func<ActivityExecutionContext, ValueTask<bool?>> readContent
             ) => activity.Set(x => x.ReadContent, readContent);
 
+        /// <inheritdoc cref="WithReadContent(ISetupActivity{SendHttpRequest}, Func{ActivityExecutionContext, ValueTask{bool?}})"/>
         public static ISetupActivity<Http.SendHttpRequest> WithReadContent(this ISetupActivity<Http.SendHttpRequest> activity, Func<ValueTask<bool?>> readContent) => activity.Set(x => x.ReadContent, readContent);
 
+        /// <inheritdoc cref="WithReadContent(ISetupActivity{SendHttpRequest}, Func{ActivityExecutionContext, ValueTask{bool?}})"/>
         public static ISetupActivity<Http.SendHttpRequest> WithReadContent(this ISetupActivity<Http.SendHttpRequest> activity, Func<ActivityExecutionContext, bool?> readContent) => activity.Set(x => x.ReadContent, readContent);
 
+        /// <inheritdoc cref="WithReadContent(ISetupActivity{SendHttpRequest}, Func{ActivityExecutionContext, ValueTask{bool?}})"/>
         public static ISetupActivity<Http.SendHttpRequest> WithReadContent(this ISetupActivity<Http.SendHttpRequest> activity, Func<bool?> readContent) => activity.Set(x => x.ReadContent, readContent);
 
+        /// <inheritdoc cref="WithReadContent(ISetupActivity{SendHttpRequest}, Func{ActivityExecutionContext, ValueTask{bool?}})"/>
         public static ISetupActivity<Http.SendHttpRequest> WithReadContent(this ISetupActivity<Http.SendHttpRequest> activity, bool? readContent) => activity.Set(x => x.ReadContent, readContent);
 
 
+        /// <summary>
+        /// Sets the response status codes that are supported. Can be used to handle different outcomes
+        /// </summary>
+        /// <param name="supportedStatusCodes">The list of supported status codes</param>
+        /// <returns>A <see cref="ISetupActivity"/> that can be used to further change properties of <see cref="SendHttpRequest"/></returns>
         public static ISetupActivity<Http.SendHttpRequest> WithSupportedHttpCodes(this ISetupActivity<Http.SendHttpRequest> activity, Func<ActivityExecutionContext, ValueTask<ICollection<int>?>> supportedStatusCodes
             ) => activity.Set(x => x.SupportedStatusCodes, supportedStatusCodes);
 
+        /// <inheritdoc cref="WithSupportedHttpCodes(ISetupActivity{SendHttpRequest}, Func{ActivityExecutionContext, ValueTask{ICollection{int}?}})"/>
         public static ISetupActivity<Http.SendHttpRequest> WithSupportedHttpCodes(this ISetupActivity<Http.SendHttpRequest> activity, Func<ValueTask<ICollection<int>?>> supportedStatusCodes) => activity.Set(x => x.SupportedStatusCodes, supportedStatusCodes);
 
+        /// <inheritdoc cref="WithSupportedHttpCodes(ISetupActivity{SendHttpRequest}, Func{ActivityExecutionContext, ValueTask{ICollection{int}?}})"/>
         public static ISetupActivity<Http.SendHttpRequest> WithSupportedHttpCodes(this ISetupActivity<Http.SendHttpRequest> activity, Func<ActivityExecutionContext, ICollection<int>> supportedStatusCodes) => activity.Set(x => x.SupportedStatusCodes, supportedStatusCodes);
 
+        /// <inheritdoc cref="WithSupportedHttpCodes(ISetupActivity{SendHttpRequest}, Func{ActivityExecutionContext, ValueTask{ICollection{int}?}})"/>
         public static ISetupActivity<Http.SendHttpRequest> WithSupportedHttpCodes(this ISetupActivity<Http.SendHttpRequest> activity, Func<ICollection<int>> supportedStatusCodes) => activity.Set(x => x.SupportedStatusCodes, supportedStatusCodes);
 
+        /// <inheritdoc cref="WithSupportedHttpCodes(ISetupActivity{SendHttpRequest}, Func{ActivityExecutionContext, ValueTask{ICollection{int}?}})"/>
         public static ISetupActivity<Http.SendHttpRequest> WithSupportedHttpCodes(this ISetupActivity<Http.SendHttpRequest> activity, ICollection<int> supportedStatusCodes) => activity.Set(x => x.SupportedStatusCodes, supportedStatusCodes);
     }
 }

--- a/src/activities/Elsa.Activities.Http/Activities/WriteHttpResponse/WriteHttpResponseBuilderExtensions.cs
+++ b/src/activities/Elsa.Activities.Http/Activities/WriteHttpResponse/WriteHttpResponseBuilderExtensions.cs
@@ -11,9 +11,19 @@ namespace Elsa.Activities.Http
 {
     public static class WriteHttpResponseBuilderExtensions
     {
+        /// <summary>
+        /// Creates a <see cref="Http.WriteHttpResponse"/> activity.
+        /// </summary>
+        /// <param name="setup">An <see cref="ISetupActivity"/> used to set the properties of the <see cref="Http.WriteHttpResponse"/> Activity.</param>
+        /// <returns>The <see cref="IActivityBuilder"/> with the Write HTTP Response activity built onto it.</returns>
+        /// <inheritdoc cref="BuilderExtensions.Then{T}(IBuilder, Action{ISetupActivity{T}}?, Action{IActivityBuilder}?, int, string?)"/>
         public static IActivityBuilder WriteHttpResponse(this IBuilder builder, Action<ISetupActivity<WriteHttpResponse>> setup, [CallerLineNumber] int lineNumber = default, [CallerFilePath] string? sourceFile = default) =>
             builder.Then(setup, null, lineNumber, sourceFile);
 
+        /// <param name="statusCode">The <see href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Status">status code</see> that is returned with the response.</param>
+        /// <param name="content">The content to send along with the response.</param>
+        /// <param name="contentType">The Content-Type header to send along with the response.</param>
+        /// <inheritdoc cref="WriteHttpResponse(IBuilder, Action{ISetupActivity{WriteHttpResponse}}, int, string?)"/>
         public static IActivityBuilder WriteHttpResponse(
             this IBuilder builder,
             Func<ActivityExecutionContext, HttpStatusCode> statusCode,
@@ -29,6 +39,7 @@ namespace Elsa.Activities.Http
                 lineNumber,
                 sourceFile);
 
+        /// <inheritdoc cref="WriteHttpResponse(IBuilder, Func{ActivityExecutionContext, HttpStatusCode}, Func{ActivityExecutionContext, ValueTask{string?}}, Func{ActivityExecutionContext, string?}, int, string?)"/>
         public static IActivityBuilder WriteHttpResponse(
             this IBuilder builder,
             Func<ActivityExecutionContext, HttpStatusCode> statusCode,
@@ -44,6 +55,7 @@ namespace Elsa.Activities.Http
                 lineNumber,
                 sourceFile);
 
+        /// <inheritdoc cref="WriteHttpResponse(IBuilder, Func{ActivityExecutionContext, HttpStatusCode}, Func{ActivityExecutionContext, ValueTask{string?}}, Func{ActivityExecutionContext, string?}, int, string?)"/>
         public static IActivityBuilder WriteHttpResponse(
             this IBuilder builder,
             Func<HttpStatusCode> statusCode,
@@ -59,6 +71,7 @@ namespace Elsa.Activities.Http
                 lineNumber,
                 sourceFile);
 
+        /// <inheritdoc cref="WriteHttpResponse(IBuilder, Func{ActivityExecutionContext, HttpStatusCode}, Func{ActivityExecutionContext, ValueTask{string?}}, Func{ActivityExecutionContext, string?}, int, string?)"/>
         public static IActivityBuilder WriteHttpResponse(
             this IBuilder builder,
             HttpStatusCode statusCode,

--- a/src/activities/Elsa.Activities.Http/Activities/WriteHttpResponse/WriteHttpResponseExtensions.cs
+++ b/src/activities/Elsa.Activities.Http/Activities/WriteHttpResponse/WriteHttpResponseExtensions.cs
@@ -10,28 +10,83 @@ namespace Elsa.Activities.Http
 {
     public static class WriteHttpResponseExtensions
     {
+        /// <summary>
+        /// Specify the status code that is returned with the HTTP response.
+        /// </summary>
+        /// <param name="value">The status code of the HTTP response</param>
+        /// <returns>A <see cref="ISetupActivity"/> that can be used to further change properties of <see cref="WriteHttpResponse"/></returns>
         public static ISetupActivity<WriteHttpResponse> WithStatusCode(this ISetupActivity<WriteHttpResponse> activity, Func<ActivityExecutionContext, ValueTask<HttpStatusCode>> value) => activity.Set(x => x.StatusCode, value);
-        public static ISetupActivity<WriteHttpResponse> WithStatusCode(this ISetupActivity<WriteHttpResponse> activity, Func<ValueTask<HttpStatusCode>> value) => activity.Set(x => x.StatusCode, value);
-        public static ISetupActivity<WriteHttpResponse> WithStatusCode(this ISetupActivity<WriteHttpResponse> activity, Func<ActivityExecutionContext, HttpStatusCode> value) => activity.Set(x => x.StatusCode, value);
-        public static ISetupActivity<WriteHttpResponse> WithStatusCode(this ISetupActivity<WriteHttpResponse> activity, Func<HttpStatusCode> value) => activity.Set(x => x.StatusCode, value);
-        public static ISetupActivity<WriteHttpResponse> WithStatusCode(this ISetupActivity<WriteHttpResponse> activity, HttpStatusCode value) => activity.Set(x => x.StatusCode, value);
         
+        /// <inheritdoc cref="WithStatusCode(ISetupActivity{WriteHttpResponse}, Func{ActivityExecutionContext, ValueTask{HttpStatusCode}})"/>
+        public static ISetupActivity<WriteHttpResponse> WithStatusCode(this ISetupActivity<WriteHttpResponse> activity, Func<ValueTask<HttpStatusCode>> value) => activity.Set(x => x.StatusCode, value);
+        
+        /// <inheritdoc cref="WithStatusCode(ISetupActivity{WriteHttpResponse}, Func{ActivityExecutionContext, ValueTask{HttpStatusCode}})"/>
+        public static ISetupActivity<WriteHttpResponse> WithStatusCode(this ISetupActivity<WriteHttpResponse> activity, Func<ActivityExecutionContext, HttpStatusCode> value) => activity.Set(x => x.StatusCode, value);
+        
+        /// <inheritdoc cref="WithStatusCode(ISetupActivity{WriteHttpResponse}, Func{ActivityExecutionContext, ValueTask{HttpStatusCode}})"/>
+        public static ISetupActivity<WriteHttpResponse> WithStatusCode(this ISetupActivity<WriteHttpResponse> activity, Func<HttpStatusCode> value) => activity.Set(x => x.StatusCode, value);
+        
+        /// <inheritdoc cref="WithStatusCode(ISetupActivity{WriteHttpResponse}, Func{ActivityExecutionContext, ValueTask{HttpStatusCode}})"/>
+        public static ISetupActivity<WriteHttpResponse> WithStatusCode(this ISetupActivity<WriteHttpResponse> activity, HttpStatusCode value) => activity.Set(x => x.StatusCode, value);
+
+
+        /// <summary>
+        /// Specify the HTTP Reponse's body.
+        /// </summary>
+        /// <param name="value">The body of the HTTP Response.</param>
+        /// <returns>A <see cref="ISetupActivity"/> that can be used to further change properties of <see cref="WriteHttpResponse"/></returns>
         public static ISetupActivity<WriteHttpResponse> WithContent(this ISetupActivity<WriteHttpResponse> activity, Func<ActivityExecutionContext, ValueTask<object?>> value) => activity.Set(x => x.Content, value);
+        
+        /// <inheritdoc cref="WithContent(ISetupActivity{WriteHttpResponse}, Func{ActivityExecutionContext, ValueTask{object?}})"/>
         public static ISetupActivity<WriteHttpResponse> WithContent(this ISetupActivity<WriteHttpResponse> activity, Func<ValueTask<object?>> value) => activity.Set(x => x.Content, value);
+        
+        /// <inheritdoc cref="WithContent(ISetupActivity{WriteHttpResponse}, Func{ActivityExecutionContext, ValueTask{object?}})"/>
         public static ISetupActivity<WriteHttpResponse> WithContent(this ISetupActivity<WriteHttpResponse> activity, Func<ActivityExecutionContext, object?> value) => activity.Set(x => x.Content, value);
+        
+        /// <inheritdoc cref="WithContent(ISetupActivity{WriteHttpResponse}, Func{ActivityExecutionContext, ValueTask{object?}})"/>
         public static ISetupActivity<WriteHttpResponse> WithContent(this ISetupActivity<WriteHttpResponse> activity, Func<object?> value) => activity.Set(x => x.Content, value);
+        
+        /// <inheritdoc cref="WithContent(ISetupActivity{WriteHttpResponse}, Func{ActivityExecutionContext, ValueTask{object?}})"/>
         public static ISetupActivity<WriteHttpResponse> WithContent(this ISetupActivity<WriteHttpResponse> activity, object? value) => activity.Set(x => x.Content, value);
 
-        public static ISetupActivity<WriteHttpResponse> WithContentType(this ISetupActivity<WriteHttpResponse> activity, Func<ActivityExecutionContext, ValueTask<object?>> value) => activity.Set(x => x.ContentType, value);
-        public static ISetupActivity<WriteHttpResponse> WithContentType(this ISetupActivity<WriteHttpResponse> activity, Func<ValueTask<object?>> value) => activity.Set(x => x.ContentType, value);
-        public static ISetupActivity<WriteHttpResponse> WithContentType(this ISetupActivity<WriteHttpResponse> activity, Func<ActivityExecutionContext, object?> value) => activity.Set(x => x.ContentType, value);
-        public static ISetupActivity<WriteHttpResponse> WithContentType(this ISetupActivity<WriteHttpResponse> activity, Func<object?> value) => activity.Set(x => x.ContentType, value);
-        public static ISetupActivity<WriteHttpResponse> WithContentType(this ISetupActivity<WriteHttpResponse> activity, object? value) => activity.Set(x => x.ContentType, value);
         
+        /// <summary>
+        /// Specify the Content-Type header of the HTTP Response
+        /// </summary>
+        /// <param name="value">The value of the Content-Type header</param>
+        /// <returns>A <see cref="ISetupActivity"/> that can be used to further change properties of <see cref="WriteHttpResponse"/></returns>
+        public static ISetupActivity<WriteHttpResponse> WithContentType(this ISetupActivity<WriteHttpResponse> activity, Func<ActivityExecutionContext, ValueTask<object?>> value) => activity.Set(x => x.ContentType, value);
+        
+        /// <inheritdoc cref="WithContent(ISetupActivity{WriteHttpResponse}, Func{ActivityExecutionContext, ValueTask{object?}})"/>
+        public static ISetupActivity<WriteHttpResponse> WithContentType(this ISetupActivity<WriteHttpResponse> activity, Func<ValueTask<object?>> value) => activity.Set(x => x.ContentType, value);
+        
+        /// <inheritdoc cref="WithContent(ISetupActivity{WriteHttpResponse}, Func{ActivityExecutionContext, ValueTask{object?}})"/>
+        public static ISetupActivity<WriteHttpResponse> WithContentType(this ISetupActivity<WriteHttpResponse> activity, Func<ActivityExecutionContext, object?> value) => activity.Set(x => x.ContentType, value);
+        
+        /// <inheritdoc cref="WithContent(ISetupActivity{WriteHttpResponse}, Func{ActivityExecutionContext, ValueTask{object?}})"/>
+        public static ISetupActivity<WriteHttpResponse> WithContentType(this ISetupActivity<WriteHttpResponse> activity, Func<object?> value) => activity.Set(x => x.ContentType, value);
+        
+        /// <inheritdoc cref="WithContent(ISetupActivity{WriteHttpResponse}, Func{ActivityExecutionContext, ValueTask{object?}})"/>
+        public static ISetupActivity<WriteHttpResponse> WithContentType(this ISetupActivity<WriteHttpResponse> activity, object? value) => activity.Set(x => x.ContentType, value);
+
+        
+        /// <summary>
+        /// Additional response headers to be added to the HTTP Response.
+        /// </summary>
+        /// <param name="value">A <see cref="Dictionary"/> of response headers.</param>
+        /// <returns>A <see cref="ISetupActivity"/> that can be used to further change properties of <see cref="WriteHttpResponse"/></returns>
         public static ISetupActivity<WriteHttpResponse> WithResponseHeaders(this ISetupActivity<WriteHttpResponse> activity, Func<ActivityExecutionContext, ValueTask<HttpResponseHeaders?>> value) => activity.Set(x => x.ResponseHeaders, value);
+        
+        /// <inheritdoc cref="WithResponseHeaders(ISetupActivity{WriteHttpResponse}, Func{ActivityExecutionContext, ValueTask{HttpResponseHeaders?}})"/>
         public static ISetupActivity<WriteHttpResponse> WithResponseHeaders(this ISetupActivity<WriteHttpResponse> activity, Func<ValueTask<HttpResponseHeaders?>> value) => activity.Set(x => x.ResponseHeaders, value);
+        
+        /// <inheritdoc cref="WithResponseHeaders(ISetupActivity{WriteHttpResponse}, Func{ActivityExecutionContext, ValueTask{HttpResponseHeaders?}})"/>
         public static ISetupActivity<WriteHttpResponse> WithResponseHeaders(this ISetupActivity<WriteHttpResponse> activity, Func<ActivityExecutionContext, HttpResponseHeaders?> value) => activity.Set(x => x.ResponseHeaders, value);
+        
+        /// <inheritdoc cref="WithResponseHeaders(ISetupActivity{WriteHttpResponse}, Func{ActivityExecutionContext, ValueTask{HttpResponseHeaders?}})"/>
         public static ISetupActivity<WriteHttpResponse> WithResponseHeaders(this ISetupActivity<WriteHttpResponse> activity, Func<HttpResponseHeaders?> value) => activity.Set(x => x.ResponseHeaders, value);
+        
+        /// <inheritdoc cref="WithResponseHeaders(ISetupActivity{WriteHttpResponse}, Func{ActivityExecutionContext, ValueTask{HttpResponseHeaders?}})"/>
         public static ISetupActivity<WriteHttpResponse> WithResponseHeaders(this ISetupActivity<WriteHttpResponse> activity, HttpResponseHeaders? value) => activity.Set(x => x.ResponseHeaders, value);
     }
 }

--- a/src/core/Elsa.Abstractions/Builders/IBuilder.cs
+++ b/src/core/Elsa.Abstractions/Builders/IBuilder.cs
@@ -6,6 +6,15 @@ namespace Elsa.Builders
 {
     public interface IBuilder
     {
+        /// <summary>
+        /// Generic method for adding an arbitrary activity to a <see cref="IBuilder"/>.
+        /// </summary>
+        /// <typeparam name="T">The activity type.</typeparam>
+        /// <param name="activityTypeName">The type name of the activity that needs to be added to the builder</param>
+        /// <param name="setup">Set the properties of activity <typeparamref name="T"/></param>
+        /// <param name="branch">Optional. Activity to execute after the execution of activity <typeparamref name="T"/></param>
+        /// <param name="activity">Optional. Activity to execute after the execution of activity <typeparamref name="T"/></param>
+        /// <returns>The <see cref="IActivityBuilder"/> with the <typeparamref name="T"/> activity built onto it.</returns>
         IActivityBuilder Then<T>(string activityTypeName, Action<ISetupActivity<T>>? setup, Action<IActivityBuilder>? branch = default, [CallerLineNumber] int lineNumber = default, [CallerFilePath] string? sourceFile = default)
             where T : class, IActivity;
 

--- a/src/core/Elsa.Core/Builders/BuilderExtensions.cs
+++ b/src/core/Elsa.Core/Builders/BuilderExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.CompilerServices;
 using Elsa.Services;
 
@@ -7,6 +7,8 @@ namespace Elsa.Builders
 {
     public static class BuilderExtensions
     {
+        /// <param name="builder">The <see cref="IBuilder"/> to add the activity on to.</param>
+        /// <inheritdoc cref="IBuilder.Then{T}(string, Action{ISetupActivity{T}}?, Action{IActivityBuilder}?, int, string?)"/>
         public static IActivityBuilder Then<T>(
             this IBuilder builder,
             Action<ISetupActivity<T>>? setup,
@@ -15,6 +17,8 @@ namespace Elsa.Builders
             [CallerFilePath] string? sourceFile = default)
             where T : class, IActivity => builder.Then(typeof(T).Name, setup, branch, lineNumber, sourceFile);
 
+        /// <param name="setup">Sets the properties of activity <see cref="IActivity"/></param>
+        /// <inheritdoc cref="Then{T}(IBuilder, Action{ISetupActivity{T}}?, Action{IActivityBuilder}?, int, string?)"/>
         public static IActivityBuilder ThenTypeNamed(
             this IBuilder builder,
             string activityTypeName,
@@ -24,6 +28,7 @@ namespace Elsa.Builders
             [CallerFilePath] string? sourceFile = default)
             => builder.Then(activityTypeName, setup, branch, lineNumber, sourceFile);
 
+        /// <inheritdoc cref="Then{T}(IBuilder, Action{ISetupActivity{T}}?, Action{IActivityBuilder}?, int, string?)"/>
         public static IActivityBuilder Then<T>(
             this IBuilder builder,
             Action<IActivityBuilder>? branch = default,
@@ -31,6 +36,7 @@ namespace Elsa.Builders
             [CallerFilePath] string? sourceFile = default) where T : class, IActivity =>
             builder.Then<T>(typeof(T).Name, branch, lineNumber, sourceFile);
 
+        /// <inheritdoc cref="Then{T}(IBuilder, Action{ISetupActivity{T}}?, Action{IActivityBuilder}?, int, string?)"/>
         public static IActivityBuilder ThenTypeNamed(
             this IBuilder builder,
             string activityTypeName,


### PR DESCRIPTION
When I create workflows using the Elsa I use the Builder API.

There is a sparse amount of XML code comments on the methods and properties so the learning curve to using the Builder API is pretty steep.

So, this is a venture to add XML code comments to Elsa. Hopefully making it easier for new users to pick it up. This PR focuses on the HTTP activities.

---

A large majority of the builder extensions are exactly the same with some of the parameter types changed around so `inheritdoc` is used quite a bit. This also means that if the maintainers of elsa-core don't think that a comment is accurate a whole swath of them can be changed rather easily.

