### PR TITLE
fix: add missing tenant id specifiers; limit tailwind css to elsa-studio-root

### DIFF
--- a/src/core/Elsa.Core/Providers/Workflows/BlobStorageWorkflowProvider.cs
+++ b/src/core/Elsa.Core/Providers/Workflows/BlobStorageWorkflowProvider.cs
@@ -133,7 +133,10 @@ namespace Elsa.Providers.Workflows
         }
 
         public override async ValueTask<IEnumerable<IWorkflowBlueprint>> FindManyByTagAsync(string tag, VersionOptions versionOptions, string? tenantId = default, CancellationToken cancellationToken = default) => 
-            await ListInternalAsync(cancellationToken).Where(x => string.Equals(tag, x.Tag, StringComparison.OrdinalIgnoreCase) && x.WithVersion(versionOptions)).ToListAsync(cancellationToken);
+            await ListInternalAsync(cancellationToken)
+                .Where(x => string.Equals(tag, x.Tag, StringComparison.OrdinalIgnoreCase) 
+                            && x.WithVersion(versionOptions) && (x.TenantId == default || x.TenantId == tenantId))
+                .ToListAsync(cancellationToken);
 
         private async IAsyncEnumerable<IWorkflowBlueprint> ListInternalAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
         {

--- a/src/core/Elsa.Core/Providers/Workflows/DatabaseWorkflowProvider.cs
+++ b/src/core/Elsa.Core/Providers/Workflows/DatabaseWorkflowProvider.cs
@@ -75,7 +75,14 @@ namespace Elsa.Providers.Workflows
 
         public override async ValueTask<IWorkflowBlueprint?> FindByDefinitionVersionIdAsync(string definitionVersionId, string? tenantId = default, CancellationToken cancellationToken = default)
         {
-            var workflowDefinition = await _workflowDefinitionStore.FindAsync(new WorkflowDefinitionVersionIdSpecification(definitionVersionId), cancellationToken);
+            var specification = (ISpecification<WorkflowDefinition>)new WorkflowDefinitionVersionIdSpecification(definitionVersionId);
+
+            if (!string.IsNullOrEmpty(tenantId))
+            { 
+                specification = specification.WithTenant(tenantId);
+            }
+
+            var workflowDefinition = await _workflowDefinitionStore.FindAsync(specification, cancellationToken);
             return workflowDefinition == null ? null : await TryMaterializeBlueprintAsync(workflowDefinition, cancellationToken);
         }
 

--- a/src/designer/elsa-workflows-studio/tailwind.config.js
+++ b/src/designer/elsa-workflows-studio/tailwind.config.js
@@ -4,6 +4,7 @@ const colors = require('tailwindcss/colors')
 const dev = process.env.NODE_ENV === 'development';
 
 module.exports = {
+  important: 'elsa-studio-root',
   content: ['./src/**/*.tsx', './src/**/*.html'],
   safelist: ['hidden', 'jtk-connector', 'jtk-endpoint', 'x6-node', 'x6-port-out', 'x6-port-label', 'x6-graph-scroller', 'rose', 'sky', 'label-container', 'node', 'start', 'activity', 'border-blue-600', 'border-green-600', 'border-red-600', {
     pattern: /gray|pink|blue|green|red|yellow|rose/


### PR DESCRIPTION
This PR attempts to address two issues my team is facing:

1. Some missing tenant id filters
2. Elsa's css files conflict with many of our website's styles because they aren't limited to `elsa-studio-root` and below