### PR TITLE
MongoDb Persistence: Cleanup and optout Serialzier for Variables object

### DIFF
--- a/src/persistence/Elsa.Persistence.MongoDb/Extensions/ServiceCollectionExtensions.cs
+++ b/src/persistence/Elsa.Persistence.MongoDb/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,3 @@
-using System;
 using Elsa.Options;
 using Elsa.Persistence.MongoDb.Options;
 using Elsa.Persistence.MongoDb.Services;
@@ -6,31 +5,35 @@ using Elsa.Persistence.MongoDb.Stores;
 using Elsa.Runtime;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using System;
 
 namespace Elsa.Persistence.MongoDb
 {
     public static class ServiceCollectionExtensions
     {
         public static ElsaOptionsBuilder UseMongoDbPersistence(this ElsaOptionsBuilder elsa, Action<ElsaMongoDbOptions> configureOptions) => UseMongoDbPersistence<ElsaMongoDbContext>(elsa, configureOptions);
-        
-        public static ElsaOptionsBuilder UseMongoDbPersistence<TDbContext>(this ElsaOptionsBuilder elsa, Action<ElsaMongoDbOptions> configureOptions) where TDbContext: ElsaMongoDbContext
+
+        public static ElsaOptionsBuilder UseMongoDbPersistence<TDbContext>(this ElsaOptionsBuilder elsa, Action<ElsaMongoDbOptions> configureOptions) where TDbContext : ElsaMongoDbContext
         {
-            AddCore<TDbContext>(elsa);
+            var tempConfig = new ElsaMongoDbOptions();
+            configureOptions(tempConfig);
             elsa.Services.Configure(configureOptions);
+            AddCore<TDbContext>(elsa, tempConfig);
 
             return elsa;
         }
 
         public static ElsaOptionsBuilder UseMongoDbPersistence(this ElsaOptionsBuilder elsa, IConfiguration configuration) => UseMongoDbPersistence<ElsaMongoDbContext>(elsa, configuration);
 
-        public static ElsaOptionsBuilder UseMongoDbPersistence<TDbContext>(this ElsaOptionsBuilder elsa, IConfiguration configuration) where TDbContext: class, IElsaMongoDbContext
+        public static ElsaOptionsBuilder UseMongoDbPersistence<TDbContext>(this ElsaOptionsBuilder elsa, IConfiguration configuration) where TDbContext : class, IElsaMongoDbContext
         {
-            AddCore<TDbContext>(elsa);
             elsa.Services.Configure<ElsaMongoDbOptions>(configuration);
+            var tempConfig = configuration.Get<ElsaMongoDbOptions>();
+            AddCore<TDbContext>(elsa, tempConfig);
             return elsa;
         }
 
-        private static void AddCore<TDbContext>(ElsaOptionsBuilder elsa) where TDbContext : class,IElsaMongoDbContext
+        private static void AddCore<TDbContext>(ElsaOptionsBuilder elsa, ElsaMongoDbOptions mongoDbOptions) where TDbContext : class, IElsaMongoDbContext
         {
             elsa.Services
                 .AddSingleton<MongoDbWorkflowDefinitionStore>()
@@ -54,7 +57,7 @@ namespace Elsa.Persistence.MongoDb
                 .UseBookmarkStore(sp => sp.GetRequiredService<MongoDbBookmarkStore>())
                 .UseTriggerStore(sp => sp.GetRequiredService<MongoDbTriggerStore>());
 
-            DatabaseRegister.RegisterMapsAndSerializers();
+            DatabaseRegister.RegisterMapsAndSerializers(mongoDbOptions);
         }
     }
 }

--- a/src/persistence/Elsa.Persistence.MongoDb/Options/ElsaMongoDbOptions.cs
+++ b/src/persistence/Elsa.Persistence.MongoDb/Options/ElsaMongoDbOptions.cs
@@ -4,5 +4,11 @@ namespace Elsa.Persistence.MongoDb.Options
     {
         public string? ConnectionString { get; set; }
         public string? DatabaseName { get; set; }
+
+        /// <summary>
+        /// This parameter to opt-out automatic registration of
+        /// <see cref="Elsa.Persistence.MongoDb.Serializers.VariablesSerializer"/>
+        /// </summary>
+        public bool DoNotRegisterVariablesSerializer { get; set; }
     }
 }

--- a/src/persistence/Elsa.Persistence.MongoDb/Serializers/TypeSerializer.cs
+++ b/src/persistence/Elsa.Persistence.MongoDb/Serializers/TypeSerializer.cs
@@ -8,7 +8,7 @@ namespace Elsa.Persistence.MongoDb.Serializers
     public class TypeSerializer : IBsonSerializer<Type>
     {
         public static TypeSerializer Instance { get; } = new();
-        public Type ValueType => typeof(Variables);
+        public Type ValueType => typeof(Type);
         public void Serialize(BsonSerializationContext context, BsonSerializationArgs args, object value) => Serialize(context, args, (Type) value);
 
         public void Serialize(BsonSerializationContext context, BsonSerializationArgs args, Type value)

--- a/test/integration/Elsa.Core.IntegrationTests/Autofixture/WithMongoDbAttribute.cs
+++ b/test/integration/Elsa.Core.IntegrationTests/Autofixture/WithMongoDbAttribute.cs
@@ -11,10 +11,11 @@ namespace Elsa.Core.IntegrationTests.Autofixture
 
         public override Action<ElsaHostBuilderBuilder> GetBuilderCustomizer()
         {
+            var connectionString = Environment.GetEnvironmentVariable("TEST_MONGODB") ?? "mongodb://localhost:27017";
             return builder => {
                 builder.ElsaCallbacks.Add(elsa => {
                     elsa.UseMongoDbPersistence(opts => {
-                        opts.ConnectionString = "mongodb://localhost:27017";
+                        opts.ConnectionString = connectionString;
                         opts.DatabaseName = dbName;
                     });
                 });


### PR DESCRIPTION
In this commit there is some cleanup of MongoDb persistence provider initialization, as well as the option to opt out the automatic registration of VariablesSerializer, to use default BsonSerializer or custom version of BsonSerializer.

The option is opt-out, so previous code is unaffected.

Added also option to specify test mongodb connection string from environment variable.

Related to #3538