### PR TITLE
Fix deadlock + multiple trigger support

### DIFF
--- a/src/modules/Elsa.Jobs.Activities/Handlers/JobExecutedHandler.cs
+++ b/src/modules/Elsa.Jobs.Activities/Handlers/JobExecutedHandler.cs
@@ -7,15 +7,22 @@ using Elsa.Workflows.Runtime.Services;
 
 namespace Elsa.Jobs.Activities.Handlers;
 
+/// <summary>
+/// A handler that resumes workflows waiting for a given job to complete.
+/// </summary>
 public class JobExecutedHandler : INotificationHandler<JobExecuted>
 {
     private readonly IWorkflowRuntime _workflowRuntime;
 
+    /// <summary>
+    /// Constructor.
+    /// </summary>
     public JobExecutedHandler(IWorkflowRuntime workflowRuntime)
     {
         _workflowRuntime = workflowRuntime;
     }
 
+    /// <inheritdoc />
     public async Task HandleAsync(JobExecuted notification, CancellationToken cancellationToken)
     {
         var job = notification.Job;
@@ -33,7 +40,7 @@ public class JobExecutedHandler : INotificationHandler<JobExecuted>
             var jobType = notification.Job.GetType();
             var payload = new EnqueuedJobPayload(job.Id);
             var jobTypeName = JobTypeNameHelper.GenerateTypeName(jobType);
-            await _workflowRuntime.ResumeWorkflowsAsync(jobTypeName, payload, new ResumeWorkflowRuntimeOptions(), cancellationToken);
+            await _workflowRuntime.ResumeWorkflowsAsync(jobTypeName, payload, new TriggerWorkflowsRuntimeOptions(), cancellationToken);
         }
     }
 }

--- a/src/modules/Elsa.MassTransit/Consumers/DispatchWorkflowRequestConsumer.cs
+++ b/src/modules/Elsa.MassTransit/Consumers/DispatchWorkflowRequestConsumer.cs
@@ -52,7 +52,7 @@ public class DispatchWorkflowRequestConsumer :
     public async Task Consume(ConsumeContext<DispatchResumeWorkflows> context)
     {
         var message = context.Message;
-        var options = new ResumeWorkflowRuntimeOptions(CorrelationId: message.CorrelationId, Input: message.Input);
+        var options = new TriggerWorkflowsRuntimeOptions(CorrelationId: message.CorrelationId, Input: message.Input);
         await _workflowRuntime.ResumeWorkflowsAsync(message.ActivityTypeName, message.BookmarkPayload, options, context.CancellationToken);
     }
 }

--- a/src/modules/Elsa.Telnyx/Handlers/TriggerWebhookDrivenActivities.cs
+++ b/src/modules/Elsa.Telnyx/Handlers/TriggerWebhookDrivenActivities.cs
@@ -36,7 +36,7 @@ internal class TriggerWebhookDrivenActivities : INotificationHandler<TelnyxWebho
         var bookmarkPayload = new WebhookEventBookmarkPayload(eventType);
 
         foreach (var activityDescriptor in activityDescriptors)
-            await _workflowRuntime.ResumeWorkflowsAsync(activityDescriptor.TypeName, bookmarkPayload, new ResumeWorkflowRuntimeOptions(correlationId, Input: input), cancellationToken);
+            await _workflowRuntime.ResumeWorkflowsAsync(activityDescriptor.TypeName, bookmarkPayload, new TriggerWorkflowsRuntimeOptions(correlationId, Input: input), cancellationToken);
     }
 
     private IEnumerable<ActivityDescriptor> FindActivityDescriptors(string eventType) =>

--- a/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Activities/Flowchart.cs
+++ b/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Activities/Flowchart.cs
@@ -27,17 +27,25 @@ public class Flowchart : Container
     }
 
     [Port] [Browsable(false)] public IActivity? Start { get; set; }
+    /// <summary>
+    /// A list of connections between activities.
+    /// </summary>
     public ICollection<Connection> Connections { get; set; } = new List<Connection>();
 
+    /// <inheritdoc />
     protected override async ValueTask ScheduleChildrenAsync(ActivityExecutionContext context)
     {
-        if (Start == null!)
+        var triggerActivityId = context.WorkflowExecutionContext.TriggerActivityId;
+        var triggerActivity = triggerActivityId != null ? Activities.FirstOrDefault(x => x.Id == triggerActivityId) : default;
+        var startActivity = triggerActivity ?? Start;
+        
+        if (startActivity == null!)
         {
             await context.CompleteActivityAsync();
             return;
         }
 
-        await context.ScheduleActivityAsync(Start);
+        await context.ScheduleActivityAsync(startActivity);
     }
 
     private async ValueTask OnDescendantCompletedAsync(ActivityCompleted signal, SignalContext context)

--- a/src/modules/Elsa.Workflows.Core/Middleware/Activities/LoggingMiddleware.cs
+++ b/src/modules/Elsa.Workflows.Core/Middleware/Activities/LoggingMiddleware.cs
@@ -6,12 +6,18 @@ using Microsoft.Extensions.Logging;
 
 namespace Elsa.Workflows.Core.Middleware.Activities;
 
+/// <summary>
+/// An activity execution middleware component that logs information about the activity being executed.
+/// </summary>
 public class LoggingMiddleware : IActivityExecutionMiddleware
 {
     private readonly ActivityMiddlewareDelegate _next;
     private readonly ILogger _logger;
     private readonly Stopwatch _stopwatch;
 
+    /// <summary>
+    /// Constructor.
+    /// </summary>
     public LoggingMiddleware(ActivityMiddlewareDelegate next, ILogger<LoggingMiddleware> logger)
     {
         _next = next;
@@ -19,18 +25,25 @@ public class LoggingMiddleware : IActivityExecutionMiddleware
         _stopwatch = new Stopwatch();
     }
 
+    /// <inheritdoc />
     public async ValueTask InvokeAsync(ActivityExecutionContext context)
     {
         var activity = context.Activity;
-        _logger.LogDebug("Executing activity {ActivityType}", activity.Type);
+        _logger.LogInformation("Executing activity {ActivityId}", activity.Id);
         _stopwatch.Restart();
         await _next(context);
         _stopwatch.Stop();
-        _logger.LogDebug("Executed activity {ActivityType} in {Elapsed}", activity.Type, _stopwatch.Elapsed);
+        _logger.LogInformation("Executed activity {ActivityId} in {Elapsed}", activity.Id, _stopwatch.Elapsed);
     }
 }
 
+/// <summary>
+/// Extends <see cref="IActivityExecutionPipelineBuilder"/> to install the <see cref="LoggingMiddleware"/> component.
+/// </summary>
 public static class LoggingMiddlewareExtensions
 {
+    /// <summary>
+    /// Installs the <see cref="LoggingMiddleware"/> component.
+    /// </summary>
     public static IActivityExecutionPipelineBuilder UseLogging(this IActivityExecutionPipelineBuilder pipelineBuilder) => pipelineBuilder.UseMiddleware<LoggingMiddleware>();
 }

--- a/src/modules/Elsa.Workflows.Core/Models/WorkflowExecutionContext.cs
+++ b/src/modules/Elsa.Workflows.Core/Models/WorkflowExecutionContext.cs
@@ -266,7 +266,7 @@ public class WorkflowExecutionContext
     /// Returns the <see cref="IActivity"/> with the specified ID from the workflow graph.
     /// </summary>
     public IActivity FindActivityByNodeId(string nodeId) => FindNodeById(nodeId).Activity;
-    
+
     /// <summary>
     /// Returns a custom property with the specified key from the <see cref="Properties"/> dictionary.
     /// </summary>

--- a/src/modules/Elsa.Workflows.Core/Pipelines/ActivityExecution/ActivityExecutionPipeline.cs
+++ b/src/modules/Elsa.Workflows.Core/Pipelines/ActivityExecution/ActivityExecutionPipeline.cs
@@ -34,7 +34,6 @@ public class ActivityExecutionPipeline : IActivityExecutionPipeline
     public async Task ExecuteAsync(ActivityExecutionContext context) => await Pipeline(context);
         
     private ActivityMiddlewareDelegate CreateDefaultPipeline() => Setup(x => x
-        .UseLogging()
         .UseExceptionHandling()
         .UseDefaultActivityInvoker()
     );

--- a/src/modules/Elsa.Workflows.Core/Pipelines/ActivityExecution/ActivityExecutionPipeline.cs
+++ b/src/modules/Elsa.Workflows.Core/Pipelines/ActivityExecution/ActivityExecutionPipeline.cs
@@ -34,6 +34,7 @@ public class ActivityExecutionPipeline : IActivityExecutionPipeline
     public async Task ExecuteAsync(ActivityExecutionContext context) => await Pipeline(context);
         
     private ActivityMiddlewareDelegate CreateDefaultPipeline() => Setup(x => x
+        .UseLogging()
         .UseExceptionHandling()
         .UseDefaultActivityInvoker()
     );

--- a/src/modules/Elsa.Workflows.Runtime/Handlers/DispatchWorkflowRequestHandler.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Handlers/DispatchWorkflowRequestHandler.cs
@@ -46,7 +46,7 @@ internal class DispatchWorkflowRequestHandler :
 
     public async Task<Unit> HandleAsync(DispatchResumeWorkflowsCommand command, CancellationToken cancellationToken)
     {
-        var options = new ResumeWorkflowRuntimeOptions(CorrelationId: command.CorrelationId, Input: command.Input);
+        var options = new TriggerWorkflowsRuntimeOptions(CorrelationId: command.CorrelationId, Input: command.Input);
         await _workflowRuntime.ResumeWorkflowsAsync(command.ActivityTypeName, command.BookmarkPayload, options, cancellationToken);
 
         return Unit.Instance;

--- a/src/modules/Elsa.Workflows.Runtime/Handlers/ResumeDispatchWorkflowActivityHandler.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Handlers/ResumeDispatchWorkflowActivityHandler.cs
@@ -4,6 +4,7 @@ using Elsa.Workflows.Core.Models;
 using Elsa.Workflows.Core.Notifications;
 using Elsa.Workflows.Runtime.Activities;
 using Elsa.Workflows.Runtime.Bookmarks;
+using Elsa.Workflows.Runtime.Models;
 using Elsa.Workflows.Runtime.Services;
 using JetBrains.Annotations;
 
@@ -15,9 +16,9 @@ namespace Elsa.Workflows.Runtime.Handlers;
 [PublicAPI]
 internal class ResumeDispatchWorkflowActivityHandler : INotificationHandler<WorkflowExecuted>
 {
-    private readonly IWorkflowRuntime _workflowRuntime;
+    private readonly IWorkflowDispatcher _workflowRuntime;
 
-    public ResumeDispatchWorkflowActivityHandler(IWorkflowRuntime workflowRuntime)
+    public ResumeDispatchWorkflowActivityHandler(IWorkflowDispatcher workflowRuntime)
     {
         _workflowRuntime = workflowRuntime;
     }
@@ -29,6 +30,7 @@ internal class ResumeDispatchWorkflowActivityHandler : INotificationHandler<Work
 
         var bookmark = new DispatchWorkflowBookmark(notification.WorkflowState.Id);
         var activityTypeName = ActivityTypeNameHelper.GenerateTypeName<DispatchWorkflow>();
-        await _workflowRuntime.ResumeWorkflowsAsync(activityTypeName, bookmark, new TriggerWorkflowsRuntimeOptions(), cancellationToken);
+        var request = new DispatchResumeWorkflowsRequest(activityTypeName, bookmark);
+        await _workflowRuntime.DispatchAsync(request, cancellationToken);
     }
 }

--- a/src/modules/Elsa.Workflows.Runtime/Handlers/ResumeDispatchWorkflowActivityHandler.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Handlers/ResumeDispatchWorkflowActivityHandler.cs
@@ -29,6 +29,6 @@ internal class ResumeDispatchWorkflowActivityHandler : INotificationHandler<Work
 
         var bookmark = new DispatchWorkflowBookmark(notification.WorkflowState.Id);
         var activityTypeName = ActivityTypeNameHelper.GenerateTypeName<DispatchWorkflow>();
-        await _workflowRuntime.TriggerWorkflowsAsync(activityTypeName, bookmark, new TriggerWorkflowsRuntimeOptions(), cancellationToken);
+        await _workflowRuntime.ResumeWorkflowsAsync(activityTypeName, bookmark, new TriggerWorkflowsRuntimeOptions(), cancellationToken);
     }
 }

--- a/src/modules/Elsa.Workflows.Runtime/Services/IWorkflowRuntime.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Services/IWorkflowRuntime.cs
@@ -22,6 +22,16 @@ public interface IWorkflowRuntime
     /// <param name="options"></param>
     /// <param name="cancellationToken"></param>
     Task<WorkflowExecutionResult> StartWorkflowAsync(string definitionId, StartWorkflowRuntimeOptions options, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Starts all workflows with triggers matching the specified activity type and bookmark payload.
+    /// </summary>
+    /// <returns></returns>
+    Task<ICollection<WorkflowExecutionResult>> StartWorkflowsAsync(
+        string activityTypeName,
+        object bookmarkPayload,
+        TriggerWorkflowsRuntimeOptions options,
+        CancellationToken cancellationToken = default);
     
     /// <summary>
     /// Resumes an existing workflow instance.
@@ -34,7 +44,7 @@ public interface IWorkflowRuntime
     /// <summary>
     /// Resumes all workflows that are bookmarked on the specified activity type. 
     /// </summary>
-    Task<ICollection<WorkflowExecutionResult>> ResumeWorkflowsAsync(string activityTypeName, object bookmarkPayload, ResumeWorkflowRuntimeOptions options, CancellationToken cancellationToken = default);
+    Task<ICollection<WorkflowExecutionResult>> ResumeWorkflowsAsync(string activityTypeName, object bookmarkPayload, TriggerWorkflowsRuntimeOptions options, CancellationToken cancellationToken = default);
     
     /// <summary>
     /// Starts all workflows and resumes existing workflow instances based on the specified activity type and bookmark payload.


### PR DESCRIPTION
This PR fixes two issues:

1. Deadlock: the workflow runtime would always deadlock when triggering workflows (because of `ResumeDispatchWorkflowActivityHandler`).
2. Having multiple triggers on a flowchart would not schedule the triggered activity, but the first activity always.

Fixes #3713