### PR TITLE
Retention module improvement #3253

### DIFF
--- a/src/modules/retention/Elsa.Retention/Contracts/IRetentionSpecificationFilter.cs
+++ b/src/modules/retention/Elsa.Retention/Contracts/IRetentionSpecificationFilter.cs
@@ -1,0 +1,12 @@
+﻿using Elsa.Models;
+using Elsa.Persistence.Specifications;
+
+namespace Elsa.Retention.Contracts
+{
+    public interface IRetentionSpecificationFilter
+    {
+        ISpecification<WorkflowInstance> GetSpecification();
+        void AddAndSpecification(ISpecification<WorkflowInstance> specification);
+        void AddOrSpecification(ISpecification<WorkflowInstance> specification);
+    }
+}

--- a/src/modules/retention/Elsa.Retention/Elsa.Retention.csproj
+++ b/src/modules/retention/Elsa.Retention/Elsa.Retention.csproj
@@ -18,6 +18,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\..\..\core\Elsa.Core\Elsa.Core.csproj" />
+      <ProjectReference Include="..\..\..\persistence\Elsa.Persistence.EntityFramework\Elsa.Persistence.EntityFramework.Core\Elsa.Persistence.EntityFramework.Core.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/modules/retention/Elsa.Retention/Extensions/ServiceCollectionExtensions.cs
+++ b/src/modules/retention/Elsa.Retention/Extensions/ServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@ using Elsa.Retention.HostedServices;
 using Elsa.Retention.Jobs;
 using Elsa.Retention.Options;
 using Elsa.Retention.Services;
+using Elsa.Retention.Stores;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
@@ -16,6 +17,8 @@ namespace Elsa.Retention.Extensions
             services
                 .Configure(configureOptions)
                 .AddSingleton(CreateRetentionFilterPipeline)
+                .AddSingleton(CreateRetentionSpecificationFilter)
+                .AddScoped<IRetentionWorkflowInstanceStore, RetentionWorkflowInstanceStore>()
                 .AddScoped<CleanupJob>()
                 .AddHostedService<CleanupHostedService>();
 
@@ -29,6 +32,16 @@ namespace Elsa.Retention.Extensions
 
             options.ConfigurePipeline(pipeline);
             return pipeline;
+        }
+
+        private static IRetentionSpecificationFilter CreateRetentionSpecificationFilter(IServiceProvider serviceProvider)
+        {
+            var options = serviceProvider.GetRequiredService<IOptions<CleanupOptions>>().Value;
+            var filter = new RetentionSpecificationFilter();
+
+            options.ConfigureSpecificationFilter(filter);
+            return filter;
+
         }
     }
 }

--- a/src/modules/retention/Elsa.Retention/HostedServices/CleanupHostedService.cs
+++ b/src/modules/retention/Elsa.Retention/HostedServices/CleanupHostedService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Elsa.Retention.Jobs;
@@ -33,10 +33,14 @@ namespace Elsa.Retention.HostedServices
         {
             using var scope = _serviceScopeFactory.CreateScope();
             var job = scope.ServiceProvider.GetRequiredService<CleanupJob>();
+            var started = false;
 
             while (!stoppingToken.IsCancellationRequested)
             {
-                await Task.Delay(_interval, stoppingToken);
+                if (started)
+                    await Task.Delay(_interval, stoppingToken);
+                else
+                    started = true;
                 await using var handle = await _distributedLockProvider.AcquireLockAsync(nameof(CleanupHostedService), cancellationToken: stoppingToken);
 
                 if (handle == null)

--- a/src/modules/retention/Elsa.Retention/Jobs/CleanupJob.cs
+++ b/src/modules/retention/Elsa.Retention/Jobs/CleanupJob.cs
@@ -3,11 +3,13 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Elsa.Models;
-using Elsa.Persistence;
+using Elsa.Persistence.EntityFramework.Core.Stores;
 using Elsa.Persistence.Specifications;
 using Elsa.Persistence.Specifications.WorkflowInstances;
 using Elsa.Retention.Contracts;
+using Elsa.Retention.Models;
 using Elsa.Retention.Options;
+using Elsa.Retention.Stores;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NodaTime;
@@ -20,22 +22,25 @@ namespace Elsa.Retention.Jobs
     /// </summary>
     public class CleanupJob
     {
-        private readonly IWorkflowInstanceStore _workflowInstanceStore;
+        private readonly IRetentionWorkflowInstanceStore _workflowInstanceStore;
         private readonly IClock _clock;
         private readonly IRetentionFilterPipeline _retentionFilterPipeline;
+        private readonly IRetentionSpecificationFilter _specificationFilter;
         private readonly CleanupOptions _options;
         private readonly ILogger _logger;
 
         public CleanupJob(
-            IWorkflowInstanceStore workflowInstanceStore,
+            IRetentionWorkflowInstanceStore workflowInstanceStore,
             IClock clock,
             IRetentionFilterPipeline retentionFilterPipeline,
+            IRetentionSpecificationFilter specificationFilter,
             IOptions<CleanupOptions> options,
             ILogger<CleanupJob> logger)
         {
             _workflowInstanceStore = workflowInstanceStore;
             _clock = clock;
             _retentionFilterPipeline = retentionFilterPipeline;
+            _specificationFilter = specificationFilter;
             _options = options.Value;
             _logger = logger;
         }
@@ -43,37 +48,32 @@ namespace Elsa.Retention.Jobs
         public async Task ExecuteAsync(CancellationToken cancellationToken = default)
         {
             var threshold = _clock.GetCurrentInstant().Minus(_options.TimeToLive);
-            var specification = new WorkflowCreatedBeforeSpecification(threshold);
-            var currentPage = 0;
+            ISpecification<WorkflowInstance> specification = new WorkflowCreatedBeforeSpecification(threshold);
             var take = _options.BatchSize;
-            var orderBy = new OrderBy<WorkflowInstance>(x => x.CreatedAt, SortDirection.Descending);
-            var collectedWorkflowInstanceIds = new List<string>();
-
+            var orderBy = new OrderBy<WorkflowInstance>(x => x.CreatedAt, SortDirection.Ascending);
+            
             // Collect workflow instances to be deleted.
             while (true)
             {
-                var paging = Paging.Page(currentPage++, take);
+                var paging = new Paging(0, take);
 
-                var workflowInstances = await _workflowInstanceStore
-                    .FindManyAsync(specification, orderBy, paging, cancellationToken)
-                    .ToList();
+                specification = specification.And(_specificationFilter.GetSpecification());
 
-                var filteredWorkflowInstances = await _retentionFilterPipeline.FilterAsync(workflowInstances, cancellationToken).ToList();
-                collectedWorkflowInstanceIds.AddRange(filteredWorkflowInstances.Select(x => x.Id));
+                var workflowInstanceId = await _workflowInstanceStore.FindManyWithDTOAsync
+                    (specification, orderBy, paging, (wfi) => new RetentionWorkflowId { Id = wfi.Id }, cancellationToken);
 
-                if (workflowInstances.Count < take)
+                // Delete collected workflow instances.
+                await DeleteManyAsync(workflowInstanceId.Select(x=>x.Id).ToArray(), cancellationToken);
+
+                if (workflowInstanceId.Count() < take)
                     break;
-            }
-            
-            // Delete collected workflow instances.
-            await DeleteManyAsync(collectedWorkflowInstanceIds, cancellationToken);
+            }           
         }
 
         private async Task DeleteManyAsync(ICollection<string> workflowInstanceIds, CancellationToken cancellationToken)
         {
             _logger.LogInformation("Deleting {WorkflowInstanceCount} workflow instances", workflowInstanceIds.Count);
-            var specification = new WorkflowInstanceIdsSpecification(workflowInstanceIds);
-            await _workflowInstanceStore.DeleteManyAsync(specification, cancellationToken);
+            await (_workflowInstanceStore as EntityFrameworkWorkflowInstanceStore).DeleteManyByIdsAsync(workflowInstanceIds, cancellationToken);
         }
     }
 }

--- a/src/modules/retention/Elsa.Retention/Models/RetentionWorkflowId.cs
+++ b/src/modules/retention/Elsa.Retention/Models/RetentionWorkflowId.cs
@@ -1,0 +1,8 @@
+﻿namespace Elsa.Retention.Models
+{
+    public class RetentionWorkflowId
+    {
+        public string Id { get; set; }
+    }
+
+}

--- a/src/modules/retention/Elsa.Retention/Options/CleanupOptions.cs
+++ b/src/modules/retention/Elsa.Retention/Options/CleanupOptions.cs
@@ -1,6 +1,7 @@
 using System;
 using Elsa.Retention.Contracts;
 using Elsa.Retention.Filters;
+using Elsa.Retention.Specifications;
 using NodaTime;
 
 namespace Elsa.Retention.Options
@@ -23,8 +24,13 @@ namespace Elsa.Retention.Options
         public int BatchSize { get; set; } = 100;
 
         /// <summary>
-        /// An action that configures the retention filter pipeline. Can be replaced with your own action to configure a custom pipeline with custom filters. 
+        /// An action that configures the retention filter pipeline (client side). Can be replaced with your own action to configure a custom pipeline with custom filters. 
         /// </summary>
         public Action<IRetentionFilterPipeline> ConfigurePipeline { get; set; } = pipeline => pipeline.AddFilter<CompletedWorkflowFilter>();
+
+        /// <summary>
+        /// An action that configures the specification filter pipeline (server side). Can be replaced with your own action to configure a custom pipeline with custom specifications. 
+        /// </summary>
+        public Action<IRetentionSpecificationFilter> ConfigureSpecificationFilter { get; set; } = specification => specification.AddAndSpecification(new CompletedWorkflowFilterSpecification());
     }
 }

--- a/src/modules/retention/Elsa.Retention/Services/RetentionSpecificationFilter.cs
+++ b/src/modules/retention/Elsa.Retention/Services/RetentionSpecificationFilter.cs
@@ -1,0 +1,23 @@
+using Elsa.Models;
+using Elsa.Persistence.Specifications;
+using Elsa.Retention.Contracts;
+
+namespace Elsa.Retention.Services
+{
+    public class RetentionSpecificationFilter : IRetentionSpecificationFilter
+    {
+        ISpecification<WorkflowInstance> _specification = default!;
+
+        public RetentionSpecificationFilter()
+        {
+            _specification = Specification<WorkflowInstance>.Identity;
+        }
+        public void AddAndSpecification(ISpecification<WorkflowInstance> specification) => _specification = _specification.And(specification);
+
+
+        public void AddOrSpecification(ISpecification<WorkflowInstance> specification) => _specification = _specification.Or(specification);
+
+        public ISpecification<WorkflowInstance> GetSpecification() => _specification;
+
+    }
+}

--- a/src/modules/retention/Elsa.Retention/Specifications/CompletedWorkflowFilterSpecification.cs
+++ b/src/modules/retention/Elsa.Retention/Specifications/CompletedWorkflowFilterSpecification.cs
@@ -1,0 +1,14 @@
+﻿using Elsa.Models;
+
+namespace Elsa.Retention.Specifications
+{
+    public class CompletedWorkflowFilterSpecification: WorkflowStatusFilterSpecification
+    {
+        public CompletedWorkflowFilterSpecification()
+            : base(new[] { WorkflowStatus.Running, WorkflowStatus.Finished })
+        {
+
+        }
+    }
+
+}

--- a/src/modules/retention/Elsa.Retention/Specifications/WorkflowStatusFilterSpecification.cs
+++ b/src/modules/retention/Elsa.Retention/Specifications/WorkflowStatusFilterSpecification.cs
@@ -1,0 +1,46 @@
+using Elsa.Models;
+using Elsa.Persistence.Specifications;
+using System.Linq.Expressions;
+using System;
+
+namespace Elsa.Retention.Specifications
+{
+
+    public class WorkflowStatusFilterSpecification : Specification<WorkflowInstance>
+    {
+        public WorkflowStatusFilterSpecification(params WorkflowStatus[] statuses)
+        {
+            Statuses = statuses;
+        }
+
+        public WorkflowStatus[] Statuses { get; }
+
+        public override Expression<Func<WorkflowInstance, bool>> ToExpression()
+        {
+
+            Expression exp = null;
+            var i = 0;
+            var param = Expression.Parameter(typeof(WorkflowInstance), "instance");
+
+            foreach (var status in Statuses)
+            {
+                var equality = Expression.Equal(Expression.Property(param, "WorkflowStatus"), Expression.Constant(status));
+                if (i == 0)
+                    exp = equality;
+                else
+                    exp = Expression.And(exp, equality);
+                i++;
+            }
+
+            Expression<Func<WorkflowInstance, bool>> lambda =
+                Expression.Lambda<Func<WorkflowInstance, bool>>(
+                    exp,
+                    new ParameterExpression[] { param });
+
+            return lambda;
+        }
+
+
+    }
+
+}

--- a/src/modules/retention/Elsa.Retention/Stores/IRetentionWorkflowInstanceStore.cs
+++ b/src/modules/retention/Elsa.Retention/Stores/IRetentionWorkflowInstanceStore.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Elsa.Models;
+using Elsa.Persistence;
+using Elsa.Persistence.Specifications;
+using System.Linq.Expressions;
+using System;
+
+namespace Elsa.Retention.Stores
+{
+    public interface IRetentionWorkflowInstanceStore : IWorkflowInstanceStore
+    {
+        Task<IEnumerable<Tdto>> FindManyWithDTOAsync<Tdto>(ISpecification<WorkflowInstance> specification, IOrderBy<WorkflowInstance>? orderBy = default, IPaging? paging = default, Expression<Func<WorkflowInstance, Tdto>> selectDtoFunc = default, CancellationToken cancellationToken = default) where Tdto : class;
+
+    }
+
+}

--- a/src/modules/retention/Elsa.Retention/Stores/RetentionWorkflowInstanceStore.cs
+++ b/src/modules/retention/Elsa.Retention/Stores/RetentionWorkflowInstanceStore.cs
@@ -1,0 +1,56 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Elsa.Models;
+using Elsa.Persistence.EntityFramework.Core.Stores;
+using Elsa.Persistence.Specifications;
+using Microsoft.Extensions.Logging;
+using Open.Linq.AsyncExtensions;
+using System.Linq.Expressions;
+using System;
+using Elsa.Persistence.EntityFramework.Core.Services;
+using AutoMapper;
+using Elsa.Serialization;
+using Microsoft.EntityFrameworkCore;
+
+namespace Elsa.Retention.Stores
+{
+    public class RetentionWorkflowInstanceStore : EntityFrameworkWorkflowInstanceStore, IRetentionWorkflowInstanceStore
+    {
+        public RetentionWorkflowInstanceStore(IElsaContextFactory dbContextFactory,
+            IMapper mapper,
+            IContentSerializer contentSerializer,
+            ILogger<EntityFrameworkWorkflowInstanceStore> logger) : base(dbContextFactory, mapper, contentSerializer, logger)
+        {
+        }
+
+        public async Task<IEnumerable<Tdto>> FindManyWithDTOAsync<Tdto>(ISpecification<WorkflowInstance> specification, IOrderBy<WorkflowInstance>? orderBy = default, IPaging? paging = default, Expression<Func<WorkflowInstance, Tdto>> selectDtoFunc = default, CancellationToken cancellationToken = default) where Tdto : class
+        {
+            var filter = MapSpecification(specification);
+
+            return await DoQuery(async dbContext =>
+            {
+                var dbSet = dbContext.Set<WorkflowInstance>();
+                var queryable = dbSet.Where(filter);
+
+                if (orderBy != null)
+                {
+                    var orderByExpression = orderBy.OrderByExpression;
+                    queryable = orderBy.SortDirection == SortDirection.Ascending ? queryable.OrderBy(orderByExpression) : queryable.OrderByDescending(orderByExpression);
+                }
+
+                if (paging != null)
+                    queryable = queryable.Skip(paging.Skip).Take(paging.Take);
+
+                var queryableDto = queryable.Select(selectDtoFunc).AsQueryable();
+                return await queryableDto.ToListAsync();
+
+            }, cancellationToken);
+        }
+
+
+
+    }
+
+}

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/Stores/EntityFrameworkStore.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/Stores/EntityFrameworkStore.cs
@@ -109,7 +109,7 @@ namespace Elsa.Persistence.EntityFramework.Core.Stores
         public virtual async Task<int> DeleteManyAsync(ISpecification<T> specification, CancellationToken cancellationToken = default)
         {
             var filter = MapSpecification(specification);
-            return await DoWork(async dbContext => await dbContext.Set<T>().Where(filter).BatchDeleteWithWorkAroundAsync(dbContext, cancellationToken), cancellationToken);
+            return await DoWork(async dbContext => await dbContext.Set<T>().Where(filter).Select(x=>x.Id).AsQueryable().BatchDeleteWithWorkAroundAsync(dbContext, cancellationToken), cancellationToken);
         }
 
         public async Task<IEnumerable<T>> FindManyAsync(ISpecification<T> specification, IOrderBy<T>? orderBy = default, IPaging? paging = default, CancellationToken cancellationToken = default)

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/Stores/EntityFrameworkWorkflowInstanceStore.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/Stores/EntityFrameworkWorkflowInstanceStore.cs
@@ -10,6 +10,7 @@ using Elsa.Persistence.EntityFramework.Core.Extensions;
 using Elsa.Persistence.EntityFramework.Core.Services;
 using Elsa.Persistence.Specifications;
 using Elsa.Serialization;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 
@@ -56,9 +57,11 @@ namespace Elsa.Persistence.EntityFramework.Core.Stores
 
             await DoWork(async dbContext =>
             {
-                await dbContext.Set<WorkflowExecutionLogRecord>().AsQueryable().Where(x => idList.Contains(x.WorkflowInstanceId)).BatchDeleteWithWorkAroundAsync(dbContext, cancellationToken);
-                await dbContext.Set<Bookmark>().AsQueryable().Where(x => idList.Contains(x.WorkflowInstanceId)).BatchDeleteWithWorkAroundAsync(dbContext, cancellationToken);
-                await dbContext.Set<WorkflowInstance>().AsQueryable().Where(x => idList.Contains(x.Id)).BatchDeleteWithWorkAroundAsync(dbContext, cancellationToken);
+#pragma warning disable IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
+                await dbContext.Set<WorkflowExecutionLogRecord>().AsQueryable().Where(x => idList.Contains(x.WorkflowInstanceId)).Select(x=>x.Id).AsQueryable().BatchDeleteWithWorkAroundAsync(dbContext, cancellationToken);
+                await dbContext.Set<Bookmark>().AsQueryable().Where(x => idList.Contains(x.WorkflowInstanceId)).Select(x => x.Id).AsQueryable().BatchDeleteWithWorkAroundAsync(dbContext, cancellationToken);
+                await dbContext.Set<WorkflowInstance>().AsQueryable().Where(x => idList.Contains(x.Id)).Select(x => x.Id).AsQueryable().BatchDeleteWithWorkAroundAsync(dbContext, cancellationToken);
+#pragma warning restore IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
             }, cancellationToken);
         }
 

--- a/src/samples/server/Elsa.Samples.Server.Host/Startup.cs
+++ b/src/samples/server/Elsa.Samples.Server.Host/Startup.cs
@@ -16,6 +16,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using NodaTime;
 using NodaTime.Serialization.JsonNet;
+using Elsa.Retention.Specifications;
 
 namespace Elsa.Samples.Server.Host
 {
@@ -108,6 +109,12 @@ namespace Elsa.Samples.Server.Host
                     // Bind options from configuration.
                     elsaSection.GetSection("Retention").Bind(options);
 
+
+                    // Configure a custom specification filter (server side) pipeline that deletes cancelled, faulted and completed workflows.
+                    options.ConfigureSpecificationFilter = filter => filter.AddAndSpecification(
+                        new WorkflowStatusFilterSpecification(WorkflowStatus.Cancelled, WorkflowStatus.Faulted, WorkflowStatus.Finished))
+                    ;
+                    
                     // Configure a custom filter pipeline that deletes completed AND faulted workflows.
                     options.ConfigurePipeline = pipeline => pipeline
                         .AddFilter(new WorkflowStatusFilter(WorkflowStatus.Cancelled, WorkflowStatus.Faulted, WorkflowStatus.Finished))


### PR DESCRIPTION
This PR aims to enhance the Retention Module by just query the Store with the necessary data.

Indeed, in the current store implementation, when a delete is realize, some select are done which get All the data of the DB. This could be very huge (when considering Data column) even for one record.

The idea is to :
- query the Store and getting only Id and then delete the record.
- filter data as much as we can on server side (using specification) 
- lower the memory consumption of this module.

to avoid Breaking Change, some elements are re-defined in the module. Maybe some method could be up to the Core Module.
