### PR TITLE
Enable opening expression editor in a modal dialog

### DIFF
--- a/src/designer/elsa-workflows-studio/src/components.d.ts
+++ b/src/designer/elsa-workflows-studio/src/components.d.ts
@@ -109,6 +109,7 @@ export namespace Components {
         "editorHeight": string;
         "expression": string;
         "language": string;
+        "opensModal": boolean;
         "padding": string;
         "serverUrl": string;
         "setExpression": (value: string) => Promise<void>;
@@ -1011,6 +1012,7 @@ declare namespace LocalJSX {
         "expression"?: string;
         "language"?: string;
         "onExpressionChanged"?: (event: CustomEvent<string>) => void;
+        "opensModal"?: boolean;
         "padding"?: string;
         "serverUrl"?: string;
         "singleLineMode"?: boolean;

--- a/src/designer/elsa-workflows-studio/src/components/editors/elsa-expression-editor/elsa-expression-editor.tsx
+++ b/src/designer/elsa-workflows-studio/src/components/editors/elsa-expression-editor/elsa-expression-editor.tsx
@@ -1,29 +1,30 @@
-import {Component, EventEmitter, h, Host, Method, Prop, State, Watch, Event} from '@stencil/core';
-import {createElsaClient} from "../../../services";
+import { Component, EventEmitter, h, Method, Prop, State, Watch, Event } from '@stencil/core';
+import { createElsaClient } from '../../../services';
 import Tunnel from '../../../data/workflow-editor';
-import {MonacoValueChangedArgs} from "../../controls/elsa-monaco/elsa-monaco";
-import {IntellisenseContext} from "../../../models";
+import { MonacoValueChangedArgs } from '../../controls/elsa-monaco/elsa-monaco';
+import { IntellisenseContext } from '../../../models';
+import { monacoEditorDialogService } from '../../../services/monaco-editor-dialog-service';
 
 @Component({
   tag: 'elsa-expression-editor',
   shadow: false,
 })
 export class ElsaExpressionEditor {
-
   @Event() expressionChanged: EventEmitter<string>;
+  @Prop() opensModal: boolean = false;
   @Prop() language: string;
   @Prop() expression: string;
-  @Prop({attribute: 'editor-height', reflect: true}) editorHeight: string = '6em';
-  @Prop({attribute: 'single-line', reflect: true}) singleLineMode: boolean = false;
+  @Prop({ attribute: 'editor-height', reflect: true }) editorHeight: string = '6em';
+  @Prop({ attribute: 'single-line', reflect: true }) singleLineMode: boolean = false;
   @Prop() padding: string;
   @Prop() context?: IntellisenseContext;
-  @Prop({mutable: true}) serverUrl: string;
-  @Prop({mutable: true}) workflowDefinitionId: string;
-  @State() currentExpression?: string
+  @Prop({ mutable: true }) serverUrl: string;
+  @Prop({ mutable: true }) workflowDefinitionId: string;
+  @State() currentExpression?: string;
 
   monacoEditor: HTMLElsaMonacoElement;
 
-  @Watch("expression")
+  @Watch('expression')
   expressionChangedHandler(newValue: string) {
     this.currentExpression = newValue;
   }
@@ -42,6 +43,9 @@ export class ElsaExpressionEditor {
     const libSource = await elsaClient.scriptingApi.getJavaScriptTypeDefinitions(this.workflowDefinitionId, this.context);
     const libUri = 'defaultLib:lib.es6.d.ts';
     await this.monacoEditor.addJavaScriptLib(libSource, libUri);
+    if (monacoEditorDialogService.monacoEditor) {
+      monacoEditorDialogService.monacoEditor.addJavaScriptLib(libSource, libUri);
+    }
   }
 
   async onMonacoValueChanged(e: MonacoValueChangedArgs) {
@@ -49,19 +53,28 @@ export class ElsaExpressionEditor {
     await this.expressionChanged.emit(e.value);
   }
 
+  onEditorClick = e => {
+    if (this.opensModal) {
+      monacoEditorDialogService.show(this.language, this.currentExpression, (e: CustomEvent) => this.setExpression(e.detail.value));
+    }
+  };
+
   render() {
     const language = this.language;
     const value = this.currentExpression;
 
     return (
-      <elsa-monaco value={value}
-                   language={language}
-                   editor-height={this.editorHeight}
-                   single-line={this.singleLineMode}
-                   padding={this.padding}
-                   onValueChanged={e => this.onMonacoValueChanged(e.detail)}
-                   ref={el => this.monacoEditor = el}/>
-    )
+      <elsa-monaco
+        value={value}
+        language={language}
+        editor-height={this.editorHeight}
+        single-line={this.singleLineMode}
+        padding={this.padding}
+        onValueChanged={e => this.onMonacoValueChanged(e.detail)}
+        onClick={this.onEditorClick}
+        ref={el => (this.monacoEditor = el)}
+      />
+    );
   }
 }
 

--- a/src/designer/elsa-workflows-studio/src/components/editors/properties/elsa-switch-cases-property/elsa-switch-cases-property.tsx
+++ b/src/designer/elsa-workflows-studio/src/components/editors/properties/elsa-switch-cases-property/elsa-switch-cases-property.tsx
@@ -117,6 +117,7 @@ export class ElsaSwitchCasesProperty {
                 single-line={true}
                 editorHeight="2.75em"
                 padding="elsa-pt-1.5 elsa-pl-1 elsa-pr-28"
+                opensModal
                 onExpressionChanged={e => this.onCaseExpressionChanged(e, switchCase)}
               />
               <div class="elsa-absolute elsa-inset-y-0 elsa-right-0 elsa-flex elsa-items-center">

--- a/src/designer/elsa-workflows-studio/src/components/screens/workflow-definition-editor/elsa-workflow-definition-editor-screen/elsa-workflow-definition-editor-screen.tsx
+++ b/src/designer/elsa-workflows-studio/src/components/screens/workflow-definition-editor/elsa-workflow-definition-editor-screen/elsa-workflow-definition-editor-screen.tsx
@@ -18,7 +18,7 @@ import {
   WorkflowTestActivityMessage,
   WorkflowTestActivityMessageStatus,
 } from '../../../../models';
-import { ActivityStats, createElsaClient, eventBus, featuresDataManager, SaveWorkflowDefinitionRequest } from '../../../../services';
+import { ActivityStats, createElsaClient, eventBus, featuresDataManager, monacoEditorDialogService, SaveWorkflowDefinitionRequest } from '../../../../services';
 import state from '../../../../utils/store';
 import WorkflowEditorTunnel, { WorkflowEditorState } from '../../../../data/workflow-editor';
 import DashboardTunnel from '../../../../data/dashboard';
@@ -644,6 +644,29 @@ export class ElsaWorkflowDefinitionEditorScreen {
           </div>`;
   };
 
+  renderMonacoEditorDialog() {
+    return (
+      <elsa-modal-dialog ref={el => {
+          monacoEditorDialogService.monacoEditorDialog = el;
+        }}>
+          <div slot="content" class="elsa-py-8 elsa-px-4">
+            <elsa-monaco
+              value=""
+              language="javascript"
+              editor-height="400px"
+              single-line={false}
+              onValueChanged={e => {
+                if (monacoEditorDialogService.valueChanged) {
+                  monacoEditorDialogService.valueChanged(e);
+                }
+              }}
+              ref={el => (monacoEditorDialogService.monacoEditor = el)}
+            />
+          </div>
+        </elsa-modal-dialog>
+    );
+  }
+
   render() {
     const tunnelState: WorkflowEditorState = {
       serverUrl: this.serverUrl,
@@ -657,6 +680,7 @@ export class ElsaWorkflowDefinitionEditorScreen {
           {this.renderCanvas()}
           {this.renderActivityPicker()}
           {this.renderActivityEditor()}
+          {this.renderMonacoEditorDialog()}
         </WorkflowEditorTunnel.Provider>
       </Host>
     );

--- a/src/designer/elsa-workflows-studio/src/services/index.ts
+++ b/src/designer/elsa-workflows-studio/src/services/index.ts
@@ -8,3 +8,4 @@ export * from './features-data-manager';
 export * from './plugin-manager';
 export * from './property-display-driver';
 export * from './property-display-manager';
+export * from './monaco-editor-dialog-service';

--- a/src/designer/elsa-workflows-studio/src/services/monaco-editor-dialog-service.ts
+++ b/src/designer/elsa-workflows-studio/src/services/monaco-editor-dialog-service.ts
@@ -1,0 +1,18 @@
+export class MonacoEditorDialogService {
+  public monacoEditor: HTMLElsaMonacoElement = null;
+  public monacoEditorDialog: HTMLElsaModalDialogElement = null;
+  public valueChanged: (e: CustomEvent) => void = null;
+
+  show(language: string, value: string, onChanged: (e: CustomEvent) => void) {
+    if (!this.monacoEditor || !this.monacoEditorDialog) {
+      return;
+    }
+    this.monacoEditor.language = language;
+    this.monacoEditor.setValue(value);
+
+    this.valueChanged = onChanged;
+    this.monacoEditorDialog.show();
+  }
+}
+
+export const monacoEditorDialogService = new MonacoEditorDialogService();


### PR DESCRIPTION
For switch activity, the cases are single line expression editors and that makes it really hard to write any meaningful code there. But making the editor multi-line and increasing its height would bloat the contents of the modal too much, so it was our client's idea to open a dialog with a bigger editor inside to make it comfortably editable and not bloat anything.