### PR TITLE
Make improvements related to x6 graphs

### DIFF
--- a/src/designer/bindings/aspnet/Elsa.Designer.Components.Web/Elsa.Designer.Components.Web.csproj
+++ b/src/designer/bindings/aspnet/Elsa.Designer.Components.Web/Elsa.Designer.Components.Web.csproj
@@ -11,10 +11,6 @@
         </Description>
         <PackageTags>elsa, workflows, aspnet, aspnetcore, blazor, html</PackageTags>
     </PropertyGroup>
-
-    <PropertyGroup>
-        <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
-    </PropertyGroup>
     
     <ItemGroup>
         <SupportedPlatform Include="browser" />

--- a/src/designer/bindings/aspnet/Elsa.Designer.Components.Web/Elsa.Designer.Components.Web.csproj
+++ b/src/designer/bindings/aspnet/Elsa.Designer.Components.Web/Elsa.Designer.Components.Web.csproj
@@ -11,6 +11,10 @@
         </Description>
         <PackageTags>elsa, workflows, aspnet, aspnetcore, blazor, html</PackageTags>
     </PropertyGroup>
+
+    <PropertyGroup>
+        <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+    </PropertyGroup>
     
     <ItemGroup>
         <SupportedPlatform Include="browser" />

--- a/src/designer/elsa-workflows-studio/src/components.d.ts
+++ b/src/designer/elsa-workflows-studio/src/components.d.ts
@@ -1282,6 +1282,7 @@ declare namespace LocalJSX {
     }
     interface ElsaWorkflowPublishButton {
         "culture"?: string;
+        "onDeleteClicked"?: (event: CustomEvent<any>) => void;
         "onExportClicked"?: (event: CustomEvent<any>) => void;
         "onImportClicked"?: (event: CustomEvent<File>) => void;
         "onPublishClicked"?: (event: CustomEvent<any>) => void;

--- a/src/designer/elsa-workflows-studio/src/components/designers/x6-designer/x6-designer.css
+++ b/src/designer/elsa-workflows-studio/src/components/designers/x6-designer/x6-designer.css
@@ -64,12 +64,12 @@
 }
 
 /* Custom selection box, that does not block creating connections from the nodes */
-g.x6-node-selected body:after {
+.x6-node-selected elsa-default-activity-template:after {
+  content: '';
   width: calc(100% + 8px);
   height: calc(100% + 8px);
   top: -4px;
   left: -4px;
-  content: '';
   position: absolute;
   border: 2px dashed #feb663;
 }

--- a/src/designer/elsa-workflows-studio/src/components/designers/x6-designer/x6-designer.tsx
+++ b/src/designer/elsa-workflows-studio/src/components/designers/x6-designer/x6-designer.tsx
@@ -267,6 +267,7 @@ export class ElsaWorkflowDesigner {
     console.log("Auto-layout applied");
   };
   connectedCallback() {
+    eventBus.on(EventTypes.WorkflowImported, this.onWorkflowImported);
     eventBus.on(EventTypes.ActivityPicked, this.onActivityPicked);
     eventBus.on(EventTypes.UpdateActivity, this.onUpdateActivityExternal);
     //eventBus.on(EventTypes.PasteActivity, this.onPasteActivity);
@@ -276,6 +277,7 @@ export class ElsaWorkflowDesigner {
   }
 
   disconnectedCallback() {
+    eventBus.detach(EventTypes.WorkflowImported, this.onWorkflowImported);
     eventBus.detach(EventTypes.ActivityPicked, this.onActivityPicked);
     eventBus.detach(EventTypes.UpdateActivity, this.onUpdateActivityExternal);
     //eventBus.detach(EventTypes.PasteActivity, this.onPasteActivity);
@@ -285,6 +287,7 @@ export class ElsaWorkflowDesigner {
   }
 
   componentWillLoad() {
+    console.info("WILL LOAD");
     this.workflowModel = this.model;
   }
 
@@ -589,6 +592,7 @@ export class ElsaWorkflowDesigner {
   }
 
   private updateGraph = async () => {
+    console.info("UPDATING GRAPH:", this.workflowModel);
     const activities = this.workflowModel.activities;
     const connections = this.workflowModel.connections;
     const edges: Array<Edge.Metadata> = [];
@@ -843,6 +847,12 @@ export class ElsaWorkflowDesigner {
   async showActivityPicker() {
     await eventBus.emit(EventTypes.ShowActivityPicker);
   }
+
+  onWorkflowImported = args => {
+    this.workflowModel = args;
+    this.updateGraph();
+    this.graph.scrollToContent();
+  };
 
   onActivityPicked = async args => {
     const activityDescriptor = args as ActivityDescriptor;

--- a/src/designer/elsa-workflows-studio/src/components/designers/x6-designer/x6-designer.tsx
+++ b/src/designer/elsa-workflows-studio/src/components/designers/x6-designer/x6-designer.tsx
@@ -52,6 +52,7 @@ export class ElsaWorkflowDesigner {
   containerObserver: ResizeObserver;
   activityDisplayContexts: Map<ActivityDesignDisplayContext> = null;
   workflowSaveTimer?: NodeJS.Timer = null;
+  edgeUpdateTimer?: NodeJS.Timer = null;
 
   @Prop() model: WorkflowModel = {
     activities: [],
@@ -102,18 +103,6 @@ export class ElsaWorkflowDesigner {
     y: 0,
     activity: null,
   };
-
-  @Watch('selectedActivityIds')
-  handleSelectedActivityIdsChanged(newValue: Array<string>) {
-    const ids = newValue || [];
-    const selectedActivities = this.workflowModel.activities.filter(x => ids.includes(x.activityId));
-    const map: Map<ActivityModel> = {};
-
-    for (const activity of selectedActivities)
-      map[activity.activityId] = activity;
-
-    this.selectedActivities = map;
-  }
 
   @Watch('activityContextMenu')
   handleActivityContextMenuChanged(newValue: ActivityContextMenuState) {
@@ -235,7 +224,7 @@ export class ElsaWorkflowDesigner {
 
   applyAutoLayout() {
     const graph = new dagre.graphlib.Graph();
-    graph.setGraph({ rankdir: "TB", nodesep: 15, ranksep: 30, align: "UL" });
+    graph.setGraph({ rankdir: "TB", nodesep: 30, ranksep: 140, align: "UL" });
 
     graph.setDefaultEdgeLabel(() => ({}));
 
@@ -244,7 +233,7 @@ export class ElsaWorkflowDesigner {
       graph.setNode(activity.activityId, {
         label: activity.activityId,
         width: Math.max(220, activityElement.width),
-        height: Math.max(64, activityElement.height) + 24
+        height: Math.max(64, activityElement.height)
       });
     });
 
@@ -256,23 +245,24 @@ export class ElsaWorkflowDesigner {
 
     this.disableEvents();
 
-    this.workflowModel.activities.forEach(activity => {
-      const node = graph.node(activity.activityId);
+    this.graph.batchUpdate(() => {
+      this.workflowModel.activities.forEach(activity => {
+        const node = graph.node(activity.activityId);
+        const cell = this.graph.getCellById(activity.activityId);
 
-      const cell = this.graph.getCellById(activity.activityId);
-      const deltaX = node.x - activity.x;
-      const deltaY = node.y - activity.y;
-      this.graph.positionCell(cell.translate(deltaX, deltaY), "top-left");
+        cell.setProp('position', { x: node.x, y: node.y });
 
-      const position = (cell as any).position({ relative: false });
-      activity.x = Math.round(position.x);
-      activity.y = Math.round(position.y);
+        activity.x = Math.round(node.x);
+        activity.y = Math.round(node.y);
 
-      (cell as any).activity = activity;
+        (cell as any).activity = activity;
+      });
     });
 
     this.graph.scrollToContent();
     this.enableEvents(true);
+
+    setTimeout(() => this.updateGraphEdgeViews(), 100);
 
     console.log("Auto-layout applied");
   };
@@ -486,6 +476,21 @@ export class ElsaWorkflowDesigner {
     return node;
   }
 
+  private getEdgeStep = (targetId: string) => {
+    // The purpose of this function is to prevent connections from overlapping because of their target nodes being on the same height
+    const targetNode = this.workflowModel.activities.find(x => x.activityId === targetId);
+    let step = 10;
+    if (targetNode) {
+      const sameHeightNodes = this.workflowModel.activities
+        .filter(x => Math.abs(x.y - targetNode.y) < 20)
+        .sort((a, b) => a.activityId > b.activityId ? 1 : -1);
+      if (sameHeightNodes.length > 1) {
+        step += sameHeightNodes.findIndex(x => x.activityId == targetNode.activityId) * 20;
+      }
+    }
+    return step;
+  }
+
   private createEdge = (connection: ConnectionModel): Edge.Metadata => {
     return {
       shape: 'elsa-edge',
@@ -496,6 +501,7 @@ export class ElsaWorkflowDesigner {
       target: connection.targetId,
       targetPort: connection.targetPort,
       outcome: connection.outcome,
+      router: this.createEdgeRouter(connection.sourceId, connection.targetId),
       labels:
         [{
           attrs: {
@@ -503,6 +509,19 @@ export class ElsaWorkflowDesigner {
           },
         }],
     };
+  }
+
+  private createEdgeRouter = (sourceId: string, targetId: string) => {
+    const sourceNode = this.activityDisplayContexts[sourceId];
+    return {
+      name: 'manhattan',
+      args: {
+        padding: 10,
+        step: this.getEdgeStep(targetId),
+        startDirections: (sourceNode?.outcomes.length > 3) ? ['bottom'] : ['right'],
+        endDirections: ['left']
+      },
+    }
   }
 
   async getActivityDisplayContext(activityModel: ActivityModel): Promise<ActivityDesignDisplayContext> {
@@ -532,6 +551,8 @@ export class ElsaWorkflowDesigner {
       return;
     }
 
+    this.updateGraphEdgeViews();
+
     const graph = this.graph;
     const graphModel = graph.toJSON();
     const activities = graphModel.cells.filter(x => x.shape == 'activity').map(x => x.activity as ActivityModel);
@@ -546,6 +567,25 @@ export class ElsaWorkflowDesigner {
       persistenceBehavior: WorkflowPersistenceBehavior.WorkflowBurst
     };
     this.updateWorkflowModel(workflowModel);
+  }
+
+  private updateGraphEdgeViews = () => {
+    // This updates the connection routing between nodes, when one node gets moved for example
+
+    this.disableEvents();
+    if (this.edgeUpdateTimer) {
+      clearTimeout(this.edgeUpdateTimer);
+    }
+    this.edgeUpdateTimer = setTimeout(() => {
+      this.edgeUpdateTimer = null;
+      const edges = this.graph.getCells().filter(x => x.shape == 'elsa-edge') as any[];
+      for(const edge of edges) {
+        edge.router = this.createEdgeRouter(edge.source.cell, edge.target.cell);
+        (this.graph.findViewByCell(edge.id) as any).update();
+      }
+    }, 10);
+
+    this.enableEvents(false);
   }
 
   private updateGraph = async () => {
@@ -574,36 +614,6 @@ export class ElsaWorkflowDesigner {
   }
 
   private findActivityById = (id: string): ActivityModel => this.workflowModel.activities.find(x => x.activityId === id);
-
-  async addActivitiesFromClipboard(copiedActivities: Array<ActivityModel>) {
-    let sourceActivityId: string;
-    this.parentActivityId = null;
-    this.parentActivityOutcome = null;
-
-    for (const key in this.selectedActivities) {
-      sourceActivityId = this.selectedActivities[key].activityId;
-    }
-
-    if (sourceActivityId != undefined) {
-      this.parentActivityId = sourceActivityId;
-      this.parentActivityOutcome = this.selectedActivities[sourceActivityId].outcomes[0];
-    }
-
-    for (const key in copiedActivities) {
-      this.addingActivity = true;
-      copiedActivities[key].activityId = uuid();
-
-      await eventBus.emit(EventTypes.UpdateActivity, this, copiedActivities[key]);
-
-      this.parentActivityId = copiedActivities[key].activityId;
-      this.parentActivityOutcome = copiedActivities[key].outcomes[0];
-    }
-
-    this.selectedActivities = {};
-    // Set to null to avoid conflict with on Activity node click event
-    this.parentActivityId = null;
-    this.parentActivityOutcome = null;
-  }
 
   createNotFoundActivityDescriptor(activityModel: ActivityModel): ActivityDescriptor {
     return {
@@ -638,7 +648,7 @@ export class ElsaWorkflowDesigner {
       }
       this.workflowSaveTimer = setTimeout(() => {
         this.workflowChanged.emit(this.workflowModel);
-      }, 100);
+      }, 200);
     }
   }
 
@@ -946,10 +956,10 @@ export class ElsaWorkflowDesigner {
         }
         {this.mode == WorkflowDesignerMode.Test ?
           <div>
-            <div id="left" style={{'z-index': '1', border:`4px solid orange`, position:`fixed`, height: `calc(100vh - 64px)`, width:`4px`, top:`64px`, bottom:`0`, left:`0`}}/>
-            <div id="right" style={{'z-index': '1', border:`4px solid orange`, position:`fixed`, height: `calc(100vh - 64px)`, width:`4px`, top:`64px`, bottom:`0`, right:`0`}}/>
-            <div id="top" style={{'z-index': '1', border:`4px solid orange`, position:`fixed`, height:`4px`, left:`0`, right:`0`, top:`64px`}}/>
-            <div id="bottom" style={{'z-index': '1', border:`4px solid orange`, position:`fixed`, height:`4px`, left:`0`, right:`0`, bottom:`0`}}/>
+            <div id="left" style={{'z-index': '1', border:`4px solid orange`, position:`absolute`, height: `calc(100vh - 64px)`, width:`4px`, top:`0`, bottom:`0`, left:`0`}}/>
+            <div id="right" style={{'z-index': '1', border:`4px solid orange`, position:`absolute`, height: `calc(100vh - 64px)`, width:`4px`, top:`0`, bottom:`0`, right:`0`}}/>
+            <div id="top" style={{'z-index': '1', border:`4px solid orange`, position:`absolute`, height:`4px`, left:`0`, right:`0`, top:`0`}}/>
+            <div id="bottom" style={{'z-index': '1', border:`4px solid orange`, position:`absolute`, height:`4px`, left:`0`, right:`0`, bottom:`0`}}/>
           </div>
           :
           undefined

--- a/src/designer/elsa-workflows-studio/src/components/designers/x6-designer/x6-designer.tsx
+++ b/src/designer/elsa-workflows-studio/src/components/designers/x6-designer/x6-designer.tsx
@@ -287,7 +287,6 @@ export class ElsaWorkflowDesigner {
   }
 
   componentWillLoad() {
-    console.info("WILL LOAD");
     this.workflowModel = this.model;
   }
 
@@ -592,7 +591,6 @@ export class ElsaWorkflowDesigner {
   }
 
   private updateGraph = async () => {
-    console.info("UPDATING GRAPH:", this.workflowModel);
     const activities = this.workflowModel.activities;
     const connections = this.workflowModel.connections;
     const edges: Array<Edge.Metadata> = [];

--- a/src/designer/elsa-workflows-studio/src/components/screens/workflow-definition-editor/elsa-workflow-definition-editor-screen/elsa-workflow-definition-editor-screen.tsx
+++ b/src/designer/elsa-workflows-studio/src/components/screens/workflow-definition-editor/elsa-workflow-definition-editor-screen/elsa-workflow-definition-editor-screen.tsx
@@ -133,7 +133,7 @@ export class ElsaWorkflowDefinitionEditorScreen {
       this.importing = false;
       this.imported = true;
       setTimeout(() => (this.imported = false), 500);
-      await eventBus.emit(EventTypes.WorkflowImported, this, this.workflowDefinition);
+      await eventBus.emit(EventTypes.WorkflowImported, this, this.workflowModel);
     } catch (e) {
       console.error(e);
       this.importing = false;

--- a/src/designer/elsa-workflows-studio/src/components/screens/workflow-definition-editor/elsa-workflow-definition-editor-screen/elsa-workflow-definition-editor-screen.tsx
+++ b/src/designer/elsa-workflows-studio/src/components/screens/workflow-definition-editor/elsa-workflow-definition-editor-screen/elsa-workflow-definition-editor-screen.tsx
@@ -94,6 +94,7 @@ export class ElsaWorkflowDefinitionEditorScreen {
   helpDialog: HTMLElsaModalDialogElement;
   activityContextMenu: HTMLDivElement;
   componentCustomButton: HTMLDivElement;
+  confirmDialog: HTMLElsaConfirmDialogElement;
 
   //connectionContextMenu: HTMLDivElement;
 
@@ -487,6 +488,18 @@ export class ElsaWorkflowDefinitionEditorScreen {
     await eventBus.emit(EventTypes.ShowWorkflowSettings);
   }
 
+  async onDeleteClicked() {
+    const t = this.t;
+    const result = await this.confirmDialog.show(t('DeleteConfirmationModel.Title'), t('DeleteConfirmationModel.Message'));
+
+    if (!result)
+      return;
+
+    const elsaClient = await createElsaClient(this.serverUrl);
+    await elsaClient.workflowDefinitionsApi.delete(this.workflowDefinition.definitionId, {allVersions: true});
+    this.history.push(`${this.basePath}/workflow-definitions`, {});
+  }
+
   async onPublishClicked() {
     await this.publishWorkflow();
   }
@@ -748,6 +761,7 @@ export class ElsaWorkflowDefinitionEditorScreen {
           </div>
         </div>
         {this.renderTestActivityMenu()}
+        <elsa-confirm-dialog ref={el => this.confirmDialog = el} culture={this.culture}/>
       </div>
     );
   }
@@ -1136,6 +1150,7 @@ export class ElsaWorkflowDefinitionEditorScreen {
         onRevertClicked={() => this.onRevertClicked()}
         onExportClicked={() => this.onExportClicked()}
         onImportClicked={e => this.onImportClicked(e.detail)}
+        onDeleteClicked={e => this.onDeleteClicked()}
         culture={this.culture}
       />
     );

--- a/src/designer/elsa-workflows-studio/src/components/screens/workflow-definition-editor/elsa-workflow-definition-editor-screen/elsa-workflow-definition-editor-screen.tsx
+++ b/src/designer/elsa-workflows-studio/src/components/screens/workflow-definition-editor/elsa-workflow-definition-editor-screen/elsa-workflow-definition-editor-screen.tsx
@@ -216,6 +216,25 @@ export class ElsaWorkflowDefinitionEditorScreen {
     }
   }
 
+  componentDidRender() {
+    if (this.el && this.componentCustomButton) {
+      let modalX = this.activityContextMenuTestState.x + 64;
+      let modalY = this.activityContextMenuTestState.y - 256;
+
+      // Fit the modal to the canvas bounds
+      const canvasBounds = this.el?.getBoundingClientRect();
+      const modalBounds = this.componentCustomButton.getBoundingClientRect();
+      const modalWidth = modalBounds?.width;
+      const modalHeight = modalBounds?.height;
+      modalX = Math.min(canvasBounds.width, modalX + modalWidth + 32) - modalWidth - 32;
+      modalY = Math.min(canvasBounds.height, modalY + modalHeight) - modalHeight - 32;
+      modalY = Math.max(0, modalY);
+
+      this.componentCustomButton.style.left = `${modalX}px`;
+      this.componentCustomButton.style.top = `${modalY}px`;
+    }
+  }
+
   connectedCallback() {
     eventBus.on(EventTypes.UpdateWorkflowSettings, this.onUpdateWorkflowSettings);
     eventBus.on(EventTypes.FlyoutPanelTabSelected, this.onFlyoutPanelTabSelected);
@@ -844,7 +863,7 @@ export class ElsaWorkflowDefinitionEditorScreen {
           {collection.map(filteredData, (v, k) => (
             <div class="elsa-ml-4">
               <p class="elsa-text-base elsa-font-medium elsa-text-gray-900">{k}</p>
-              <pre class="elsa-mt-1 elsa-text-sm elsa-text-gray-500 elsa-overflow-x-auto">{v}</pre>
+              <pre class="elsa-mt-1 elsa-text-sm elsa-text-gray-500 elsa-overflow-x-auto" style={{ "max-width": "30rem"}}>{v}</pre>
             </div>
           ))}
           {hasBody ? renderComponentCustomButton() : undefined}
@@ -891,7 +910,7 @@ export class ElsaWorkflowDefinitionEditorScreen {
         }}
         ref={el => (this.componentCustomButton = el)}
       >
-        <div class="elsa-rounded-lg elsa-shadow-lg elsa-ring-1 elsa-ring-black elsa-ring-opacity-5 elsa-overflow-hidden">{!!message ? renderMessage() : renderLoader()}</div>
+        <div class="elsa-rounded-lg elsa-shadow-lg elsa-ring-1 elsa-ring-black elsa-ring-opacity-5 elsa-overflow-x-hidden elsa-overflow-y-auto" style={{ "max-height": "700px" }}>{!!message ? renderMessage() : renderLoader()}</div>
       </div>
     );
   };

--- a/src/designer/elsa-workflows-studio/src/components/screens/workflow-definition-editor/elsa-workflow-definition-editor-screen/localizations.ts
+++ b/src/designer/elsa-workflows-studio/src/components/screens/workflow-definition-editor/elsa-workflow-definition-editor-screen/localizations.ts
@@ -11,7 +11,11 @@ export const resources = {
       "ConnectionContextMenu": {
         "Paste": "Paste",
       },
-      'Restart': 'Restart'
+      'Restart': 'Restart',
+      'DeleteConfirmationModel': {
+        'Title': 'Delete Workflow Definition',
+        'Message': 'Are you sure you wish to permanently delete this workflow, including all of its workflow instances?'
+      }
     }
   },
   'zh-CN': {
@@ -26,7 +30,11 @@ export const resources = {
       "ConnectionContextMenu": {
         "Paste": "粘贴",
       },
-      'Restart': '重启'
+      'Restart': '重启',
+      'DeleteConfirmationModel': {
+        'Title': '删除工作流程定义',
+        'Message': '你确定要永久删除这个工作流程，包括它的所有工作流程实例？'
+      }
     }
   },
   'nl-NL': {
@@ -41,7 +49,11 @@ export const resources = {
       "ConnectionContextMenu": {
         "Paste": "Plakken",
       },
-      'Restart': 'Herstarten'
+      'Restart': 'Herstarten',
+      'DeleteConfirmationModel': {
+        'Title': 'Verwijder Workflow Definitie',
+        'Message': 'Weet je zeker dat je deze workflow permanent wilt verwijderen, inclusief alle bijbehorende workflow instanties?'
+      }
     }
   },
   'fa-IR': {
@@ -56,7 +68,11 @@ export const resources = {
       "ConnectionContextMenu": {
         "Paste": "Paste",
       },
-      'Restart': 'راه اندازی مجدد'
+      'Restart': 'راه اندازی مجدد',
+      'DeleteConfirmationModel': {
+        'Title': 'حذف تعریف فرآیند',
+        'Message': 'آیا از حذف این فرآیند و همه جریانهای آن اطمینان دارید?'
+      }
     }
   },
   'de-DE': {
@@ -71,7 +87,11 @@ export const resources = {
       "ConnectionContextMenu": {
         "Paste": "Einfügen",
       },
-      'Restart': 'Neustarten'
+      'Restart': 'Neustarten',
+      'DeleteConfirmationModel': {
+        'Title': 'Ablaufdefinition entfernen',
+        'Message': 'Sind Sie sicher, dass sie die Definition und die dazugehörigen Instanzen unwiderruflich löschen wollen?'
+      }
     }
   },
 };

--- a/src/designer/elsa-workflows-studio/src/components/screens/workflow-definition-editor/elsa-workflow-publish-button/elsa-workflow-publish-button.tsx
+++ b/src/designer/elsa-workflows-studio/src/components/screens/workflow-definition-editor/elsa-workflow-publish-button/elsa-workflow-publish-button.tsx
@@ -20,6 +20,7 @@ export class ElsaWorkflowPublishButton {
   @Event({bubbles: true}) revertClicked: EventEmitter;
   @Event({bubbles: true}) exportClicked: EventEmitter;
   @Event({bubbles: true}) importClicked: EventEmitter<File>;
+  @Event({bubbles: true}) deleteClicked: EventEmitter;
 
   i18next: i18n;
   menu: HTMLElement;
@@ -80,6 +81,14 @@ export class ElsaWorkflowPublishButton {
     leave(this.menu);
   }
 
+  onDeleteClick = async (e: Event) => {
+    e.preventDefault();
+
+    this.deleteClicked.emit();
+
+    leave(this.menu);
+  }
+
   async onFileInputChange(e: Event) {
     const files = this.fileInput.files;
 
@@ -122,6 +131,10 @@ export class ElsaWorkflowPublishButton {
 
                   <a href="#" onClick={e => this.onImportClick(e)} class="elsa-block elsa-px-4 elsa-py-2 elsa-text-sm elsa-text-gray-700 hover:elsa-bg-gray-100 hover:elsa-text-gray-900" role="menuitem">
                     {t('Import')}
+                  </a>
+
+                  <a href="#" onClick={e => this.onDeleteClick(e)} class="elsa-block elsa-px-4 elsa-py-2 elsa-text-sm elsa-text-red-700 hover:elsa-bg-gray-100 hover:elsa-text-gray-900" role="menuitem">
+                    {t('Delete')}
                   </a>
                 </div>
               </div>

--- a/src/designer/elsa-workflows-studio/src/components/screens/workflow-instance-viewer/elsa-workflow-instance-viewer-screen/elsa-workflow-instance-viewer-screen.tsx
+++ b/src/designer/elsa-workflows-studio/src/components/screens/workflow-instance-viewer/elsa-workflow-instance-viewer-screen/elsa-workflow-instance-viewer-screen.tsx
@@ -146,6 +146,25 @@ export class ElsaWorkflowInstanceViewerScreen {
     }
   }
 
+  componentDidRender() {
+    if (this.el && this.contextMenu) {
+      let modalX = this.activityContextMenuState.x + 64;
+      let modalY = this.activityContextMenuState.y - 256;
+
+      // Fit the modal to the canvas bounds
+      const canvasBounds = this.el?.getBoundingClientRect();
+      const modalBounds = this.contextMenu.getBoundingClientRect();
+      const modalWidth = modalBounds?.width;
+      const modalHeight = modalBounds?.height;
+      modalX = Math.min(canvasBounds.width, modalX + modalWidth + 32) - modalWidth - 32;
+      modalY = Math.min(canvasBounds.height, modalY + modalHeight) - modalHeight - 32;
+      modalY = Math.max(0, modalY);
+
+      this.contextMenu.style.left = `${modalX}px`;
+      this.contextMenu.style.top = `${modalY}px`;
+    }
+  }
+
   async loadActivityDescriptors() {
     const client = await createElsaClient(this.serverUrl);
     state.activityDescriptors = await client.activitiesApi.list();

--- a/src/designer/elsa-workflows-studio/src/globals/tailwind.css
+++ b/src/designer/elsa-workflows-studio/src/globals/tailwind.css
@@ -2478,12 +2478,12 @@ select {
   right: 0px;
 }
 
-.elsa-right-1 {
-  right: 0.25rem;
+.elsa-top-8 {
+  top: 2rem;
 }
 
-.elsa-right-1\/2 {
-  right: 50%;
+.elsa-right-1 {
+  right: 0.25rem;
 }
 
 .elsa-top-20 {
@@ -2492,10 +2492,6 @@ select {
 
 .elsa-top-4 {
   top: 1rem;
-}
-
-.elsa-top-8 {
-  top: 2rem;
 }
 
 .elsa-bottom-0 {
@@ -2532,10 +2528,6 @@ select {
 
 .elsa-right-10 {
   right: 2.5rem;
-}
-
-.elsa-z-1 {
-  z-index: 1;
 }
 
 .elsa-z-10 {
@@ -2895,10 +2887,6 @@ select {
   max-width: 65ch;
 }
 
-.elsa-flex-auto {
-  flex: 0 0 auto;
-}
-
 .elsa-flex-1 {
   flex: 1 1 0%;
 }
@@ -2923,11 +2911,6 @@ select {
 .elsa-translate-x-0 {
   --tw-translate-x: 0px;
   transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
-}
-
-
-.elsa-translate-x--1\/2 {
-  transform: translateX(-50%);
 }
 
 .elsa-translate-y-4 {
@@ -3071,6 +3054,12 @@ select {
   row-gap: 2rem;
 }
 
+.elsa-space-x-4 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(1rem * var(--tw-space-x-reverse));
+  margin-left: calc(1rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
 .elsa-space-x-8 > :not([hidden]) ~ :not([hidden]) {
   --tw-space-x-reverse: 0;
   margin-right: calc(2rem * var(--tw-space-x-reverse));
@@ -3099,12 +3088,6 @@ select {
   --tw-space-x-reverse: 0;
   margin-right: calc(2.5rem * var(--tw-space-x-reverse));
   margin-left: calc(2.5rem * calc(1 - var(--tw-space-x-reverse)));
-}
-
-.elsa-space-x-4 > :not([hidden]) ~ :not([hidden]) {
-  --tw-space-x-reverse: 0;
-  margin-right: calc(1rem * var(--tw-space-x-reverse));
-  margin-left: calc(1rem * calc(1 - var(--tw-space-x-reverse)));
 }
 
 .elsa-space-y-3 > :not([hidden]) ~ :not([hidden]) {
@@ -3501,6 +3484,10 @@ select {
   overflow-y: auto;
 }
 
+.elsa-overflow-x-hidden {
+  overflow-x: hidden;
+}
+
 .elsa-overflow-x-scroll {
   overflow-x: scroll;
 }
@@ -3558,12 +3545,12 @@ select {
   border-width: 1px;
 }
 
-.elsa-border-0 {
-  border-width: 0px;
-}
-
 .elsa-border-2 {
   border-width: 2px;
+}
+
+.elsa-border-0 {
+  border-width: 0px;
 }
 
 .elsa-border-t {
@@ -8072,6 +8059,11 @@ select {
   padding-bottom: 0.75rem;
 }
 
+.elsa-px-6 {
+  padding-left: 1.5rem;
+  padding-right: 1.5rem;
+}
+
 .elsa-py-8 {
   padding-top: 2rem;
   padding-bottom: 2rem;
@@ -8090,11 +8082,6 @@ select {
 .elsa-px-1 {
   padding-left: 0.25rem;
   padding-right: 0.25rem;
-}
-
-.elsa-px-6 {
-  padding-left: 1.5rem;
-  padding-right: 1.5rem;
 }
 
 .elsa-px-8 {
@@ -8136,6 +8123,10 @@ select {
 
 .elsa-pt-1 {
   padding-top: 0.25rem;
+}
+
+.elsa-pr-3 {
+  padding-right: 0.75rem;
 }
 
 .elsa-pt-4 {
@@ -8204,10 +8195,6 @@ select {
 
 .elsa-pr-2 {
   padding-right: 0.5rem;
-}
-
-.elsa-pr-3 {
-  padding-right: 0.75rem;
 }
 
 .elsa-pl-8 {
@@ -8295,12 +8282,12 @@ select {
   line-height: 1.25rem;
 }
 
-.elsa-leading-4 {
-  line-height: 1rem;
-}
-
 .elsa-leading-8 {
   line-height: 2rem;
+}
+
+.elsa-leading-4 {
+  line-height: 1rem;
 }
 
 .elsa-tracking-wider {
@@ -12065,12 +12052,8 @@ svg.jtk-connector.jtk-hover path {
   color: rgb(96 165 250 / var(--tw-text-opacity));
 }
 
-svg.jtk-connector.jtk-hover::before {
-  display: block;
-  width: 4px;
-  height: 4px;
-  background: red;
-  content: '';
+.jtk-endpoint {
+  z-index: 3;
 }
 
 .elsa-w-2-5 {
@@ -12087,20 +12070,19 @@ svg.jtk-connector.jtk-hover::before {
   margin-left: calc(0.125rem * calc(1 - var(--tw-space-x-reverse)));
 }
 
-.node.activity, .node.start, .node.add .label-container {
+.node.activity,
+.node.start,
+.node.add .label-container {
   fill: transparent;
 }
 
-.node.activity .label-container, .node.start .label-container {
+.node.activity .label-container,
+.node.start .label-container {
   stroke: none;
 }
 
 .hidden {
   display: none;
-}
-
-.elsa-break-words {
-  overflow-wrap: break-word;
 }
 
 .focus-within\:elsa-text-gray-600:focus-within {
@@ -12143,6 +12125,16 @@ svg.jtk-connector.jtk-hover::before {
   background-color: rgb(29 78 216 / var(--tw-bg-opacity));
 }
 
+.hover\:elsa-bg-green-500:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(34 197 94 / var(--tw-bg-opacity));
+}
+
+.hover\:elsa-bg-yellow-500:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(234 179 8 / var(--tw-bg-opacity));
+}
+
 .hover\:elsa-bg-red-700:hover {
   --tw-bg-opacity: 1;
   background-color: rgb(185 28 28 / var(--tw-bg-opacity));
@@ -12151,11 +12143,6 @@ svg.jtk-connector.jtk-hover::before {
 .hover\:elsa-bg-gray-700:hover {
   --tw-bg-opacity: 1;
   background-color: rgb(55 65 81 / var(--tw-bg-opacity));
-}
-
-.hover\:elsa-bg-green-500:hover {
-  --tw-bg-opacity: 1;
-  background-color: rgb(34 197 94 / var(--tw-bg-opacity));
 }
 
 .hover\:elsa-text-gray-500:hover {
@@ -12233,6 +12220,11 @@ svg.jtk-connector.jtk-hover::before {
 .focus\:elsa-border-green-700:focus {
   --tw-border-opacity: 1;
   border-color: rgb(21 128 61 / var(--tw-border-opacity));
+}
+
+.focus\:elsa-border-yellow-50:focus {
+  --tw-border-opacity: 1;
+  border-color: rgb(254 252 232 / var(--tw-border-opacity));
 }
 
 .focus\:elsa-bg-gray-100:focus {
@@ -12320,6 +12312,11 @@ svg.jtk-connector.jtk-hover::before {
 .active\:elsa-bg-green-700:active {
   --tw-bg-opacity: 1;
   background-color: rgb(21 128 61 / var(--tw-bg-opacity));
+}
+
+.active\:elsa-bg-yellow-500:active {
+  --tw-bg-opacity: 1;
+  background-color: rgb(234 179 8 / var(--tw-bg-opacity));
 }
 
 .active\:elsa-text-gray-700:active {

--- a/src/designer/elsa-workflows-studio/stencil.config.dist.ts
+++ b/src/designer/elsa-workflows-studio/stencil.config.dist.ts
@@ -3,13 +3,12 @@ import { postcss } from '@stencil/postcss';
 import postcssImport from 'postcss-import';
 import tailwindcss from 'tailwindcss';
 import cssnano from 'cssnano';
-import replace from '@rollup/plugin-replace';
 
 // @ts-ignore
 const purgecss = require('@fullhuman/postcss-purgecss')({
   content: ['./src/**/*.tsx', './src/**/*.html'],
   defaultExtractor: content => content.match(/[A-Za-z0-9-_:/]+/g) || [],
-  safelist: ['jtk-connector', 'jtk-endpoint', 'x6-node', 'x6-port-out', 'x6-port-label', 'x6-graph-scroller'],
+  safelist: ['hidden', 'jtk-connector', 'jtk-endpoint', 'x6-node', 'x6-node-selected', 'elsa-default-activity-template', 'x6-port-out', 'x6-port-label', 'x6-graph-scroller', 'rose', 'sky', /gray/, /pink/, /blue/, /green/, /red/, /yellow/, /rose/, 'label-container', 'node', 'start', 'activity', 'elsa-border-blue-600', 'elsa-border-green-600', 'elsa-border-red-600'],
 });
 
 export const config: Config = {

--- a/src/designer/elsa-workflows-studio/stencil.config.prod.ts
+++ b/src/designer/elsa-workflows-studio/stencil.config.prod.ts
@@ -3,13 +3,12 @@ import {postcss} from '@stencil/postcss';
 import postcssImport from 'postcss-import';
 import tailwindcss from 'tailwindcss';
 import cssnano from 'cssnano';
-import replace from '@rollup/plugin-replace';
 
 // @ts-ignore
 const purgecss = require('@fullhuman/postcss-purgecss')({
   content: ['./src/**/*.tsx', './src/**/*.html'],
   defaultExtractor: content => content.match(/[A-Za-z0-9-_:/]+/g) || [],
-  safelist: ['jtk-connector', 'jtk-endpoint', 'x6-node', 'x6-port-out', 'x6-port-label', 'x6-graph-scroller'],
+  safelist: ['hidden', 'jtk-connector', 'jtk-endpoint', 'x6-node', 'x6-node-selected', 'elsa-default-activity-template', 'x6-port-out', 'x6-port-label', 'x6-graph-scroller', 'rose', 'sky', /gray/, /pink/, /blue/, /green/, /red/, /yellow/, /rose/, 'label-container', 'node', 'start', 'activity', 'elsa-border-blue-600', 'elsa-border-green-600', 'elsa-border-red-600']
 });
 
 export const config: Config = {

--- a/src/designer/elsa-workflows-studio/stencil.config.ts
+++ b/src/designer/elsa-workflows-studio/stencil.config.ts
@@ -14,7 +14,7 @@ const tailwindDev: boolean = process.argv && process.argv.indexOf('--tailwind:de
 const purgecss = require('@fullhuman/postcss-purgecss')({
   content: ['./src/**/*.tsx', './src/**/*.html'],
   defaultExtractor: content => content.match(/[A-Za-z0-9-_:/]+/g) || [],
-  safelist: ['hidden', 'jtk-connector', 'jtk-endpoint', 'x6-node', 'x6-port-out', 'x6-port-label', 'x6-graph-scroller', 'rose', 'sky', /gray/, /pink/, /blue/, /green/, /red/, /yellow/, /rose/, 'label-container', 'node', 'start', 'activity', 'elsa-border-blue-600', 'elsa-border-green-600', 'elsa-border-red-600'],
+  safelist: ['hidden', 'jtk-connector', 'jtk-endpoint', 'x6-node', 'x6-node-selected', 'elsa-default-activity-template', 'x6-port-out', 'x6-port-label', 'x6-graph-scroller', 'rose', 'sky', /gray/, /pink/, /blue/, /green/, /red/, /yellow/, /rose/, 'label-container', 'node', 'start', 'activity', 'elsa-border-blue-600', 'elsa-border-green-600', 'elsa-border-red-600'],
 });
 
 export const config: Config = {


### PR DESCRIPTION
1. Improve graph connection generation by calculating `step` value to the edge routing depending on the layout of the target nodes
2. Update connection views, when moving one node, so nodes won't hide the connections underneath them
3. Allow pasting of nodes to cursor position (useful when pasting to another workflow)
4. Fix showing the node selection style in all environments (updated the stencil configs - purge css safelist)
5. Make auto-layout use batch update, so the whole operation can be undone with ctrl+z
6. Improve the per-activity test result window positioning, so it wouldn't appear outside the screen and also make it scrollable