### PR TITLE
adding UseTenantSignaler to ElsaOptionsBuilder

### DIFF
--- a/src/core/Elsa.Core/Options/ElsaOptions.cs
+++ b/src/core/Elsa.Core/Options/ElsaOptions.cs
@@ -64,7 +64,8 @@ namespace Elsa.Options
         public Type DefaultWorkflowStorageProviderType { get; set; }
         public WorkflowChannelOptions WorkflowChannelOptions { get; set; } = new();
 
-        internal bool UseTenantSignaler { get; set; } = false;
+        [Obsolete("ElsaOptions.UseTenantSignaler = true is deprecated, please use ElsaOptionsBuilder.UseTenantSignaler() instead.", false)]
+        public bool UseTenantSignaler { get; set; } = false;
 
         internal Func<IServiceProvider, IWorkflowDefinitionStore> WorkflowDefinitionStoreFactory { get; set; }
         internal Func<IServiceProvider, IWorkflowInstanceStore> WorkflowInstanceStoreFactory { get; set; }

--- a/src/core/Elsa.Core/Options/ElsaOptions.cs
+++ b/src/core/Elsa.Core/Options/ElsaOptions.cs
@@ -64,7 +64,7 @@ namespace Elsa.Options
         public Type DefaultWorkflowStorageProviderType { get; set; }
         public WorkflowChannelOptions WorkflowChannelOptions { get; set; } = new();
 
-        public bool UseTenantSignaler { get; set; } = false;
+        internal bool UseTenantSignaler { get; set; } = false;
 
         internal Func<IServiceProvider, IWorkflowDefinitionStore> WorkflowDefinitionStoreFactory { get; set; }
         internal Func<IServiceProvider, IWorkflowInstanceStore> WorkflowInstanceStoreFactory { get; set; }

--- a/src/core/Elsa.Core/Options/ElsaOptionsBuilder.cs
+++ b/src/core/Elsa.Core/Options/ElsaOptionsBuilder.cs
@@ -112,6 +112,12 @@ namespace Elsa.Options
             return this;
         }
 
+        public ElsaOptionsBuilder UseTenantSignaler()
+        {
+            ElsaOptions.UseTenantSignaler = true;
+            return this;
+        }
+
         public ElsaOptionsBuilder AddWorkflow(IWorkflow workflow)
         {
             Services.AddSingleton(workflow);


### PR DESCRIPTION
These changes allow the user to enable the TenantSignaler in a more convenient way. #3336 