### PR TITLE
Mongo db can't write to read only properties

### DIFF
--- a/src/core/Elsa.Abstractions/Models/ActivityDefinition.cs
+++ b/src/core/Elsa.Abstractions/Models/ActivityDefinition.cs
@@ -13,6 +13,6 @@ namespace Elsa.Models
         public bool LoadWorkflowContext { get; set; }
         public bool SaveWorkflowContext { get; set; }
         public ICollection<ActivityDefinitionProperty> Properties { get; set; } = new List<ActivityDefinitionProperty>();
-        public IDictionary<string, string> PropertyStorageProviders { get; } = new Dictionary<string, string>();
+        public IDictionary<string, string> PropertyStorageProviders { get; set; } = new Dictionary<string, string>();
     }
 }


### PR DESCRIPTION
This change will fix an issue where PropertyStorageProviders on ActivityDefinition isn't be read or written in MongoDB

https://github.com/elsa-workflows/elsa-core/blob/6daa8e456e8a3ab2b20da20d214626f259881b1f/src/core/Elsa.Abstractions/Models/ActivityDefinition.cs#L16

As discussed in #3103, mongo by default ignores read only properties so the PropertyStorageProviders selected in the designer is never persisted.

Adding the setter allows mongo to read and write and doesn't appear cause any issues elsewhere.
