### PR TITLE
If eager join is set, clear scheduled activities on join

### DIFF
--- a/test/integration/Elsa.Core.IntegrationTests/Workflows/ForkEagerJoinWorkflow.cs
+++ b/test/integration/Elsa.Core.IntegrationTests/Workflows/ForkEagerJoinWorkflow.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using Elsa.Activities.Console;
 using Elsa.Activities.ControlFlow;
 using Elsa.Builders;
@@ -8,16 +9,21 @@ namespace Elsa.Core.IntegrationTests.Workflows
     public class ForkEagerJoinWorkflow : IWorkflow
     {
         private readonly bool _eagerJoin;
-        
-        public ForkEagerJoinWorkflow(bool eagerJoin)
+        private readonly string[] _branches;
+
+        public ForkEagerJoinWorkflow(bool eagerJoin, bool reverseBranchOrder)
         {
             _eagerJoin = eagerJoin;
+
+            _branches = new[] { "Branch 1", "Branch 2" };
+
+            if (reverseBranchOrder) _branches = _branches.Reverse().ToArray();
         }
         
         public void Build(IWorkflowBuilder builder)
         {
             builder.StartWith<Fork>(
-                    activity => activity.Set(x => x.Branches, new HashSet<string>(new[] { "Branch 1", "Branch 2" })),
+                    activity => activity.Set(x => x.Branches, new HashSet<string>(_branches)),
                     fork =>
                     {
                         fork.When("Branch 1").SignalReceived("Signal1");

--- a/test/integration/Elsa.Core.IntegrationTests/Workflows/ForkJoinWorkflowTests.cs
+++ b/test/integration/Elsa.Core.IntegrationTests/Workflows/ForkJoinWorkflowTests.cs
@@ -91,7 +91,7 @@ namespace Elsa.Core.IntegrationTests.Workflows
         [Fact(DisplayName = "Normal join should not eagerly clear blocking activities")]
         public async Task Test03()
         {
-            var workflow = new ForkEagerJoinWorkflow(false);
+            var workflow = new ForkEagerJoinWorkflow(false, false);
             var workflowBlueprint = WorkflowBuilder.Build(workflow);
             var workflowResult = await WorkflowStarter.StartWorkflowAsync(workflowBlueprint);
             var workflowInstance = workflowResult.WorkflowInstance!;
@@ -99,15 +99,37 @@ namespace Elsa.Core.IntegrationTests.Workflows
             Assert.Equal(2, workflowInstance.BlockingActivities.Count);
         }
         
-        [Fact(DisplayName = "Eager join should not clear all blocking activities")]
+        [Fact(DisplayName = "Eager join should clear all blocking activities")]
         public async Task Test04()
         {
-            var workflow = new ForkEagerJoinWorkflow(true);
+            var workflow = new ForkEagerJoinWorkflow(true, false);
             var workflowBlueprint = WorkflowBuilder.Build(workflow);
             var workflowResult = await WorkflowStarter.StartWorkflowAsync(workflowBlueprint);
             var workflowInstance = workflowResult.WorkflowInstance!;
 
             Assert.Single(workflowInstance.BlockingActivities);
+        }
+        
+        [Fact(DisplayName = "Eager join should clear blocking and scheduled activities")]
+        public async Task Test05()
+        {
+            var workflow = new ForkEagerJoinWorkflow(true, true);
+            var workflowBlueprint = WorkflowBuilder.Build(workflow);
+            var workflowResult = await WorkflowStarter.StartWorkflowAsync(workflowBlueprint);
+            var workflowInstance = workflowResult.WorkflowInstance!;
+
+            Assert.Single(workflowInstance.BlockingActivities);
+        }
+        
+        [Fact(DisplayName = "Normal join should not clear scheduled activities")]
+        public async Task Test06()
+        {
+            var workflow = new ForkEagerJoinWorkflow(false, true);
+            var workflowBlueprint = WorkflowBuilder.Build(workflow);
+            var workflowResult = await WorkflowStarter.StartWorkflowAsync(workflowBlueprint);
+            var workflowInstance = workflowResult.WorkflowInstance!;
+
+            Assert.Equal(2, workflowInstance.BlockingActivities.Count);
         }
 
         private async Task<WorkflowInstance> TriggerSignalAsync(IWorkflowBlueprint workflowBlueprint, WorkflowInstance workflowInstance, string signal)

--- a/test/unit/Elsa.UnitTests/Models/SimpleStackTests.cs
+++ b/test/unit/Elsa.UnitTests/Models/SimpleStackTests.cs
@@ -1,0 +1,27 @@
+using Xunit;
+
+namespace Elsa.Models;
+
+public class SimpleStackTests
+{
+    [Fact(DisplayName = "Testing simple stack push, pop, peek, and remove operations")]
+    public void PushPopAndRemove()
+    {
+        var sut = new SimpleStack<string>();
+        
+        sut.Push("1");
+        sut.Push("2");
+        sut.Push("3");
+        sut.Push("4");
+        
+        Assert.Equal("4", sut.Peek());
+        Assert.Equal("4", sut.Peek());
+        Assert.Equal("4", sut.Pop());
+        Assert.Equal("3", sut.Peek());
+
+        sut.Remove("2");
+        
+        Assert.Equal("3", sut.Pop());
+        Assert.Equal("1", sut.Pop());
+    }
+}


### PR DESCRIPTION
Another aspect of the recently added eager join option is that of branch order. You will get a little bit different behavior dependent on in which branch the block activity is. If the blocking activity is executed before the joining branch it will be cleared, but if the blocking activity is executed after the joining branch it will be blocking after the execution, because it was not blocking at the time of the join, it was scheduled.

With this PR a join of an EagerJoin will also clear all scheduled activities inside the fork, effectively stopping all execution.

If you don't think that this should be the behavior of EagerJoin, perhaps this could be added as another option to the Join?