### PR TITLE
fix EnumerableTypeDefinitionProvider #3477

### DIFF
--- a/src/scripting/Elsa.Scripting.JavaScript/Typings/EnumerableTypeDefinitionProvider.cs
+++ b/src/scripting/Elsa.Scripting.JavaScript/Typings/EnumerableTypeDefinitionProvider.cs
@@ -1,8 +1,8 @@
-﻿using System;
-using System.Collections;
-using System.Linq;
 using Elsa.Scripting.JavaScript.Services;
 using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections;
+using System.Linq;
 
 namespace Elsa.Scripting.JavaScript.Typings
 {
@@ -20,10 +20,13 @@ namespace Elsa.Scripting.JavaScript.Typings
         public override string GetTypeDefinition(TypeDefinitionContext context, Type type)
         {
             var providers = _serviceProvider.GetServices<ITypeDefinitionProvider>().Where(x => x is not EnumerableTypeDefinitionProvider).ToList();
+            var commonTypesProvider = providers.OfType<CommonTypeDefinitionProvider>().FirstOrDefault();
             var elementType = type.IsArray ? type.GetElementType()! : type.GetGenericArguments().FirstOrDefault();
-            var typeScriptType = elementType != null ? providers.FirstOrDefault(x => x.SupportsType(context, elementType))?.GetTypeDefinition(context, elementType) : null;
+            var typeScriptType = commonTypesProvider?.SupportsType(context, elementType) == true ?
+                commonTypesProvider.GetTypeDefinition(context, elementType) :
+                elementType.Name;
 
-            return typeScriptType == null ? "[]" : $"Array<{typeScriptType}>";
+            return $"{typeScriptType}[]";
         }
     }
 }

--- a/test/unit/Elsa.UnitTests/Scripting/JavaScript/Typings/EnumerableTypeDefinitionProviderTests.cs
+++ b/test/unit/Elsa.UnitTests/Scripting/JavaScript/Typings/EnumerableTypeDefinitionProviderTests.cs
@@ -1,0 +1,54 @@
+using AutoFixture;
+using AutoFixture.AutoMoq;
+using Elsa.Scripting.JavaScript.Services;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Xunit;
+
+namespace Elsa.Scripting.JavaScript.Typings
+{
+    public class EnumerableTypeDefinitionProviderTests
+    {
+        [Theory(DisplayName = "The EnumerableTypeDefinitionProvider should return valid typescript definition even for complex types")]
+        [InlineData(typeof(SomeComplexType[]), nameof(SomeComplexType))]
+        [InlineData(typeof(List<SomeComplexType>), nameof(SomeComplexType))]
+        [InlineData(typeof(Collection<SomeComplexType>), nameof(SomeComplexType))]
+        [InlineData(typeof(List<string>), "string")]
+        [InlineData(typeof(string[]), "string")]
+        [InlineData(typeof(int[]), "number")]
+        public void EnumerableTypeDefinitionProvider_if_provider_supports_collection_of_types(Type collectionType, string expectedElementType)
+        {
+            var serviceProvider = SetupTypeDefinitionProviders(new Fixture());
+
+            var sut = new EnumerableTypeDefinitionProvider(serviceProvider);
+
+            var result = sut.GetTypeDefinition(
+                new TypeDefinitionContext(default, default),
+                collectionType);
+
+            Assert.Equal($"{expectedElementType}[]", result);
+        }
+
+        private static IServiceProvider SetupTypeDefinitionProviders(IFixture fixture)
+        {
+            fixture.Customize(new AutoMoqCustomization());
+            var serviceProvider = fixture.Freeze<IServiceProvider>();
+            Mock.Get(serviceProvider)
+                .Setup(x => x.GetService(typeof(IEnumerable<ITypeDefinitionProvider>)))
+                .Returns(() => new ITypeDefinitionProvider[] {
+                    new BlacklistedTypeDefinitionProvider(),
+                    new EnumTypeDefinitionProvider(),
+                    new CommonTypeDefinitionProvider()
+                });
+            return serviceProvider;
+        }
+    }
+
+    internal class SomeComplexType
+    {
+        public string Name { get; set; }
+        public int Number { get; set; }
+    }
+}


### PR DESCRIPTION
This should fix #3477 
I'm quite new with xUnit, if the test could be better, please provide me some guidance.

Imho I found the design of the TypeDefinitionProvider a bit confusing: if I've understood it correctly, I would have preferred to split the responsibility of collecting types (`CollectTypes`) from that of returning the Typescript definition types (`SupportsType/GetTypeDefinition`); because they are not even cohesive responsibilities.
In fact, up to date, I don't see any providers that do both.