### PR TITLE
Implicit fork & join

### DIFF
--- a/Elsa.sln.DotSettings
+++ b/Elsa.sln.DotSettings
@@ -1,4 +1,5 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_LIMIT/@EntryValue">300</s:Int64>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Comparers/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Computables/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Configurer/@EntryIndexedValue">True</s:Boolean>

--- a/Elsa.sln.DotSettings
+++ b/Elsa.sln.DotSettings
@@ -1,5 +1,9 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_LIMIT/@EntryValue">300</s:Int64>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Comparers/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Computables/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Configurer/@EntryIndexedValue">True</s:Boolean>

--- a/src/bundles/Elsa.WorkflowServer.Web/Program.cs
+++ b/src/bundles/Elsa.WorkflowServer.Web/Program.cs
@@ -60,6 +60,7 @@ services
             .AddActivity<Flowchart>()
             .AddActivity<FlowDecision>()
             .AddActivity<FlowSwitch>()
+            .AddActivity<FlowJoin>()
             .AddActivity<Elsa.Scheduling.Activities.Delay>()
             .AddActivity<Elsa.Scheduling.Activities.Timer>()
             .AddActivity<ForEach>()

--- a/src/designer/elsa-workflows-designer/src/components/icons/activities/flow-join.tsx
+++ b/src/designer/elsa-workflows-designer/src/components/icons/activities/flow-join.tsx
@@ -1,0 +1,13 @@
+import {FunctionalComponent, h} from '@stencil/core';
+import {ActivityIconSettings, getActivityIconCssClass} from "./models";
+
+export const FlowJoinIcon: FunctionalComponent<ActivityIconSettings> = (settings) => (
+  <svg class={getActivityIconCssClass(settings)} width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <path stroke="none" d="M0 0h24v24H0z"/>
+    <circle cx="12" cy="18" r="2"/>
+    <circle cx="7" cy="6" r="2"/>
+    <circle cx="17" cy="6" r="2"/>
+    <path d="M7 8v2a2 2 0 0 0 2 2h6a2 2 0 0 0 2 -2v-2"/>
+    <line x1="12" y1="12" x2="12" y2="16"/>
+  </svg>
+);

--- a/src/designer/elsa-workflows-designer/src/services/activity-icon-registry.tsx
+++ b/src/designer/elsa-workflows-designer/src/services/activity-icon-registry.tsx
@@ -15,6 +15,7 @@ import {
   WriteLineIcon
 } from "../components/icons/activities";
 import {WriteHttpResponseIcon} from "../components/icons/activities/write-http-response";
+import {FlowJoinIcon} from "../components/icons/activities/flow-join";
 
 export type ActivityType = string;
 export type ActivityIcon = (ActivityIconSettings?) => any;
@@ -37,6 +38,7 @@ export class ActivityIconRegistry {
     this.add('Elsa.FlowDecision', settings => <FlowDecisionIcon size={settings?.size}/>);
     this.add('Elsa.Event', settings => <EventIcon size={settings?.size}/>);
     this.add('Elsa.RunJavaScript', settings => <RunJavaScriptIcon size={settings?.size}/>);
+    this.add('Elsa.FlowJoin', settings => <FlowJoinIcon size={settings?.size}/>);
   }
 
   public add(activityType: ActivityType, icon: ActivityIcon) {

--- a/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Activities/FlowJoin.cs
+++ b/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Activities/FlowJoin.cs
@@ -47,7 +47,7 @@ public class FlowJoin : ActivityBase, IJoinNode
     {
         // Clear any bookmarks created between this join and its most recent fork.
         var connections = flowchart.Connections;
-        var inboundActivities = connections.LeftInboundActivities(this).Select(x => x.Id).ToList();
+        var inboundActivities = connections.LeftAncestorActivities(this).Select(x => x.Id).ToList();
         context.WorkflowExecutionContext.Bookmarks.RemoveWhere(x => inboundActivities.Contains(x.ActivityId));
     }
 }

--- a/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Activities/FlowJoin.cs
+++ b/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Activities/FlowJoin.cs
@@ -27,16 +27,24 @@ public class FlowJoin : Activity, IJoinNode
     {
         var activityExecutionContext = context.ActivityExecutionContext;
         var mode = activityExecutionContext.Get(Mode);
-        
-        if (mode == JoinMode.WaitAny)
-            return true;
-
-        // Wait for all left-inbound activities to have executed.
         var scope = context.Scope;
         var executionCount = scope.GetExecutionCount(context.Activity);
         var inboundActivities = context.InboundActivities;
-        var haveAllInboundActivitiesExecuted = inboundActivities.All(x => scope.GetExecutionCount(x) > executionCount);
+        
+        if (mode == JoinMode.WaitAny)
+        {
+            // Only return true if we didn't execute before.
+            var hasAnyInboundActivityExecuted = inboundActivities.Any(x => scope.GetExecutionCount(x) > executionCount);
+            return hasAnyInboundActivityExecuted;
+        }
+        else
+        {
+            // Wait for all left-inbound activities to have executed.
+            var haveAllInboundActivitiesExecuted = inboundActivities.All(x => scope.GetExecutionCount(x) > executionCount);
 
-        return haveAllInboundActivitiesExecuted;
+            return haveAllInboundActivitiesExecuted;    
+        }
+
+        
     }
 }

--- a/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Activities/FlowJoin.cs
+++ b/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Activities/FlowJoin.cs
@@ -1,0 +1,42 @@
+using Elsa.Workflows.Core.Activities.Flowchart.Contracts;
+using Elsa.Workflows.Core.Attributes;
+using Elsa.Workflows.Core.Models;
+
+namespace Elsa.Workflows.Core.Activities.Flowchart.Activities;
+
+[Activity("Elsa", "Flow", "Merge multiple branches into a single branch of execution.")]
+public class FlowJoin : Activity, IJoinNode
+{
+    [Input] public Input<JoinMode> Mode { get; set; } = new(JoinMode.WaitAll);
+
+    protected override void Execute(ActivityExecutionContext context)
+    {
+        // Clear any bookmarks created between this join and its most recent fork.
+        var joinNode = context.ActivityNode;
+        var forkNode = context.ActivityNode.Fork();
+
+        if (forkNode == null)
+            return;
+
+        var ancestry = joinNode.AncestryTo(forkNode).ToList();
+
+        // TODO: Remove any bookmarks created by any nodes in the ancestry path.
+    }
+
+    public bool GetShouldExecute(FlowJoinContext context)
+    {
+        var activityExecutionContext = context.ActivityExecutionContext;
+        var mode = activityExecutionContext.Get(Mode);
+        
+        if (mode == JoinMode.WaitAny)
+            return true;
+
+        // Wait for all left-inbound activities to have executed.
+        var scope = context.Scope;
+        var executionCount = scope.GetExecutionCount(context.Activity);
+        var inboundActivities = context.InboundActivities;
+        var haveAllInboundActivitiesExecuted = inboundActivities.All(x => scope.GetExecutionCount(x) > executionCount);
+
+        return haveAllInboundActivitiesExecuted;
+    }
+}

--- a/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Activities/FlowJoin.cs
+++ b/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Activities/FlowJoin.cs
@@ -1,50 +1,53 @@
+using Elsa.Common.Extensions;
 using Elsa.Workflows.Core.Activities.Flowchart.Contracts;
+using Elsa.Workflows.Core.Activities.Flowchart.Extensions;
+using Elsa.Workflows.Core.Activities.Flowchart.Models;
 using Elsa.Workflows.Core.Attributes;
 using Elsa.Workflows.Core.Models;
 
 namespace Elsa.Workflows.Core.Activities.Flowchart.Activities;
 
 [Activity("Elsa", "Flow", "Merge multiple branches into a single branch of execution.")]
-public class FlowJoin : Activity, IJoinNode
+public class FlowJoin : ActivityBase, IJoinNode
 {
     [Input] public Input<JoinMode> Mode { get; set; } = new(JoinMode.WaitAll);
 
-    protected override void Execute(ActivityExecutionContext context)
+    protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
     {
-        // Clear any bookmarks created between this join and its most recent fork.
-        var joinNode = context.ActivityNode;
-        var forkNode = context.ActivityNode.Fork();
+        var flowchartExecutionContext = context.ParentActivityExecutionContext!;
+        var flowchart = (Flowchart)flowchartExecutionContext.Activity;
+        var inboundActivities = flowchart.Connections.LeftInboundActivities(this).ToList();
+        var flowScope = flowchartExecutionContext.GetProperty<FlowScope>(Flowchart.ScopeProperty)!;
+        var executionCount = flowScope.GetExecutionCount(this);
+        var mode = context.Get(Mode);
 
-        if (forkNode == null)
-            return;
+        switch (mode)
+        {
+            case JoinMode.WaitAll:
+                // If all left-inbound activities have executed, complete & continue.
+                var haveAllInboundActivitiesExecuted = inboundActivities.All(x => flowScope.GetExecutionCount(x) > executionCount);
 
-        var ancestry = joinNode.AncestryTo(forkNode).ToList();
+                if (haveAllInboundActivitiesExecuted)
+                    await context.CompleteActivityAsync();
+                break;
+            case JoinMode.WaitAny:
+                // Only complete if we haven't already executed.
+                var alreadyExecuted = inboundActivities.Max(x => flowScope.GetExecutionCount(x)) == executionCount;
 
-        // TODO: Remove any bookmarks created by any nodes in the ancestry path.
+                if (!alreadyExecuted)
+                {
+                    await context.CompleteActivityAsync();
+                    ClearBookmarks(flowchart, context);
+                }
+                break;
+        }
     }
 
-    public bool GetShouldExecute(FlowJoinContext context)
+    private void ClearBookmarks(Flowchart flowchart, ActivityExecutionContext context)
     {
-        var activityExecutionContext = context.ActivityExecutionContext;
-        var mode = activityExecutionContext.Get(Mode);
-        var scope = context.Scope;
-        var executionCount = scope.GetExecutionCount(context.Activity);
-        var inboundActivities = context.InboundActivities;
-        
-        if (mode == JoinMode.WaitAny)
-        {
-            // Only return true if we didn't execute before.
-            var hasAnyInboundActivityExecuted = inboundActivities.Any(x => scope.GetExecutionCount(x) > executionCount);
-            return hasAnyInboundActivityExecuted;
-        }
-        else
-        {
-            // Wait for all left-inbound activities to have executed.
-            var haveAllInboundActivitiesExecuted = inboundActivities.All(x => scope.GetExecutionCount(x) > executionCount);
-
-            return haveAllInboundActivitiesExecuted;    
-        }
-
-        
+        // Clear any bookmarks created between this join and its most recent fork.
+        var connections = flowchart.Connections;
+        var inboundActivities = connections.LeftInboundActivities(this).Select(x => x.Id).ToList();
+        context.WorkflowExecutionContext.Bookmarks.RemoveWhere(x => inboundActivities.Contains(x.ActivityId));
     }
 }

--- a/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Activities/Flowchart.cs
+++ b/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Activities/Flowchart.cs
@@ -1,3 +1,4 @@
+using Elsa.Workflows.Core.Activities.Flowchart.Extensions;
 using Elsa.Workflows.Core.Activities.Flowchart.Models;
 using Elsa.Workflows.Core.Attributes;
 using Elsa.Workflows.Core.Models;
@@ -9,6 +10,9 @@ namespace Elsa.Workflows.Core.Activities.Flowchart.Activities;
 [Activity("Elsa", "Flow", "A flowchart is a collection of activities and connections between them.")]
 public class Flowchart : Container
 {
+    private const string ScopesProperty = "Scopes";
+    private const string ScopeProperty = "Scope";
+
     public Flowchart()
     {
         OnSignalReceived<ActivityCompleted>(OnDescendantCompletedAsync);
@@ -32,33 +36,62 @@ public class Flowchart : Container
     {
         await ScheduleChildrenAsync(signal, context);
     }
-    
+
     private async Task ScheduleChildrenAsync(ActivityCompleted signal, SignalContext context)
     {
-        var activityExecutionContext = context.ReceiverActivityExecutionContext;
-        var parent = context.SenderActivityExecutionContext.Activity;
+        var flowchartActivityExecutionContext = context.ReceiverActivityExecutionContext;
+        var completedActivity = context.SenderActivityExecutionContext.Activity;
 
-        if (parent == null!)
+        if (completedActivity == null!)
             return;
 
         // Ignore completed activities that are not immediate children.
-        var isDirectChild = Activities.Contains(parent);
-        
+        var isDirectChild = Activities.Contains(completedActivity);
+
         if (!isDirectChild)
             return;
 
         // If a specific outcome was provided by the completed activity, use it to find the connection to the next activity.
-        Func<Connection, bool> outboundConnectionsQuery = signal.Result is Outcome outcome 
-            ? connection => connection.Source == parent && connection.SourcePort == outcome.Name 
-            : connection => connection.Source == parent;
+        Func<Connection, bool> outboundConnectionsQuery = signal.Result is Outcome outcome
+            ? connection => connection.Source == completedActivity && connection.SourcePort == outcome.Name
+            : connection => connection.Source == completedActivity;
 
         var outboundConnections = Connections.Where(outboundConnectionsQuery).ToList();
         var children = outboundConnections.Select(x => x.Target).ToList();
-
+        var scope = flowchartActivityExecutionContext.GetProperty(ScopeProperty, () => new FlowScope());
+        
+        scope.RegisterActivityExecution(completedActivity);
+        
         if (children.Any())
-            activityExecutionContext.ScheduleActivities(children);
-        else
-            await activityExecutionContext.CompleteActivityAsync();
+        {
+            
+            scope.AddActivities(children);
+
+            // Only schedule children that have not yet already executed in the current scope.
+            var filteredChildren = scope.ExcludeExecutedActivities(children).ToList();
+            children = filteredChildren;
+
+            var executedActivities = scope.Activities.Values.Where(x => x.HasExecuted).Select(x => x.ActivityId).ToList();
+            
+            // Schedule each child, but only if all of its inbound activities have already executed.
+            foreach (var activity in children)
+            {
+                var inboundActivities = Connections.InboundActivities(activity).ToList();
+                var haveInboundActivitiesExecuted = inboundActivities.All(x => executedActivities.Contains(x.Id));
+                
+                if(haveInboundActivitiesExecuted)
+                    flowchartActivityExecutionContext.ScheduleActivity(activity);
+            }
+        }
+
+        if (!children.Any())
+        {
+            // If there are no more pending activities in any of the scopes, mark this activity as completed.
+            var hasPendingChildren = scope.HasPendingActivities();
+
+            if (!hasPendingChildren)
+                await flowchartActivityExecutionContext.CompleteActivityAsync();
+        }
 
         context.StopPropagation();
     }

--- a/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Contracts/IJoinNode.cs
+++ b/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Contracts/IJoinNode.cs
@@ -1,0 +1,15 @@
+using Elsa.Workflows.Core.Activities.Flowchart.Models;
+using Elsa.Workflows.Core.Models;
+using Elsa.Workflows.Core.Services;
+
+namespace Elsa.Workflows.Core.Activities.Flowchart.Contracts;
+
+/// <summary>
+/// Gives implementing activities a chance to customize certain flowchart execution behaviors.
+/// </summary>
+public interface IJoinNode : IActivity
+{
+    bool GetShouldExecute(FlowJoinContext context);
+}
+
+public record FlowJoinContext(ActivityExecutionContext ActivityExecutionContext, FlowScope Scope, Activities.Flowchart Flowchart, IActivity Activity, ICollection<IActivity> InboundActivities);

--- a/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Contracts/IJoinNode.cs
+++ b/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Contracts/IJoinNode.cs
@@ -1,5 +1,3 @@
-using Elsa.Workflows.Core.Activities.Flowchart.Models;
-using Elsa.Workflows.Core.Models;
 using Elsa.Workflows.Core.Services;
 
 namespace Elsa.Workflows.Core.Activities.Flowchart.Contracts;
@@ -9,7 +7,4 @@ namespace Elsa.Workflows.Core.Activities.Flowchart.Contracts;
 /// </summary>
 public interface IJoinNode : IActivity
 {
-    bool GetShouldExecute(FlowJoinContext context);
 }
-
-public record FlowJoinContext(ActivityExecutionContext ActivityExecutionContext, FlowScope Scope, Activities.Flowchart Flowchart, IActivity Activity, ICollection<IActivity> InboundActivities);

--- a/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Extensions/ConnectionsExtensions.cs
+++ b/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Extensions/ConnectionsExtensions.cs
@@ -19,4 +19,10 @@ public static class ConnectionsExtensions
                 yield return descendant;
         }
     }
+    
+    public static IEnumerable<Connection> InboundConnections(this ICollection<Connection> allConnections, IActivity activity) => 
+        allConnections.Where(x => x.Target == activity).ToList();
+
+    public static IEnumerable<IActivity> InboundActivities(this ICollection<Connection> allConnections, IActivity activity) => 
+        allConnections.InboundConnections(activity).Select(x => x.Source);
 }

--- a/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Extensions/ConnectionsExtensions.cs
+++ b/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Extensions/ConnectionsExtensions.cs
@@ -7,22 +7,39 @@ public static class ConnectionsExtensions
 {
     public static IEnumerable<Connection> Descendants(this ICollection<Connection> allConnections, IActivity parent)
     {
-        var children = allConnections.Where(x => parent == x.Source).ToList();
+        var visitedActivities = new HashSet<IActivity>();
+        return allConnections.Descendants(parent, visitedActivities);
+    }
+
+    public static IEnumerable<Connection> InboundConnections(this ICollection<Connection> allConnections, IActivity activity) => allConnections.Where(x => x.Target == activity).ToList();
+
+    public static IEnumerable<Connection> LeftInboundConnections(this ICollection<Connection> allConnections, IActivity activity)
+    {
+        // We only take "left" inbound connections, which means we exclude descendent connections looping back. 
+        var descendantConnections = allConnections.Descendants(activity).ToList();
+        var filteredConnections = allConnections.InboundConnections(activity).Except(descendantConnections).ToList();
+
+        return filteredConnections;
+    }
+
+    public static IEnumerable<IActivity> InboundActivities(this ICollection<Connection> allConnections, IActivity activity) => allConnections.InboundConnections(activity).Select(x => x.Source);
+    public static IEnumerable<IActivity> LeftInboundActivities(this ICollection<Connection> allConnections, IActivity activity) => allConnections.LeftInboundConnections(activity).Select(x => x.Source);
+
+    private static IEnumerable<Connection> Descendants(this ICollection<Connection> allConnections, IActivity parent, ISet<IActivity> visitedActivities)
+    {
+        var children = allConnections.Where(x => parent == x.Source && !visitedActivities.Contains(x.Target)).ToList();
 
         foreach (var child in children)
         {
+            visitedActivities.Add(child.Target);
             yield return child;
 
-            var descendants = allConnections.Descendants(child.Target).ToList();
+            var descendants = allConnections.Descendants(child.Target, visitedActivities).ToList();
 
             foreach (var descendant in descendants)
+            {
                 yield return descendant;
+            }
         }
     }
-    
-    public static IEnumerable<Connection> InboundConnections(this ICollection<Connection> allConnections, IActivity activity) => 
-        allConnections.Where(x => x.Target == activity).ToList();
-
-    public static IEnumerable<IActivity> InboundActivities(this ICollection<Connection> allConnections, IActivity activity) => 
-        allConnections.InboundConnections(activity).Select(x => x.Source);
 }

--- a/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Extensions/ConnectionsExtensions.cs
+++ b/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Extensions/ConnectionsExtensions.cs
@@ -27,9 +27,19 @@ public static class ConnectionsExtensions
 
         return filteredConnections;
     }
+    
+    public static IEnumerable<Connection> LeftAncestorConnections(this ICollection<Connection> connections, IActivity activity)
+    {
+        // We only take "left" inbound connections, which means we exclude descendent connections looping back. 
+        var descendantConnections = connections.Descendants(activity).ToList();
+        var filteredConnections = connections.Ancestors(activity).Except(descendantConnections).ToList();
+
+        return filteredConnections;
+    }
 
     public static IEnumerable<IActivity> InboundActivities(this ICollection<Connection> connections, IActivity activity) => connections.InboundConnections(activity).Select(x => x.Source);
     public static IEnumerable<IActivity> LeftInboundActivities(this ICollection<Connection> connections, IActivity activity) => connections.LeftInboundConnections(activity).Select(x => x.Source);
+    public static IEnumerable<IActivity> LeftAncestorActivities(this ICollection<Connection> connections, IActivity activity) => connections.LeftAncestorConnections(activity).Select(x => x.Source);
 
     private static IEnumerable<Connection> Descendants(this ICollection<Connection> connections, IActivity parent, ISet<IActivity> visitedActivities)
     {

--- a/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Extensions/ConnectionsExtensions.cs
+++ b/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Extensions/ConnectionsExtensions.cs
@@ -5,40 +5,64 @@ namespace Elsa.Workflows.Core.Activities.Flowchart.Extensions;
 
 public static class ConnectionsExtensions
 {
-    public static IEnumerable<Connection> Descendants(this ICollection<Connection> allConnections, IActivity parent)
+    public static IEnumerable<Connection> Descendants(this ICollection<Connection> connections, IActivity parent)
     {
         var visitedActivities = new HashSet<IActivity>();
-        return allConnections.Descendants(parent, visitedActivities);
+        return connections.Descendants(parent, visitedActivities);
+    }
+    
+    public static IEnumerable<Connection> Ancestors(this ICollection<Connection> connections, IActivity activity)
+    {
+        var visitedActivities = new HashSet<IActivity>();
+        return connections.Ancestors(activity, visitedActivities);
     }
 
-    public static IEnumerable<Connection> InboundConnections(this ICollection<Connection> allConnections, IActivity activity) => allConnections.Where(x => x.Target == activity).ToList();
+    public static IEnumerable<Connection> InboundConnections(this ICollection<Connection> connections, IActivity activity) => connections.Where(x => x.Target == activity).ToList();
 
-    public static IEnumerable<Connection> LeftInboundConnections(this ICollection<Connection> allConnections, IActivity activity)
+    public static IEnumerable<Connection> LeftInboundConnections(this ICollection<Connection> connections, IActivity activity)
     {
         // We only take "left" inbound connections, which means we exclude descendent connections looping back. 
-        var descendantConnections = allConnections.Descendants(activity).ToList();
-        var filteredConnections = allConnections.InboundConnections(activity).Except(descendantConnections).ToList();
+        var descendantConnections = connections.Descendants(activity).ToList();
+        var filteredConnections = connections.InboundConnections(activity).Except(descendantConnections).ToList();
 
         return filteredConnections;
     }
 
-    public static IEnumerable<IActivity> InboundActivities(this ICollection<Connection> allConnections, IActivity activity) => allConnections.InboundConnections(activity).Select(x => x.Source);
-    public static IEnumerable<IActivity> LeftInboundActivities(this ICollection<Connection> allConnections, IActivity activity) => allConnections.LeftInboundConnections(activity).Select(x => x.Source);
+    public static IEnumerable<IActivity> InboundActivities(this ICollection<Connection> connections, IActivity activity) => connections.InboundConnections(activity).Select(x => x.Source);
+    public static IEnumerable<IActivity> LeftInboundActivities(this ICollection<Connection> connections, IActivity activity) => connections.LeftInboundConnections(activity).Select(x => x.Source);
 
-    private static IEnumerable<Connection> Descendants(this ICollection<Connection> allConnections, IActivity parent, ISet<IActivity> visitedActivities)
+    private static IEnumerable<Connection> Descendants(this ICollection<Connection> connections, IActivity parent, ISet<IActivity> visitedActivities)
     {
-        var children = allConnections.Where(x => parent == x.Source && !visitedActivities.Contains(x.Target)).ToList();
+        var children = connections.Where(x => parent == x.Source && !visitedActivities.Contains(x.Target)).ToList();
 
         foreach (var child in children)
         {
             visitedActivities.Add(child.Target);
             yield return child;
 
-            var descendants = allConnections.Descendants(child.Target, visitedActivities).ToList();
+            var descendants = connections.Descendants(child.Target, visitedActivities).ToList();
 
             foreach (var descendant in descendants)
             {
                 yield return descendant;
+            }
+        }
+    }
+    
+    private static IEnumerable<Connection> Ancestors(this ICollection<Connection> connections, IActivity activity, ISet<IActivity> visitedActivities)
+    {
+        var parents = connections.Where(x => activity == x.Target && !visitedActivities.Contains(x.Source)).ToList();
+
+        foreach (var parent in parents)
+        {
+            visitedActivities.Add(parent.Source);
+            yield return parent;
+
+            var ancestors = connections.Ancestors(parent.Source, visitedActivities).ToList();
+
+            foreach (var ancestor in ancestors)
+            {
+                yield return ancestor;
             }
         }
     }

--- a/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Models/ActivityFlowState.cs
+++ b/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Models/ActivityFlowState.cs
@@ -1,0 +1,22 @@
+using System.Diagnostics;
+using System.Text.Json.Serialization;
+
+namespace Elsa.Workflows.Core.Activities.Flowchart.Models;
+
+[DebuggerDisplay("Activity = {ActivityId}, HasExecuted = {HasExecuted}")]
+public class ActivityFlowState
+{
+    [JsonConstructor]
+    public ActivityFlowState()
+    {
+    }
+
+    public ActivityFlowState(string activityId, bool hasExecuted = false)
+    {
+        ActivityId = activityId;
+        HasExecuted = hasExecuted;
+    }
+    
+    public string ActivityId { get; set; } = default!;
+    public bool HasExecuted { get; set; }
+}

--- a/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Models/ActivityFlowState.cs
+++ b/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Models/ActivityFlowState.cs
@@ -3,7 +3,7 @@ using System.Text.Json.Serialization;
 
 namespace Elsa.Workflows.Core.Activities.Flowchart.Models;
 
-[DebuggerDisplay("Activity = {ActivityId}, HasExecuted = {HasExecuted}")]
+[DebuggerDisplay("ActivityId = {ActivityId}, ExecutionCount = {ExecutionCount}")]
 public class ActivityFlowState
 {
     [JsonConstructor]
@@ -11,12 +11,12 @@ public class ActivityFlowState
     {
     }
 
-    public ActivityFlowState(string activityId, bool hasExecuted = false)
+    public ActivityFlowState(string activityId, long executionCount = 0)
     {
         ActivityId = activityId;
-        HasExecuted = hasExecuted;
+        ExecutionCount = executionCount;
     }
     
     public string ActivityId { get; set; } = default!;
-    public bool HasExecuted { get; set; }
+    public long ExecutionCount { get; set; }
 }

--- a/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Models/FlowScope.cs
+++ b/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Models/FlowScope.cs
@@ -1,0 +1,63 @@
+using System.Text.Json.Serialization;
+using Elsa.Workflows.Core.Services;
+
+namespace Elsa.Workflows.Core.Activities.Flowchart.Models;
+
+public class FlowScope
+{
+    [JsonConstructor]
+    public FlowScope()
+    {
+    }
+
+    public FlowScope(string ownerActivityId)
+    {
+        OwnerActivityId = ownerActivityId;
+        Activities.Add(ownerActivityId, new ActivityFlowState(ownerActivityId, true));
+    }
+
+    /// <summary>
+    /// The activity from which the scope was created.
+    /// </summary>
+    public string OwnerActivityId { get; set; } = default!;
+
+    /// <summary>
+    /// A list of scheduled activity IDs and a flag whether they executed or not.
+    /// </summary>
+    public IDictionary<string, ActivityFlowState> Activities { get; set; } =
+        new Dictionary<string, ActivityFlowState>();
+
+    public void AddActivities(IEnumerable<IActivity> activities, bool executed = false)
+    {
+        foreach (var activity in activities)
+            AddActivity(activity, executed);
+    }
+    
+    public void AddActivity(IActivity activity, bool executed = false)
+    {
+        if (!Activities.ContainsKey(activity.Id))
+            Activities.Add(activity.Id, new ActivityFlowState(activity.Id, executed));
+    }
+    
+    public void RegisterActivityExecution(IActivity activity)
+    {
+        Activities[activity.Id] = new ActivityFlowState(activity.Id, true);
+    }
+
+    public void MarkAsExecuted(IActivity activity)
+    {
+        if (Activities.TryGetValue(activity.Id, out var state))
+            state.HasExecuted = true;
+    }
+
+    /// <summary>
+    /// Return a list excluding any activities that already executed.
+    /// </summary>
+    public IEnumerable<IActivity> ExcludeExecutedActivities(IEnumerable<IActivity> activities) =>
+        activities.Where(x => !Activities.ContainsKey(x.Id) || !Activities[x.Id].HasExecuted);
+
+    public bool HasPendingActivities() => Activities.Values.Any(x => !x.HasExecuted);
+
+    public bool HaveExecuted(IEnumerable<IActivity> activities) => activities.All(activity =>
+        Activities.TryGetValue(activity.Id, out var f) && f.HasExecuted);
+}

--- a/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Models/JoinMode.cs
+++ b/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Models/JoinMode.cs
@@ -1,0 +1,7 @@
+namespace Elsa.Workflows.Core.Activities.Flowchart.Activities;
+
+public enum JoinMode
+{
+    WaitAll,
+    WaitAny
+}

--- a/src/modules/Elsa.Workflows.Core/Implementations/ActivityInvoker.cs
+++ b/src/modules/Elsa.Workflows.Core/Implementations/ActivityInvoker.cs
@@ -21,22 +21,10 @@ public class ActivityInvoker : IActivityInvoker
         ActivityExecutionContext? owner,
         IEnumerable<MemoryBlockReference>? memoryReferences = default)
     {
-        var cancellationToken = workflowExecutionContext.CancellationToken;
-
-        // Get a handle to the parent execution context.
-        var parentActivityExecutionContext = owner;
-        var parentExpressionExecutionContext = parentActivityExecutionContext?.ExpressionExecutionContext;
-
         // Setup an activity execution context.
         var workflowMemory = workflowExecutionContext.MemoryRegister;
-        var workflow = workflowExecutionContext.Workflow;
-        var transientProperties = workflowExecutionContext.TransientProperties;
-        var input = workflowExecutionContext.Input;
-        var applicationProperties = ExpressionExecutionContextExtensions.CreateApplicationPropertiesFrom(workflow, transientProperties, input);
-        var parentMemory = parentActivityExecutionContext?.ExpressionExecutionContext.Memory ?? workflowMemory;
         var activityMemory = new MemoryRegister(workflowMemory);
-        var expressionExecutionContext = new ExpressionExecutionContext(_serviceProvider, parentMemory, parentExpressionExecutionContext, applicationProperties, cancellationToken);
-        var activityExecutionContext = new ActivityExecutionContext(workflowExecutionContext, parentActivityExecutionContext, expressionExecutionContext, activity, cancellationToken);
+        var activityExecutionContext = workflowExecutionContext.CreateActivityExecutionContext(activity, owner);
 
         // Declare memory.
         if (memoryReferences != null)

--- a/src/modules/Elsa.Workflows.Core/Models/ActivityBase.cs
+++ b/src/modules/Elsa.Workflows.Core/Models/ActivityBase.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Text.Json.Serialization;
 using Elsa.Workflows.Core.Behaviors;
 using Elsa.Workflows.Core.Helpers;
@@ -5,6 +6,7 @@ using Elsa.Workflows.Core.Services;
 
 namespace Elsa.Workflows.Core.Models;
 
+[DebuggerDisplay("{Type} - {Id}")]
 public abstract class ActivityBase : IActivity, ISignalHandler
 {
     private readonly ICollection<SignalHandlerRegistration> _signalHandlers = new List<SignalHandlerRegistration>();

--- a/src/modules/Elsa.Workflows.Core/Models/ActivityExecutionContext.cs
+++ b/src/modules/Elsa.Workflows.Core/Models/ActivityExecutionContext.cs
@@ -135,6 +135,18 @@ public class ActivityExecutionContext
     public void ClearBookmarks() => _bookmarks.Clear();
 
     public T? GetProperty<T>(string key) => ApplicationProperties!.TryGetValue<T?>(key, out var value) ? value : default;
+    
+    public T GetProperty<T>(string key, Func<T> defaultValue)
+    {
+        if (ApplicationProperties.TryGetValue<T?>(key, out var value)) 
+            return value!;
+        
+        value = defaultValue();
+        ApplicationProperties[key] = value!;
+
+        return value!;
+    }
+
     public void SetProperty<T>(string key, T? value) => ApplicationProperties[key] = value!;
 
     public T UpdateProperty<T>(string key, Func<T?, T> updater) where T : notnull

--- a/src/modules/Elsa.Workflows.Core/Models/ActivityNode.cs
+++ b/src/modules/Elsa.Workflows.Core/Models/ActivityNode.cs
@@ -45,44 +45,4 @@ public class ActivityNode
 
     public IEnumerable<ActivityNode> Siblings() => Parents.SelectMany(parent => parent.Children);
     public IEnumerable<ActivityNode> SiblingsAndCousins() => Parents.SelectMany(parent => parent.Descendants());
-
-    /// <summary>
-    /// Traverses up the descendants until a single common ancestor is found (the fork).
-    /// </summary>
-    public ActivityNode? Fork()
-    {
-        var currentParents = Parents;
-
-        while (currentParents.Any())
-        {
-            var grandParents = currentParents.SelectMany(x => x.Parents).Distinct().ToList();
-
-            if (grandParents.Count == 1)
-                return grandParents.Single();
-
-            currentParents = grandParents;
-        }
-
-        return null;
-    }
-
-    /// <summary>
-    /// Returns a list of nodes representing the ancestry from the current node to the specified common ancestry (aka the fork).
-    /// </summary>
-    public IEnumerable<ActivityNode> AncestryTo(ActivityNode fork)
-    {
-        var currentParents = Parents;
-
-        while (currentParents.Any())
-        {
-            foreach (var parent in currentParents)
-            {
-                if (parent.Ancestors().Contains(fork))
-                    yield return parent;
-
-            }
-
-            currentParents = currentParents.SelectMany(x => x.Parents).ToList();
-        }
-    }
 }

--- a/src/modules/Elsa.Workflows.Core/Models/ActivityNode.cs
+++ b/src/modules/Elsa.Workflows.Core/Models/ActivityNode.cs
@@ -22,27 +22,67 @@ public class ActivityNode
         foreach (var child in Children)
         {
             yield return child;
-                
+
             var descendants = child.Descendants();
 
             foreach (var descendant in descendants)
                 yield return descendant;
         }
     }
-        
+
     public IEnumerable<ActivityNode> Ancestors()
     {
         foreach (var parent in Parents)
         {
             yield return parent;
-                
+
             var ancestors = parent.Ancestors();
 
             foreach (var ancestor in ancestors)
                 yield return ancestor;
         }
     }
-        
+
     public IEnumerable<ActivityNode> Siblings() => Parents.SelectMany(parent => parent.Children);
     public IEnumerable<ActivityNode> SiblingsAndCousins() => Parents.SelectMany(parent => parent.Descendants());
+
+    /// <summary>
+    /// Traverses up the descendants until a single common ancestor is found (the fork).
+    /// </summary>
+    public ActivityNode? Fork()
+    {
+        var currentParents = Parents;
+
+        while (currentParents.Any())
+        {
+            var grandParents = currentParents.SelectMany(x => x.Parents).Distinct().ToList();
+
+            if (grandParents.Count == 1)
+                return grandParents.Single();
+
+            currentParents = grandParents;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Returns a list of nodes representing the ancestry from the current node to the specified common ancestry (aka the fork).
+    /// </summary>
+    public IEnumerable<ActivityNode> AncestryTo(ActivityNode fork)
+    {
+        var currentParents = Parents;
+
+        while (currentParents.Any())
+        {
+            foreach (var parent in currentParents)
+            {
+                if (parent.Ancestors().Contains(fork))
+                    yield return parent;
+
+            }
+
+            currentParents = currentParents.SelectMany(x => x.Parents).ToList();
+        }
+    }
 }

--- a/src/modules/Elsa.Workflows.Core/Models/WorkflowExecutionContext.cs
+++ b/src/modules/Elsa.Workflows.Core/Models/WorkflowExecutionContext.cs
@@ -140,7 +140,7 @@ public class WorkflowExecutionContext
         var applicationProperties = ExpressionExecutionContextExtensions.CreateApplicationPropertiesFrom(Workflow, TransientProperties, Input);
         var parentMemory = parentContext?.ExpressionExecutionContext.Memory ?? MemoryRegister;
         var expressionExecutionContext = new ExpressionExecutionContext(_serviceProvider, parentMemory, parentExpressionExecutionContext, applicationProperties, CancellationToken);
-        var activityExecutionContext = new ActivityExecutionContext(this, default, expressionExecutionContext, activity, CancellationToken);
+        var activityExecutionContext = new ActivityExecutionContext(this, parentContext, expressionExecutionContext, activity, CancellationToken);
         return activityExecutionContext;
     }
 

--- a/src/modules/Elsa.Workflows.Management/Implementations/ActivityDescriber.cs
+++ b/src/modules/Elsa.Workflows.Management/Implementations/ActivityDescriber.cs
@@ -98,7 +98,8 @@ public class ActivityDescriber : IActivityDescriber
         {
             var inputAttribute = propertyInfo.GetCustomAttribute<InputAttribute>();
             var descriptionAttribute = propertyInfo.GetCustomAttribute<DescriptionAttribute>();
-            var wrappedPropertyType = propertyInfo.PropertyType.GenericTypeArguments[0];
+            var propertyType = propertyInfo.PropertyType;
+            var wrappedPropertyType = !typeof(Input).IsAssignableFrom(propertyType) ? propertyType : propertyInfo.PropertyType.GenericTypeArguments[0];
 
             yield return new InputDescriptor
             (

--- a/src/modules/Elsa.Workflows.Management/Implementations/PropertyOptionsResolver.cs
+++ b/src/modules/Elsa.Workflows.Management/Implementations/PropertyOptionsResolver.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using Elsa.Workflows.Core.Attributes;
+using Elsa.Workflows.Core.Models;
 using Elsa.Workflows.Management.Extensions;
 using Elsa.Workflows.Management.Models;
 using Elsa.Workflows.Management.Services;
@@ -38,13 +39,14 @@ public class PropertyOptionsResolver : IPropertyOptionsResolver
     {
         var isNullable = activityPropertyInfo.PropertyType.IsNullableType();
         var propertyType = isNullable ? activityPropertyInfo.PropertyType.GetTypeOfNullable() : activityPropertyInfo.PropertyType;
+        var wrappedPropertyType = !typeof(Input).IsAssignableFrom(propertyType) ? propertyType : activityPropertyInfo.PropertyType.GenericTypeArguments[0];
 
         items = null;
 
-        if (!propertyType.IsEnum)
+        if (!wrappedPropertyType.IsEnum)
             return false;
             
-        items = propertyType.GetEnumNames().Select(x => new SelectListItem(x.Humanize(LetterCasing.Title), x)).ToList();
+        items = wrappedPropertyType.GetEnumNames().Select(x => new SelectListItem(x.Humanize(LetterCasing.Title), x)).ToList();
 
         if (isNullable)
             items.Insert(0, new SelectListItem("-", ""));


### PR DESCRIPTION
This PR enhances the Flowchart activity by supporting implicit forks & joins.

By default, implicit joins always employ a "wait all" strategy.
If you need a "wait any" join mode, use the explicit "Flow Join" activity and configure its mode with "Wait Any".

The following screenshots displays what's now possible:

<img width="1502" alt="image" src="https://user-images.githubusercontent.com/938393/194873442-cd9c7e23-adb6-437c-b74f-1af98b6fdf3b.png">

It showcases two implicit forks, one implicit join and one explicit join.
When running this workflow, the output will look like this:

```shell
Start
Line 2
Line 2a
Line 1

<after 5 seconds...>

Will happen
End
```