### PR TITLE
Use log scopes with a better `ToString()` implementation.

### DIFF
--- a/src/activities/Elsa.Activities.Telnyx/TelnyxWebhookLogScope.cs
+++ b/src/activities/Elsa.Activities.Telnyx/TelnyxWebhookLogScope.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Elsa.Activities.Telnyx
+{
+    internal class TelnyxWebhookLogScope : IReadOnlyList<KeyValuePair<string, object?>>
+    {
+        private string? _cachedToString;
+
+        public string? CorrelationId { get; }
+
+        public TelnyxWebhookLogScope(string? correlationId) => this.CorrelationId = correlationId;
+
+        public int Count => string.IsNullOrEmpty(this.CorrelationId) ? 0 : 1;
+
+        public KeyValuePair<string, object?> this[int index]
+        {
+            get
+            {
+                if (index != 0 || this.Count == 0)
+                    throw new ArgumentOutOfRangeException(nameof(index));
+
+                return new(nameof(CorrelationId), CorrelationId);
+            }
+        }
+
+        public IEnumerator<KeyValuePair<string, object?>> GetEnumerator()
+        {
+            for (var i = 0; i < Count; i++) yield return this[i];
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public override string ToString()
+            => _cachedToString ??= FormattableString.Invariant($"{nameof(CorrelationId)}: {CorrelationId}");
+    }
+}

--- a/src/activities/Elsa.Activities.Telnyx/Webhooks/Services/WebhookHandler.cs
+++ b/src/activities/Elsa.Activities.Telnyx/Webhooks/Services/WebhookHandler.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO.Pipelines;
 using System.Text;
 using System.Threading.Tasks;
@@ -41,7 +41,7 @@ namespace Elsa.Activities.Telnyx.Webhooks.Services
             
             if (!string.IsNullOrEmpty(correlationId))
             {
-                using var loggingScope = _logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId });
+                using var loggingScope = _logger.BeginScope(new TelnyxWebhookLogScope(correlationId));
                 _logger.LogDebug("Telnyx webhook payload received: {@Webhook}", webhook);
                 await _mediator.Publish(new TelnyxWebhookReceived(webhook), cancellationToken);
             }

--- a/src/activities/Elsa.Activities.Temporal.Quartz/Jobs/RunQuartzWorkflowInstanceJob.cs
+++ b/src/activities/Elsa.Activities.Temporal.Quartz/Jobs/RunQuartzWorkflowInstanceJob.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Elsa.Services;
 using Microsoft.Extensions.Logging;
@@ -24,7 +24,7 @@ namespace Elsa.Activities.Temporal.Quartz.Jobs
             var workflowInstanceId = dataMap.GetString("WorkflowInstanceId")!;
             var activityId = dataMap.GetString("ActivityId")!;
 
-            using var loggingScope = _logger.BeginScope(new Dictionary<string, object> { ["WorkflowInstanceId"] = workflowInstanceId });
+            using var loggingScope = _logger.BeginScope(new WorkflowInstanceLogScope(workflowInstanceId));
             await _workflowInstanceDispatcher.DispatchAsync(new ExecuteWorkflowInstanceRequest(workflowInstanceId, activityId), cancellationToken);
         }
     }

--- a/src/activities/Elsa.Activities.Temporal.Quartz/Services/QuartzWorkflowInstanceScheduler.cs
+++ b/src/activities/Elsa.Activities.Temporal.Quartz/Services/QuartzWorkflowInstanceScheduler.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Elsa.Activities.Temporal.Common.Services;
@@ -31,7 +31,7 @@ namespace Elsa.Activities.Temporal.Quartz.Services
 
         public async Task ScheduleAsync(string workflowInstanceId, string activityId, Instant startAt, Duration? interval, CancellationToken cancellationToken = default)
         {
-            using var loggingScope = _logger.BeginScope(new Dictionary<string, object> { ["WorkflowInstanceId"] = workflowInstanceId });
+            using var loggingScope = _logger.BeginScope(new WorkflowInstanceLogScope(workflowInstanceId));
             var triggerBuilder = CreateTrigger(workflowInstanceId, activityId).StartAt(startAt.ToDateTimeOffset());
 
             if (interval != null && interval != Duration.Zero)
@@ -43,14 +43,14 @@ namespace Elsa.Activities.Temporal.Quartz.Services
 
         public async Task ScheduleAsync(string workflowInstanceId, string activityId, string cronExpression, CancellationToken cancellationToken = default)
         {
-            using var loggingScope = _logger.BeginScope(new Dictionary<string, object> { ["WorkflowInstanceId"] = workflowInstanceId });
+            using var loggingScope = _logger.BeginScope(new WorkflowInstanceLogScope(workflowInstanceId));
             var trigger = CreateTrigger(workflowInstanceId, activityId).WithCronSchedule(cronExpression).Build();
             await ScheduleJob(trigger, cancellationToken);
         }
 
         public async Task UnscheduleAsync(string workflowInstanceId, string activityId, CancellationToken cancellationToken)
         {
-            using var loggingScope = _logger.BeginScope(new Dictionary<string, object> { ["WorkflowInstanceId"] = workflowInstanceId });
+            using var loggingScope = _logger.BeginScope(new WorkflowInstanceLogScope(workflowInstanceId));
             var scheduler = await _schedulerProvider.GetSchedulerAsync(cancellationToken);
             var trigger = CreateTriggerKey(workflowInstanceId, activityId);
             var existingTrigger = await scheduler.GetTrigger(trigger, cancellationToken);
@@ -61,7 +61,7 @@ namespace Elsa.Activities.Temporal.Quartz.Services
 
         public async Task UnscheduleAsync(string workflowInstanceId, CancellationToken cancellationToken)
         {
-            using var loggingScope = _logger.BeginScope(new Dictionary<string, object> { ["WorkflowInstanceId"] = workflowInstanceId });
+            using var loggingScope = _logger.BeginScope(new WorkflowInstanceLogScope(workflowInstanceId));
             var scheduler = await _schedulerProvider.GetSchedulerAsync(cancellationToken);
             var groupName = CreateTriggerGroupKey(workflowInstanceId);
             var existingTriggers = await scheduler.GetTriggerKeys(GroupMatcher<TriggerKey>.GroupEquals(groupName), cancellationToken);

--- a/src/activities/Elsa.Activities.Temporal.Quartz/WorkflowInstanceLogScope.cs
+++ b/src/activities/Elsa.Activities.Temporal.Quartz/WorkflowInstanceLogScope.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Elsa.Activities.Temporal.Quartz
+{
+    internal class WorkflowInstanceLogScope : IReadOnlyList<KeyValuePair<string, object?>>
+    {
+        private string? _cachedToString;
+
+        public string? WorkflowInstanceId { get; }
+
+        public WorkflowInstanceLogScope(string? workflowInstanceId) => this.WorkflowInstanceId = workflowInstanceId;
+
+        public int Count => string.IsNullOrEmpty(this.WorkflowInstanceId) ? 0 : 1;
+
+        public KeyValuePair<string, object?> this[int index]
+        {
+            get
+            {
+                if (index != 0 || this.Count == 0)
+                    throw new ArgumentOutOfRangeException(nameof(index));
+
+                return new(nameof(WorkflowInstanceId), WorkflowInstanceId);
+            }
+        }
+
+        public IEnumerator<KeyValuePair<string, object?>> GetEnumerator()
+        {
+            for (var i = 0; i < Count; i++) yield return this[i];
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public override string ToString()
+            => _cachedToString ??= FormattableString.Invariant($"{nameof(WorkflowInstanceId)}: {WorkflowInstanceId}");
+    }
+}

--- a/src/core/Elsa.Core/Services/Dispatch/QueuingWorkflowDispatcher.cs
+++ b/src/core/Elsa.Core/Services/Dispatch/QueuingWorkflowDispatcher.cs
@@ -30,7 +30,7 @@ namespace Elsa.Services.Dispatch
 
         public async Task DispatchAsync(ExecuteWorkflowInstanceRequest request, CancellationToken cancellationToken = default)
         {
-            using var loggingScope = _logger.BeginScope(new Dictionary<string, object> { ["WorkflowInstanceId"] = request.WorkflowInstanceId });
+            using var loggingScope = _logger.BeginScope(new WorkflowInstanceLogScope(request.WorkflowInstanceId));
             var workflowInstance = await _workflowInstanceStore.FindByIdAsync(request.WorkflowInstanceId, cancellationToken);
 
             if (workflowInstance == null)

--- a/src/core/Elsa.Core/Services/Workflows/WorkflowRunner.cs
+++ b/src/core/Elsa.Core/Services/Workflows/WorkflowRunner.cs
@@ -51,7 +51,7 @@ namespace Elsa.Services.Workflows
             string? activityId = default,
             CancellationToken cancellationToken = default)
         {
-            using var loggingScope = _logger.BeginScope(new Dictionary<string, object> { ["WorkflowInstanceId"] = workflowInstance.Id });
+            using var loggingScope = _logger.BeginScope(new WorkflowInstanceLogScope(workflowInstance.Id));
             await using var workflowExecutionScope = _serviceScopeFactory.CreateAsyncScope();
 
             var input = await _workflowStorageService.LoadAsync(workflowInstance, cancellationToken);

--- a/src/core/Elsa.Core/WorkflowInstanceLogScope.cs
+++ b/src/core/Elsa.Core/WorkflowInstanceLogScope.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Elsa
+{
+    internal class WorkflowInstanceLogScope : IReadOnlyList<KeyValuePair<string, object?>>
+    {
+        private string? _cachedToString;
+
+        public string? WorkflowInstanceId { get; }
+
+        public WorkflowInstanceLogScope(string? workflowInstanceId) => this.WorkflowInstanceId = workflowInstanceId;
+
+        public int Count => string.IsNullOrEmpty(this.WorkflowInstanceId) ? 0 : 1;
+
+        public KeyValuePair<string, object?> this[int index]
+        {
+            get
+            {
+                if (index != 0 || this.Count == 0)
+                    throw new ArgumentOutOfRangeException(nameof(index));
+
+                return new(nameof(WorkflowInstanceId), WorkflowInstanceId);
+            }
+        }
+
+        public IEnumerator<KeyValuePair<string, object?>> GetEnumerator()
+        {
+            for (var i = 0; i < Count; i++) yield return this[i];
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public override string ToString()
+            => _cachedToString ??= FormattableString.Invariant($"{nameof(WorkflowInstanceId)}: {WorkflowInstanceId}");
+    }
+}


### PR DESCRIPTION
For loggers such as the console logger just write the result of `ToString()` method (see [here](https://github.com/dotnet/runtime/blob/0589ce6c3022f4b9b7571268be5f97f45a003ad7/src/libraries/Microsoft.Extensions.Logging.Console/src/SimpleConsoleFormatter.cs#L207)).

Which results in it writing something like:
```
=> SpanId:f126fcaa1f140d25, TraceId:0bd70f4174cd963684d8fd55e4dc2ecb, ParentId:0000000000000000 => ConnectionId:0HMM16A1C5J1U => RequestPath:/test-path RequestId:0HMM16A1C5J1U:00000009 => System.Collections.Generic.Dictionary`2[System.String,System.Object]
```

Of note is the `System.Collections.Generic.Dictionary`2[System.String,System.Object]` part.

This just replaces those dictionaries with some concrete types (based on [aspnetcore/ConnectionLogScope.cs](https://github.com/dotnet/aspnetcore/blob/c85baf8db0c72ae8e68643029d514b2e737c9fae/src/SignalR/common/Http.Connections/src/Internal/ConnectionLogScope.cs)) to override the `ToString()` method and allow for better log messages.