### PR TITLE
Check the result and throw if it's a fault

### DIFF
--- a/src/core/Elsa.Core/Services/Workflows/WorkflowRunner.cs
+++ b/src/core/Elsa.Core/Services/Workflows/WorkflowRunner.cs
@@ -325,14 +325,14 @@ namespace Elsa.Services.Workflows
 
                     workflowExecutionContext.CompletePass();
                     workflowInstance.LastExecutedActivityId = currentActivityId;
-                    
+
                     await CheckIfCompositeEventAsync(isComposite
                         , compositeScheduledValue
                         , new ActivityExecutionResultExecuted(result, activityExecutionContext)
                         , _mediator
                         , cancellationToken);
 
-                    if (workflowInstance.WorkflowStatus == WorkflowStatus.Faulted) 
+                    if (workflowInstance.WorkflowStatus == WorkflowStatus.Faulted)
                         await _mediator.Publish(new WorkflowFaulting(activityExecutionContext, activity), cancellationToken);
 
                     await _mediator.Publish(new WorkflowExecutionPassCompleted(workflowExecutionContext, activityExecutionContext), cancellationToken);
@@ -381,12 +381,24 @@ namespace Elsa.Services.Workflows
         {
             try
             {
-                return await activityOperation(activityExecutionContext, activity);
+                var result = await activityOperation(activityExecutionContext, activity);
+
+                if (result is FaultResult)
+                {
+                    var faultResult = (result as FaultResult);
+
+                    if (faultResult?.Exception != null)
+                        throw faultResult.Exception;
+
+                    throw new Exception(faultResult?.Message);
+                }
+
+                return result;
             }
             catch (Exception e)
             {
                 _logger.LogWarning(e, "Failed to run activity {ActivityId} of workflow {WorkflowInstanceId}", activity.Id, activityExecutionContext.WorkflowInstance.Id);
-                
+
                 await _mediator.Publish(new ActivityFaulted(e, activityExecutionContext, activity), cancellationToken);
 
                 return new FaultResult(e);

--- a/src/core/Elsa.Core/Services/Workflows/WorkflowRunner.cs
+++ b/src/core/Elsa.Core/Services/Workflows/WorkflowRunner.cs
@@ -383,10 +383,8 @@ namespace Elsa.Services.Workflows
             {
                 var result = await activityOperation(activityExecutionContext, activity);
 
-                if (result is FaultResult)
+                if (result is FaultResult faultResult)
                 {
-                    var faultResult = (result as FaultResult);
-
                     if (faultResult?.Exception != null)
                         throw faultResult.Exception;
 


### PR DESCRIPTION
Updating the workflow runner to throw if a FaultResult is returned by the Activity.

As highlighted in #2723 if you return a FaultResult from an activity, the execution log doesn't get the fault added to it so it won't be displayed in the designer.

To correct this i've checked to see if the result of the activity is a faultResult and throw an exception so sends a ActivityFaulted event.

We could also expand the ActivityFaulted to accept a message as well as the exception so it matches FaultResult and in the handler resolve whether it's to use the Message or the Exception rather than having to create/thow an exception.