### PR TITLE
Workflow Instance UI Display Fix

### DIFF
--- a/src/designer/elsa-workflows-studio/src/components/screens/workflow-instance-viewer/elsa-workflow-instance-viewer-screen/elsa-workflow-instance-viewer-screen.tsx
+++ b/src/designer/elsa-workflows-studio/src/components/screens/workflow-instance-viewer/elsa-workflow-instance-viewer-screen/elsa-workflow-instance-viewer-screen.tsx
@@ -266,8 +266,8 @@ export class ElsaWorkflowInstanceViewerScreen {
     const workflowFault = !!workflowInstance ? workflowInstance.faults : null;
     const activityData = workflowInstance.activityData[activity.activityId] || {};
     const lifecycle = activityData['_Lifecycle'] || {};
-    const executing = !!lifecycle.executing;
-    const executed = !!lifecycle.executed;
+    const executing = lifecycle.executing ?? lifecycle.Executing;
+    const executed = lifecycle.executed ?? lifecycle.Executed;
 
     if (!!workflowFault && workflowFault.find(x => x.faultedActivityId == activity.activityId))
       return 'red';
@@ -286,8 +286,8 @@ export class ElsaWorkflowInstanceViewerScreen {
     const workflowFault = !!workflowInstance ? workflowInstance.faults : null;
     const activityData = workflowInstance.activityData[activity.activityId] || {};
     const lifecycle = activityData['_Lifecycle'] || {};
-    const executing = !!lifecycle.executing;
-    const executed = !!lifecycle.executed;
+    const executing = lifecycle.executing ?? lifecycle.Executing;
+    const executed = lifecycle.executed ?? lifecycle.Executed;
 
     let icon: string;
 


### PR DESCRIPTION
Fixes issue in [#2845](https://github.com/elsa-workflows/elsa-core/issues/2845)

We use MongoDB to store data, ActivityLifecycle properties are getting parsed into the MongoDB as Uppercase. Therefore as described in the Issue, the status UI doesn't show so no green border for successful activities or green icon. 

This just adds a check if the default value (lowercase) is null then it will try the uppercase property.