### PR TITLE
Enhance WorkflowDefinition id liquid filter

### DIFF
--- a/src/core/Elsa.Core/Persistence/Specifications/WorkflowDefinitions/WorkflowDefinitionNameSpecification.cs
+++ b/src/core/Elsa.Core/Persistence/Specifications/WorkflowDefinitions/WorkflowDefinitionNameSpecification.cs
@@ -1,7 +1,9 @@
+using Elsa.Models;
+
+using LinqKit;
+
 using System;
 using System.Linq.Expressions;
-using Elsa.Models;
-using LinqKit;
 
 namespace Elsa.Persistence.Specifications.WorkflowDefinitions;
 
@@ -11,6 +13,7 @@ public class WorkflowDefinitionNameSpecification : Specification<WorkflowDefinit
     {
         Name = name;
         VersionOptions = versionOptions;
+        TenantId = tenantId;
     }
 
     public string Name { get; set; }

--- a/src/scripting/Elsa.Scripting.Liquid/Filters/WorkflowDefinitionIdFilter.cs
+++ b/src/scripting/Elsa.Scripting.Liquid/Filters/WorkflowDefinitionIdFilter.cs
@@ -1,45 +1,62 @@
-﻿using System;
-using System.Linq;
-using System.Threading.Tasks;
 using Elsa.Models;
+using Elsa.Persistence;
 using Elsa.Scripting.Liquid.Services;
 using Elsa.Services;
+
 using Fluid;
 using Fluid.Values;
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace Elsa.Scripting.Liquid.Filters
 {
     public class WorkflowDefinitionIdFilter : ILiquidFilter
     {
         private readonly IWorkflowRegistry _workflowRegistry;
+        private readonly IWorkflowInstanceStore _workflowInstanceStore;
 
-        public WorkflowDefinitionIdFilter(IWorkflowRegistry workflowRegistry) => _workflowRegistry = workflowRegistry;
-
+        public WorkflowDefinitionIdFilter(IWorkflowRegistry workflowRegistry, IWorkflowInstanceStore workflowInstanceStore)
+        {
+            _workflowRegistry = workflowRegistry;
+            _workflowInstanceStore = workflowInstanceStore;
+        }
         public async ValueTask<FluidValue> ProcessAsync(FluidValue input, FilterArguments arguments, TemplateContext context)
         {
             var queryType = arguments.Values?.FirstOrDefault()?.ToStringValue() ?? "name";
+            string? tenantId = null;
+            if (arguments.Values?.Count() > 1)
+            {
+                var wfInstanceId = arguments.Values?.LastOrDefault().ToStringValue();
+                if (wfInstanceId is not null)
+                {
+                    var wfInstance = await _workflowInstanceStore.FindByIdAsync(wfInstanceId);
+                    tenantId = wfInstance?.TenantId;
+                }
+            }
             var queryValue = input.ToStringValue();
 
             var task = queryType switch
             {
-                "name" => GetWorkflowDefinitionIdByName(queryValue) ,
-                "tag" => GetWorkflowDefinitionIdByTag(queryValue),
+                "name" => GetWorkflowDefinitionIdByName(queryValue, tenantId),
+                "tag" => GetWorkflowDefinitionIdByTag(queryValue, tenantId),
                 _ => throw new ArgumentOutOfRangeException()
             };
 
             var workflowDefinitionId = await task;
             return new StringValue(workflowDefinitionId);
         }
-        
-        private async Task<string?> GetWorkflowDefinitionIdByTag(string tag)
+
+        private async Task<string?> GetWorkflowDefinitionIdByTag(string tag, string? tenantId = null)
         {
-            var workflowBlueprint = await _workflowRegistry.FindByTagAsync(tag, VersionOptions.Published);
+            var workflowBlueprint = await _workflowRegistry.FindByTagAsync(tag, VersionOptions.Published, tenantId: tenantId);
             return workflowBlueprint?.Id;
         }
 
-        private async Task<string?> GetWorkflowDefinitionIdByName(string name)
+        private async Task<string?> GetWorkflowDefinitionIdByName(string name, string? tenantId = null)
         {
-            var workflowBlueprint = await _workflowRegistry.FindByNameAsync(name, VersionOptions.Published);
+            var workflowBlueprint = await _workflowRegistry.FindByNameAsync(name, VersionOptions.Published, tenantId: tenantId);
             return workflowBlueprint?.Id;
         }
     }


### PR DESCRIPTION
This PR enhances the core liquid filter WorkflowDefinitionIdFilter with another optional parameter. The parameter can take an (optional) workflow definition Id from which the tenant id will be used to find the workflow definition in the right tenant.

This can be used to call a subworkflow from a tenant specific workflow. Without this adapter liquid filter the workflow definition will always be searched in the default tenant.

The new syntax (following liquid syntax would be):

`{{ \"<name of the workflow>\" | workflow_definition_id:\"name\",WorkflowInstanceId }}`
or by tag
`{{ \"<tag of the workflow>\" | workflow_definition_id:\"tag\",WorkflowInstanceId }}`