### PR TITLE
Fix return type in `instantFromLocalDate` type def

### DIFF
--- a/src/scripting/Elsa.Scripting.JavaScript/Handlers/RenderJavaScriptDateTimeTypeDefinitions.cs
+++ b/src/scripting/Elsa.Scripting.JavaScript/Handlers/RenderJavaScriptDateTimeTypeDefinitions.cs
@@ -34,7 +34,7 @@ namespace Elsa.Scripting.JavaScript.Handlers
             output.AppendLine("declare function durationFromDays(days: number): Duration;");
             output.AppendLine("declare function formatInstant(instant: Instant, format: string, culture?: CultureInfo): string;");
             output.AppendLine("declare function localDateFromInstant(instant: Instant): LocalDate;");
-            output.AppendLine("declare function instantFromLocalDate(localDate: LocalDate): LocalDate;");
+            output.AppendLine("declare function instantFromLocalDate(localDate: LocalDate): Instant;");
             output.AppendLine("declare function durationBetween(a: Instant, b: Instant): Duration;");
             output.AppendLine("declare function periodFromNow(pastInstant: Instant): Period;");
             output.AppendLine("declare function jsonEncode(value: any): string;");


### PR DESCRIPTION
The return type for the `instantFromLocalDate` javascript function is `Instant`, actually, but the type definition provider reports `LocalDate` to the client.