### PR TITLE
Fix premature cleaning of scopes after retrying faulted workflow

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 image: Visual Studio 2022
 
 environment:
-    elsa_version: 2.10.0
+    elsa_version: 2.11.0
     elsa_build_version: 0.0.0
     nodejs_version: "19.0.1"
     # AppVeyor installs Java on its build agents by default, but it
@@ -28,7 +28,7 @@ init:
                 $env:elsa_build_version="$($env:elsa_version)-preview.$($env:APPVEYOR_BUILD_NUMBER)"
             }
 
-version: 2.10.0.{build}
+version: 2.11.0.{build}
 
 pull_requests:
     do_not_increment_build_number: true

--- a/src/activities/Elsa.Activities.Email/Services/ISmtpService.cs
+++ b/src/activities/Elsa.Activities.Email/Services/ISmtpService.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Elsa.Services.Models;
 using MimeKit;
@@ -7,6 +8,9 @@ namespace Elsa.Activities.Email.Services
 {
     public interface ISmtpService
     {
+        [Obsolete("Use the overload without the ActivityExecutionContext parameter instead.")]
         Task SendAsync(ActivityExecutionContext context, MimeMessage message, CancellationToken cancellationToken);
+        
+        Task SendAsync(MimeMessage message, CancellationToken cancellationToken);
     }
 }

--- a/src/activities/Elsa.Activities.Email/Services/MailKitSmtpService.cs
+++ b/src/activities/Elsa.Activities.Email/Services/MailKitSmtpService.cs
@@ -28,7 +28,9 @@ namespace Elsa.Activities.Email.Services
             _logger = logger;
         }
 
-        public async Task SendAsync(ActivityExecutionContext context, MimeMessage message, CancellationToken cancellationToken)
+        public async Task SendAsync(ActivityExecutionContext context, MimeMessage message, CancellationToken cancellationToken) => await SendAsync(message, cancellationToken);
+
+        public async Task SendAsync(MimeMessage message, CancellationToken cancellationToken)
         {
             switch (_options.DeliveryMethod)
             {

--- a/src/activities/Elsa.Activities.Telnyx/Activities/BridgeCalls.cs
+++ b/src/activities/Elsa.Activities.Telnyx/Activities/BridgeCalls.cs
@@ -21,7 +21,7 @@ namespace Elsa.Activities.Telnyx.Activities
     [Action(
         Category = Constants.Category,
         Description = "Bridge two call control calls.",
-        Outcomes = new[] { TelnyxOutcomeNames.Bridged, TelnyxOutcomeNames.CallIsNoLongerActive },
+        Outcomes = new[] { TelnyxOutcomeNames.Bridging, TelnyxOutcomeNames.Bridged, TelnyxOutcomeNames.CallIsNoLongerActive },
         DisplayName = "Bridge Calls"
     )]
     public class BridgeCalls : Activity
@@ -88,7 +88,7 @@ namespace Elsa.Activities.Telnyx.Activities
             try
             {
                 await _telnyxClient.Calls.BridgeCallsAsync(callControlIdA, request, context.CancellationToken);
-                return Suspend();
+                return Combine(Outcome(TelnyxOutcomeNames.Bridging), Suspend());
             }
             catch (ApiException e)
             {

--- a/src/activities/Elsa.Activities.Telnyx/Activities/Dial.cs
+++ b/src/activities/Elsa.Activities.Telnyx/Activities/Dial.cs
@@ -23,7 +23,18 @@ namespace Elsa.Activities.Telnyx.Activities
     [Action(
         Category = Constants.Category,
         Description = "Dial a number or SIP URI from a given connection.",
-        Outcomes = new[] { TelnyxOutcomeNames.CallInitiated, TelnyxOutcomeNames.Answered, TelnyxOutcomeNames.Hangup, TelnyxOutcomeNames.MachineGreetingEnded, OutcomeNames.Done },
+        Outcomes = new[]
+        {
+            TelnyxOutcomeNames.CallInitiated,
+            TelnyxOutcomeNames.Answered,
+            TelnyxOutcomeNames.Hangup,
+            TelnyxOutcomeNames.MachineDetectionEnded,
+            TelnyxOutcomeNames.MachineDetected,
+            TelnyxOutcomeNames.MachineGreetingEnded,
+            TelnyxOutcomeNames.AnsweredByHuman,
+            TelnyxOutcomeNames.AnsweredByMachine,
+            OutcomeNames.Done
+        },
         DisplayName = "Dial"
     )]
     public class Dial : Activity
@@ -80,6 +91,14 @@ namespace Elsa.Activities.Telnyx.Activities
             SupportedSyntaxes = new[] { SyntaxNames.JavaScript, SyntaxNames.Liquid })]
         public string? CommandId { get; set; }
 
+        [ActivityInput(
+            Hint = "Start recording automatically after an event. Disabled by default.",
+            UIHint = ActivityInputUIHints.Dropdown,
+            Options = new[] { "", "record-from-answer" },
+            DefaultValue = "",
+            SupportedSyntaxes = new[] { SyntaxNames.Literal, SyntaxNames.JavaScript, SyntaxNames.Liquid })]
+        public string? Record { get; set; }
+
         [ActivityInput(Label = "Custom Headers", Hint = "Custom headers to be added to the SIP INVITE.", Category = PropertyCategories.Advanced, UIHint = ActivityInputUIHints.Json)]
         public IList<Header>? CustomHeaders { get; set; }
 
@@ -121,12 +140,19 @@ namespace Elsa.Activities.Telnyx.Activities
             SupportedSyntaxes = new[] { SyntaxNames.Literal, SyntaxNames.JavaScript, SyntaxNames.Liquid })]
         public bool SuspendWorkflow { get; set; } = true;
 
+        [ActivityInput(
+            Hint = "Set to true to use advanced dial flow.",
+            Category = PropertyCategories.Advanced,
+            SupportedSyntaxes = new[] { SyntaxNames.Literal, SyntaxNames.JavaScript, SyntaxNames.Liquid })]
+        public bool UseAdvancedFlow { get; set; }
+
         [ActivityOutput] public DialResponse? DialResponse { get; set; }
         [ActivityOutput] public CallPayload? Output { get; set; }
         [ActivityOutput] public CallAnsweredPayload? AnsweredOutput { get; set; }
         [ActivityOutput] public CallHangupPayload? HangupOutput { get; set; }
         [ActivityOutput] public CallInitiatedPayload? InitiatedOutput { get; set; }
         [ActivityOutput] public CallMachineGreetingEndedBase MachineGreetingEndedOutput { get; set; }
+        [ActivityOutput] public CallMachineDetectionEndedBase MachineDetectionEndedOutput { get; set; }
 
         protected override async ValueTask<IActivityExecutionResult> OnExecuteAsync(ActivityExecutionContext context)
         {
@@ -146,20 +172,22 @@ namespace Elsa.Activities.Telnyx.Activities
             Output = payload;
 
             context.LogOutputProperty(this, "Output", payload);
-            
+
             if (!context.HasCallControlId())
                 context.SetCallControlId(payload!.CallControlId);
-            
-            if(!context.HasCallLegId())
+
+            if (!context.HasCallLegId())
                 context.SetCallLegId(payload!.CallLegId);
 
             return payload switch
             {
+                CallInitiatedPayload initiatedPayload => InitiatedOutcome(initiatedPayload),
+                CallHangupPayload hangupPayload => HangupOutcome(hangupPayload),
+                CallAnsweredPayload answeredPayload => AnsweredOutcome(answeredPayload),
+                CallMachinePremiumDetectionEnded machinePremiumDetectionEnded => MachineDetectionEndedOutcome(machinePremiumDetectionEnded),
                 CallMachineGreetingEnded greetingEndedPayload => MachineGreetingEndedOutcome(greetingEndedPayload),
                 CallMachinePremiumGreetingEnded premiumGreetingEndedPayload => MachineGreetingEndedOutcome(premiumGreetingEndedPayload),
-                CallAnsweredPayload answeredPayload => AnsweredOutcome(answeredPayload),
-                CallHangupPayload hangupPayload => HangupOutcome(hangupPayload),
-                CallInitiatedPayload initiatedPayload => Combine(InitiatedOutcome(initiatedPayload), Suspend()),
+
                 _ => throw new ArgumentOutOfRangeException(nameof(payload))
             };
         }
@@ -167,7 +195,16 @@ namespace Elsa.Activities.Telnyx.Activities
         private IActivityExecutionResult AnsweredOutcome(CallAnsweredPayload payload)
         {
             AnsweredOutput = payload;
-            return Outcome(TelnyxOutcomeNames.Answered, payload);
+
+            var results = new List<IActivityExecutionResult>
+            {
+                Outcome(TelnyxOutcomeNames.Answered, payload)
+            };
+
+            if (UseAdvancedFlow && AnsweringMachineDetection != "disabled" && !string.IsNullOrWhiteSpace(AnsweringMachineDetection))
+                results.Add(Suspend());
+
+            return Combine(results);
         }
 
         private IActivityExecutionResult HangupOutcome(CallHangupPayload payload)
@@ -179,13 +216,36 @@ namespace Elsa.Activities.Telnyx.Activities
         private IActivityExecutionResult InitiatedOutcome(CallInitiatedPayload payload)
         {
             InitiatedOutput = payload;
-            return Outcome(TelnyxOutcomeNames.CallInitiated, payload);
+            return Combine(Outcome(TelnyxOutcomeNames.CallInitiated, payload), Suspend());
+        }
+
+        private IActivityExecutionResult MachineDetectionEndedOutcome(CallMachinePremiumDetectionEnded payload)
+        {
+            MachineDetectionEndedOutput = payload;
+
+            var results = new List<IActivityExecutionResult>
+            {
+                Outcome(TelnyxOutcomeNames.MachineDetectionEnded)
+            };
+
+            if (UseAdvancedFlow)
+            {
+                if (payload.Result == "machine")
+                {
+                    results.Add(Outcome(TelnyxOutcomeNames.MachineDetected));
+                    results.Add(Suspend());
+                }
+                else
+                    results.Add(Outcome(TelnyxOutcomeNames.AnsweredByHuman));
+            }
+
+            return Combine(results);
         }
 
         private IActivityExecutionResult MachineGreetingEndedOutcome(CallMachineGreetingEndedBase payload)
         {
             MachineGreetingEndedOutput = payload;
-            return Outcome(TelnyxOutcomeNames.MachineGreetingEnded, payload);
+            return Outcomes(new[] { TelnyxOutcomeNames.MachineGreetingEnded, TelnyxOutcomeNames.AnsweredByMachine }, payload);
         }
 
         private async Task<DialResponse> DialAsync(ActivityExecutionContext context)
@@ -210,6 +270,7 @@ namespace Elsa.Activities.Telnyx.Activities
                 CustomHeaders,
                 SipAuthUsername,
                 SipAuthPassword,
+                string.IsNullOrEmpty(Record) ? null : Record,
                 TimeLimitSecs,
                 TimeoutSecs,
                 WebhookUrl,
@@ -321,5 +382,11 @@ namespace Elsa.Activities.Telnyx.Activities
         public static ISetupActivity<Dial> WithSuspendWorkflow(this ISetupActivity<Dial> setup, Func<ValueTask<bool>> value) => setup.Set(x => x.SuspendWorkflow, value);
         public static ISetupActivity<Dial> WithSuspendWorkflow(this ISetupActivity<Dial> setup, Func<bool> value) => setup.Set(x => x.SuspendWorkflow, value);
         public static ISetupActivity<Dial> WithSuspendWorkflow(this ISetupActivity<Dial> setup, bool value) => setup.Set(x => x.SuspendWorkflow, value);
+
+        public static ISetupActivity<Dial> WithRecord(this ISetupActivity<Dial> setup, Func<ActivityExecutionContext, ValueTask<string?>> value) => setup.Set(x => x.Record, value);
+        public static ISetupActivity<Dial> WithRecord(this ISetupActivity<Dial> setup, Func<ActivityExecutionContext, string?> value) => setup.Set(x => x.Record, value);
+        public static ISetupActivity<Dial> WithRecord(this ISetupActivity<Dial> setup, Func<ValueTask<string?>> value) => setup.Set(x => x.Record, value);
+        public static ISetupActivity<Dial> WithRecord(this ISetupActivity<Dial> setup, Func<string?> value) => setup.Set(x => x.Record, value);
+        public static ISetupActivity<Dial> WithRecord(this ISetupActivity<Dial> setup, string? value) => setup.Set(x => x.Record, value);
     }
 }

--- a/src/activities/Elsa.Activities.Telnyx/Client/Models/Requests.cs
+++ b/src/activities/Elsa.Activities.Telnyx/Client/Models/Requests.cs
@@ -69,6 +69,7 @@ namespace Elsa.Activities.Telnyx.Client.Models
         IList<Header>? CustomHeaders,
         string? SipAuthUsername,
         string? SipAuthPassword,
+        string? Record,
         int? TimeLimitSecs,
         int? TimeoutSecs,
         string? WebhookUrl,

--- a/src/activities/Elsa.Activities.Telnyx/Client/Models/Responses.cs
+++ b/src/activities/Elsa.Activities.Telnyx/Client/Models/Responses.cs
@@ -5,26 +5,21 @@ namespace Elsa.Activities.Telnyx.Client.Models
 {
     public class TelnyxResponse<T>
     {
-        public T Data { get; set; } = default!;
+        [JsonProperty("data")] public T Data { get; set; } = default!;
     }
 
-    public class DialResponse
+    public class DialResponse : CallStatus
     {
-        public string CallControlId { get; set; } = default!;
-        public string CallLegId { get; set; } = default!;
-        public string CallSessionId { get; set; } = default!;
-        public bool IsAlive { get; set; } = default!;
-        public string RecordType { get; set; } = default!;
     }
 
     public class NumberLookupResponse
     {
-        public CallerName CallerName { get; set; } = default!;
-        public Carrier Carrier { get; set; } = default!;
-        public string CountryCode { get; set; } = default!;
-        public string Fraud { get; set; } = default!;
-        public string NationalFormat { get; set; } = default!;
-        public string PhoneNumber { get; set; } = default!;
+        [JsonProperty("caller_name")]public CallerName CallerName { get; set; } = default!;
+        [JsonProperty("carrier")]public Carrier Carrier { get; set; } = default!;
+        [JsonProperty("country_code")]public string CountryCode { get; set; } = default!;
+        [JsonProperty("fraud")]public string Fraud { get; set; } = default!;
+        [JsonProperty("national_format")]public string NationalFormat { get; set; } = default!;
+        [JsonProperty("p")]public string PhoneNumber { get; set; } = default!;
         public Portability Portability { get; set; } = default!;
         public string RecordType { get; set; } = default!;
     }
@@ -48,16 +43,25 @@ namespace Elsa.Activities.Telnyx.Client.Models
 
     public class Carrier
     {
-        public string ErrorCode { get; set; } = default!;
-        public string MobileCountryCode { get; set; } = default!;
-        public int MobileNetworkCode { get; set; } = default!;
-        public string Name { get; set; } = default!;
-        public string Type { get; set; } = default!;
+        [JsonProperty("error_code")]public string ErrorCode { get; set; } = default!;
+        [JsonProperty("mobile_country_code")]public string MobileCountryCode { get; set; } = default!;
+        [JsonProperty("mobile_network_code")]public int MobileNetworkCode { get; set; } = default!;
+        [JsonProperty("name")]public string Name { get; set; } = default!;
+        [JsonProperty("type")]public string Type { get; set; } = default!;
     }
 
     public class CallerName
     {
         [JsonProperty("caller_name")] public string Name { get; set; } = default!;
-        public string ErrorCode { get; set; } = default!;
+        [JsonProperty("error_code")]public string ErrorCode { get; set; } = default!;
+    }
+
+    public class CallStatus
+    {
+        [JsonProperty("call_control_id")] public string CallControlId { get; set; } = default!;
+        [JsonProperty("call_leg_id")] public string CallLegId { get; set; } = default!;
+        [JsonProperty("call_session_id")] public string CallSessionId { get; set; } = default!;
+        [JsonProperty("is_alive")] public bool IsAlive { get; set; } = default!;
+        [JsonProperty("record_type")] public string RecordType { get; set; } = default!;
     }
 }

--- a/src/activities/Elsa.Activities.Telnyx/Client/Services/ICallsApi.cs
+++ b/src/activities/Elsa.Activities.Telnyx/Client/Services/ICallsApi.cs
@@ -42,5 +42,7 @@ namespace Elsa.Activities.Telnyx.Client.Services
 
         [Post("/v2/calls/{callControlId}/actions/speak")]
         Task SpeakTextAsync(string callControlId, [Body] SpeakTextRequest request, CancellationToken cancellationToken = default);
-    }
+        
+        [Get("/v2/calls/{callControlId}")]
+        Task<TelnyxResponse<CallStatus>> GetStatusAsync(string callControlId, CancellationToken cancellationToken = default); }
 }

--- a/src/activities/Elsa.Activities.Telnyx/Handlers/ResumeAnswerCall.cs
+++ b/src/activities/Elsa.Activities.Telnyx/Handlers/ResumeAnswerCall.cs
@@ -1,4 +1,5 @@
 ﻿using Elsa.Activities.Telnyx.Activities;
+using Elsa.Activities.Telnyx.Providers.Bookmarks;
 using Elsa.Activities.Telnyx.Webhooks.Payloads.Call;
 using Elsa.Services;
 
@@ -8,6 +9,11 @@ namespace Elsa.Activities.Telnyx.Handlers
     {
         public ResumeAnswerCall(IWorkflowLaunchpad workflowLaunchpad) : base(workflowLaunchpad)
         {
+        }
+
+        protected override IBookmark CreateBookmark(CallPayload receivedPayload)
+        {
+            return new AnswerCallBookmark();
         }
     }
 }

--- a/src/activities/Elsa.Activities.Telnyx/Handlers/ResumeBridgeCalls.cs
+++ b/src/activities/Elsa.Activities.Telnyx/Handlers/ResumeBridgeCalls.cs
@@ -1,4 +1,5 @@
 using Elsa.Activities.Telnyx.Activities;
+using Elsa.Activities.Telnyx.Providers.Bookmarks;
 using Elsa.Activities.Telnyx.Webhooks.Payloads.Call;
 using Elsa.Services;
 
@@ -8,6 +9,11 @@ namespace Elsa.Activities.Telnyx.Handlers
     {
         public ResumeBridgeCalls(IWorkflowLaunchpad workflowLaunchpad) : base(workflowLaunchpad)
         {
+        }
+
+        protected override IBookmark CreateBookmark(CallPayload receivedPayload)
+        {
+            return new BridgeCallsBookmark();
         }
     }
 }

--- a/src/activities/Elsa.Activities.Telnyx/Handlers/ResumeDial.cs
+++ b/src/activities/Elsa.Activities.Telnyx/Handlers/ResumeDial.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Elsa.Activities.Telnyx.Activities;
+using Elsa.Activities.Telnyx.Providers.Bookmarks;
 using Elsa.Activities.Telnyx.Webhooks.Payloads.Call;
 using Elsa.Services;
 
@@ -13,6 +14,14 @@ namespace Elsa.Activities.Telnyx.Handlers
         }
 
         protected override IEnumerable<Type> GetSupportedPayloadTypes() => new[]
-            { typeof(CallInitiatedPayload), typeof(CallAnsweredPayload), typeof(CallHangupPayload), typeof(CallMachineGreetingEnded), typeof(CallMachinePremiumGreetingEnded) };
+            { typeof(CallInitiatedPayload), typeof(CallAnsweredPayload), typeof(CallHangupPayload), typeof(CallMachinePremiumDetectionEnded), typeof(CallMachineGreetingEnded), typeof(CallMachinePremiumGreetingEnded) };
+
+        protected override IBookmark CreateBookmark(CallPayload receivedPayload)
+        {
+            return new DialBookmark
+            {
+                CallControlId = receivedPayload.CallControlId
+            };
+        }
     }
 }

--- a/src/activities/Elsa.Activities.Telnyx/Handlers/ResumeGatherUsingAudio.cs
+++ b/src/activities/Elsa.Activities.Telnyx/Handlers/ResumeGatherUsingAudio.cs
@@ -1,4 +1,5 @@
 ﻿using Elsa.Activities.Telnyx.Activities;
+using Elsa.Activities.Telnyx.Providers.Bookmarks;
 using Elsa.Activities.Telnyx.Webhooks.Payloads.Call;
 using Elsa.Services;
 
@@ -8,6 +9,11 @@ namespace Elsa.Activities.Telnyx.Handlers
     {
         public ResumeGatherUsingAudio(IWorkflowLaunchpad workflowLaunchpad) : base(workflowLaunchpad)
         {
+        }
+
+        protected override IBookmark CreateBookmark(CallPayload receivedPayload)
+        {
+            return new GatherUsingAudioBookmark();
         }
     }
 }

--- a/src/activities/Elsa.Activities.Telnyx/Handlers/ResumeGatherUsingSpeak.cs
+++ b/src/activities/Elsa.Activities.Telnyx/Handlers/ResumeGatherUsingSpeak.cs
@@ -1,4 +1,5 @@
 ﻿using Elsa.Activities.Telnyx.Activities;
+using Elsa.Activities.Telnyx.Providers.Bookmarks;
 using Elsa.Activities.Telnyx.Webhooks.Payloads.Call;
 using Elsa.Services;
 
@@ -8,6 +9,11 @@ namespace Elsa.Activities.Telnyx.Handlers
     {
         public ResumeGatherUsingSpeak(IWorkflowLaunchpad workflowLaunchpad) : base(workflowLaunchpad)
         {
+        }
+
+        protected override IBookmark CreateBookmark(CallPayload receivedPayload)
+        {
+            return new GatherUsingSpeakBookmark();
         }
     }
 }

--- a/src/activities/Elsa.Activities.Telnyx/Handlers/ResumePlayAudio.cs
+++ b/src/activities/Elsa.Activities.Telnyx/Handlers/ResumePlayAudio.cs
@@ -1,4 +1,5 @@
 ﻿using Elsa.Activities.Telnyx.Activities;
+using Elsa.Activities.Telnyx.Providers.Bookmarks;
 using Elsa.Activities.Telnyx.Webhooks.Payloads.Call;
 using Elsa.Services;
 
@@ -8,6 +9,11 @@ namespace Elsa.Activities.Telnyx.Handlers
     {
         public ResumePlayAudio(IWorkflowLaunchpad workflowLaunchpad) : base(workflowLaunchpad)
         {
+        }
+
+        protected override IBookmark CreateBookmark(CallPayload receivedPayload)
+        {
+            return new PlayAudioBookmark();
         }
     }
 }

--- a/src/activities/Elsa.Activities.Telnyx/Handlers/ResumeSpeakText.cs
+++ b/src/activities/Elsa.Activities.Telnyx/Handlers/ResumeSpeakText.cs
@@ -1,4 +1,5 @@
 ﻿using Elsa.Activities.Telnyx.Activities;
+using Elsa.Activities.Telnyx.Providers.Bookmarks;
 using Elsa.Activities.Telnyx.Webhooks.Payloads.Call;
 using Elsa.Services;
 
@@ -8,6 +9,11 @@ namespace Elsa.Activities.Telnyx.Handlers
     {
         public ResumeSpeakText(IWorkflowLaunchpad workflowLaunchpad) : base(workflowLaunchpad)
         {
+        }
+
+        protected override IBookmark CreateBookmark(CallPayload receivedPayload)
+        {
+            return new SpeakTextBookmark();
         }
     }
 }

--- a/src/activities/Elsa.Activities.Telnyx/Handlers/ResumeStartRecording.cs
+++ b/src/activities/Elsa.Activities.Telnyx/Handlers/ResumeStartRecording.cs
@@ -1,4 +1,5 @@
 using Elsa.Activities.Telnyx.Activities;
+using Elsa.Activities.Telnyx.Providers.Bookmarks;
 using Elsa.Activities.Telnyx.Webhooks.Payloads.Call;
 using Elsa.Services;
 
@@ -8,6 +9,11 @@ namespace Elsa.Activities.Telnyx.Handlers
     {
         public ResumeStartRecording(IWorkflowLaunchpad workflowLaunchpad) : base(workflowLaunchpad)
         {
+        }
+
+        protected override IBookmark CreateBookmark(CallPayload receivedPayload)
+        {
+            return new StartRecordingBookmark();
         }
     }
 }

--- a/src/activities/Elsa.Activities.Telnyx/Handlers/ResumeStopAudioPlayback.cs
+++ b/src/activities/Elsa.Activities.Telnyx/Handlers/ResumeStopAudioPlayback.cs
@@ -1,4 +1,5 @@
 ﻿using Elsa.Activities.Telnyx.Activities;
+using Elsa.Activities.Telnyx.Providers.Bookmarks;
 using Elsa.Activities.Telnyx.Webhooks.Payloads.Call;
 using Elsa.Services;
 
@@ -8,6 +9,11 @@ namespace Elsa.Activities.Telnyx.Handlers
     {
         public ResumeStopAudioPlayback(IWorkflowLaunchpad workflowLaunchpad) : base(workflowLaunchpad)
         {
+        }
+
+        protected override IBookmark CreateBookmark(CallPayload receivedPayload)
+        {
+            return new StopAudioPlaybackBookmark();
         }
     }
 }

--- a/src/activities/Elsa.Activities.Telnyx/Handlers/ResumeTransferCall.cs
+++ b/src/activities/Elsa.Activities.Telnyx/Handlers/ResumeTransferCall.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Elsa.Activities.Telnyx.Activities;
+using Elsa.Activities.Telnyx.Providers.Bookmarks;
 using Elsa.Activities.Telnyx.Webhooks.Payloads.Call;
 using Elsa.Services;
 
@@ -13,5 +14,9 @@ namespace Elsa.Activities.Telnyx.Handlers
         }
         
         protected override IEnumerable<Type> GetSupportedPayloadTypes() => new[] {typeof(CallAnsweredPayload), typeof(CallHangupPayload)};
+        protected override IBookmark CreateBookmark(CallPayload receivedPayload)
+        {
+            return new TransferCallBookmark();
+        }
     }
 }

--- a/src/activities/Elsa.Activities.Telnyx/Handlers/ResumeWebhookDrivenActivity.cs
+++ b/src/activities/Elsa.Activities.Telnyx/Handlers/ResumeWebhookDrivenActivity.cs
@@ -43,11 +43,11 @@ namespace Elsa.Activities.Telnyx.Handlers
                 return;
 
             var correlationId = receivedPayload.GetCorrelationId();
-            var bookmark = CreateBookmark();
+            var bookmark = CreateBookmark(receivedPayload);
             var context = new WorkflowsQuery(ActivityTypeName, bookmark, correlationId);
             await _workflowLaunchpad.CollectAndDispatchWorkflowsAsync(context, new WorkflowInput(receivedPayload), cancellationToken);
         }
 
-        protected virtual IBookmark CreateBookmark() => new GatherUsingSpeakBookmark();
+        protected abstract IBookmark CreateBookmark(CallPayload receivedPayload);
     }
 }

--- a/src/activities/Elsa.Activities.Telnyx/OutcomeNames.cs
+++ b/src/activities/Elsa.Activities.Telnyx/OutcomeNames.cs
@@ -12,11 +12,15 @@
         public const string ValidInput = "Valid Input";
         public const string InvalidInput = "Invalid Input";
         public const string Transferring = "Transferring";
+        public const string Bridging = "Bridging";
         public const string Bridged = "Bridged";
         public const string LegABridged = "Call A Answered";
         public const string LegBBridged = "Call B Answered";
         public const string MachineDetectionEnded = "Machine Detection Ended";
+        public const string MachineDetected = "Machine Detected";
         public const string MachineGreetingEnded = "Machine Greeting Ended";
+        public const string AnsweredByMachine = "Answered by Machine";
+        public const string AnsweredByHuman = "Answered by Human";
         public const string FinishedSpeaking = "Finished Speaking";
         public const string FinishedRecording = "Finished Recording";
         public const string CallPlaybackStarted = "Playback Started";

--- a/src/activities/Elsa.Activities.Telnyx/Providers/Bookmarks/DialBookmark.cs
+++ b/src/activities/Elsa.Activities.Telnyx/Providers/Bookmarks/DialBookmark.cs
@@ -1,3 +1,6 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using Elsa.Activities.Telnyx.Activities;
 using Elsa.Services;
 
@@ -5,9 +8,23 @@ namespace Elsa.Activities.Telnyx.Providers.Bookmarks
 {
     public class DialBookmark : IBookmark
     {
+        public string CallControlId { get; set; } = default!;
     }
 
     public class DialBookmarkProvider : DefaultBookmarkProvider<DialBookmark, Dial>
     {
+        public override async ValueTask<IEnumerable<BookmarkResult>> GetBookmarksAsync(BookmarkProviderContext<Dial> context, CancellationToken cancellationToken)
+        {
+            var dialResponse = await context.ReadActivityPropertyAsync(x => x.DialResponse, cancellationToken);
+            var callControlId = dialResponse!.CallControlId;
+            
+            var bookmark = new DialBookmark
+            {
+                CallControlId = callControlId
+            };
+
+            var result = Result(bookmark);
+            return new[] { result };
+        }
     }
 }

--- a/src/core/Elsa.Core/Handlers/InfiniteLoopDetectionHandler.cs
+++ b/src/core/Elsa.Core/Handlers/InfiniteLoopDetectionHandler.cs
@@ -48,10 +48,11 @@ namespace Elsa.Handlers
             if (loopDetected)
             {
                 _logger.LogWarning(
-                    "Infinite loop detected on activity {ActivityId} of workflow instance {WorkflowInstanceId} of workflow definition {WorkflowDefinitionId}",
+                    "Infinite loop detected on activity {ActivityId} of workflow instance {WorkflowInstanceId} of workflow definition {WorkflowDefinitionId}. Source: {ActivitySource}",
                     context.ActivityId,
                     context.WorkflowInstance.Id,
-                    context.WorkflowInstance.DefinitionId);
+                    context.WorkflowInstance.DefinitionId,
+                    context.ActivityBlueprint.Source);
 
                 await HandleLoopAsync(context);
                 await detector.ResetAsync(context);

--- a/src/core/Elsa.Core/Services/Workflows/WorkflowRunner.cs
+++ b/src/core/Elsa.Core/Services/Workflows/WorkflowRunner.cs
@@ -238,6 +238,7 @@ namespace Elsa.Services.Workflows
                     var currentActivityBlueprint = workflowExecutionContext.WorkflowBlueprint.Activities.First(bp => bp.Id == workflowExecutionContext.WorkflowInstance.CurrentActivity.ActivityId);
                     workflowExecutionContext.AddEntry(currentActivityBlueprint, "Faulted", null, SimpleException.FromException(e));
                 }
+
                 return new RunWorkflowResult(workflowExecutionContext.WorkflowInstance, activity.Id, e, false);
             }
         }
@@ -331,8 +332,11 @@ namespace Elsa.Services.Workflows
                         , _mediator
                         , cancellationToken);
 
-                    if (workflowInstance.WorkflowStatus == WorkflowStatus.Faulted)
+                    if (workflowExecutionContext.Status == WorkflowStatus.Faulted)
+                    {
                         await _mediator.Publish(new WorkflowFaulting(activityExecutionContext, activity), cancellationToken);
+                        break;
+                    }
 
                     await _mediator.Publish(new WorkflowExecutionPassCompleted(workflowExecutionContext, activityExecutionContext), cancellationToken);
 
@@ -350,8 +354,11 @@ namespace Elsa.Services.Workflows
 
             workflowInstance.CurrentActivity = null;
 
-            if (workflowExecutionContext.HasBlockingActivities)
-                workflowExecutionContext.Suspend();
+            if (workflowExecutionContext.Status != WorkflowStatus.Faulted)
+            {
+                if (workflowExecutionContext.HasBlockingActivities)
+                    workflowExecutionContext.Suspend();
+            }
 
             if (workflowExecutionContext.Status == WorkflowStatus.Running)
                 await workflowExecutionContext.CompleteAsync();

--- a/src/designer/elsa-workflows-studio/package.json
+++ b/src/designer/elsa-workflows-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elsa-workflows/elsa-workflows-studio",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "description": "Elsa Workflow Studio is a collection of web components to manage Elsa workflows stored on an Elsa Workflows server.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR fixes an issue where execution scopes are cleared prematurely in the event of a faulting workflow. 

As seen in issue #3669, this leads to an unintended behavior.