### PR TITLE
feat: 🎸 AzureServiceBus - TenantIdResolver

### DIFF
--- a/src/activities/Elsa.Activities.AzureServiceBus/Extensions/ServiceCollectionExtensions.cs
+++ b/src/activities/Elsa.Activities.AzureServiceBus/Extensions/ServiceCollectionExtensions.cs
@@ -28,6 +28,7 @@ namespace Elsa.Activities.AzureServiceBus.Extensions
                 .AddSingleton(CreateServiceBusManagementClient)
                 .AddSingleton<IMessageSenderFactory, MessageSenderFactory>()
                 .AddSingleton<IWorkerManager, WorkerManager>()
+                .AddSingleton<IAzureServiceBusTenantIdResolver, DefaultAzureServiceBusTenantIdResolver>()
                 .AddHostedService<StartWorkers>()
                 .AddBookmarkProvider<MessageReceivedBookmarkProvider>()
                 ;

--- a/src/activities/Elsa.Activities.AzureServiceBus/Services/DefaultAzureServiceBusTenantIdResolver.cs
+++ b/src/activities/Elsa.Activities.AzureServiceBus/Services/DefaultAzureServiceBusTenantIdResolver.cs
@@ -1,0 +1,32 @@
+// file:	Elsa.Activities.AzureServiceBus\Services\NoOpAzureServiceBusTenantIdResolver.cs
+//
+// summary:	Implements the no operation azure service bus tenant identifier resolver class
+using Azure.Messaging.ServiceBus;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Elsa.Activities.AzureServiceBus.Services
+{
+    /// <summary>
+    /// A no operation azure service bus tenant identifier resolver.
+    /// </summary>
+    public class DefaultAzureServiceBusTenantIdResolver : IAzureServiceBusTenantIdResolver
+    {
+        /// <summary>
+        /// Resolves.
+        /// </summary>
+        /// <param name="message"> The message.</param>
+        /// <param name="queueOrTopic"> The queue or topic.</param>
+        /// <param name="subscription"> The subscription.</param>
+        /// <param name="tags"> The tags.</param>
+        /// <param name="cancellationToken"> A token that allows processing to be cancelled.</param>
+        /// <returns>
+        /// A string?
+        /// </returns>
+        public ValueTask<string?> Resolve(ServiceBusMessage message, string queueOrTopic, string? subscription, HashSet<string> tags, CancellationToken cancellationToken)
+        {
+            return new ValueTask<string?>();
+        }
+    }
+}

--- a/src/activities/Elsa.Activities.AzureServiceBus/Services/DefaultAzureServiceBusTenantIdResolver.cs
+++ b/src/activities/Elsa.Activities.AzureServiceBus/Services/DefaultAzureServiceBusTenantIdResolver.cs
@@ -24,7 +24,7 @@ namespace Elsa.Activities.AzureServiceBus.Services
         /// <returns>
         /// A string?
         /// </returns>
-        public ValueTask<string?> Resolve(ServiceBusMessage message, string queueOrTopic, string? subscription, HashSet<string> tags, CancellationToken cancellationToken)
+        public ValueTask<string?> ResolveAsync(ServiceBusMessage message, string queueOrTopic, string? subscription, HashSet<string> tags, CancellationToken cancellationToken)
         {
             return new ValueTask<string?>();
         }

--- a/src/activities/Elsa.Activities.AzureServiceBus/Services/IAzureServiceBusTenantIdResolver.cs
+++ b/src/activities/Elsa.Activities.AzureServiceBus/Services/IAzureServiceBusTenantIdResolver.cs
@@ -24,6 +24,6 @@ namespace Elsa.Activities.AzureServiceBus.Services
         /// <returns>
         /// A string?
         /// </returns>
-        ValueTask<string?> Resolve(ServiceBusMessage message, string queueOrTopic, string? subscription, HashSet<string> tags, CancellationToken cancellationToken);
+        ValueTask<string?> ResolveAsync(ServiceBusMessage message, string queueOrTopic, string? subscription, HashSet<string> tags, CancellationToken cancellationToken);
     }
 }

--- a/src/activities/Elsa.Activities.AzureServiceBus/Services/IAzureServiceBusTenantIdResolver.cs
+++ b/src/activities/Elsa.Activities.AzureServiceBus/Services/IAzureServiceBusTenantIdResolver.cs
@@ -1,0 +1,29 @@
+// file:	Elsa.Activities.AzureServiceBus\Services\IAzureServiceBusTenantIdResolver.cs
+//
+// summary:	Declares the IAzureServiceBusTenantIdResolver interface
+using Azure.Messaging.ServiceBus;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Elsa.Activities.AzureServiceBus.Services
+{
+    /// <summary>
+    /// Interface for azure service bus tenant identifier resolver.
+    /// </summary>
+    public interface IAzureServiceBusTenantIdResolver
+    {
+        /// <summary>
+        /// Resolves.
+        /// </summary>
+        /// <param name="message"> The message.</param>
+        /// <param name="queueOrTopic"> The queue or topic.</param>
+        /// <param name="subscription"> The subscription.</param>
+        /// <param name="tags"> The tags.</param>
+        /// <param name="cancellationToken"> A token that allows processing to be cancelled.</param>
+        /// <returns>
+        /// A string?
+        /// </returns>
+        ValueTask<string?> Resolve(ServiceBusMessage message, string queueOrTopic, string? subscription, HashSet<string> tags, CancellationToken cancellationToken);
+    }
+}

--- a/src/activities/Elsa.Activities.AzureServiceBus/Services/Worker.cs
+++ b/src/activities/Elsa.Activities.AzureServiceBus/Services/Worker.cs
@@ -98,7 +98,7 @@ namespace Elsa.Activities.AzureServiceBus.Services
 
         private async Task TriggerWorkflowsAsync(ServiceBusMessage message, CancellationToken cancellationToken)
         {
-            var tenantId = await _tenantIdResolver.Resolve(message, QueueOrTopic, Subscription, Tags, cancellationToken);
+            var tenantId = await _tenantIdResolver.ResolveAsync(message, QueueOrTopic, Subscription, Tags, cancellationToken);
             var correlationId = message.CorrelationId;
 
             var model = new MessageModel

--- a/src/activities/Elsa.Activities.AzureServiceBus/Services/Worker.cs
+++ b/src/activities/Elsa.Activities.AzureServiceBus/Services/Worker.cs
@@ -24,6 +24,7 @@ namespace Elsa.Activities.AzureServiceBus.Services
         private readonly IServiceScopeFactory _serviceScopeFactory;
         private readonly ILogger _logger;
         private readonly ServiceBusProcessor _processor;
+        private readonly IAzureServiceBusTenantIdResolver _tenantIdResolver;
 
         public Worker(
             string queueOrTopic,
@@ -33,6 +34,7 @@ namespace Elsa.Activities.AzureServiceBus.Services
             ServiceBusAdministrationClient administrationClient,
             IServiceScopeFactory serviceScopeFactory,
             IOptions<AzureServiceBusOptions> options,
+            IAzureServiceBusTenantIdResolver tenantIdResolver,
             ILogger<Worker> logger)
         {
             QueueOrTopic = queueOrTopic;
@@ -42,6 +44,7 @@ namespace Elsa.Activities.AzureServiceBus.Services
             _administrationClient = administrationClient;
             _serviceScopeFactory = serviceScopeFactory;
             _logger = logger;
+            _tenantIdResolver = tenantIdResolver;
 
             var processorOptions = new ServiceBusProcessorOptions
             {
@@ -95,6 +98,7 @@ namespace Elsa.Activities.AzureServiceBus.Services
 
         private async Task TriggerWorkflowsAsync(ServiceBusMessage message, CancellationToken cancellationToken)
         {
+            var tenantId = await _tenantIdResolver.Resolve(message, QueueOrTopic, Subscription, Tags, cancellationToken);
             var correlationId = message.CorrelationId;
 
             var model = new MessageModel
@@ -116,7 +120,7 @@ namespace Elsa.Activities.AzureServiceBus.Services
             };
 
             var bookmark = new MessageReceivedBookmark(QueueOrTopic, Subscription);
-            var launchContext = new WorkflowsQuery(ActivityType, bookmark, correlationId);
+            var launchContext = new WorkflowsQuery(ActivityType, bookmark, correlationId, TenantId: tenantId);
 
             using var scope = _serviceScopeFactory.CreateScope();
             var workflowLaunchpad = scope.ServiceProvider.GetRequiredService<IWorkflowLaunchpad>();

--- a/test/integration/Elsa.Core.IntegrationTests/Workflows/ServiceBusWorkflowTest.cs
+++ b/test/integration/Elsa.Core.IntegrationTests/Workflows/ServiceBusWorkflowTest.cs
@@ -34,6 +34,7 @@ namespace Elsa.Core.IntegrationTests.Workflows
                     services
                         .AddSingleton<IWorkflowLaunchpad, WorkflowLaunchpad>()
                         .AddSingleton<IWorkerManager, WorkerManager>()
+                        .AddSingleton<IAzureServiceBusTenantIdResolver, DefaultAzureServiceBusTenantIdResolver>()
                         .AddSingleton(WorkflowRegistryMoq.Object)
                         .AddBookmarkProvider<MessageReceivedBookmarkProvider>()
                         .AddHostedService<StartWorkers>();


### PR DESCRIPTION
This PR is in response to #3667 Feature: Azure Service Bus Tenant Id Resolver.

Introduces a new interface `IAzureServiceBusTenantIdResolver` with a single method `ResolveAsync`  this method will pass all the relevant details from the Worker to the Resolver.

By Default Elsa will ship with a "NoOp" resolver called `DefaultAzureServiceBusTenantIdResolver` which returns a null string.

This will be added to dependency injection as a singleton (resolved from the root scope when workers are created).

Applications may override this behavior by registering a custom instance of the `IAzureServiceBusTenantIdResolver` **after** the call to `AddAzureServiceBusActivities(...)`.

Such as the code snippet below.

```
services.AddElsa(c =>
              {
                 // ...omitted
                  c.AddAzureServiceBusActivities(az => az.ConnectionString = "");
              })
              .AddSingleton<IAzureServiceBusTenantIdResolver, CustomAzureServiceBusTenantIdResolver>();
```
