### PR TITLE
Adding Statements to Catch if expression has no value. 

### DIFF
--- a/src/designer/elsa-workflows-studio/src/components/editors/elsa-multi-expression-editor/elsa-multi-expression-editor.tsx
+++ b/src/designer/elsa-workflows-studio/src/components/editors/elsa-multi-expression-editor/elsa-multi-expression-editor.tsx
@@ -68,9 +68,12 @@ export class ElsaMultiExpressionEditor {
 
     this.selectedSyntax = syntax;
     this.syntaxChanged.emit(syntax);
-
     this.currentValue = this.expressions[syntax ? syntax : this.defaultSyntax || SyntaxNames.Literal];
-    await this.expressionEditor.setExpression(this.currentValue);
+	if(this.currentValue){
+		await this.expressionEditor.setExpression(this.currentValue);
+	}
+
+
 
     this.closeContextMenu();
   }
@@ -81,8 +84,10 @@ export class ElsaMultiExpressionEditor {
 
   onExpressionChanged(e: CustomEvent<string>) {
     const expression = e.detail;
-    this.expressions[this.selectedSyntax || this.defaultSyntax] = expression;
-    this.expressionChanged.emit(expression);
+	if(expression){
+		this.expressions[this.selectedSyntax || this.defaultSyntax] = expression;
+		this.expressionChanged.emit(expression);
+	}
   }
 
   render() {


### PR DESCRIPTION
Found an Issue when removing data from an input box, or changing it from Default to JavaScript/Liquid would add the value to the Array i.e `{ JavaScript: "" }` . Just wrapped an if to check the value before it does this. Means empty string values would get passed through if you clear the value of an expression or if you just switched Default -> JavaScript without entering anything. 