### PR TITLE
Allow handling SendHttpRequest content as bytes

### DIFF
--- a/src/activities/Elsa.Activities.Http/Activities/SendHttpRequest/SendHttpRequest.cs
+++ b/src/activities/Elsa.Activities.Http/Activities/SendHttpRequest/SendHttpRequest.cs
@@ -64,7 +64,7 @@ namespace Elsa.Activities.Http
         /// The body to send along with the request.
         /// </summary>
         [ActivityInput(Hint = "The HTTP content to send along with the request.", UIHint = ActivityInputUIHints.MultiLine, SupportedSyntaxes = new[] { SyntaxNames.JavaScript, SyntaxNames.Liquid })]
-        public string? Content { get; set; }
+        public object? Content { get; set; }
 
         /// <summary>
         /// The Content Type header to send along with the request body.
@@ -260,11 +260,17 @@ namespace Elsa.Activities.Http
 
             if (methodSupportsBody)
             {
-                var body = Content;
+                var bodyAsString = Content as string;
+                var bodyAsBytes = Content as byte[];
                 var contentType = ContentType;
 
-                if (!string.IsNullOrWhiteSpace(body))
-                    request.Content = new StringContent(body, Encoding.UTF8, contentType);
+                if (!string.IsNullOrWhiteSpace(bodyAsString))
+                    request.Content = new StringContent(bodyAsString, Encoding.UTF8, contentType);
+                else if (bodyAsBytes != null)
+                {
+                    request.Content = new ByteArrayContent(bodyAsBytes);
+                    request.Content.Headers.ContentType = MediaTypeHeaderValue.Parse(contentType);
+                }
             }
 
             if (!string.IsNullOrWhiteSpace(authorizationHeaderValue))


### PR DESCRIPTION
This is a continuation of the topic started with the previous PR, which I closed:
https://github.com/elsa-workflows/elsa-core/pull/3473
The picture below is the gist of it:
![image](https://user-images.githubusercontent.com/89777473/204794401-46820d36-2eae-4356-97b4-35e98650fdaf.png)

It turns out, that by using javascript in the content field, we can take the output of the previous SendHttpRequest, and put it into the body. However, since the Content field currently is a string, the file data will get corrupt in the middle of the conversion, even if we use something like `String.fromCharCode.apply(null, activities.PictureGet.ResponseContent())` to turn the bytes into string.

But this is issue is easily solved, by turning Content into object, and then check by type whether to send as string or as byte array.