### PR TITLE
Fix for dynamic model changes are not triggering re-rendering x6 designer

### DIFF
--- a/src/designer/elsa-workflows-studio/src/components/designers/x6-designer/x6-designer.tsx
+++ b/src/designer/elsa-workflows-studio/src/components/designers/x6-designer/x6-designer.tsx
@@ -134,6 +134,12 @@ export class ElsaWorkflowDesigner {
     setTimeout(() => this.updateGraph(), 1);
   }
 
+  @Watch('model')
+  handleModelChanged(newValue: WorkflowModel) {
+    this.updateWorkflowModel(newValue, false);
+    setTimeout(() => this.updateGraph(), 1);
+  }
+
   @Method()
   async removeActivity(activity: ActivityModel) {
     const cell = this.graph.getCells().find(x => x.id === activity.activityId);


### PR DESCRIPTION
Found issue while using WorkflowEditor blazor component in dynamically changing workflow definition ids. Api calls were successful, model setup correctly by elsaStudio but x6 designer weren't re-rendering. This PR fixes that issue.