### PR TITLE
Queue-based activity scheduler

### DIFF
--- a/src/modules/Elsa.Workflows.Core/Extensions/WorkflowExecutionContextExtensions.cs
+++ b/src/modules/Elsa.Workflows.Core/Extensions/WorkflowExecutionContextExtensions.cs
@@ -26,7 +26,7 @@ public static class WorkflowExecutionContextExtensions
         var activityInvoker = workflowExecutionContext.GetRequiredService<IActivityInvoker>();
         var workflow = workflowExecutionContext.Workflow;
         var workItem = new ActivityWorkItem(workflow.Root.Id, async () => await activityInvoker.InvokeAsync(workflowExecutionContext, workflow.Root));
-        workflowExecutionContext.Scheduler.Push(workItem);
+        workflowExecutionContext.Scheduler.Schedule(workItem);
     }
 
     /// <summary>
@@ -41,7 +41,7 @@ public static class WorkflowExecutionContextExtensions
         // Schedule the activity to resume.
         var activityInvoker = workflowExecutionContext.GetRequiredService<IActivityInvoker>();
         var workItem = new ActivityWorkItem(bookmarkedActivity.Id, async () => await activityInvoker.InvokeAsync(bookmarkedActivityContext));
-        workflowExecutionContext.Scheduler.Push(workItem);
+        workflowExecutionContext.Scheduler.Schedule(workItem);
 
         // If no resumption point was specified, use Noop to prevent the regular "ExecuteAsync" method to be invoked.
         workflowExecutionContext.ExecuteDelegate = bookmark.CallbackMethodName != null ? bookmarkedActivity.GetResumeActivityDelegate(bookmark.CallbackMethodName) : WorkflowExecutionContext.Complete;
@@ -62,7 +62,7 @@ public static class WorkflowExecutionContextExtensions
     {
         var activityInvoker = workflowExecutionContext.GetRequiredService<IActivityInvoker>();
         var workItem = new ActivityWorkItem(activity.Id, async () => await activityInvoker.InvokeAsync(workflowExecutionContext, activity, owner, references), tag);
-        workflowExecutionContext.Scheduler.Push(workItem);
+        workflowExecutionContext.Scheduler.Schedule(workItem);
 
         if (completionCallback != null)
             workflowExecutionContext.AddCompletionCallback(owner, activity, completionCallback);

--- a/src/modules/Elsa.Workflows.Core/Implementations/ActivitySchedulerFactory.cs
+++ b/src/modules/Elsa.Workflows.Core/Implementations/ActivitySchedulerFactory.cs
@@ -4,5 +4,6 @@ namespace Elsa.Workflows.Core.Implementations;
 
 public class ActivitySchedulerFactory : IActivitySchedulerFactory
 {
-    public IActivityScheduler CreateScheduler() => new ActivityScheduler();
+    //public IActivityScheduler CreateScheduler() => new StackBasedActivityScheduler();
+    public IActivityScheduler CreateScheduler() => new QueueBasedActivityScheduler();
 }

--- a/src/modules/Elsa.Workflows.Core/Implementations/QueueBasedActivityScheduler.cs
+++ b/src/modules/Elsa.Workflows.Core/Implementations/QueueBasedActivityScheduler.cs
@@ -1,0 +1,15 @@
+using Elsa.Workflows.Core.Models;
+using Elsa.Workflows.Core.Services;
+
+namespace Elsa.Workflows.Core.Implementations;
+
+public class QueueBasedActivityScheduler : IActivityScheduler
+{
+    private readonly Queue<ActivityWorkItem> _queue = new();
+
+    public bool HasAny => _queue.Any();
+    public void Schedule(ActivityWorkItem activity) => _queue.Enqueue(activity);
+    public ActivityWorkItem Take() => _queue.Dequeue();
+    public IEnumerable<ActivityWorkItem> List() => _queue.ToList();
+    public void Clear() => _queue.Clear();
+}

--- a/src/modules/Elsa.Workflows.Core/Implementations/StackBasedActivityScheduler.cs
+++ b/src/modules/Elsa.Workflows.Core/Implementations/StackBasedActivityScheduler.cs
@@ -3,13 +3,13 @@ using Elsa.Workflows.Core.Services;
 
 namespace Elsa.Workflows.Core.Implementations;
 
-public class ActivityScheduler : IActivityScheduler
+public class StackBasedActivityScheduler : IActivityScheduler
 {
     private readonly Stack<ActivityWorkItem> _stack = new();
 
     public bool HasAny => _stack.Any();
-    public void Push(ActivityWorkItem activity) => _stack.Push(activity);
-    public ActivityWorkItem Pop() => _stack.Pop();
+    public void Schedule(ActivityWorkItem activity) => _stack.Push(activity);
+    public ActivityWorkItem Take() => _stack.Pop();
     public IEnumerable<ActivityWorkItem> List() => _stack.ToList();
     public void Clear() => _stack.Clear();
 }

--- a/src/modules/Elsa.Workflows.Core/Pipelines/WorkflowExecution/Components/ActivitySchedulerMiddleware.cs
+++ b/src/modules/Elsa.Workflows.Core/Pipelines/WorkflowExecution/Components/ActivitySchedulerMiddleware.cs
@@ -25,7 +25,7 @@ public class ActivitySchedulerMiddleware : WorkflowExecutionMiddleware
         while (scheduler.HasAny)
         {
             // Pop next work item for execution.
-            var currentWorkItem = scheduler.Pop();
+            var currentWorkItem = scheduler.Take();
 
             // Execute work item.
             await currentWorkItem.Execute();

--- a/src/modules/Elsa.Workflows.Core/Services/IActivityScheduler.cs
+++ b/src/modules/Elsa.Workflows.Core/Services/IActivityScheduler.cs
@@ -3,14 +3,14 @@ using Elsa.Workflows.Core.Models;
 namespace Elsa.Workflows.Core.Services;
 
 /// <summary>
-/// The scheduler is a stack-based list containing work items to execute.
-/// It continuously pops the next work item from the stack until there are no more items left.
+/// The scheduler contains work items to execute.
+/// It continuously takes the next work item from the list until there are no more items left.
 /// </summary>
 public interface IActivityScheduler
 {
     bool HasAny { get; }
-    void Push(ActivityWorkItem workItem);
-    ActivityWorkItem Pop();
+    void Schedule(ActivityWorkItem workItem);
+    ActivityWorkItem Take();
     IEnumerable<ActivityWorkItem> List();
     void Clear();
 }


### PR DESCRIPTION
This PR introduces a queue-based implementation that replaces the original Elsa 1 & 2 stack-based scheduler.

The queue-based scheduler will execute activities in a first-in-first-out manner, effectively achieving a breadth-first execution of workflows that branch out into multiple paths.

This prevents issues such as branch-exhaustion, where one branch that is scheduled could take a long time, preventing other branches from executing.

This does not parallelize branches. For that, we need activities themselves to execute in the background (subject of a separate PR).

To demonstrate the difference in behavior, take a look at the following workflow:

<img width="1726" alt="image" src="https://user-images.githubusercontent.com/938393/195399525-468b35a0-7821-403a-834d-b3891b319cde.png">

With the stack-based scheduler, each individual branch will execute one by one. In other words, branch 1 first executes until it reaches its end, then branch 2, then branch 3, as can be seen by the output:

```shell
Start
Branch 3
Branch 3b
Branch 3a
Branch 3c
Branch 2
Branch 2b
Branch 2a
Branch 2c
Branch 1
Branch 1b
Branch 1a
Branch 1c
End
```

Notice also that execution doesn't begin with Branch 1 as you might expect, because the last activity pushed onto the stack will execute first.

Switching to the queue-based scheduler, the output looks like this:

```shell
Start
Branch 1
Branch 2
Branch 3
Branch 1a
Branch 1b
Branch 2a
Branch 2b
Branch 3a
Branch 3b
Branch 1c
Branch 2c
Branch 3c
End
```

Notice here that the order of execution appears more intuitive, and also that each branch executes only one level at a time, allowing other branches to execute as well.

I think that the queue-based approach is preferable, but I also know that some workflows out there rely on a fork executing one branch at a time as a whole, so for that reason it might be good to give the user the option to configure what scheduler to use.

To configure the scheduler, configure the **Workflows feature** like this:

```csharp
// Configure the stack-based scheduler:
services.AddElsa(elsa => elsa.UseWorkflows(workflows => workflows.WithActivitySchedulerFactory<StackBasedActivitySchedulerFactory>());

// Or configure the queue-based scheduler (used by default):
services.AddElsa(elsa => elsa.UseWorkflows(workflows => workflows.WithActivitySchedulerFactory<QueueBasedActivitySchedulerFactory>());
```