### PR TITLE
Activities Kafka: Changed LogLevel to Information

### DIFF
--- a/src/activities/Elsa.Activities.Kafka/Services/Worker.cs
+++ b/src/activities/Elsa.Activities.Kafka/Services/Worker.cs
@@ -64,7 +64,7 @@ namespace Elsa.Activities.Kafka.Services
 
         private async Task OnMessageReceivedAsync(KafkaMessageEvent ev)
         {
-            _logger.LogWarning("Message received for Topic {Topic}", _client.Configuration.Topic);
+            _logger.LogInformation("Message received for Topic {Topic}", _client.Configuration.Topic);
 
             await TriggerWorkflowsAsync(ev, ev.CancellationToken);
         }


### PR DESCRIPTION
There is no need to log every incoming KafkaMessage as a warning. This just fills up logs with unnessecary warnings.