### PR TITLE
Webhooks

### DIFF
--- a/Elsa.sln
+++ b/Elsa.sln
@@ -144,6 +144,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.EntityFrameworkCore.Po
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Samples.RunTaskIntegration", "src\samples\aspnet\Elsa.Samples.RunTaskIntegration\Elsa.Samples.RunTaskIntegration.csproj", "{51050209-EC2F-4DC7-8F46-07E22B7811CD}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Webhooks", "src\modules\Elsa.Webhooks\Elsa.Webhooks.csproj", "{2BBFDE36-28A7-4875-8EBE-CC25C76B97FF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Samples.Webhooks.WorkflowServer", "src\samples\aspnet\Elsa.Samples.Webhooks.WorkflowServer\Elsa.Samples.Webhooks.WorkflowServer.csproj", "{130A7A00-A9AF-4EA8-8107-BBEA07F166DF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Samples.Webhooks.ExternalApp", "src\samples\aspnet\Elsa.Samples.Webhooks.ExternalApp\Elsa.Samples.Webhooks.ExternalApp.csproj", "{036D287A-33E1-4B28-BE13-14AEA16BC91F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -362,6 +368,18 @@ Global
 		{51050209-EC2F-4DC7-8F46-07E22B7811CD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{51050209-EC2F-4DC7-8F46-07E22B7811CD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{51050209-EC2F-4DC7-8F46-07E22B7811CD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2BBFDE36-28A7-4875-8EBE-CC25C76B97FF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2BBFDE36-28A7-4875-8EBE-CC25C76B97FF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2BBFDE36-28A7-4875-8EBE-CC25C76B97FF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2BBFDE36-28A7-4875-8EBE-CC25C76B97FF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{130A7A00-A9AF-4EA8-8107-BBEA07F166DF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{130A7A00-A9AF-4EA8-8107-BBEA07F166DF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{130A7A00-A9AF-4EA8-8107-BBEA07F166DF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{130A7A00-A9AF-4EA8-8107-BBEA07F166DF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{036D287A-33E1-4B28-BE13-14AEA16BC91F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{036D287A-33E1-4B28-BE13-14AEA16BC91F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{036D287A-33E1-4B28-BE13-14AEA16BC91F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{036D287A-33E1-4B28-BE13-14AEA16BC91F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{155227F0-A33B-40AA-A4B4-06F813EB921B} = {61017E64-6D00-49CB-9E81-5002DC8F7D5F}
@@ -424,5 +442,8 @@ Global
 		{536EFB55-EEA1-4761-9A72-D4EA84A6DB70} = {56C2FFB8-EA54-45B5-A095-4A78142EB4B5}
 		{AA84DBF7-F70F-4673-8DC2-6EFBE3E9BF83} = {5BA4A8FA-F7F4-45B3-AEC8-8886D35AAC79}
 		{51050209-EC2F-4DC7-8F46-07E22B7811CD} = {56C2FFB8-EA54-45B5-A095-4A78142EB4B5}
+		{2BBFDE36-28A7-4875-8EBE-CC25C76B97FF} = {5BA4A8FA-F7F4-45B3-AEC8-8886D35AAC79}
+		{130A7A00-A9AF-4EA8-8107-BBEA07F166DF} = {56C2FFB8-EA54-45B5-A095-4A78142EB4B5}
+		{036D287A-33E1-4B28-BE13-14AEA16BC91F} = {56C2FFB8-EA54-45B5-A095-4A78142EB4B5}
 	EndGlobalSection
 EndGlobal

--- a/src/bundles/Elsa.WorkflowServer.Web/Elsa.WorkflowServer.Web.csproj
+++ b/src/bundles/Elsa.WorkflowServer.Web/Elsa.WorkflowServer.Web.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+        <TargetFramework>net7.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>

--- a/src/bundles/Elsa.WorkflowServer.Web/Program.cs
+++ b/src/bundles/Elsa.WorkflowServer.Web/Program.cs
@@ -59,8 +59,6 @@ services.AddHandlersFrom<Program>();
 services.AddHealthChecks();
 services.AddCors(cors => cors.AddDefaultPolicy(policy => policy.AllowAnyHeader().AllowAnyMethod().AllowAnyOrigin()));
 services.AddHttpContextAccessor();
-services.AddSingleton<IAuthorizationHandler, LocalHostRequirementHandler>();
-services.AddAuthorization(options => options.AddPolicy(IdentityPolicyNames.SecurityRoot, policy => policy.AddRequirements(new LocalHostRequirement())));
 
 // Configure middleware pipeline.
 var app = builder.Build();

--- a/src/modules/Elsa.Common/Exceptions/MissingConfigurationException.cs
+++ b/src/modules/Elsa.Common/Exceptions/MissingConfigurationException.cs
@@ -1,0 +1,12 @@
+namespace Elsa.Common.Exceptions;
+
+/// <summary>
+/// Configuration is missing.
+/// </summary>
+public class MissingConfigurationException : Exception
+{
+    /// <inheritdoc />
+    public MissingConfigurationException(string message) : base(message)
+    {
+    }
+}

--- a/src/modules/Elsa.Identity/Features/DefaultAuthenticationFeature.cs
+++ b/src/modules/Elsa.Identity/Features/DefaultAuthenticationFeature.cs
@@ -1,7 +1,9 @@
 using Elsa.Features.Abstractions;
 using Elsa.Features.Attributes;
 using Elsa.Features.Services;
+using Elsa.Requirements;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Elsa.Identity.Features;
@@ -26,5 +28,7 @@ public class DefaultAuthenticationFeature : FeatureBase
         Services
             .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
             .AddJwtBearer(JwtBearerDefaults.AuthenticationScheme, identityOptions.ConfigureJwtBearerOptions);
-    }
+        
+        Services.AddSingleton<IAuthorizationHandler, LocalHostRequirementHandler>();
+        Services.AddAuthorization(options => options.AddPolicy(IdentityPolicyNames.SecurityRoot, policy => policy.AddRequirements(new LocalHostRequirement())));    }
 }

--- a/src/modules/Elsa.Identity/Features/IdentityFeature.cs
+++ b/src/modules/Elsa.Identity/Features/IdentityFeature.cs
@@ -1,3 +1,4 @@
+using Elsa.Common.Exceptions;
 using Elsa.Common.Features;
 using Elsa.Extensions;
 using Elsa.Features.Abstractions;
@@ -59,6 +60,9 @@ public class IdentityFeature : FeatureBase
     /// <inheritdoc />
     public override void Apply()
     {
+        if (string.IsNullOrWhiteSpace(TokenOptions.SigningKey))
+            throw new MissingConfigurationException("SigningKey is a required setting for the Identity feature.");
+        
         Services.Configure<IdentityTokenOptions>(options => options.CopyFrom(TokenOptions));
         
         Services

--- a/src/modules/Elsa.Webhooks/Commands/InvokeWebhook.cs
+++ b/src/modules/Elsa.Webhooks/Commands/InvokeWebhook.cs
@@ -1,0 +1,9 @@
+using Elsa.Mediator.Services;
+using Elsa.Webhooks.Models;
+
+namespace Elsa.Webhooks.Commands;
+
+/// <summary>
+/// Represents a command to invoke all registered webhook endpoints.
+/// </summary>
+public record InvokeWebhook(WebhookRegistration WebhookRegistration, WebhookEvent WebhookEvent) : ICommand;

--- a/src/modules/Elsa.Webhooks/Elsa.Webhooks.csproj
+++ b/src/modules/Elsa.Webhooks/Elsa.Webhooks.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <Import Project="..\..\..\common.props" />
+    <Import Project="..\..\..\configureawait.props" />
+
+    <PropertyGroup>
+        <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+        <Description>
+            Provides a way to register webhook endpoints that should be invoked when certain event occur.
+        </Description>
+        <PackageTags>elsa, module, webhooks</PackageTags>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Elsa.Workflows.Runtime\Elsa.Workflows.Runtime.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.0.1" />
+    </ItemGroup>
+
+</Project>

--- a/src/modules/Elsa.Webhooks/Extensions/ModuleExtensions.cs
+++ b/src/modules/Elsa.Webhooks/Extensions/ModuleExtensions.cs
@@ -1,0 +1,19 @@
+using Elsa.Features.Services;
+using Elsa.Webhooks.Features;
+
+namespace Elsa.Webhooks.Extensions;
+
+/// <summary>
+/// Adds extensions to <see cref="IModule"/> that enables the <see cref="WebhooksFeature"/> feature.
+/// </summary>
+public static class ModuleExtensions
+{
+    /// <summary>
+    /// Enables and configures the <see cref="WebhooksFeature"/> feature.
+    /// </summary>
+    public static IModule UseWebhooks(this IModule module, Action<WebhooksFeature>? configure = default)
+    {
+        module.Configure(configure);
+        return module;
+    }
+}

--- a/src/modules/Elsa.Webhooks/Features/WebhooksFeature.cs
+++ b/src/modules/Elsa.Webhooks/Features/WebhooksFeature.cs
@@ -26,36 +26,36 @@ public class WebhooksFeature : FeatureBase
     public Func<IServiceProvider, IWebhookDispatcher> WebhookDispatcher { get; set; } = sp => sp.GetRequiredService<BackgroundWebhookDispatcher>();
 
     /// <summary>
-    /// A delegate that is invoked when configuring <see cref="WebhookOptions"/>.
+    /// A delegate that is invoked when configuring <see cref="Options.WebhookOptions"/>.
     /// </summary>
-    public Action<WebhookOptions> ConfigureWebhookOptions { get; set; } = _ => { };
+    public Action<WebhookOptions> WebhookOptions { get; set; } = _ => { };
 
     /// <summary>
-    /// A delegate to configure the <see cref="HttpClient"/> used when invoking webhook endpoints.
+    /// A delegate to configure the <see cref="System.Net.Http.HttpClient"/> used when invoking webhook endpoints.
     /// </summary>
-    public Action<IServiceProvider, HttpClient> ConfigureHttpClient { get; set; } = (_, _) => { };
+    public Action<IServiceProvider, HttpClient> HttpClient { get; set; } = (_, _) => { };
 
     /// <summary>
     /// A delegate to configure the <see cref="IHttpClientBuilder"/>. For example, to configure Polly policies.
     /// </summary>
-    public Action<IHttpClientBuilder> ConfigureHttpClientBuilder { get; set; } = builder => builder.AddTransientHttpErrorPolicy(policy => policy.WaitAndRetryAsync(3, retry => TimeSpan.FromSeconds(retry)));
+    public Action<IHttpClientBuilder> HttpClientBuilder { get; set; } = builder => builder.AddTransientHttpErrorPolicy(policy => policy.WaitAndRetryAsync(3, retry => TimeSpan.FromSeconds(retry)));
 
     /// <summary>
-    /// Registers the specified webhook with <see cref="WebhookOptions"/>
+    /// Registers the specified webhook with <see cref="Options.WebhookOptions"/>
     /// </summary>
     public WebhooksFeature RegisterWebhook(Uri endpoint) => RegisterWebhook(new WebhookRegistration(endpoint));
     
     /// <summary>
-    /// Registers the specified webhook with <see cref="WebhookOptions"/>
+    /// Registers the specified webhook with <see cref="Options.WebhookOptions"/>
     /// </summary>
     public WebhooksFeature RegisterWebhook(WebhookRegistration registration) => RegisterWebhooks(registration);
     
     /// <summary>
-    /// Registers the specified webhooks with <see cref="WebhookOptions"/>
+    /// Registers the specified webhooks with <see cref="Options.WebhookOptions"/>
     /// </summary>
     public WebhooksFeature RegisterWebhooks(params WebhookRegistration[] registrations)
     {
-        Services.Configure<WebhookOptions>(options => options.WebhookRegistrations.AddRange(registrations));
+        Services.Configure<WebhookOptions>(options => options.Endpoints.AddRange(registrations));
         return this;
     }
 
@@ -69,9 +69,9 @@ public class WebhooksFeature : FeatureBase
             .AddSingleton<IWebhookRegistrationService, DefaultWebhookRegistrationService>()
             .AddSingleton<IWebhookRegistrationProvider, OptionsWebhookRegistrationProvider>();
 
-        Services.Configure(ConfigureWebhookOptions);
+        Services.Configure(WebhookOptions);
 
-        var httpClientBuilder = Services.AddHttpClient<IWebhookInvoker, HttpWebhookInvoker>(ConfigureHttpClient);
-        ConfigureHttpClientBuilder(httpClientBuilder);
+        var httpClientBuilder = Services.AddHttpClient<IWebhookInvoker, HttpWebhookInvoker>(HttpClient);
+        HttpClientBuilder(httpClientBuilder);
     }
 }

--- a/src/modules/Elsa.Webhooks/Features/WebhooksFeature.cs
+++ b/src/modules/Elsa.Webhooks/Features/WebhooksFeature.cs
@@ -1,0 +1,77 @@
+using Elsa.Extensions;
+using Elsa.Features.Abstractions;
+using Elsa.Features.Services;
+using Elsa.Webhooks.Implementations;
+using Elsa.Webhooks.Models;
+using Elsa.Webhooks.Options;
+using Elsa.Webhooks.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Polly;
+
+namespace Elsa.Webhooks.Features;
+
+/// <summary>
+/// Installs and configures services that let the user register webhook endpoints.
+/// </summary>
+public class WebhooksFeature : FeatureBase
+{
+    /// <inheritdoc />
+    public WebhooksFeature(IModule module) : base(module)
+    {
+    }
+
+    /// <summary>
+    /// A delegate that resolves the <see cref="IWebhookDispatcher"/> to use.
+    /// </summary>
+    public Func<IServiceProvider, IWebhookDispatcher> WebhookDispatcher { get; set; } = sp => sp.GetRequiredService<BackgroundWebhookDispatcher>();
+
+    /// <summary>
+    /// A delegate that is invoked when configuring <see cref="WebhookOptions"/>.
+    /// </summary>
+    public Action<WebhookOptions> ConfigureWebhookOptions { get; set; } = _ => { };
+
+    /// <summary>
+    /// A delegate to configure the <see cref="HttpClient"/> used when invoking webhook endpoints.
+    /// </summary>
+    public Action<IServiceProvider, HttpClient> ConfigureHttpClient { get; set; } = (_, _) => { };
+
+    /// <summary>
+    /// A delegate to configure the <see cref="IHttpClientBuilder"/>. For example, to configure Polly policies.
+    /// </summary>
+    public Action<IHttpClientBuilder> ConfigureHttpClientBuilder { get; set; } = builder => builder.AddTransientHttpErrorPolicy(policy => policy.WaitAndRetryAsync(3, retry => TimeSpan.FromSeconds(retry)));
+
+    /// <summary>
+    /// Registers the specified webhook with <see cref="WebhookOptions"/>
+    /// </summary>
+    public WebhooksFeature RegisterWebhook(Uri endpoint) => RegisterWebhook(new WebhookRegistration(endpoint));
+    
+    /// <summary>
+    /// Registers the specified webhook with <see cref="WebhookOptions"/>
+    /// </summary>
+    public WebhooksFeature RegisterWebhook(WebhookRegistration registration) => RegisterWebhooks(registration);
+    
+    /// <summary>
+    /// Registers the specified webhooks with <see cref="WebhookOptions"/>
+    /// </summary>
+    public WebhooksFeature RegisterWebhooks(params WebhookRegistration[] registrations)
+    {
+        Services.Configure<WebhookOptions>(options => options.WebhookRegistrations.AddRange(registrations));
+        return this;
+    }
+
+    /// <inheritdoc />
+    public override void Apply()
+    {
+        Services
+            .AddHandlersFrom<WebhooksFeature>()
+            .AddSingleton<BackgroundWebhookDispatcher>()
+            .AddSingleton(WebhookDispatcher)
+            .AddSingleton<IWebhookRegistrationService, DefaultWebhookRegistrationService>()
+            .AddSingleton<IWebhookRegistrationProvider, OptionsWebhookRegistrationProvider>();
+
+        Services.Configure(ConfigureWebhookOptions);
+
+        var httpClientBuilder = Services.AddHttpClient<IWebhookInvoker, HttpWebhookInvoker>(ConfigureHttpClient);
+        ConfigureHttpClientBuilder(httpClientBuilder);
+    }
+}

--- a/src/modules/Elsa.Webhooks/FodyWeavers.xml
+++ b/src/modules/Elsa.Webhooks/FodyWeavers.xml
@@ -1,0 +1,3 @@
+﻿<Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
+  <ConfigureAwait />
+</Weavers>

--- a/src/modules/Elsa.Webhooks/Handlers/InvokeWebhookHandler.cs
+++ b/src/modules/Elsa.Webhooks/Handlers/InvokeWebhookHandler.cs
@@ -1,0 +1,29 @@
+using Elsa.Mediator.Models;
+using Elsa.Mediator.Services;
+using Elsa.Webhooks.Commands;
+using Elsa.Webhooks.Services;
+
+namespace Elsa.Webhooks.Handlers;
+
+/// <summary>
+/// Handles the <see cref="InvokeWebhook"/> command. 
+/// </summary>
+public class InvokeWebhookHandler : ICommandHandler<InvokeWebhook>
+{
+    private readonly IWebhookInvoker _webhookInvoker;
+
+    /// <summary>
+    /// Constructor.
+    /// </summary>
+    public InvokeWebhookHandler(IWebhookInvoker webhookInvoker)
+    {
+        _webhookInvoker = webhookInvoker;
+    }
+    
+    /// <inheritdoc />
+    public async Task<Unit> HandleAsync(InvokeWebhook command, CancellationToken cancellationToken)
+    {
+        await _webhookInvoker.InvokeWebhookAsync(command.WebhookRegistration, command.WebhookEvent, cancellationToken);
+        return Unit.Instance;
+    }
+}

--- a/src/modules/Elsa.Webhooks/Handlers/RunTaskHandler.cs
+++ b/src/modules/Elsa.Webhooks/Handlers/RunTaskHandler.cs
@@ -1,0 +1,35 @@
+using Elsa.Common.Services;
+using Elsa.Mediator.Services;
+using Elsa.Webhooks.Models;
+using Elsa.Webhooks.Services;
+using Elsa.Workflows.Runtime.Bookmarks;
+using Elsa.Workflows.Runtime.Notifications;
+
+namespace Elsa.Webhooks.Handlers;
+
+/// <summary>
+/// Handles the <see cref="RunTaskRequest"/> notification and asynchronously invokes all registered webhook endpoints.
+/// </summary>
+public class RunTaskHandler : INotificationHandler<RunTaskRequest>
+{
+    private readonly IWebhookDispatcher _webhookDispatcher;
+    private readonly ISystemClock _systemClock;
+
+    /// <summary>
+    /// Constructor.
+    /// </summary>
+    public RunTaskHandler(IWebhookDispatcher webhookDispatcher, ISystemClock systemClock)
+    {
+        _webhookDispatcher = webhookDispatcher;
+        _systemClock = systemClock;
+    }
+    
+    /// <inheritdoc />
+    public async Task HandleAsync(RunTaskRequest notification, CancellationToken cancellationToken)
+    {
+        var payload = new RunTaskWebhook(notification.TaskId, notification.TaskName, notification.TaskParams);
+        var now = _systemClock.UtcNow;
+        var webhookEvent = new WebhookEvent("RunTask", payload, now);
+        await _webhookDispatcher.DispatchAsync(webhookEvent, cancellationToken);
+    }
+}

--- a/src/modules/Elsa.Webhooks/Implementations/BackgroundWebhookDispatcher.cs
+++ b/src/modules/Elsa.Webhooks/Implementations/BackgroundWebhookDispatcher.cs
@@ -6,7 +6,7 @@ using Elsa.Webhooks.Services;
 namespace Elsa.Webhooks.Implementations;
 
 /// <summary>
-/// Uses a background channel to asynchronously invoke each webhook endpoint.
+/// Uses a background channel to asynchronously invoke each webhook url.
 /// </summary>
 public class BackgroundWebhookDispatcher : IWebhookDispatcher
 {

--- a/src/modules/Elsa.Webhooks/Implementations/BackgroundWebhookDispatcher.cs
+++ b/src/modules/Elsa.Webhooks/Implementations/BackgroundWebhookDispatcher.cs
@@ -1,0 +1,36 @@
+using Elsa.Mediator.Services;
+using Elsa.Webhooks.Commands;
+using Elsa.Webhooks.Models;
+using Elsa.Webhooks.Services;
+
+namespace Elsa.Webhooks.Implementations;
+
+/// <summary>
+/// Uses a background channel to asynchronously invoke each webhook endpoint.
+/// </summary>
+public class BackgroundWebhookDispatcher : IWebhookDispatcher
+{
+    private readonly IBackgroundCommandSender _backgroundCommandSender;
+    private readonly IWebhookRegistrationService _webhookRegistrationService;
+
+    /// <summary>
+    /// Constructor.
+    /// </summary>
+    public BackgroundWebhookDispatcher(IBackgroundCommandSender backgroundCommandSender, IWebhookRegistrationService webhookRegistrationService)
+    {
+        _backgroundCommandSender = backgroundCommandSender;
+        _webhookRegistrationService = webhookRegistrationService;
+    }
+
+    /// <inheritdoc />
+    public async Task DispatchAsync(WebhookEvent webhookEvent, CancellationToken cancellationToken = default)
+    {
+        var registrations = await _webhookRegistrationService.ListByEventTypeAsync(webhookEvent.EventType, cancellationToken);
+
+        foreach (var registration in registrations)
+        {
+            var notification = new InvokeWebhook(registration, webhookEvent);
+            await _backgroundCommandSender.SendAsync(notification, cancellationToken);
+        }
+    }
+}

--- a/src/modules/Elsa.Webhooks/Implementations/DefaultWebhookRegistrationService.cs
+++ b/src/modules/Elsa.Webhooks/Implementations/DefaultWebhookRegistrationService.cs
@@ -1,0 +1,35 @@
+using System.Runtime.CompilerServices;
+using Elsa.Webhooks.Models;
+using Elsa.Webhooks.Services;
+
+namespace Elsa.Webhooks.Implementations;
+
+/// <inheritdoc />
+public class DefaultWebhookRegistrationService : IWebhookRegistrationService
+{
+    private readonly IEnumerable<IWebhookRegistrationProvider> _providers;
+
+    /// <summary>
+    /// Constructor.
+    /// </summary>
+    /// <param name="providers"></param>
+    public DefaultWebhookRegistrationService(IEnumerable<IWebhookRegistrationProvider> providers)
+    {
+        _providers = providers;
+    }
+    
+    /// <inheritdoc />
+    public async ValueTask<IEnumerable<WebhookRegistration>> ListByEventTypeAsync(string eventType, CancellationToken cancellationToken) => 
+        await EnumerateByEventTypeAsync(eventType, cancellationToken).ToListAsync(cancellationToken);
+
+    private async IAsyncEnumerable<WebhookRegistration> EnumerateByEventTypeAsync(string eventType, [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        foreach (var provider in _providers)
+        {
+            var registrations = await provider.ListAsync(eventType, cancellationToken);
+
+            foreach (var registration in registrations)
+                yield return registration;
+        }
+    }
+}

--- a/src/modules/Elsa.Webhooks/Implementations/HttpWebhookInvoker.cs
+++ b/src/modules/Elsa.Webhooks/Implementations/HttpWebhookInvoker.cs
@@ -22,7 +22,7 @@ public class HttpWebhookInvoker : IWebhookInvoker
     /// <inheritdoc />
     public async Task InvokeWebhookAsync(WebhookRegistration registration, WebhookEvent webhookEvent, CancellationToken cancellationToken = default)
     {
-        var url = registration.Endpoint;
+        var url = registration.Url;
         await _httpClient.PostAsJsonAsync(url, webhookEvent, cancellationToken);
     }
 }

--- a/src/modules/Elsa.Webhooks/Implementations/HttpWebhookInvoker.cs
+++ b/src/modules/Elsa.Webhooks/Implementations/HttpWebhookInvoker.cs
@@ -1,0 +1,28 @@
+using System.Net.Http.Json;
+using Elsa.Webhooks.Models;
+using Elsa.Webhooks.Services;
+
+namespace Elsa.Webhooks.Implementations;
+
+/// <summary>
+/// An implementation of <see cref="IWebhookInvoker"/> that uses a named <see cref="HttpClient"/>.
+/// </summary>
+public class HttpWebhookInvoker : IWebhookInvoker
+{
+    private readonly HttpClient _httpClient;
+
+    /// <summary>
+    /// Constructor.
+    /// </summary>
+    public HttpWebhookInvoker(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+    
+    /// <inheritdoc />
+    public async Task InvokeWebhookAsync(WebhookRegistration registration, WebhookEvent webhookEvent, CancellationToken cancellationToken = default)
+    {
+        var url = registration.Endpoint;
+        await _httpClient.PostAsJsonAsync(url, webhookEvent, cancellationToken);
+    }
+}

--- a/src/modules/Elsa.Webhooks/Implementations/OptionsWebhookRegistrationProvider.cs
+++ b/src/modules/Elsa.Webhooks/Implementations/OptionsWebhookRegistrationProvider.cs
@@ -23,5 +23,5 @@ public class OptionsWebhookRegistrationProvider : IWebhookRegistrationProvider
 
     /// <inheritdoc />
     public ValueTask<IEnumerable<WebhookRegistration>> ListAsync(string eventType, CancellationToken cancellationToken) => 
-        new(_options.WebhookRegistrations.Where(x => !x.EventTypes.Any() || x.EventTypes.Contains(eventType)));
+        new(_options.Endpoints.Where(x => !x.EventTypes.Any() || x.EventTypes.Contains(eventType)));
 }

--- a/src/modules/Elsa.Webhooks/Implementations/OptionsWebhookRegistrationProvider.cs
+++ b/src/modules/Elsa.Webhooks/Implementations/OptionsWebhookRegistrationProvider.cs
@@ -1,0 +1,27 @@
+using Elsa.Webhooks.Models;
+using Elsa.Webhooks.Options;
+using Elsa.Webhooks.Services;
+using Microsoft.Extensions.Options;
+
+namespace Elsa.Webhooks.Implementations;
+
+/// <summary>
+/// Provides webhook registrations from the <see cref="WebhookOptions"/> options.
+/// </summary>
+public class OptionsWebhookRegistrationProvider : IWebhookRegistrationProvider
+{
+    private readonly WebhookOptions _options;
+
+    /// <summary>
+    /// Constructor.
+    /// </summary>
+    /// <param name="options"></param>
+    public OptionsWebhookRegistrationProvider(IOptions<WebhookOptions> options)
+    {
+        _options = options.Value;
+    }
+
+    /// <inheritdoc />
+    public ValueTask<IEnumerable<WebhookRegistration>> ListAsync(string eventType, CancellationToken cancellationToken) => 
+        new(_options.WebhookRegistrations.Where(x => !x.EventTypes.Any() || x.EventTypes.Contains(eventType)));
+}

--- a/src/modules/Elsa.Webhooks/Models/RunTaskWebhook.cs
+++ b/src/modules/Elsa.Webhooks/Models/RunTaskWebhook.cs
@@ -1,0 +1,6 @@
+namespace Elsa.Webhooks.Models;
+
+/// <summary>
+/// Stores payload information about the RunTask webhook event type.
+/// </summary>
+public record RunTaskWebhook(string TaskId, string TaskName, object? TaskParams);

--- a/src/modules/Elsa.Webhooks/Models/WebhookEvent.cs
+++ b/src/modules/Elsa.Webhooks/Models/WebhookEvent.cs
@@ -1,6 +1,6 @@
 namespace Elsa.Webhooks.Models;
 
 /// <summary>
-/// A payload sent to a webhook endpoint.
+/// A payload sent to a webhook url.
 /// </summary>
 public record WebhookEvent(string EventType, object Payload, DateTimeOffset Timestamp);

--- a/src/modules/Elsa.Webhooks/Models/WebhookEvent.cs
+++ b/src/modules/Elsa.Webhooks/Models/WebhookEvent.cs
@@ -1,0 +1,6 @@
+namespace Elsa.Webhooks.Models;
+
+/// <summary>
+/// A payload sent to a webhook endpoint.
+/// </summary>
+public record WebhookEvent(string EventType, object Payload, DateTimeOffset Timestamp);

--- a/src/modules/Elsa.Webhooks/Models/WebhookRegistration.cs
+++ b/src/modules/Elsa.Webhooks/Models/WebhookRegistration.cs
@@ -3,7 +3,7 @@ using System.Text.Json.Serialization;
 namespace Elsa.Webhooks.Models;
 
 /// <summary>
-/// Represents a webhook endpoint registration
+/// Represents a webhook url registration
 /// </summary>
 public class WebhookRegistration
 {
@@ -18,15 +18,15 @@ public class WebhookRegistration
     /// <summary>
     /// Constructor.
     /// </summary>
-    public WebhookRegistration(Uri endpoint)
+    public WebhookRegistration(Uri url)
     {
-        Endpoint = endpoint;
+        Url = url;
     }
     
     /// <summary>
     /// The URL to deliver the webhook event to.
     /// </summary>
-    public Uri Endpoint { get; set; } = default!;
+    public Uri Url { get; set; } = default!;
 
     /// <summary>
     /// A whitelist of event types to deliver. If empty, all events will be delivered.

--- a/src/modules/Elsa.Webhooks/Models/WebhookRegistration.cs
+++ b/src/modules/Elsa.Webhooks/Models/WebhookRegistration.cs
@@ -1,0 +1,35 @@
+using System.Text.Json.Serialization;
+
+namespace Elsa.Webhooks.Models;
+
+/// <summary>
+/// Represents a webhook endpoint registration
+/// </summary>
+public class WebhookRegistration
+{
+    /// <summary>
+    /// Constructor.
+    /// </summary>
+    [JsonConstructor]
+    public WebhookRegistration()
+    {
+    }
+
+    /// <summary>
+    /// Constructor.
+    /// </summary>
+    public WebhookRegistration(Uri endpoint)
+    {
+        Endpoint = endpoint;
+    }
+    
+    /// <summary>
+    /// The URL to deliver the webhook event to.
+    /// </summary>
+    public Uri Endpoint { get; set; } = default!;
+
+    /// <summary>
+    /// A whitelist of event types to deliver. If empty, all events will be delivered.
+    /// </summary>
+    public HashSet<string> EventTypes { get; set; } = new();
+}

--- a/src/modules/Elsa.Webhooks/Options/WebhookOptions.cs
+++ b/src/modules/Elsa.Webhooks/Options/WebhookOptions.cs
@@ -1,0 +1,14 @@
+using Elsa.Webhooks.Models;
+
+namespace Elsa.Webhooks.Options;
+
+/// <summary>
+/// Provides various options related to webhooks.
+/// </summary>
+public class WebhookOptions
+{
+    /// <summary>
+    /// Stores a list of webhook registrations.
+    /// </summary>
+    public ICollection<WebhookRegistration> WebhookRegistrations { get; set; } = new List<WebhookRegistration>();
+}

--- a/src/modules/Elsa.Webhooks/Options/WebhookOptions.cs
+++ b/src/modules/Elsa.Webhooks/Options/WebhookOptions.cs
@@ -10,5 +10,5 @@ public class WebhookOptions
     /// <summary>
     /// Stores a list of webhook registrations.
     /// </summary>
-    public ICollection<WebhookRegistration> WebhookRegistrations { get; set; } = new List<WebhookRegistration>();
+    public ICollection<WebhookRegistration> Endpoints { get; set; } = new List<WebhookRegistration>();
 }

--- a/src/modules/Elsa.Webhooks/Services/IWebhookDispatcher.cs
+++ b/src/modules/Elsa.Webhooks/Services/IWebhookDispatcher.cs
@@ -1,0 +1,14 @@
+using Elsa.Webhooks.Models;
+
+namespace Elsa.Webhooks.Services;
+
+/// <summary>
+/// Asynchronously invokes all registered webhooks.
+/// </summary>
+public interface IWebhookDispatcher
+{
+    /// <summary>
+    /// Dispatches the specified webhook event.
+    /// </summary>
+    Task DispatchAsync(WebhookEvent webhookEvent, CancellationToken cancellationToken = default);
+}

--- a/src/modules/Elsa.Webhooks/Services/IWebhookInvoker.cs
+++ b/src/modules/Elsa.Webhooks/Services/IWebhookInvoker.cs
@@ -3,7 +3,7 @@ using Elsa.Webhooks.Models;
 namespace Elsa.Webhooks.Services;
 
 /// <summary>
-/// Invokes a single registered webhook endpoint.
+/// Invokes a single registered webhook url.
 /// </summary>
 public interface IWebhookInvoker
 {

--- a/src/modules/Elsa.Webhooks/Services/IWebhookInvoker.cs
+++ b/src/modules/Elsa.Webhooks/Services/IWebhookInvoker.cs
@@ -1,0 +1,14 @@
+using Elsa.Webhooks.Models;
+
+namespace Elsa.Webhooks.Services;
+
+/// <summary>
+/// Invokes a single registered webhook endpoint.
+/// </summary>
+public interface IWebhookInvoker
+{
+    /// <summary>
+    /// Invokes the specified webhook registration with the specified webhook event..
+    /// </summary>
+    Task InvokeWebhookAsync(WebhookRegistration registration, WebhookEvent webhookEvent, CancellationToken cancellationToken = default);
+}

--- a/src/modules/Elsa.Webhooks/Services/IWebhookRegistrationProvider.cs
+++ b/src/modules/Elsa.Webhooks/Services/IWebhookRegistrationProvider.cs
@@ -1,0 +1,14 @@
+using Elsa.Webhooks.Models;
+
+namespace Elsa.Webhooks.Services;
+
+/// <summary>
+/// Provides a list of webhook registrations.
+/// </summary>
+public interface IWebhookRegistrationProvider
+{
+    /// <summary>
+    /// Returns a list of webhook registrations.
+    /// </summary>
+    ValueTask<IEnumerable<WebhookRegistration>> ListAsync(string eventType, CancellationToken cancellationToken);
+}

--- a/src/modules/Elsa.Webhooks/Services/IWebhookRegistrationService.cs
+++ b/src/modules/Elsa.Webhooks/Services/IWebhookRegistrationService.cs
@@ -1,0 +1,14 @@
+using Elsa.Webhooks.Models;
+
+namespace Elsa.Webhooks.Services;
+
+/// <summary>
+/// Provides a list of webhook registrations.
+/// </summary>
+public interface IWebhookRegistrationService
+{
+    /// <summary>
+    /// Returns a list of webhook registrations matching the specified event.
+    /// </summary>
+    ValueTask<IEnumerable<WebhookRegistration>> ListByEventTypeAsync(string eventType, CancellationToken cancellationToken = default);
+}

--- a/src/modules/Elsa.Workflows.Api/Endpoints/Tasks/Complete/Constants.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/Tasks/Complete/Constants.cs
@@ -1,0 +1,13 @@
+
+namespace Elsa.Workflows.Api.Endpoints.Tasks.Complete;
+
+/// <summary>
+/// Provides policy names accepted by the <see cref="Complete"/> endpoint.
+/// </summary>
+public static class Constants
+{
+    /// <summary>
+    /// The policy name accepted by this endpoint.
+    /// </summary>
+    public const string PolicyName = "CompleteTask";
+}

--- a/src/modules/Elsa.Workflows.Api/Endpoints/Tasks/Complete/Endpoint.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/Tasks/Complete/Endpoint.cs
@@ -1,0 +1,33 @@
+using Elsa.Abstractions;
+using Elsa.Workflows.Runtime.Activities;
+using Elsa.Workflows.Runtime.Services;
+
+namespace Elsa.Workflows.Api.Endpoints.Tasks.Complete;
+
+/// <summary>
+/// Resumes the <see cref="RunTask"/> activity matching the received Task ID.
+/// </summary>
+public class Complete : ElsaEndpoint<Request, Response>
+{
+    private readonly ITaskReporter _taskReporter;
+
+    /// <inheritdoc />
+    public Complete(ITaskReporter taskReporter)
+    {
+        _taskReporter = taskReporter;
+    }
+
+    /// <inheritdoc />
+    public override void Configure()
+    {
+        Post("/tasks/{taskId}/complete");
+        ConfigurePermissions("complete:task");
+    }
+
+    /// <inheritdoc />
+    public override async Task HandleAsync(Request request, CancellationToken cancellationToken)
+    {
+        await _taskReporter.ReportCompletionAsync(request.TaskId, request.Result, cancellationToken);
+        if (!HttpContext.Response.HasStarted) await SendOkAsync(cancellationToken);
+    }
+}

--- a/src/modules/Elsa.Workflows.Api/Endpoints/Tasks/Complete/Endpoint.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/Tasks/Complete/Endpoint.cs
@@ -21,7 +21,7 @@ public class Complete : ElsaEndpoint<Request, Response>
     public override void Configure()
     {
         Post("/tasks/{taskId}/complete");
-        ConfigurePermissions("complete:task");
+        Policies("CompleteTask");
     }
 
     /// <inheritdoc />

--- a/src/modules/Elsa.Workflows.Api/Endpoints/Tasks/Complete/Models.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/Tasks/Complete/Models.cs
@@ -1,0 +1,11 @@
+namespace Elsa.Workflows.Api.Endpoints.Tasks.Complete;
+
+public class Request
+{
+    public string TaskId { get; set; } = default!;
+    public object? Result { get; set; }
+}
+
+public class Response
+{
+}

--- a/src/modules/Elsa.Workflows.Api/Features/WorkflowsApiFeature.cs
+++ b/src/modules/Elsa.Workflows.Api/Features/WorkflowsApiFeature.cs
@@ -1,6 +1,8 @@
 using Elsa.Extensions;
 using Elsa.Features.Abstractions;
 using Elsa.Features.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Elsa.Workflows.Api.Features;
 
@@ -14,15 +16,22 @@ public class WorkflowsApiFeature : FeatureBase
     {
     }
 
+    /// <summary>
+    /// A delegate that configures the policy requirements for the /tasks/{taskId}/complete API endpoint. 
+    /// </summary>
+    public Action<AuthorizationPolicyBuilder> CompleteTaskPolicy { get; set; } = policy => policy.RequireAuthenticatedUser();
+
     /// <inheritdoc />
     public override void Configure()
     {
+        
         Module.AddFastEndpointsAssembly(GetType());
     }
 
     /// <inheritdoc />
     public override void Apply()
     {
+        Services.AddAuthorization(auth => auth.AddPolicy("CompleteTask", CompleteTaskPolicy));
         Module.AddFastEndpointsFromModule();
     }
 }

--- a/src/samples/aspnet/Elsa.Samples.Webhooks.ExternalApp/Controllers/BackgroundWorker.cs
+++ b/src/samples/aspnet/Elsa.Samples.Webhooks.ExternalApp/Controllers/BackgroundWorker.cs
@@ -1,0 +1,19 @@
+using Elsa.Samples.Webhooks.ExternalApp.Models;
+
+namespace Elsa.Samples.Webhooks.ExternalApp.Controllers;
+
+public class BackgroundWorker
+{
+    private readonly HttpClient _httpClient;
+
+    public BackgroundWorker(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+    
+    public async Task RunAsync(RunTaskPayload taskPayload)
+    {
+        var taskId = taskPayload.TaskId;
+        await _httpClient.PostAsJsonAsync($"tasks/{taskId}/complete", new { Foo = "Bar"  });
+    }
+}

--- a/src/samples/aspnet/Elsa.Samples.Webhooks.ExternalApp/Controllers/WebhooksController.cs
+++ b/src/samples/aspnet/Elsa.Samples.Webhooks.ExternalApp/Controllers/WebhooksController.cs
@@ -1,3 +1,4 @@
+using Elsa.Samples.Webhooks.ExternalApp.Jobs;
 using Elsa.Samples.Webhooks.ExternalApp.Models;
 using Microsoft.AspNetCore.Mvc;
 
@@ -7,17 +8,17 @@ namespace Elsa.Samples.Webhooks.ExternalApp.Controllers;
 [Route("webhooks")]
 public class WebhooksController : ControllerBase
 {
-    private readonly BackgroundWorker _backgroundWorker;
+    private readonly DeliverFoodJob _deliverFoodJob;
 
-    public WebhooksController(BackgroundWorker backgroundWorker)
+    public WebhooksController(DeliverFoodJob deliverFoodJob)
     {
-        _backgroundWorker = backgroundWorker;
+        _deliverFoodJob = deliverFoodJob;
     }
     
     [HttpPost("run-task")]
     public IActionResult RunTask(WebhookEvent<RunTaskPayload> model)
     {
-        Task.Factory.StartNew(() => _backgroundWorker.RunAsync(model.Payload));
+        Task.Factory.StartNew(() => _deliverFoodJob.RunAsync(model.Payload));
         return Accepted();
     }
 }

--- a/src/samples/aspnet/Elsa.Samples.Webhooks.ExternalApp/Controllers/WebhooksController.cs
+++ b/src/samples/aspnet/Elsa.Samples.Webhooks.ExternalApp/Controllers/WebhooksController.cs
@@ -1,0 +1,23 @@
+using Elsa.Samples.Webhooks.ExternalApp.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Elsa.Samples.Webhooks.ExternalApp.Controllers;
+
+[ApiController]
+[Route("webhooks")]
+public class WebhooksController : ControllerBase
+{
+    private readonly BackgroundWorker _backgroundWorker;
+
+    public WebhooksController(BackgroundWorker backgroundWorker)
+    {
+        _backgroundWorker = backgroundWorker;
+    }
+    
+    [HttpPost("run-task")]
+    public IActionResult RunTask(WebhookEvent<RunTaskPayload> model)
+    {
+        Task.Factory.StartNew(() => _backgroundWorker.RunAsync(model.Payload));
+        return Accepted();
+    }
+}

--- a/src/samples/aspnet/Elsa.Samples.Webhooks.ExternalApp/Elsa.Samples.Webhooks.ExternalApp.csproj
+++ b/src/samples/aspnet/Elsa.Samples.Webhooks.ExternalApp/Elsa.Samples.Webhooks.ExternalApp.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+    <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+    </PropertyGroup>
+
+</Project>

--- a/src/samples/aspnet/Elsa.Samples.Webhooks.ExternalApp/Jobs/DeliverFoodJob.cs
+++ b/src/samples/aspnet/Elsa.Samples.Webhooks.ExternalApp/Jobs/DeliverFoodJob.cs
@@ -1,12 +1,12 @@
 using Elsa.Samples.Webhooks.ExternalApp.Models;
 
-namespace Elsa.Samples.Webhooks.ExternalApp.Controllers;
+namespace Elsa.Samples.Webhooks.ExternalApp.Jobs;
 
-public class BackgroundWorker
+public class DeliverFoodJob
 {
     private readonly HttpClient _httpClient;
 
-    public BackgroundWorker(HttpClient httpClient)
+    public DeliverFoodJob(HttpClient httpClient)
     {
         _httpClient = httpClient;
     }
@@ -14,6 +14,6 @@ public class BackgroundWorker
     public async Task RunAsync(RunTaskPayload taskPayload)
     {
         var taskId = taskPayload.TaskId;
-        await _httpClient.PostAsJsonAsync($"tasks/{taskId}/complete", new { Foo = "Bar"  });
+        await _httpClient.PostAsJsonAsync($"tasks/{taskId}/complete", new { Result = "Pizza"  });
     }
 }

--- a/src/samples/aspnet/Elsa.Samples.Webhooks.ExternalApp/Models/RunTaskPayload.cs
+++ b/src/samples/aspnet/Elsa.Samples.Webhooks.ExternalApp/Models/RunTaskPayload.cs
@@ -1,0 +1,3 @@
+namespace Elsa.Samples.Webhooks.ExternalApp.Models;
+
+public record RunTaskPayload(string TaskId, string TaskName, object? TaskParams);

--- a/src/samples/aspnet/Elsa.Samples.Webhooks.ExternalApp/Models/WebhookEvent.cs
+++ b/src/samples/aspnet/Elsa.Samples.Webhooks.ExternalApp/Models/WebhookEvent.cs
@@ -1,0 +1,3 @@
+namespace Elsa.Samples.Webhooks.ExternalApp.Models;
+
+public record WebhookEvent<T>(string EventType, T Payload);

--- a/src/samples/aspnet/Elsa.Samples.Webhooks.ExternalApp/Program.cs
+++ b/src/samples/aspnet/Elsa.Samples.Webhooks.ExternalApp/Program.cs
@@ -6,7 +6,10 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddControllers();
 
 // Configure the background worker with an HTTP client that can report workflow task completion.
-builder.Services.AddHttpClient<BackgroundWorker>(httpClient => httpClient.BaseAddress = new Uri("https://localhost:7164/elsa/api"));
+builder.Services.AddHttpClient<BackgroundWorker>(httpClient =>
+{
+    httpClient.BaseAddress = new Uri("https://localhost:7164/elsa/api/");
+});
 
 var app = builder.Build();
 

--- a/src/samples/aspnet/Elsa.Samples.Webhooks.ExternalApp/Program.cs
+++ b/src/samples/aspnet/Elsa.Samples.Webhooks.ExternalApp/Program.cs
@@ -1,4 +1,5 @@
 using Elsa.Samples.Webhooks.ExternalApp.Controllers;
+using Elsa.Samples.Webhooks.ExternalApp.Jobs;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -6,7 +7,7 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddControllers();
 
 // Configure the background worker with an HTTP client that can report workflow task completion.
-builder.Services.AddHttpClient<BackgroundWorker>(httpClient =>
+builder.Services.AddHttpClient<DeliverFoodJob>(httpClient =>
 {
     httpClient.BaseAddress = new Uri("https://localhost:7164/elsa/api/");
 });

--- a/src/samples/aspnet/Elsa.Samples.Webhooks.ExternalApp/Program.cs
+++ b/src/samples/aspnet/Elsa.Samples.Webhooks.ExternalApp/Program.cs
@@ -1,0 +1,17 @@
+using Elsa.Samples.Webhooks.ExternalApp.Controllers;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+builder.Services.AddControllers();
+
+// Configure the background worker with an HTTP client that can report workflow task completion.
+builder.Services.AddHttpClient<BackgroundWorker>(httpClient => httpClient.BaseAddress = new Uri("https://localhost:7164/elsa/api"));
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+app.UseHttpsRedirection();
+app.UseAuthorization();
+app.MapControllers();
+app.Run();

--- a/src/samples/aspnet/Elsa.Samples.Webhooks.ExternalApp/Properties/launchSettings.json
+++ b/src/samples/aspnet/Elsa.Samples.Webhooks.ExternalApp/Properties/launchSettings.json
@@ -1,0 +1,37 @@
+﻿{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:51659",
+      "sslPort": 44329
+    }
+  },
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:5221",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:7100;http://localhost:5221",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/samples/aspnet/Elsa.Samples.Webhooks.ExternalApp/appsettings.json
+++ b/src/samples/aspnet/Elsa.Samples.Webhooks.ExternalApp/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/src/samples/aspnet/Elsa.Samples.Webhooks.WorkflowServer/Elsa.Samples.Webhooks.WorkflowServer.csproj
+++ b/src/samples/aspnet/Elsa.Samples.Webhooks.WorkflowServer/Elsa.Samples.Webhooks.WorkflowServer.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+    <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\bundles\Elsa\Elsa.csproj" />
+        <ProjectReference Include="..\..\..\modules\Elsa.Http\Elsa.Http.csproj" />
+        <ProjectReference Include="..\..\..\modules\Elsa.Identity\Elsa.Identity.csproj" />
+        <ProjectReference Include="..\..\..\modules\Elsa.Webhooks\Elsa.Webhooks.csproj" />
+        <ProjectReference Include="..\..\..\modules\Elsa.Workflows.Api\Elsa.Workflows.Api.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/samples/aspnet/Elsa.Samples.Webhooks.WorkflowServer/Program.cs
+++ b/src/samples/aspnet/Elsa.Samples.Webhooks.WorkflowServer/Program.cs
@@ -8,25 +8,28 @@ using Microsoft.Extensions.DependencyInjection;
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
-builder.Services.AddControllers();
 builder.Services.AddHandlersFrom<Program>();
 
 builder.Services.AddElsa(elsa =>
 {
-    elsa.AddWorkflow<HungryWorkflow>();
-    elsa.UseHttp();
-    elsa.UseIdentity(identity => identity.IdentityOptions.CreateDefaultAdmin = true);
-    elsa.UseWorkflowsApi();
-    elsa.UseDefaultAuthentication();
-    elsa.UseWebhooks(webhooks => webhooks.RegisterWebhook(new Uri("https://localhost:7100/webhooks/run-task")));
+    elsa.AddWorkflow<HungryWorkflow>()
+    .UseHttp()
+    .UseIdentity(identity =>
+    {
+        identity.IdentityOptions.CreateDefaultAdmin = true;
+        identity.TokenOptions.SigningKey = "secret-signing-key-for-tokens";
+    })
+    .UseWorkflowsApi()
+    .UseDefaultAuthentication()
+    .UseWebhooks(webhooks => webhooks.RegisterWebhook(new Uri("https://localhost:7100/webhooks/run-task")));
 });
 
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.
 app.UseHttpsRedirection();
+app.UseAuthentication();
 app.UseAuthorization();
-app.MapControllers();
 app.UseWorkflowsApi();
 app.UseWorkflows();
 app.Run();

--- a/src/samples/aspnet/Elsa.Samples.Webhooks.WorkflowServer/Program.cs
+++ b/src/samples/aspnet/Elsa.Samples.Webhooks.WorkflowServer/Program.cs
@@ -3,6 +3,7 @@ using Elsa.Extensions;
 using Elsa.Samples.Webhooks.WorkflowServer.Workflows;
 using Elsa.Webhooks.Extensions;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -21,7 +22,7 @@ builder.Services.AddElsa(elsa =>
     })
     .UseWorkflowsApi(api => api.CompleteTaskPolicy = policy => policy.RequireAssertion(_ => true)) // Allows anonymous requests. Will be replaced with an API key scheme.
     .UseDefaultAuthentication()
-    .UseWebhooks(webhooks => webhooks.RegisterWebhook(new Uri("https://localhost:7100/webhooks/run-task")));
+    .UseWebhooks(webhooks => webhooks.WebhookOptions = options => builder.Configuration.GetSection("Webhooks").Bind(options));
 });
 
 var app = builder.Build();

--- a/src/samples/aspnet/Elsa.Samples.Webhooks.WorkflowServer/Program.cs
+++ b/src/samples/aspnet/Elsa.Samples.Webhooks.WorkflowServer/Program.cs
@@ -1,0 +1,32 @@
+using System;
+using Elsa.Extensions;
+using Elsa.Samples.Webhooks.WorkflowServer.Workflows;
+using Elsa.Webhooks.Extensions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+builder.Services.AddControllers();
+builder.Services.AddHandlersFrom<Program>();
+
+builder.Services.AddElsa(elsa =>
+{
+    elsa.AddWorkflow<HungryWorkflow>();
+    elsa.UseHttp();
+    elsa.UseIdentity(identity => identity.IdentityOptions.CreateDefaultAdmin = true);
+    elsa.UseWorkflowsApi();
+    elsa.UseDefaultAuthentication();
+    elsa.UseWebhooks(webhooks => webhooks.RegisterWebhook(new Uri("https://localhost:7100/webhooks/run-task")));
+});
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+app.UseHttpsRedirection();
+app.UseAuthorization();
+app.MapControllers();
+app.UseWorkflowsApi();
+app.UseWorkflows();
+app.Run();

--- a/src/samples/aspnet/Elsa.Samples.Webhooks.WorkflowServer/Program.cs
+++ b/src/samples/aspnet/Elsa.Samples.Webhooks.WorkflowServer/Program.cs
@@ -19,7 +19,7 @@ builder.Services.AddElsa(elsa =>
         identity.IdentityOptions.CreateDefaultAdmin = true;
         identity.TokenOptions.SigningKey = "secret-signing-key-for-tokens";
     })
-    .UseWorkflowsApi()
+    .UseWorkflowsApi(api => api.CompleteTaskPolicy = policy => policy.RequireAssertion(_ => true)) // Allows anonymous requests. Will be replaced with an API key scheme.
     .UseDefaultAuthentication()
     .UseWebhooks(webhooks => webhooks.RegisterWebhook(new Uri("https://localhost:7100/webhooks/run-task")));
 });

--- a/src/samples/aspnet/Elsa.Samples.Webhooks.WorkflowServer/Properties/launchSettings.json
+++ b/src/samples/aspnet/Elsa.Samples.Webhooks.WorkflowServer/Properties/launchSettings.json
@@ -1,0 +1,37 @@
+﻿{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:6242",
+      "sslPort": 44309
+    }
+  },
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:5042",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:7164;http://localhost:5042",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/samples/aspnet/Elsa.Samples.Webhooks.WorkflowServer/Workflows/HungryWorkflow.cs
+++ b/src/samples/aspnet/Elsa.Samples.Webhooks.WorkflowServer/Workflows/HungryWorkflow.cs
@@ -1,0 +1,37 @@
+using Elsa.Http;
+using Elsa.Workflows.Core.Activities;
+using Elsa.Workflows.Core.Models;
+using Elsa.Workflows.Core.Services;
+using Elsa.Workflows.Runtime.Activities;
+using Microsoft.AspNetCore.Http;
+
+namespace Elsa.Samples.Webhooks.WorkflowServer.Workflows;
+
+public class HungryWorkflow : WorkflowBase
+{
+    protected override void Build(IWorkflowBuilder builder)
+    {
+        var deliveredFood = new Variable<string>();
+        
+        builder.Root = new Sequence
+        {
+            Activities =
+            {
+                new HttpEndpoint
+                {
+                    Path = new("/hungry"),
+                    SupportedMethods = new (new[]{HttpMethods.Post}),
+                    CanStartWorkflow = true
+                },
+                new WriteLine("Hunger detected!"),
+                new RunTask("OrderFood")
+                {
+                    TaskParams = new(new { Food = "Pizza" }),
+                    Result = new Output<object>(deliveredFood)
+                },
+                new WriteLine(context => $"Eating the {deliveredFood.Get(context)}"),
+                new WriteLine("Hunger satisfied!")
+            }
+        };
+    }
+}

--- a/src/samples/aspnet/Elsa.Samples.Webhooks.WorkflowServer/appsettings.Development.json
+++ b/src/samples/aspnet/Elsa.Samples.Webhooks.WorkflowServer/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/samples/aspnet/Elsa.Samples.Webhooks.WorkflowServer/appsettings.Development.json
+++ b/src/samples/aspnet/Elsa.Samples.Webhooks.WorkflowServer/appsettings.Development.json
@@ -1,8 +1,0 @@
-{
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
-    }
-  }
-}

--- a/src/samples/aspnet/Elsa.Samples.Webhooks.WorkflowServer/appsettings.json
+++ b/src/samples/aspnet/Elsa.Samples.Webhooks.WorkflowServer/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/src/samples/aspnet/Elsa.Samples.Webhooks.WorkflowServer/appsettings.json
+++ b/src/samples/aspnet/Elsa.Samples.Webhooks.WorkflowServer/appsettings.json
@@ -5,5 +5,15 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Webhooks": {
+    "Endpoints": [
+      {
+        "EventTypes": [
+          "RunTask"
+        ],
+        "Url": "https://localhost:7100/webhooks/run-task"
+      }
+    ]
+  }
 }

--- a/src/samples/aspnet/Elsa.Samples.Webhooks.WorkflowServer/run-workflow.http
+++ b/src/samples/aspnet/Elsa.Samples.Webhooks.WorkflowServer/run-workflow.http
@@ -1,0 +1,1 @@
+POST https://localhost:7164/workflows/hungry

--- a/src/samples/aspnet/Elsa.Samples.WorkflowServer/Program.cs
+++ b/src/samples/aspnet/Elsa.Samples.WorkflowServer/Program.cs
@@ -1,6 +1,8 @@
 using Elsa.EntityFrameworkCore.Extensions;
 using Elsa.EntityFrameworkCore.Modules.Management;
 using Elsa.Extensions;
+using Elsa.Identity;
+using Elsa.Requirements;
 
 var builder = WebApplication.CreateBuilder(args);
 

--- a/src/samples/aspnet/Elsa.Samples.WorkflowServer/Properties/launchSettings.json
+++ b/src/samples/aspnet/Elsa.Samples.WorkflowServer/Properties/launchSettings.json
@@ -24,7 +24,7 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "launchUrl": "swagger",
-      "applicationUrl": "https://localhost:7248;http://localhost:5066",
+      "applicationUrl": "https://localhost:7228;http://localhost:5066",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }


### PR DESCRIPTION
This PR adds a new module called **Webhooks**.

The module allows users to register HTTP endpoints to be invoked when certain events occur.

Currently, it only invokes webhooks for the "RunTask" event, but the goal is for this module to be extensible by other modules that can add more webhook event types.

Webhook endpoints can be configured via appsettings, but additional sources can be implemented (e.g. a DB persistent provider could be added to allow users to define webhooks from the dashboard)

Combining the webhooks module together with the RunTask activity from a workflow makes it easy to integrate external applications with a workflow via HTTP communications, without necessarily having to write custom activities.

Unrelated to the Webhooks module, but a future addition could be to have an activity type provider that dynamically produces "RunTask" activities based on task descriptions created by the user.