### PR TITLE
Fix for EnumerableTypeDefinitionProvider #3614 and fix Kafka project build

### DIFF
--- a/src/activities/Elsa.Activities.Kafka/Elsa.Activities.Kafka.csproj
+++ b/src/activities/Elsa.Activities.Kafka/Elsa.Activities.Kafka.csproj
@@ -1,13 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+    <Import Project="..\..\..\common.props" />
+    <Import Project="..\..\..\configureawait.props" />
+    
     <PropertyGroup>
-        <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+        <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
         <Description>
             Elsa is a set of workflow libraries and tools that enable lean and mean workflowing capabilities in any .NET Core application.
-            This package provides activities to send and receive messages using Rabbit MQ.</Description>
+            This package provides activities to send and receive messages using Kafka.</Description>        
         <PackageTags>elsa, workflows</PackageTags>
-            This package provides activities to send and receive messages using Kafka.</Description>
-        <PackageTags>elsa, workflows, kafka</PackageTags>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 

--- a/src/scripting/Elsa.Scripting.JavaScript/Typings/EnumerableTypeDefinitionProvider.cs
+++ b/src/scripting/Elsa.Scripting.JavaScript/Typings/EnumerableTypeDefinitionProvider.cs
@@ -22,7 +22,7 @@ namespace Elsa.Scripting.JavaScript.Typings
             var providers = _serviceProvider.GetServices<ITypeDefinitionProvider>().Where(x => x is not EnumerableTypeDefinitionProvider).ToList();
             var commonTypesProvider = providers.OfType<CommonTypeDefinitionProvider>().FirstOrDefault();
             var elementType = type.IsArray ? type.GetElementType()! : type.GetGenericArguments().FirstOrDefault();
-            var typeScriptType = elementType!= null ?
+            var typeScriptType = elementType != null ?
                 commonTypesProvider?.SupportsType(context, elementType) == true ?
                     commonTypesProvider.GetTypeDefinition(context, elementType)
                     : elementType.Name

--- a/src/scripting/Elsa.Scripting.JavaScript/Typings/EnumerableTypeDefinitionProvider.cs
+++ b/src/scripting/Elsa.Scripting.JavaScript/Typings/EnumerableTypeDefinitionProvider.cs
@@ -22,9 +22,11 @@ namespace Elsa.Scripting.JavaScript.Typings
             var providers = _serviceProvider.GetServices<ITypeDefinitionProvider>().Where(x => x is not EnumerableTypeDefinitionProvider).ToList();
             var commonTypesProvider = providers.OfType<CommonTypeDefinitionProvider>().FirstOrDefault();
             var elementType = type.IsArray ? type.GetElementType()! : type.GetGenericArguments().FirstOrDefault();
-            var typeScriptType = commonTypesProvider?.SupportsType(context, elementType) == true ?
-                commonTypesProvider.GetTypeDefinition(context, elementType) :
-                elementType.Name;
+            var typeScriptType = elementType!= null ?
+                commonTypesProvider?.SupportsType(context, elementType) == true ?
+                    commonTypesProvider.GetTypeDefinition(context, elementType)
+                    : elementType.Name
+                : "";
 
             return $"{typeScriptType}[]";
         }


### PR DESCRIPTION
Fix #3614 by reintroducing check whether `elementType` is `null`.

Fix Kafka project and main branch build.