### PR TITLE
Publish symbol packages

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -103,7 +103,9 @@ after_test:
 
 artifacts:
     -   path: '**/*.nupkg'
-        name: Packages
+        name: Packages        
+    -   path: '**/*.snupkg'
+        name: Symbol Packages
     -   path: '**/TestResults/TestResults.xml'
 
 deploy:


### PR DESCRIPTION
I've added the .snupkg files to the Appveyor Artifacts definition in order to be able to access them in the deployment step.

See the [AppVeyor Docs](https://www.appveyor.com/docs/packaging-artifacts/#basics):
>  ... deployment is not possible unless a file is listed as an artifact first.


This should be the last part for achieving  #2977.