### PR TITLE
Fault array, fix retry, new parameter in Join activity

### DIFF
--- a/src/core/Elsa.Abstractions/Models/WorkflowInstance.cs
+++ b/src/core/Elsa.Abstractions/Models/WorkflowInstance.cs
@@ -14,6 +14,7 @@ namespace Elsa.Models
             Variables = new Variables();
             ScheduledActivities = new SimpleStack<ScheduledActivity>();
             Scopes = new SimpleStack<ActivityScope>();
+            Faults = new SimpleStack<WorkflowFault>();
         }
 
         public string DefinitionId { get; set; } = default!;
@@ -56,7 +57,7 @@ namespace Elsa.Models
             Metadata[key] = value;
         }
 
-        public WorkflowFault? Fault { get; set; }
+        public SimpleStack<WorkflowFault> Faults { get; set; }
         public SimpleStack<ScheduledActivity> ScheduledActivities { get; set; }
         public SimpleStack<ActivityScope> Scopes { get; set; }
         public ScheduledActivity? CurrentActivity { get; set; }

--- a/src/core/Elsa.Abstractions/Services/Models/WorkflowExecutionContext.cs
+++ b/src/core/Elsa.Abstractions/Services/Models/WorkflowExecutionContext.cs
@@ -188,7 +188,7 @@ namespace Elsa.Services.Models
             var clock = ServiceProvider.GetRequiredService<IClock>();
             WorkflowInstance.WorkflowStatus = WorkflowStatus.Faulted;
             WorkflowInstance.FaultedAt = clock.GetCurrentInstant();
-            WorkflowInstance.Fault = new WorkflowFault(SimpleException.FromException(exception), message, activityId, activityInput, resuming);
+            WorkflowInstance.Faults.Push(new WorkflowFault(SimpleException.FromException(exception), message, activityId, activityInput, resuming));
             Exception = exception;
         }
 
@@ -197,7 +197,7 @@ namespace Elsa.Services.Models
             var clock = ServiceProvider.GetRequiredService<IClock>();
             WorkflowInstance.WorkflowStatus = WorkflowStatus.Cancelled;
             WorkflowInstance.CancelledAt = clock.GetCurrentInstant();
-            WorkflowInstance.Fault = new WorkflowFault(SimpleException.FromException(exception), message, activityId, activityInput, resuming);
+            WorkflowInstance.Faults.Push(new WorkflowFault(SimpleException.FromException(exception), message, activityId, activityInput, resuming));
         }
 
         public async Task CompleteAsync()
@@ -218,7 +218,7 @@ namespace Elsa.Services.Models
                 WorkflowInstance.WorkflowStatus = WorkflowStatus.Cancelled;
                 WorkflowInstance.CancelledAt = now;
             }
-            if(WorkflowInstance.Fault != null)
+            if(WorkflowInstance.Faults != null && WorkflowInstance.Faults.Count > 0)
             {
                 WorkflowInstance.WorkflowStatus = WorkflowStatus.Faulted;
                 WorkflowInstance.FaultedAt = now;

--- a/src/core/Elsa.Core/Activities/Workflows/RunWorkflow/Helper/HashHelper.cs
+++ b/src/core/Elsa.Core/Activities/Workflows/RunWorkflow/Helper/HashHelper.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Elsa.Activities.Workflows.Helper
+{
+    public static class HashHelper
+    {
+        public static string Hash(object entity)
+        {
+            var seen = new HashSet<object>();
+            var properties = GetAllSimpleProperties(entity, seen);
+            return string.Join("",properties.Select(p => Encoding.ASCII.GetBytes(p.ToString()).AsEnumerable()).Aggregate((ag, next) => ag.Concat(next)).ToArray());
+        }
+
+        private static IEnumerable<object> GetAllSimpleProperties(object entity, HashSet<object> seen)
+        {
+            var properties = entity.GetType().GetProperties();
+            if (properties.Length == 0)
+            {
+                yield return entity;
+            }
+            foreach (var property in properties)
+            {
+                var t = property.PropertyType;
+                if (t == typeof(int) || t ==  typeof(long) || t == typeof(string)) yield return property.GetValue(entity) ?? "null";
+                else if (seen.Add(property)) // Handle cyclic references
+                {
+                    foreach (var simple in GetAllSimpleProperties(property, seen)) yield return simple;
+                }
+            }
+        }
+
+        
+    }
+}

--- a/src/core/Elsa.Core/Activities/Workflows/RunWorkflow/RunWorkflow.cs
+++ b/src/core/Elsa.Core/Activities/Workflows/RunWorkflow/RunWorkflow.cs
@@ -125,7 +125,6 @@ namespace Elsa.Activities.Workflows
             WorkflowStatus? childWorkflowStatus;
             WorkflowInstance? childWorkflowInstance;
 
-
             //Someway the initial input changes when retrying, so we hash the values
             //when retrying this activity if faulted, if there is only one with this activity id in the workflow, we dont need to use the hash because
             //ChildWorkflowInstanceId will have the id of the subworkflow but, if it has failed in a loop, as ChildWorkflowInstanceId is metadata, it will always
@@ -166,8 +165,6 @@ namespace Elsa.Activities.Workflows
                 childWorkflowStatus = childWorkflowInstance.WorkflowStatus;
                 ChildWorkflowInstanceId = childWorkflowInstance.Id;
 
-                
-
                 context.JournalData.Add("Workflow Blueprint ID", workflowBlueprint?.Id);
                 context.JournalData.Add("Workflow Instance ID", childWorkflowInstance.Id);
                 context.JournalData.Add("Workflow Instance Status", childWorkflowInstance.WorkflowStatus);
@@ -178,7 +175,6 @@ namespace Elsa.Activities.Workflows
 
                 if (workflowBlueprint == null || workflowBlueprint.Id == context.WorkflowInstance.DefinitionId)
                     return Outcome("Not Found");
-
 
                 var result = await _startsWorkflow.StartWorkflowAsync(workflowBlueprint!, TenantId, new WorkflowInput(Input), CorrelationId, ContextId, cancellationToken: cancellationToken);
                 childWorkflowInstance = result.WorkflowInstance!;

--- a/src/core/Elsa.Core/Handlers/CompensateWorkflow.cs
+++ b/src/core/Elsa.Core/Handlers/CompensateWorkflow.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Elsa.Activities.Compensation;
@@ -23,7 +24,7 @@ public class CompensateWorkflow : INotificationHandler<WorkflowFaulting>
     {
         var activityExecutionContext = notification.ActivityExecutionContext;
         var exception = activityExecutionContext.WorkflowExecutionContext.Exception;
-        var message = activityExecutionContext.WorkflowInstance.Fault?.Message;
+        var message = activityExecutionContext.WorkflowInstance.Faults.FirstOrDefault(x => x.FaultedActivityId == notification.ActivityExecutionContext.ActivityId)?.Message;
         _compensationService.Compensate(notification.ActivityExecutionContext, exception, message);
         return Task.CompletedTask;
     }

--- a/src/designer/elsa-workflows-studio/src/components/editors/properties/elsa-dropdown-property/elsa-dropdown-property.tsx
+++ b/src/designer/elsa-workflows-studio/src/components/editors/properties/elsa-dropdown-property/elsa-dropdown-property.tsx
@@ -20,7 +20,7 @@ export class ElsaDropdownProperty {
   async componentWillLoad() {
     const defaultSyntax = this.propertyDescriptor.defaultSyntax || SyntaxNames.Literal;
     this.currentValue = this.propertyModel.expressions[defaultSyntax] || undefined;
-    const dependsOnEvent = this.propertyDescriptor.options?.context.dependsOnEvent;
+    const dependsOnEvent = this.propertyDescriptor.options?.context?.dependsOnEvent;
 
     // Does this property have a dependency on another property?
     if (!!dependsOnEvent) {

--- a/src/designer/elsa-workflows-studio/src/components/screens/workflow-definition-editor/elsa-workflow-definition-editor-screen/elsa-workflow-definition-editor-screen.tsx
+++ b/src/designer/elsa-workflows-studio/src/components/screens/workflow-definition-editor/elsa-workflow-definition-editor-screen/elsa-workflow-definition-editor-screen.tsx
@@ -763,7 +763,7 @@ export class ElsaWorkflowDefinitionEditorScreen {
 
       return (
         <div class="elsa-ml-4">
-          <elsa-workflow-fault-information workflowFault={this.workflowInstance?.fault}
+          <elsa-workflow-fault-information workflowFault={this.workflowInstance?.faults.find(x => x.faultedActivityId == this.selectedActivityId)}
                                            faultedAt={this.workflowInstance?.faultedAt}/>
         </div>
       );

--- a/src/designer/elsa-workflows-studio/src/components/screens/workflow-instance-viewer/elsa-workflow-instance-journal/elsa-workflow-instance-journal.tsx
+++ b/src/designer/elsa-workflows-studio/src/components/screens/workflow-instance-viewer/elsa-workflow-instance-journal/elsa-workflow-instance-journal.tsx
@@ -76,14 +76,14 @@ export class ElsaWorkflowInstanceJournal {
 
   getEventColor(eventName: string) {
     const map = {
-      'Executing': 'blue',
-      'Executed': 'green',
-      'Faulted': 'rose',
-      'Warning': 'yellow',
-      'Information': 'blue',
+      'Executing': 'elsa-bg-blue-500',
+      'Executed': 'elsa-bg-green-500',
+      'Faulted': 'elsa-bg-rose-500',
+      'Warning': 'elsa-bg-yellow-500',
+      'Information': 'elsa-bg-blue-500',
     };
 
-    return map[eventName] || 'gray';
+    return map[eventName] || 'elsa-bg-gray-500';
   }
 
   getStatusColor(status: WorkflowStatus) {
@@ -243,7 +243,7 @@ export class ElsaWorkflowInstanceJournal {
               <div class="elsa-relative elsa-flex elsa-space-x-3">
                 <div>
                   <span
-                    class={`elsa-h-8 elsa-w-8 elsa-rounded-full elsa-bg-${eventColor}-500 elsa-flex elsa-items-center elsa-justify-center elsa-ring-8 elsa-ring-white elsa-mr-1`}
+                    class={`elsa-h-8 elsa-w-8 elsa-rounded-full ${eventColor} elsa-flex elsa-items-center elsa-justify-center elsa-ring-8 elsa-ring-white elsa-mr-1`}
                     innerHTML={activityIcon}/>
                 </div>
                 <div class="elsa-min-w-0 elsa-flex-1 elsa-pt-1.5 elsa-flex elsa-justify-between elsa-space-x-4">
@@ -256,7 +256,7 @@ export class ElsaWorkflowInstanceJournal {
                     <span
                       class="elsa-relative elsa-inline-flex elsa-items-center elsa-rounded-full elsa-border elsa-border-gray-300 elsa-px-3 elsa-py-0.5 elsa-text-sm">
                       <span class="elsa-absolute elsa-flex-shrink-0 elsa-flex elsa-items-center elsa-justify-center">
-                        <span class={`elsa-h-1.5 elsa-w-1.5 elsa-rounded-full elsa-bg-${eventColor}-500`}
+                        <span class={`elsa-h-1.5 elsa-w-1.5 elsa-rounded-full ${eventColor}`}
                               aria-hidden="true"/>
                       </span>
                       <span class="elsa-ml-3.5 elsa-font-medium elsa-text-gray-900">{eventName}</span>
@@ -403,7 +403,7 @@ export class ElsaWorkflowInstanceJournal {
           <dd class="elsa-text-gray-900 elsa-break-all">
             <span class="elsa-relative elsa-inline-flex elsa-items-center elsa-rounded-full">
               <span class="elsa-flex-shrink-0 elsa-flex elsa-items-center elsa-justify-center">
-                <span class={`elsa-w-2-5 elsa-h-2-5 elsa-rounded-full elsa-bg-${eventColor}-500`}
+                <span class={`elsa-w-2-5 elsa-h-2-5 elsa-rounded-full ${eventColor}`}
                       aria-hidden="true"/>
               </span>
               <span class="elsa-ml-3.5">{workflowInstance.workflowStatus || '-'}</span>

--- a/src/designer/elsa-workflows-studio/src/components/screens/workflow-instance-viewer/elsa-workflow-instance-journal/elsa-workflow-instance-journal.tsx
+++ b/src/designer/elsa-workflows-studio/src/components/screens/workflow-instance-viewer/elsa-workflow-instance-journal/elsa-workflow-instance-journal.tsx
@@ -150,6 +150,7 @@ export class ElsaWorkflowInstanceJournal {
     const workflowBlueprint = this.workflowBlueprint;
     const activityBlueprints: Array<ActivityBlueprint> = workflowBlueprint.activities || [];
     const selectedRecordId = this.selectedRecordId;
+    
 
     const renderRecord = (record: WorkflowExecutionLogRecord, index: number) => {
       var prevItemReverseIndex = allItems
@@ -242,7 +243,7 @@ export class ElsaWorkflowInstanceJournal {
               <div class="elsa-relative elsa-flex elsa-space-x-3">
                 <div>
                   <span
-                    class="elsa-h-8 elsa-w-8 elsa-rounded-full elsa-bg-green-500 elsa-flex elsa-items-center elsa-justify-center elsa-ring-8 elsa-ring-white elsa-mr-1"
+                    class={`elsa-h-8 elsa-w-8 elsa-rounded-full elsa-bg-${eventColor}-500 elsa-flex elsa-items-center elsa-justify-center elsa-ring-8 elsa-ring-white elsa-mr-1`}
                     innerHTML={activityIcon}/>
                 </div>
                 <div class="elsa-min-w-0 elsa-flex-1 elsa-pt-1.5 elsa-flex elsa-justify-between elsa-space-x-4">

--- a/src/designer/elsa-workflows-studio/src/components/screens/workflow-instance-viewer/elsa-workflow-instance-viewer-screen/elsa-workflow-instance-viewer-screen.tsx
+++ b/src/designer/elsa-workflows-studio/src/components/screens/workflow-instance-viewer/elsa-workflow-instance-viewer-screen/elsa-workflow-instance-viewer-screen.tsx
@@ -263,13 +263,13 @@ export class ElsaWorkflowInstanceViewerScreen {
 
   getActivityBorderColor = (activity: ActivityModel): string => {
     const workflowInstance = this.workflowInstance;
-    const workflowFault = !!workflowInstance ? workflowInstance.fault : null;
+    const workflowFault = !!workflowInstance ? workflowInstance.faults : null;
     const activityData = workflowInstance.activityData[activity.activityId] || {};
     const lifecycle = activityData['_Lifecycle'] || {};
     const executing = !!lifecycle.executing;
     const executed = !!lifecycle.executed;
 
-    if (!!workflowFault && workflowFault.faultedActivityId == activity.activityId)
+    if (!!workflowFault && workflowFault.find(x => x.faultedActivityId == activity.activityId))
       return 'red';
 
     if (executed)
@@ -283,7 +283,7 @@ export class ElsaWorkflowInstanceViewerScreen {
 
   renderActivityStatsButton = (activity: ActivityModel): string => {
     const workflowInstance = this.workflowInstance;
-    const workflowFault = !!workflowInstance ? workflowInstance.fault : null;
+    const workflowFault = !!workflowInstance ? workflowInstance.faults : null;
     const activityData = workflowInstance.activityData[activity.activityId] || {};
     const lifecycle = activityData['_Lifecycle'] || {};
     const executing = !!lifecycle.executing;
@@ -291,7 +291,7 @@ export class ElsaWorkflowInstanceViewerScreen {
 
     let icon: string;
 
-    if (!!workflowFault && workflowFault.faultedActivityId == activity.activityId) {
+    if (!!workflowFault && workflowFault.find(x => x.faultedActivityId == activity.activityId)) {
       icon = `<svg class="elsa-flex-shrink-0 elsa-h-6 elsa-w-6 elsa-text-red-600" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <circle cx="12" cy="12" r="10"/>
                 <line x1="12" y1="8" x2="12" y2="12"/>
@@ -347,12 +347,12 @@ export class ElsaWorkflowInstanceViewerScreen {
 
   renderActivityPerformanceMenu = () => {
     const activityStats: ActivityStats = this.activityStats;
-
+    
     const renderFault = () => {
       if (!activityStats.fault)
         return;
-
-      return <elsa-workflow-fault-information workflowFault={this.workflowInstance.fault} faultedAt={this.workflowInstance.faultedAt} />;
+      
+      return <elsa-workflow-fault-information workflowFault={this.workflowInstance.faults.find(x => x.faultedActivityId == this.selectedActivityId)} faultedAt={this.workflowInstance.faultedAt} />;
     };
 
     const renderPerformance = () => {

--- a/src/designer/elsa-workflows-studio/src/models/domain.ts
+++ b/src/designer/elsa-workflows-studio/src/models/domain.ts
@@ -121,7 +121,7 @@ export interface WorkflowInstance {
   activityData?: Map<any>;
   activityOutput?: Map<any>;
   blockingActivities: Array<BlockingActivity>;
-  fault?: WorkflowFault;
+  faults?: Array<WorkflowFault>;
   scheduledActivities: Array<ScheduledActivity>;
   scopes: Array<ActivityScope>;
   currentActivity: ScheduledActivity;

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/Configuration/WorkflowInstanceConfiguration.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/Configuration/WorkflowInstanceConfiguration.cs
@@ -18,7 +18,7 @@ namespace Elsa.Persistence.EntityFramework.Core.Configuration
             builder.Ignore(x => x.ActivityData);
             builder.Ignore(x => x.Metadata);
             builder.Ignore(x => x.BlockingActivities);
-            builder.Ignore(x => x.Fault);
+            builder.Ignore(x => x.Faults);
             builder.Ignore(x => x.ScheduledActivities);
             builder.Ignore(x => x.Scopes);
             builder.Ignore(x => x.Variables);

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/Stores/EntityFrameworkWorkflowInstanceStore.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/Stores/EntityFrameworkWorkflowInstanceStore.cs
@@ -79,7 +79,7 @@ namespace Elsa.Persistence.EntityFramework.Core.Stores
                 entity.BlockingActivities,
                 entity.ScheduledActivities,
                 entity.Scopes,
-                entity.Fault,
+                entity.Faults,
                 entity.CurrentActivity
             };
 
@@ -100,7 +100,7 @@ namespace Elsa.Persistence.EntityFramework.Core.Stores
                 entity.BlockingActivities,
                 entity.ScheduledActivities,
                 entity.Scopes,
-                entity.Fault,
+                entity.Faults,
                 entity.CurrentActivity
             };
 
@@ -126,7 +126,7 @@ namespace Elsa.Persistence.EntityFramework.Core.Stores
             entity.BlockingActivities = data.BlockingActivities;
             entity.ScheduledActivities = data.ScheduledActivities;
             entity.Scopes = data.Scopes;
-            entity.Fault = data.Fault;
+            entity.Faults = data.Faults;
             entity.CurrentActivity = data.CurrentActivity;
         }
     }

--- a/src/server/Elsa.Server.Api/Endpoints/WorkflowInstances/Retry.cs
+++ b/src/server/Elsa.Server.Api/Endpoints/WorkflowInstances/Retry.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading;
+using System.Threading;
 using System.Threading.Tasks;
 using Elsa.Models;
 using Elsa.Persistence;
@@ -65,7 +65,7 @@ namespace Elsa.Server.Api.Endpoints.WorkflowInstances
                 return StatusCode(500, new
                 {
                     WorkflowInstanceId = workflowInstance.Id,
-                    Fault = workflowInstance.Fault
+                    Fault = workflowInstance.Faults
                 }).ConfigureForEndpoint();
 
             return Response.HasStarted

--- a/test/integration/Elsa.Core.IntegrationTests/Scripting/JavaScript/JavaScriptExpressionsIntegrationTests.cs
+++ b/test/integration/Elsa.Core.IntegrationTests/Scripting/JavaScript/JavaScriptExpressionsIntegrationTests.cs
@@ -152,7 +152,7 @@ namespace Elsa.Core.IntegrationTests.Scripting.JavaScript
                 var workflowInstance = runWorkflowResult.WorkflowInstance!;
 
                 Assert.NotNull(workflowInstance);
-                Assert.Null(workflowInstance.Fault);
+                Assert.Empty(workflowInstance.Faults);
             }
 
             public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;


### PR DESCRIPTION
**This PR has breaking changes**

Hi, I will try to set up my needs to explain what is this PR about. We are migrating our app core from custom Hangfire jobs to Elsa workflows with custom activities to enrich our app and also to have the ability to modify the workflows without making changes on the code. So, the first thing I did was to copy my hangfire flow to custom activities on Elsa. Everything was OK and the workflow was being executing with the same results. Then, I started do dig more, so, I purpossely failed some activities (custom and fault activity) to try the retry functionality and it wasn't working. Already opened an [issue with the problem ](https://github.com/elsa-workflows/elsa-core/issues/3180). If I couldn't retry my failed activities, I would need to give up elsa, so I started to checking the core code. I saw that Workflowinstance.CurrentActivity was always null, so the reviver was always using the first workflow activity as retry. But also found another problem (at least in my scenario). Elsa was only saving to database the last fault activity, so, in a loop or fork, just the last fault activity was being tagged as faulted, the others were OK. I changed the fault attribute to faults as SimpleStack. Now, I can save all the faulted activities. And, then, changed the reviver to check if there are faulted activities to schedule on retry. Now it's working good, even the retry. Now you can retry all the faulted activities inside a loop. 
![imagen](https://user-images.githubusercontent.com/30892914/177147010-6e01ffbb-5dba-4ffc-be21-160c07a95aea.png)
![imagen](https://user-images.githubusercontent.com/30892914/177147065-c700075c-0598-4680-94db-55834f52e5f8.png)

(Be careful with how you design your loop. If the activities input are dependant on other activities, for example, the output of the loop, it won't work as expected, because it will use the last output of the loop as input for every activity that uses "return foreach.Output()". The way to solve this is to transmit the input from the first activity in the loop to the input of the next activity, just returning it as output.)

Also, I found another problem. In a fork scenario, the final join continues the execution (with both configuration modes) even if the inbound activities has failed (tagged as faulted). I added a new parameter (bool) to the Join activity that prevents that. It checks if there are fault or scheduled activities (this change is chained with the previous) and stop the execution. Just changed IsDone method. Now, it will add to the journal the activities that have faulted, like the inbounds journal data.
![imagen](https://user-images.githubusercontent.com/30892914/177146831-18f18d44-6e75-4e3a-9db2-18e7a7d02f33.png)

There are 2 activity list checked on isDone. Faults is used to know if there are some faults in the current workflowinstance execution. The Scheduled activity list is used on retry. When you retry a faulted workflow, it moves the activities from Faults to scheduled list.

Finally, I updated the designer with the new Faults parameter (was Fault) and now, all the faulted activities in the designer are tagged red.
![imagen](https://user-images.githubusercontent.com/30892914/177143457-4e26e3a5-1cbf-4c50-9158-23dd5e6210de.png)

