### PR TITLE
Allow sending input as http request body and output the response content

### DIFF
--- a/src/activities/Elsa.Activities.Http/Models/HttpContentData.cs
+++ b/src/activities/Elsa.Activities.Http/Models/HttpContentData.cs
@@ -1,0 +1,8 @@
+namespace Elsa.Activities.Http.Models
+{
+    public class HttpContentData
+    {
+        public string? ContentType { get; set; }
+        public object Content { get; set; }
+    }
+}


### PR DESCRIPTION
Our client has this specific requirement to fetch a file from an url, and then make a request to another url with that file attached as content. These changes aim to solve this.