### PR TITLE
Check if attachments object is empty string

### DIFF
--- a/src/activities/Elsa.Activities.Email/Activities/SendEmail/SendEmail.cs
+++ b/src/activities/Elsa.Activities.Email/Activities/SendEmail/SendEmail.cs
@@ -121,6 +121,9 @@ namespace Elsa.Activities.Email
 
             if (attachments != null)
             {
+                if (attachments is string && string.IsNullOrWhiteSpace((string)attachments))
+                    return;
+                    
                 var index = 0;
                 var attachmentObjects = InterpretAttachmentsModel(attachments);
 


### PR DESCRIPTION
If attachments object is empty string, ignore and return from method.

Fixes #3162