### PR TITLE
Retention module improvement v2 #3253

### DIFF
--- a/src/core/Elsa.Abstractions/Persistence/IStore.cs
+++ b/src/core/Elsa.Abstractions/Persistence/IStore.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Elsa.Models;
@@ -17,5 +19,6 @@ namespace Elsa.Persistence
         Task<IEnumerable<T>> FindManyAsync(ISpecification<T> specification, IOrderBy<T>? orderBy = default, IPaging? paging = default, CancellationToken cancellationToken = default);
         Task<int> CountAsync(ISpecification<T> specification, CancellationToken cancellationToken = default);
         Task<T?> FindAsync(ISpecification<T> specification, CancellationToken cancellationToken = default);
-    }
+
+        }
 }

--- a/src/core/Elsa.Abstractions/Persistence/IWorkflowInstanceStore.cs
+++ b/src/core/Elsa.Abstractions/Persistence/IWorkflowInstanceStore.cs
@@ -1,8 +1,17 @@
 using Elsa.Models;
+using Elsa.Persistence.Specifications;
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Elsa.Persistence
 {
     public interface IWorkflowInstanceStore : IStore<WorkflowInstance>
     {
+        //This method allow the use to get only specific field from the store repository, which enable to perform better queries.
+        Task<IEnumerable<TOut>> FindManyAsync<TOut>(ISpecification<WorkflowInstance> specification, Expression<Func<WorkflowInstance, TOut>> funcMapping, IOrderBy<WorkflowInstance>? orderBy = default, IPaging? paging = default, CancellationToken cancellationToken = default) where TOut : class;
+
     }
 }

--- a/src/core/Elsa.Core/Persistence/Decorators/EventPublishingWorkflowInstanceStore.cs
+++ b/src/core/Elsa.Core/Persistence/Decorators/EventPublishingWorkflowInstanceStore.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -78,5 +78,9 @@ namespace Elsa.Persistence.Decorators
         public Task<int> CountAsync(ISpecification<WorkflowInstance> specification, CancellationToken cancellationToken = default) => _store.CountAsync(specification, cancellationToken);
 
         public Task<WorkflowInstance?> FindAsync(ISpecification<WorkflowInstance> specification, CancellationToken cancellationToken = default) => _store.FindAsync(specification, cancellationToken);
+
+        public Task<IEnumerable<TOut>> FindManyAsync<TOut>(ISpecification<WorkflowInstance> specification
+            , System.Linq.Expressions.Expression<System.Func<WorkflowInstance, TOut>> funcMapping, IOrderBy<WorkflowInstance>? orderBy = null, IPaging? paging = null, CancellationToken cancellationToken = default) where TOut : class
+        => _store.FindManyAsync<TOut>(specification, funcMapping, orderBy,paging, cancellationToken);
     }
 }

--- a/src/core/Elsa.Core/Persistence/Decorators/EventPublishingWorkflowInstanceStore.cs
+++ b/src/core/Elsa.Core/Persistence/Decorators/EventPublishingWorkflowInstanceStore.cs
@@ -58,11 +58,12 @@ namespace Elsa.Persistence.Decorators
 
         public async Task<int> DeleteManyAsync(ISpecification<WorkflowInstance> specification, CancellationToken cancellationToken = default)
         {
-            var instances = await FindManyAsync(specification, cancellationToken: cancellationToken).ToList();
+            var instancesId = await FindManyAsync<string>(specification, (wf)=> wf.Id,cancellationToken: cancellationToken).ToList();
             var count = await _store.DeleteManyAsync(specification, cancellationToken);
 
-            if (instances.Any())
+            if (instancesId.Any())
             {
+                var instances = instancesId.Select(id => new WorkflowInstance() { Id = id });
                 foreach (var instance in instances)
                     await _mediator.Publish(new WorkflowInstanceDeleted(instance), cancellationToken);
 

--- a/src/core/Elsa.Core/Persistence/Decorators/InitializingWorkflowDefinitionStore.cs
+++ b/src/core/Elsa.Core/Persistence/Decorators/InitializingWorkflowDefinitionStore.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -61,6 +61,7 @@ namespace Elsa.Persistence.Decorators
 
         public Task<WorkflowDefinition?> FindAsync(ISpecification<WorkflowDefinition> specification, CancellationToken cancellationToken) => _store.FindAsync(specification, cancellationToken);
 
+        
         private WorkflowDefinition Initialize(WorkflowDefinition workflowDefinition)
         {
             if (string.IsNullOrWhiteSpace(workflowDefinition.Id))

--- a/src/core/Elsa.Core/Persistence/InMemory/InMemoryStore.cs
+++ b/src/core/Elsa.Core/Persistence/InMemory/InMemoryStore.cs
@@ -95,7 +95,15 @@ namespace Elsa.Persistence.InMemory
             var dictionary = await GetDictionaryAsync();
             return dictionary.Values.AsQueryable().FirstOrDefault(specification.ToExpression());
         }
-        
+
+        public async Task<IEnumerable<TOut>> FindManyAsync<TOut>(ISpecification<T> specification
+            , System.Linq.Expressions.Expression<System.Func<T, TOut>> funcMapping
+            , IOrderBy<T>? orderBy = null, IPaging? paging = null, CancellationToken cancellationToken = default) where TOut : class
+        {
+            var dictionary = await GetDictionaryAsync();
+            var query = dictionary.Values.AsQueryable().Apply(specification).Apply(orderBy).Apply(paging);
+            return query.Select(funcMapping).ToList();
+        }
         private async Task<IDictionary<string, T>> GetDictionaryAsync() => await MemoryCache.GetOrCreateAsync(CacheKey, _ => Task.FromResult(new ConcurrentDictionary<string, T>()));
         private void SetDictionary(IDictionary<string, T> dictionary) => MemoryCache.Set(CacheKey, dictionary);
     }

--- a/src/modules/retention/Elsa.Retention/Contracts/IRetentionSpecificationFilter.cs
+++ b/src/modules/retention/Elsa.Retention/Contracts/IRetentionSpecificationFilter.cs
@@ -1,0 +1,11 @@
+using Elsa.Models;
+using Elsa.Persistence.Specifications;
+
+namespace Elsa.Retention.Contracts;
+
+public interface IRetentionSpecificationFilter
+{
+    ISpecification<WorkflowInstance> GetSpecification();
+    void AddAndSpecification(ISpecification<WorkflowInstance> specification);
+    void AddOrSpecification(ISpecification<WorkflowInstance> specification);
+}

--- a/src/modules/retention/Elsa.Retention/HostedServices/CleanupHostedService.cs
+++ b/src/modules/retention/Elsa.Retention/HostedServices/CleanupHostedService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Elsa.Retention.Jobs;
@@ -33,10 +33,14 @@ namespace Elsa.Retention.HostedServices
         {
             using var scope = _serviceScopeFactory.CreateScope();
             var job = scope.ServiceProvider.GetRequiredService<CleanupJob>();
+            var started = false;
 
             while (!stoppingToken.IsCancellationRequested)
             {
-                await Task.Delay(_interval, stoppingToken);
+                if (started)
+                    await Task.Delay(_interval, stoppingToken);
+                else
+                    started = true;
                 await using var handle = await _distributedLockProvider.AcquireLockAsync(nameof(CleanupHostedService), cancellationToken: stoppingToken);
 
                 if (handle == null)

--- a/src/modules/retention/Elsa.Retention/Jobs/CleanupJob.cs
+++ b/src/modules/retention/Elsa.Retention/Jobs/CleanupJob.cs
@@ -44,7 +44,6 @@ namespace Elsa.Retention.Jobs
         {
             var threshold = _clock.GetCurrentInstant().Minus(_options.TimeToLive);
             var specification = new WorkflowCreatedBeforeSpecification(threshold);
-            var currentPage = 0;
             var take = _options.BatchSize;
             var orderBy = new OrderBy<WorkflowInstance>(x => x.CreatedAt, SortDirection.Descending);
             
@@ -52,7 +51,7 @@ namespace Elsa.Retention.Jobs
             // Collect workflow instances to be deleted.
             while (true)
             {
-                var paging = Paging.Page(currentPage++, take);
+                var paging = new Paging(0, take); ;
 
                 var workflowInstances = await _workflowInstanceStore
                     .FindManyAsync<string>(specification,(wf)=>wf.Id ,orderBy, paging, cancellationToken)

--- a/src/modules/retention/Elsa.Retention/Options/CleanupOptions.cs
+++ b/src/modules/retention/Elsa.Retention/Options/CleanupOptions.cs
@@ -1,6 +1,7 @@
 using System;
 using Elsa.Retention.Contracts;
 using Elsa.Retention.Filters;
+using Elsa.Retention.Specifications;
 using NodaTime;
 
 namespace Elsa.Retention.Options
@@ -26,5 +27,12 @@ namespace Elsa.Retention.Options
         /// An action that configures the retention filter pipeline. Can be replaced with your own action to configure a custom pipeline with custom filters. 
         /// </summary>
         public Action<IRetentionFilterPipeline> ConfigurePipeline { get; set; } = pipeline => pipeline.AddFilter<CompletedWorkflowFilter>();
+
+
+        /// <summary>
+        /// An action that configures the specification filter pipeline (server side). Can be replaced with your own action to configure a custom pipeline with custom specifications. 
+        /// </summary>
+        public Action<IRetentionSpecificationFilter> ConfigureSpecificationFilter { get; set; } = specification => specification.AddAndSpecification(new CompletedWorkflowFilterSpecification());
+
     }
 }

--- a/src/modules/retention/Elsa.Retention/Services/RetentionSpecificationFilter.cs
+++ b/src/modules/retention/Elsa.Retention/Services/RetentionSpecificationFilter.cs
@@ -1,0 +1,26 @@
+using Elsa.Models;
+using Elsa.Persistence.Specifications;
+using Elsa.Retention.Contracts;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Elsa.Retention.Services
+{
+    public class RetentionSpecificationFilter : IRetentionSpecificationFilter
+    {
+        ISpecification<WorkflowInstance> _specification = default!;
+
+        public RetentionSpecificationFilter()
+        {
+            _specification = Specification<WorkflowInstance>.Identity;
+        }
+        public void AddAndSpecification(ISpecification<WorkflowInstance> specification) => _specification = _specification.And(specification);
+
+
+        public void AddOrSpecification(ISpecification<WorkflowInstance> specification) => _specification = _specification.Or(specification);
+
+        public ISpecification<WorkflowInstance> GetSpecification() => _specification;
+
+    }
+}

--- a/src/modules/retention/Elsa.Retention/Specifications/CompletedWorkflowFilterSpecification.cs
+++ b/src/modules/retention/Elsa.Retention/Specifications/CompletedWorkflowFilterSpecification.cs
@@ -1,0 +1,15 @@
+using Elsa.Models;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Elsa.Retention.Specifications
+{
+    public class CompletedWorkflowFilterSpecification : WorkflowStatusFilterSpecification
+    {
+        public CompletedWorkflowFilterSpecification()
+            : base(new[] { WorkflowStatus.Running, WorkflowStatus.Finished })
+        {
+
+        }
+    }
+}

--- a/src/modules/retention/Elsa.Retention/Specifications/WorkflowStatusFilterSpecification.cs
+++ b/src/modules/retention/Elsa.Retention/Specifications/WorkflowStatusFilterSpecification.cs
@@ -1,0 +1,44 @@
+using Elsa.Models;
+using Elsa.Persistence.Specifications;
+using System;
+using System.Linq.Expressions;
+
+namespace Elsa.Retention.Specifications
+{
+    public class WorkflowStatusFilterSpecification : Specification<WorkflowInstance>
+    {
+        public WorkflowStatusFilterSpecification(params WorkflowStatus[] statuses)
+        {
+            Statuses = statuses;
+        }
+
+        public WorkflowStatus[] Statuses { get; }
+
+        public override Expression<Func<WorkflowInstance, bool>> ToExpression()
+        {
+
+            Expression exp = null;
+            var i = 0;
+            var param = Expression.Parameter(typeof(WorkflowInstance), "instance");
+
+            foreach (var status in Statuses)
+            {
+                var equality = Expression.Equal(Expression.Property(param, "WorkflowStatus"), Expression.Constant(status));
+                if (i == 0)
+                    exp = equality;
+                else
+                    exp = Expression.And(exp, equality);
+                i++;
+            }
+
+            Expression<Func<WorkflowInstance, bool>> lambda =
+                Expression.Lambda<Func<WorkflowInstance, bool>>(
+                    exp,
+                    new ParameterExpression[] { param });
+
+            return lambda;
+        }
+
+
+    }
+}

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/Stores/EntityFrameworkStore.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/Stores/EntityFrameworkStore.cs
@@ -109,7 +109,7 @@ namespace Elsa.Persistence.EntityFramework.Core.Stores
         public virtual async Task<int> DeleteManyAsync(ISpecification<T> specification, CancellationToken cancellationToken = default)
         {
             var filter = MapSpecification(specification);
-            return await DoWork(async dbContext => await dbContext.Set<T>().Where(filter).BatchDeleteWithWorkAroundAsync(dbContext, cancellationToken), cancellationToken);
+            return await DoWork(async dbContext => await dbContext.Set<T>().Where(filter).Select(x=>x.Id).AsQueryable().BatchDeleteWithWorkAroundAsync(dbContext, cancellationToken), cancellationToken);
         }
 
         public async Task<IEnumerable<T>> FindManyAsync(ISpecification<T> specification, IOrderBy<T>? orderBy = default, IPaging? paging = default, CancellationToken cancellationToken = default)

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/Stores/EntityFrameworkWorkflowInstanceStore.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/Stores/EntityFrameworkWorkflowInstanceStore.cs
@@ -45,10 +45,9 @@ namespace Elsa.Persistence.EntityFramework.Core.Stores
 
         public override async Task<int> DeleteManyAsync(ISpecification<WorkflowInstance> specification, CancellationToken cancellationToken = default)
         {
-            var workflowInstances = (await FindManyAsync(specification, cancellationToken: cancellationToken)).ToList();
-            var workflowInstanceIds = workflowInstances.Select(x => x.Id).ToArray();
+            var workflowInstanceIds = (await FindManyAsync<string>(specification,(wf)=> wf.Id,  cancellationToken: cancellationToken)).ToList();
             await DeleteManyByIdsAsync(workflowInstanceIds, cancellationToken);
-            return workflowInstances.Count;
+            return workflowInstanceIds.Count;
         }
 
         public async Task DeleteManyByIdsAsync(IEnumerable<string> ids, CancellationToken cancellationToken = default)

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/Stores/EntityFrameworkWorkflowInstanceStore.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/Stores/EntityFrameworkWorkflowInstanceStore.cs
@@ -10,6 +10,7 @@ using Elsa.Persistence.EntityFramework.Core.Extensions;
 using Elsa.Persistence.EntityFramework.Core.Services;
 using Elsa.Persistence.Specifications;
 using Elsa.Serialization;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 
@@ -56,9 +57,11 @@ namespace Elsa.Persistence.EntityFramework.Core.Stores
 
             await DoWork(async dbContext =>
             {
-                await dbContext.Set<WorkflowExecutionLogRecord>().AsQueryable().Where(x => idList.Contains(x.WorkflowInstanceId)).BatchDeleteWithWorkAroundAsync(dbContext, cancellationToken);
-                await dbContext.Set<Bookmark>().AsQueryable().Where(x => idList.Contains(x.WorkflowInstanceId)).BatchDeleteWithWorkAroundAsync(dbContext, cancellationToken);
-                await dbContext.Set<WorkflowInstance>().AsQueryable().Where(x => idList.Contains(x.Id)).BatchDeleteWithWorkAroundAsync(dbContext, cancellationToken);
+#pragma warning disable IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
+                await dbContext.Set<WorkflowExecutionLogRecord>().AsQueryable().Where(x => idList.Contains(x.WorkflowInstanceId)).Select(x=>x.Id).AsQueryable().BatchDeleteWithWorkAroundAsync(dbContext, cancellationToken);
+                await dbContext.Set<Bookmark>().AsQueryable().Where(x => idList.Contains(x.WorkflowInstanceId)).Select(x => x.Id).AsQueryable().BatchDeleteWithWorkAroundAsync(dbContext, cancellationToken);
+                await dbContext.Set<WorkflowInstance>().AsQueryable().Where(x => idList.Contains(x.Id)).Select(x => x.Id).AsQueryable().BatchDeleteWithWorkAroundAsync(dbContext, cancellationToken);
+#pragma warning restore IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
             }, cancellationToken);
         }
 

--- a/src/persistence/Elsa.Persistence.MongoDb/Stores/MongoDbStore.cs
+++ b/src/persistence/Elsa.Persistence.MongoDb/Stores/MongoDbStore.cs
@@ -76,5 +76,8 @@ namespace Elsa.Persistence.MongoDb.Stores
         public async Task<T?> FindAsync(ISpecification<T> specification, CancellationToken cancellationToken = default) => await Collection.AsQueryable().Where(specification.ToExpression()).FirstOrDefaultAsync(cancellationToken);
 
         protected FilterDefinition<T> GetFilter(string id) => Builders<T>.Filter.Where(x => x.Id == id);
+
+        public async Task<IEnumerable<TOut>> FindManyAsync<TOut>(ISpecification<T> specification, System.Linq.Expressions.Expression<System.Func<T, TOut>> funcMapping, IOrderBy<T>? orderBy = null, IPaging? paging = null, CancellationToken cancellationToken = default) where TOut : class
+        => await Collection.AsQueryable().Apply(specification).Apply(orderBy).Apply(paging).Select(funcMapping).ToListAsync(cancellationToken);
     }
 }

--- a/src/samples/server/Elsa.Samples.Server.Host/Startup.cs
+++ b/src/samples/server/Elsa.Samples.Server.Host/Startup.cs
@@ -16,6 +16,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using NodaTime;
 using NodaTime.Serialization.JsonNet;
+using Elsa.Retention.Specifications;
 
 namespace Elsa.Samples.Server.Host
 {
@@ -108,6 +109,12 @@ namespace Elsa.Samples.Server.Host
                     // Bind options from configuration.
                     elsaSection.GetSection("Retention").Bind(options);
 
+
+                    // Configure a custom specification filter (server side) pipeline that deletes cancelled, faulted and completed workflows.
+                    options.ConfigureSpecificationFilter = filter => filter.AddAndSpecification(
+                        new WorkflowStatusFilterSpecification(WorkflowStatus.Cancelled, WorkflowStatus.Faulted, WorkflowStatus.Finished))
+                    ;
+                    
                     // Configure a custom filter pipeline that deletes completed AND faulted workflows.
                     options.ConfigurePipeline = pipeline => pipeline
                         .AddFilter(new WorkflowStatusFilter(WorkflowStatus.Cancelled, WorkflowStatus.Faulted, WorkflowStatus.Finished))


### PR DESCRIPTION
this PR aims to replace the last proposal : #3278  to solve issue of timeout in retention module (#3253)

Indeed, in the current store implementation, when a delete is realize, some select are done which get All the data of the DB. This could be very huge (when considering Data column) even for one record.

The idea is to :

- query the Store and getting only Id and then delete the record.
- filter data as much as we can on server side (using specification)
- lower the memory consumption of this module.

with this change, the time spent to delete is taken moslty in the BatchDeleteWithWorkAroundAsync() (and not in the multiple previous findMany )
