### PR TITLE
Upgraded Rebus to remove warnings

### DIFF
--- a/src/activities/Elsa.Activities.RabbitMq/Elsa.Activities.RabbitMq.csproj
+++ b/src/activities/Elsa.Activities.RabbitMq/Elsa.Activities.RabbitMq.csproj
@@ -17,7 +17,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Rebus.RabbitMq" Version="7.3.4" />
+      <PackageReference Include="Rebus.RabbitMq" Version="8.0.0" />
     </ItemGroup>
 
 </Project>

--- a/src/core/Elsa.Abstractions/Elsa.Abstractions.csproj
+++ b/src/core/Elsa.Abstractions/Elsa.Abstractions.csproj
@@ -25,7 +25,7 @@
         <PackageReference Include="NodaTime" Version="3.0.9" />
         <PackageReference Include="NodaTime.Serialization.JsonNet" Version="3.0.0" />
         <PackageReference Include="Open.Linq.AsyncExtensions" Version="1.2.0" />
-        <PackageReference Include="Rebus" Version="6.6.2" />
+        <PackageReference Include="Rebus" Version="7.0.0" />
         <PackageReference Include="System.Linq.Async" Version="5.1.0" />
         <PackageReference Include="System.Text.Json" Version="6.0.1" />
         <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />

--- a/src/core/Elsa.Core/Elsa.Core.csproj
+++ b/src/core/Elsa.Core/Elsa.Core.csproj
@@ -36,8 +36,8 @@
         <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
         <PackageReference Include="NodaTime.Serialization.JsonNet" Version="3.0.0" />
         <PackageReference Include="Open.Linq.AsyncExtensions" Version="1.2.0" />
-        <PackageReference Include="Rebus.Microsoft.Extensions.Logging" Version="3.0.0" />
-        <PackageReference Include="Rebus.ServiceProvider" Version="7.0.0" />
+        <PackageReference Include="Rebus.Microsoft.Extensions.Logging" Version="4.0.0" />
+        <PackageReference Include="Rebus.ServiceProvider" Version="8.4.0" />
         <PackageReference Include="Scrutor" Version="3.3.0" />
         <PackageReference Include="Storage.Net" Version="9.3.0" />
         <PackageReference Include="System.Linq.Async" Version="5.1.0" />

--- a/src/samples/worker/Elsa.Samples.RebusErrorWorker/Elsa.Samples.RebusErrorWorker.csproj
+++ b/src/samples/worker/Elsa.Samples.RebusErrorWorker/Elsa.Samples.RebusErrorWorker.csproj
@@ -7,7 +7,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
-        <PackageReference Include="Rebus.AzureServiceBus" Version="9.0.8" />
+        <PackageReference Include="Rebus.AzureServiceBus" Version="9.3.2" />
         <PackageReference Include="System.Text.Encodings.Web" Version="7.0.0" />
     </ItemGroup>
 

--- a/src/samples/worker/Elsa.Samples.RebusWorker/Elsa.Samples.RebusWorker.csproj
+++ b/src/samples/worker/Elsa.Samples.RebusWorker/Elsa.Samples.RebusWorker.csproj
@@ -7,7 +7,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
-        <PackageReference Include="Rebus.AzureServiceBus" Version="9.0.8" />
+        <PackageReference Include="Rebus.AzureServiceBus" Version="9.3.2" />
         <PackageReference Include="System.Text.Encodings.Web" Version="7.0.0" />
     </ItemGroup>
 

--- a/src/servicebus/Elsa.Rebus.AzureServiceBus/Elsa.Rebus.AzureServiceBus.csproj
+++ b/src/servicebus/Elsa.Rebus.AzureServiceBus/Elsa.Rebus.AzureServiceBus.csproj
@@ -17,7 +17,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Rebus.AzureServiceBus" Version="9.0.8" />
+        <PackageReference Include="Rebus.AzureServiceBus" Version="9.3.2" />
     </ItemGroup>
 
 </Project>

--- a/src/servicebus/Elsa.Rebus.RabbitMq/Elsa.Rebus.RabbitMq.csproj
+++ b/src/servicebus/Elsa.Rebus.RabbitMq/Elsa.Rebus.RabbitMq.csproj
@@ -17,7 +17,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Rebus.RabbitMq" Version="7.3.4" />
+        <PackageReference Include="Rebus.RabbitMq" Version="8.0.0" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
When using .NET 6 / 7 we were getting warnings in rebus due to version mismatches:

```
warning NU1608: Detected package version outside of dependency constraint: 
Rebus.Microsoft.Extensions.Logging 3.0.0 requires microsoft.extensions.logging (>= 6.0.0 && < 7.0.0) 
but version Microsoft.Extensions.Logging 7.0.0 was resolved. [TargetFramework=net6.0]
```

```
warning NU1608: Detected package version outside of dependency constraint: 
Rebus.Microsoft.Extensions.Logging 3.0.0 requires microsoft.extensions.logging (>= 6.0.0 && < 7.0.0) 
but version Microsoft.Extensions.Logging 7.0.0 was resolved. [TargetFramework=net7.0]
```

This PR resolves these issues:
https://github.com/rebus-org/Rebus.Microsoft.Extensions.Logging/pull/11

The other warnings were resolved in other PRs:

```
warning NU1608: Detected package version outside of dependency constraint: 
Rebus.ServiceProvider 7.0.0 requires Microsoft.Extensions.Hosting.Abstractions (>= 3.0.0 && < 7.0.0) 
but version Microsoft.Extensions.Hosting.Abstractions 7.0.0 was resolved.
```
