### PR TITLE
Different Datype for JS function setOutcomes

### DIFF
--- a/src/scripting/Elsa.Scripting.JavaScript/Activities/RunJavaScript/RunJavaScript.cs
+++ b/src/scripting/Elsa.Scripting.JavaScript/Activities/RunJavaScript/RunJavaScript.cs
@@ -60,10 +60,10 @@ namespace Elsa.Activities.JavaScript
             void ConfigureEngine(Engine engine)
             {
                 void SetOutcome(string value) => outcomes.Add(value);
-                void SetOutcomes(IEnumerable<string> values) => outcomes.AddRange(values);
+                void SetOutcomes(string[] values) => outcomes.AddRange(values);
 
-                engine.SetValue("setOutcome", (Action<string>)SetOutcome);
-                engine.SetValue("setOutcomes", (Action<IEnumerable<string>>)SetOutcomes);
+                engine.SetValue("setOutcome", SetOutcome);
+                engine.SetValue("setOutcomes", SetOutcomes);
             }
 
             var output = await _javaScriptService.EvaluateAsync(script, typeof(object), context, ConfigureEngine, context.CancellationToken);


### PR DESCRIPTION
https://github.com/elsa-workflows/elsa-core/issues/3555

casting to `<IEnumerable<string>>` causes an exception. Changing the datatype to `string[]` removes the need for the cast. I tested this successfully using the workflow in the attached issue.