### PR TITLE
Inject the Authentication handler to override the anonymous handler t…

### DIFF
--- a/src/samples/aspnet/Elsa.Samples.HttpEndpointSecurity/Startup.cs
+++ b/src/samples/aspnet/Elsa.Samples.HttpEndpointSecurity/Startup.cs
@@ -1,5 +1,7 @@
+using System;
 using System.IdentityModel.Tokens.Jwt;
 using System.Text;
+using Elsa.Activities.Http.Services;
 using Elsa.Samples.HttpEndpointSecurity.Options;
 using Elsa.Samples.HttpEndpointSecurity.Services;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -61,8 +63,15 @@ namespace Elsa.Samples.HttpEndpointSecurity
             // Elsa.
             services
                 .AddElsa(elsa => elsa
-                    .AddHttpActivities(http => Configuration.GetSection("Elsa:Server").Bind(http))
-                    .AddWorkflowsFrom<Startup>()
+                    .AddHttpActivities(http =>
+
+                    {
+                        http.HttpEndpointAuthorizationHandlerFactory =
+                            ActivatorUtilities.GetServiceOrCreateInstance<AuthenticationBasedHttpEndpointAuthorizationHandler>;
+                        http.BaseUrl = new Uri(Configuration["Elsa:Server:BaseUrl"]);
+                        http.BasePath = Configuration["Elsa:Server:BasePath"];
+                    }
+                    ).AddWorkflowsFrom<Startup>()
                 );
 
             // Application Services.


### PR DESCRIPTION
This sample for HttpEnpoint Auth Sample was not working since this [commit](https://github.com/elsa-workflows/elsa-core/commit/d06199f9eec593df3c7f42ff13681b265996e050#diff-4ad3fb9e3856a376c1892940934b0c1160aad52b2c5ed9de77d333674e983fa0)

To address this need to inject the AuthenticationBasedHttpEndpointAuthorizationHandler during the options setup for HttpActivity. 

@sfmskywalker 