### PR TITLE
Allow Swagger OpenAPI file to include name of enums

### DIFF
--- a/src/server/Elsa.Server.Api/Extensions/SchemaFilters/XEnumNamesSchemaFilter.cs
+++ b/src/server/Elsa.Server.Api/Extensions/SchemaFilters/XEnumNamesSchemaFilter.cs
@@ -1,0 +1,25 @@
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+using System;
+using System.Linq;
+
+namespace Elsa.Server.Api.Extensions.SchemaFilters
+{
+    public class XEnumNamesSchemaFilter : ISchemaFilter
+    {
+        private const string NAME = "x-enumNames";
+
+        public void Apply(OpenApiSchema model, SchemaFilterContext context)
+        {
+            var typeInfo = context.Type;
+            if (typeInfo.IsEnum && !model.Extensions.ContainsKey(NAME))
+            {
+                var names = Enum.GetNames(context.Type);
+                var arr = new OpenApiArray();
+                arr.AddRange(names.Select(name => new OpenApiString(name)));
+                model.Extensions.Add(NAME, arr);
+            }
+        }
+    }
+}

--- a/src/server/Elsa.Server.Api/Extensions/ServiceCollectionExtensions.cs
+++ b/src/server/Elsa.Server.Api/Extensions/ServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using Elsa;
 using Elsa.Models;
 using Elsa.Server.Api;
+using Elsa.Server.Api.Extensions.SchemaFilters;
 using Elsa.Server.Api.Mapping;
 using Elsa.Server.Api.Services;
 using Elsa.Server.Api.Swagger.Examples;
@@ -79,6 +80,9 @@ namespace Microsoft.Extensions.DependencyInjection
                         Type = PrimitiveType.String.ToString().ToLower(),
                         Example = new OpenApiString("System.String, mscorlib")
                     });
+
+                    //Allow enums to be displayed
+                    c.SchemaFilter<XEnumNamesSchemaFilter>();
 
                     configure?.Invoke(c);
                 });


### PR DESCRIPTION
Currently, the OpenAPI file on /swagger/v1/swagger.json does not include information on enums.
Example: 

```json
"WorkflowPersistenceBehavior": {
        "enum": [
          0,
          1,
          2
        ],
        "type": "integer",
        "format": "int32"
      },
```

With this fix the output is now: 

```json
  "WorkflowPersistenceBehavior": {
        "enum": [
          0,
          1,
          2
        ],
        "type": "integer",
        "format": "int32",
        "x-enumNames": [
          "Suspended",
          "WorkflowBurst",
          "ActivityExecuted"
        ]
      },
```

This means that tools like NSwag can now generate HttpClients with the correct enums.