### PR TITLE
Restore Fault property and mark it as obsolete. Patched it for less impact (ref PR 3182)

### DIFF
--- a/src/core/Elsa.Abstractions/Models/WorkflowInstance.cs
+++ b/src/core/Elsa.Abstractions/Models/WorkflowInstance.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Elsa.Comparers;
 using Elsa.Services.Models;
@@ -56,8 +57,27 @@ namespace Elsa.Models
         {
             Metadata[key] = value;
         }
+        [Obsolete("This property is obsolete. Use Faults instead.", false)]
+        public WorkflowFault? Fault { get; set; }
 
-        public SimpleStack<WorkflowFault> Faults { get; set; }
+        private SimpleStack<WorkflowFault> _faults;
+        public SimpleStack<WorkflowFault> Faults {
+            get
+            {
+                return _faults ??= new SimpleStack<WorkflowFault>();
+            }
+            set
+            {
+                //Temporal patch to decrease the Faults change impact
+                var result = value ?? new SimpleStack<WorkflowFault>();
+                if (Fault != null)
+                {
+                    result.Push(Fault);
+                    Fault = null;
+                }
+                _faults = result;
+            }
+        }
         public SimpleStack<ScheduledActivity> ScheduledActivities { get; set; }
         public SimpleStack<ActivityScope> Scopes { get; set; }
         public ScheduledActivity? CurrentActivity { get; set; }

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/Configuration/WorkflowInstanceConfiguration.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/Configuration/WorkflowInstanceConfiguration.cs
@@ -18,6 +18,7 @@ namespace Elsa.Persistence.EntityFramework.Core.Configuration
             builder.Ignore(x => x.ActivityData);
             builder.Ignore(x => x.Metadata);
             builder.Ignore(x => x.BlockingActivities);
+            builder.Ignore(x => x.Fault);
             builder.Ignore(x => x.Faults);
             builder.Ignore(x => x.ScheduledActivities);
             builder.Ignore(x => x.Scopes);

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/Stores/EntityFrameworkWorkflowInstanceStore.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/Stores/EntityFrameworkWorkflowInstanceStore.cs
@@ -79,6 +79,7 @@ namespace Elsa.Persistence.EntityFramework.Core.Stores
                 entity.BlockingActivities,
                 entity.ScheduledActivities,
                 entity.Scopes,
+                entity.Fault,
                 entity.Faults,
                 entity.CurrentActivity
             };
@@ -100,6 +101,7 @@ namespace Elsa.Persistence.EntityFramework.Core.Stores
                 entity.BlockingActivities,
                 entity.ScheduledActivities,
                 entity.Scopes,
+                entity.Fault,
                 entity.Faults,
                 entity.CurrentActivity
             };
@@ -126,6 +128,7 @@ namespace Elsa.Persistence.EntityFramework.Core.Stores
             entity.BlockingActivities = data.BlockingActivities;
             entity.ScheduledActivities = data.ScheduledActivities;
             entity.Scopes = data.Scopes;
+            entity.Fault = data.Fault;
             entity.Faults = data.Faults;
             entity.CurrentActivity = data.CurrentActivity;
         }


### PR DESCRIPTION
Hi,
as I said [in this PR](https://github.com/elsa-workflows/elsa-core/pull/3182) I've changed the code to reduce the impact on the Faults change. It keeps the Fault property but the first time a workflow instance is initialized, it moves the Fault property value to the new Faults property.
@sfmskywalker 