### PR TITLE
HTTP Endpoint activity Xml support

### DIFF
--- a/src/activities/Elsa.Activities.Http/Extensions/ServiceCollectionExtensions.cs
+++ b/src/activities/Elsa.Activities.Http/Extensions/ServiceCollectionExtensions.cs
@@ -46,6 +46,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services
                 .AddSingleton<IHttpRequestBodyParser, DefaultHttpRequestBodyParser>()
                 .AddSingleton<IHttpRequestBodyParser, JsonHttpRequestBodyParser>()
+                .AddSingleton<IHttpRequestBodyParser, XmlHttpRequestBodyParser>()
                 .AddSingleton<IHttpRequestBodyParser, FormHttpRequestBodyParser>()
                 .AddSingleton<IHttpResponseContentReader, PlainTextHttpResponseContentReader>()
                 .AddSingleton<IHttpResponseContentReader, JsonRawHttpResponseContentReader>()

--- a/src/activities/Elsa.Activities.Http/Middleware/HttpEndpointMiddleware.cs
+++ b/src/activities/Elsa.Activities.Http/Middleware/HttpEndpointMiddleware.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Xml;
 using System.Net;
 using System.Net.Mime;
 using System.Threading;
@@ -160,6 +161,11 @@ namespace Elsa.Activities.Http.Middleware
                     return;
                 }
                 catch (JsonReaderException e)
+                {
+                    await WriteBadRequestResponseAsync(e);
+                    return;
+                }
+                catch (XmlException e)
                 {
                     await WriteBadRequestResponseAsync(e);
                     return;

--- a/src/activities/Elsa.Activities.Http/Parsers/Request/XmlHttpRequestBodyParser.cs
+++ b/src/activities/Elsa.Activities.Http/Parsers/Request/XmlHttpRequestBodyParser.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Xml;
+using System.Dynamic;
+using System.Threading;
+using System.Threading.Tasks;
+using Elsa.Activities.Http.Contracts;
+using Elsa.Activities.Http.Extensions;
+using Elsa.Serialization;
+using Microsoft.AspNetCore.Http;
+using Newtonsoft.Json;
+
+namespace Elsa.Activities.Http.Parsers.Request
+{
+    public class XmlHttpRequestBodyParser : IHttpRequestBodyParser
+    {
+        private readonly IContentSerializer _serializer;
+
+        public XmlHttpRequestBodyParser(IContentSerializer serializer)
+        {
+            _serializer = serializer;
+        }
+        
+        public int Priority => 0;
+        public string?[] SupportedContentTypes => new[] { "application/xml", "text/xml" };
+        
+        public async Task<object?> ParseAsync(HttpRequest request, Type? targetType = default, CancellationToken cancellationToken = default)
+        {
+            var xml = await request.ReadContentAsStringAsync(cancellationToken);
+
+            if (xml == null)
+                return default;
+            
+            var doc = new XmlDocument();
+            doc.LoadXml(xml);
+            string json = JsonConvert.SerializeXmlNode(doc);
+
+            targetType ??= typeof(ExpandoObject);
+            return _serializer.Deserialize(json, targetType)!;
+        }
+    }
+}


### PR DESCRIPTION
In #3245 I've added simple XML support to SendHTTPRequest activity.

Adding similar support for HTTPEndpoint activity.
