### PR TITLE
Publish symbol packages to the v3 NuGet API.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -115,7 +115,7 @@ deploy:
         api_key:
             secure: uMFx5IwBzcjYIJVy+F+zbLl01Ei7MoxEOut9zWXVAu/SjaITJNTg6PAE1zFWi1TZ
         skip_symbols: false
-        symbol_server: https://www.nuget.org/api/v2/symbolpackage # remove to push symbols to SymbolSource.org
+        symbol_server: https://api.nuget.org/v3/index.json # remove to push symbols to SymbolSource.org
         artifact: /Elsa.*(\.|\.s)nupkg/
         on:
             APPVEYOR_REPO_TAG: true


### PR DESCRIPTION
The symbol packages don't seem to be available from nuget.org.

I can't verify that this fixes the issue as it requires actually pushing the packages but based on [How to publish NuGet symbol packages using the new symbol package format '.snupkg' | Microsoft Learn](https://learn.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg#publishing-a-symbol-package) it looks like this _might_ resolve the issue.