### PR TITLE
DeleteMany fixes

### DIFF
--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/Extensions/QueryableBulkExtensions.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/Extensions/QueryableBulkExtensions.cs
@@ -10,9 +10,10 @@ namespace Elsa.Persistence.EntityFramework.Core.Extensions
     {
         public static async Task<int> BatchDeleteWithWorkAroundAsync<T>(this IQueryable<T> queryable, DbContext elsaContext, CancellationToken cancellationToken = default) where T : class
         {
-            if (elsaContext.Database.IsOracle())
+            if (elsaContext.Database.IsMySql() || elsaContext.Database.IsOracle())
             {
-                // Oracle need this workaround also https://github.com/borisdj/EFCore.BulkExtensions/issues/375 is solved.
+                // Need this workaround https://github.com/borisdj/EFCore.BulkExtensions/issues/553 is solved.
+                // Oracle also https://github.com/borisdj/EFCore.BulkExtensions/issues/375
                 var records = await queryable.ToListAsync(cancellationToken);
 
                 foreach (var record in records) 

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/Extensions/QueryableBulkExtensions.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/Extensions/QueryableBulkExtensions.cs
@@ -10,10 +10,9 @@ namespace Elsa.Persistence.EntityFramework.Core.Extensions
     {
         public static async Task<int> BatchDeleteWithWorkAroundAsync<T>(this IQueryable<T> queryable, DbContext elsaContext, CancellationToken cancellationToken = default) where T : class
         {
-            if (elsaContext.Database.IsPostgres() || elsaContext.Database.IsMySql() || elsaContext.Database.IsOracle())
+            if (elsaContext.Database.IsOracle())
             {
-                // Need this workaround https://github.com/borisdj/EFCore.BulkExtensions/issues/553 is solved.
-                // Oracle also https://github.com/borisdj/EFCore.BulkExtensions/issues/375
+                // Oracle need this workaround also https://github.com/borisdj/EFCore.BulkExtensions/issues/375 is solved.
                 var records = await queryable.ToListAsync(cancellationToken);
 
                 foreach (var record in records) 

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/Stores/EntityFrameworkWorkflowInstanceStore.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/Stores/EntityFrameworkWorkflowInstanceStore.cs
@@ -62,11 +62,9 @@ namespace Elsa.Persistence.EntityFramework.Core.Stores
 
             await DoWork(async dbContext =>
             {
-                var helper = dbContext.GetService<ISqlGenerationHelper>();
-                var placeholders = string.Join(",", Enumerable.Range(0, idList.Count).Select(i => "{" + i + "}"));
-                await dbContext.Database.ExecuteSqlRawAsync($"delete from {dbContext.WorkflowExecutionLogRecords.EntityType.GetSchemaQualifiedTableNameWithQuotes(helper)} where WorkflowInstanceId in ({placeholders})", idList, cancellationToken);
-                await dbContext.Database.ExecuteSqlRawAsync($"delete from {dbContext.Bookmarks.EntityType.GetSchemaQualifiedTableNameWithQuotes(helper)} where WorkflowInstanceId in ({placeholders})", idList, cancellationToken);
-                await dbContext.Database.ExecuteSqlRawAsync($"delete from {dbContext.WorkflowInstances.EntityType.GetSchemaQualifiedTableNameWithQuotes(helper)} where Id in ({placeholders})", idList, cancellationToken);
+                await dbContext.Set<WorkflowExecutionLogRecord>().AsQueryable().Where(x => idList.Contains(x.WorkflowInstanceId)).BatchDeleteWithWorkAroundAsync(dbContext, cancellationToken);
+                await dbContext.Set<Bookmark>().AsQueryable().Where(x => idList.Contains(x.WorkflowInstanceId)).BatchDeleteWithWorkAroundAsync(dbContext, cancellationToken);
+                await dbContext.Set<WorkflowInstance>().AsQueryable().Where(x => idList.Contains(x.Id)).BatchDeleteWithWorkAroundAsync(dbContext, cancellationToken);
             }, cancellationToken);
         }
 


### PR DESCRIPTION
BatchDeleteWithWorkAroundAsync was referencing an issue that looks to be resolved, I tested it and it works on a postgres database, I was however not able to test it on a mysql db, so I didn't change the mysql implementation.

DeleteMany generated sql that couldn't be executed with psql (WorkflowInstanceId would need to be within quotation marks) but the batch delete looked like it generated performant sql.