### PR TITLE
MySql - Set schemaName to Empty to allow using GetSchemaQualifiedTableName()

### DIFF
--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/ElsaContext.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/ElsaContext.cs
@@ -16,7 +16,18 @@ namespace Elsa.Persistence.EntityFramework.Core
         {
         }
 
-        public virtual string? Schema => Database.IsSqlite() ? default : ElsaSchema;
+        public virtual string? Schema
+        {
+            get
+            {
+                if (Database.IsSqlite())
+                    return default;
+                if (Database.IsMySql()) // MySql does not support the EF Core concept of schema (Pomelo Doc)
+                    return default;
+
+                return ElsaSchema;
+            }
+        }
         public DbSet<WorkflowDefinition> WorkflowDefinitions { get; set; } = default!;
         public DbSet<WorkflowInstance> WorkflowInstances { get; set; } = default!;
         public DbSet<WorkflowExecutionLogRecord> WorkflowExecutionLogRecords { get; set; } = default!;


### PR DESCRIPTION
Regarding the Pomelo [documentation](https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/wiki/Configuration-Options) :

`MySQL does not support the EF Core concept of schemas`

Schema are more or less the same thing as the Db Name (in the connectionstring).

To allow GetSchemaQualifiedTableName() to be use, we need to remove the Schema information for Mysql. The dbContext take care during the call of the Db to use. Without this we can't use a connection string like : 

`"MySql": "Server=localhost;Database=mycustomdb;Uid=root;Pwd=my-secret-pw;"`   because Database must be equal to Elsa (and it seems to be case sensitive...)



