### PR TITLE
Prevent rescheduling of looping/scoped activities if faulted

### DIFF
--- a/src/core/Elsa.Core/Handlers/RescheduleBranchingActivitiesAndContainers.cs
+++ b/src/core/Elsa.Core/Handlers/RescheduleBranchingActivitiesAndContainers.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Elsa.Events;
@@ -39,7 +39,8 @@ namespace Elsa.Handlers
             // Re-schedule the current scope activity.
             workflowInstance.Scopes.Remove(scope);
             workflowInstance.ActivityData.GetItem(scope.ActivityId)!.SetState("Unwinding", true);
-            workflowExecutionContext.ScheduleActivity(scope.ActivityId);
+            if (workflowInstance.WorkflowStatus != WorkflowStatus.Faulted)
+                workflowExecutionContext.ScheduleActivity(scope.ActivityId);
 
             return Task.CompletedTask;
         }


### PR DESCRIPTION
I believe this fixes #3020, maybe even #3001.
I've tested `For`, `For Each`, `While`.... loop inside loop, etc.....

What I don't know how it "interacts" with compensation activities......