### PR TITLE
Retention specification fixes

### DIFF
--- a/src/modules/retention/Elsa.Retention/Specifications/CompletedWorkflowFilterSpecification.cs
+++ b/src/modules/retention/Elsa.Retention/Specifications/CompletedWorkflowFilterSpecification.cs
@@ -1,13 +1,11 @@
 using Elsa.Models;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Elsa.Retention.Specifications
 {
     public class CompletedWorkflowFilterSpecification : WorkflowStatusFilterSpecification
     {
         public CompletedWorkflowFilterSpecification()
-            : base(new[] { WorkflowStatus.Running, WorkflowStatus.Finished })
+            : base(WorkflowStatus.Finished)
         {
 
         }

--- a/src/modules/retention/Elsa.Retention/Specifications/WorkflowStatusFilterSpecification.cs
+++ b/src/modules/retention/Elsa.Retention/Specifications/WorkflowStatusFilterSpecification.cs
@@ -27,7 +27,7 @@ namespace Elsa.Retention.Specifications
                 if (i == 0)
                     exp = equality;
                 else
-                    exp = Expression.And(exp, equality);
+                    exp = Expression.Or(exp, equality);
                 i++;
             }
 


### PR DESCRIPTION
I couldn't get the current default retention to work. The default specification generated a query that was looking for a workflow with the status running AND finished, which could never be true. This PR adjusted that to be OR instead.

I might misunderstand something but to me it feels like only finished workflows should be removed by default so I removed the running from the list