### PR TITLE
Mongo serializer registration

### DIFF
--- a/src/persistence/Elsa.Persistence.MongoDb/Services/DatabaseRegister.cs
+++ b/src/persistence/Elsa.Persistence.MongoDb/Services/DatabaseRegister.cs
@@ -3,6 +3,7 @@ using Elsa.Models;
 using Elsa.Persistence.MongoDb.Serializers;
 using Elsa.Services.Models;
 using MongoDb.Bson.NodaTime;
+using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 
 namespace Elsa.Persistence.MongoDb.Services
@@ -33,19 +34,19 @@ namespace Elsa.Persistence.MongoDb.Services
                     cm.SetIsRootClass(true);
                     cm.MapIdProperty(x => x.Id);
                 });
-                
+
                 BsonClassMap.RegisterClassMap<WorkflowDefinition>(cm =>
                 {
                     cm.MapProperty(p => p.Variables).SetSerializer(VariablesSerializer.Instance);
                     cm.AutoMap();
                 });
-                
+
                 BsonClassMap.RegisterClassMap<WorkflowInstance>(cm =>
                 {
                     cm.MapProperty(p => p.Variables).SetSerializer(VariablesSerializer.Instance);
                     cm.AutoMap();
                 });
-                
+
                 BsonClassMap.RegisterClassMap<Bookmark>(cm => cm.AutoMap());
                 BsonClassMap.RegisterClassMap<WorkflowExecutionLogRecord>(cm => cm.AutoMap());
                 BsonClassMap.RegisterClassMap<WorkflowOutputReference>(cm => cm.AutoMap());
@@ -60,16 +61,50 @@ namespace Elsa.Persistence.MongoDb.Services
 
         private static void RegisterSerializers()
         {
-            if (BsonSerializer.LookupSerializer<VariablesSerializer>() == null)
+            try
+            {
                 BsonSerializer.RegisterSerializer(VariablesSerializer.Instance);
-            if (BsonSerializer.LookupSerializer<JObjectSerializer>() == null)
+            }
+            catch (BsonSerializationException ex)
+            {
+
+            }
+
+            try
+            {
                 BsonSerializer.RegisterSerializer(JObjectSerializer.Instance);
-            if (BsonSerializer.LookupSerializer<ObjectSerializer>() == null)
+            }
+            catch (BsonSerializationException ex)
+            {
+
+            }
+
+            try
+            {
                 BsonSerializer.RegisterSerializer(ObjectSerializer.Instance);
-            if (BsonSerializer.LookupSerializer<TypeSerializer>() == null)
+            }
+            catch (BsonSerializationException ex)
+            {
+
+            }
+
+            try
+            {
                 BsonSerializer.RegisterSerializer(TypeSerializer.Instance);
-            if (BsonSerializer.LookupSerializer<InstantSerializer>() == null)
+            }
+            catch (BsonSerializationException ex)
+            {
+
+            }
+
+            try
+            {
                 BsonSerializer.RegisterSerializer(new InstantSerializer());
+            }
+            catch (BsonSerializationException ex)
+            {
+
+            }
         }
     }
 }

--- a/src/persistence/Elsa.Persistence.MongoDb/Services/DatabaseRegister.cs
+++ b/src/persistence/Elsa.Persistence.MongoDb/Services/DatabaseRegister.cs
@@ -2,6 +2,7 @@ using System;
 using Elsa.Models;
 using Elsa.Persistence.MongoDb.Serializers;
 using Elsa.Services.Models;
+using Microsoft.Extensions.Logging;
 using MongoDb.Bson.NodaTime;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
@@ -10,7 +11,7 @@ namespace Elsa.Persistence.MongoDb.Services
 {
     public static class DatabaseRegister
     {
-        public static void RegisterMapsAndSerializers()
+        public static void RegisterMapsAndSerializers(ILogger logger = null)
         {
             // In unit tests, the method is called several times, which throws an exception because the entity is already registered
             // If an error is thrown, the remaining registrations are no longer processed
@@ -19,7 +20,7 @@ namespace Elsa.Persistence.MongoDb.Services
             if (firstPass == false)
                 return;
 
-            RegisterSerializers();
+            RegisterSerializers(logger);
         }
 
         private static bool Map()
@@ -59,7 +60,7 @@ namespace Elsa.Persistence.MongoDb.Services
             return true;
         }
 
-        private static void RegisterSerializers()
+        private static void RegisterSerializers(ILogger logger = null)
         {
             try
             {
@@ -67,7 +68,7 @@ namespace Elsa.Persistence.MongoDb.Services
             }
             catch (BsonSerializationException ex)
             {
-
+                logger?.LogWarning(ex, "Couldn't register {serializer_name}", nameof(VariablesSerializer));
             }
 
             try
@@ -76,7 +77,7 @@ namespace Elsa.Persistence.MongoDb.Services
             }
             catch (BsonSerializationException ex)
             {
-
+                logger?.LogWarning(ex, "Couldn't register {serializer_name}", nameof(JObjectSerializer));
             }
 
             try
@@ -85,7 +86,7 @@ namespace Elsa.Persistence.MongoDb.Services
             }
             catch (BsonSerializationException ex)
             {
-
+                logger?.LogWarning(ex, "Couldn't register {serializer_name}", nameof(ObjectSerializer));
             }
 
             try
@@ -94,7 +95,7 @@ namespace Elsa.Persistence.MongoDb.Services
             }
             catch (BsonSerializationException ex)
             {
-
+                logger?.LogWarning(ex, "Couldn't register {serializer_name}", nameof(TypeSerializer));
             }
 
             try
@@ -103,7 +104,7 @@ namespace Elsa.Persistence.MongoDb.Services
             }
             catch (BsonSerializationException ex)
             {
-
+                logger?.LogWarning(ex, "Couldn't register {serializer_name}", nameof(InstantSerializer));
             }
         }
     }


### PR DESCRIPTION
Correcting issue #2998.

Adding try catch around the registration instead of if (BsonSerializer.LookupSerializer<JObjectSerializer>() == null).

As mentioned in the issue, BsonSerializer.LookupSerializer is not being used for the correct purpose here.


https://github.com/elsa-workflows/elsa-core/blob/f2fa88f42f30e9db4f68d948ca02b9f8d28889b1/src/persistence/Elsa.Persistence.MongoDb/Services/DatabaseRegister.cs#L63-L64

It will try and find a serializer for VariablesSerializer (MongoDB.Bson.Serialization.BsonClassMapSerializer<Elsa.Persistence.MongoDb.Serializers.VariablesSerializer>) if it doesn't find one then it will create one and return that.

This means those serializers never get registered.

I believe this issue is also the cause of https://github.com/elsa-workflows/elsa-core/issues/3008