### PR TITLE
don't lowercase the Path Parameters in the URI (#3187)

### DIFF
--- a/src/activities/Elsa.Activities.Http/Middleware/HttpEndpointMiddleware.cs
+++ b/src/activities/Elsa.Activities.Http/Middleware/HttpEndpointMiddleware.cs
@@ -248,7 +248,7 @@ namespace Elsa.Activities.Http.Middleware
         }
 
         private string? GetPath(PathString? basePath, HttpContext httpContext) => basePath != null
-            ? httpContext.Request.Path.StartsWithSegments(basePath.Value, out _, out var remainingPath) ? remainingPath.Value.ToLowerInvariant() : null
-            : httpContext.Request.Path.Value.ToLowerInvariant();
+            ? httpContext.Request.Path.StartsWithSegments(basePath.Value, out _, out var remainingPath) ? remainingPath.Value : null
+            : httpContext.Request.Path.Value;
     }
 }


### PR DESCRIPTION
This PR resolve issue #3187

As what I read, only Scheme and Host part of the URI should be compared case-insensitive and can be normalized to lowercase.

This PR fix Elsa v2 , another have to be done for v3.