### PR TITLE
Add output picker for SetWorkflowOutput activity

### DIFF
--- a/src/designer/elsa-workflows-designer/package.json
+++ b/src/designer/elsa-workflows-designer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elsa-workflows/elsa-workflows-designer",
-  "version": "3.0.2-preview.52",
+  "version": "3.0.2-preview.53",
   "description": "A workflow designer for Elsa 3",
   "main": "./dist/index.cjs.js",
   "module": "./dist/index.js",

--- a/src/designer/elsa-workflows-designer/src/components.d.ts
+++ b/src/designer/elsa-workflows-designer/src/components.d.ts
@@ -188,6 +188,9 @@ export namespace Components {
     interface ElsaNotificationsManager {
         "modalState": boolean;
     }
+    interface ElsaOutputPickerInput {
+        "inputContext": ActivityInputContext;
+    }
     interface ElsaPager {
         "page": number;
         "pageSize": number;
@@ -246,10 +249,6 @@ export namespace Components {
     interface ElsaWidgets {
         "widgets": Array<Widget>;
     }
-    interface ElsaWorkflowDefinitionActivitySettings {
-        "inputs"?: Array<InputDefinition>;
-        "outputs"?: Array<OutputDefinition>;
-    }
     interface ElsaWorkflowDefinitionBrowser {
     }
     interface ElsaWorkflowDefinitionEditor {
@@ -271,6 +270,10 @@ export namespace Components {
     }
     interface ElsaWorkflowDefinitionEditorToolboxActivities {
         "graph": Graph;
+    }
+    interface ElsaWorkflowDefinitionInputOutputSettings {
+        "inputs"?: Array<InputDefinition>;
+        "outputs"?: Array<OutputDefinition>;
     }
     interface ElsaWorkflowDefinitionPickerInput {
         "inputContext": ActivityInputContext;
@@ -396,10 +399,6 @@ export interface ElsaVariablesEditorCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLElsaVariablesEditorElement;
 }
-export interface ElsaWorkflowDefinitionActivitySettingsCustomEvent<T> extends CustomEvent<T> {
-    detail: T;
-    target: HTMLElsaWorkflowDefinitionActivitySettingsElement;
-}
 export interface ElsaWorkflowDefinitionBrowserCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLElsaWorkflowDefinitionBrowserElement;
@@ -411,6 +410,10 @@ export interface ElsaWorkflowDefinitionEditorCustomEvent<T> extends CustomEvent<
 export interface ElsaWorkflowDefinitionEditorToolbarCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLElsaWorkflowDefinitionEditorToolbarElement;
+}
+export interface ElsaWorkflowDefinitionInputOutputSettingsCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLElsaWorkflowDefinitionInputOutputSettingsElement;
 }
 export interface ElsaWorkflowDefinitionPropertiesEditorCustomEvent<T> extends CustomEvent<T> {
     detail: T;
@@ -607,6 +610,12 @@ declare global {
         prototype: HTMLElsaNotificationsManagerElement;
         new (): HTMLElsaNotificationsManagerElement;
     };
+    interface HTMLElsaOutputPickerInputElement extends Components.ElsaOutputPickerInput, HTMLStencilElement {
+    }
+    var HTMLElsaOutputPickerInputElement: {
+        prototype: HTMLElsaOutputPickerInputElement;
+        new (): HTMLElsaOutputPickerInputElement;
+    };
     interface HTMLElsaPagerElement extends Components.ElsaPager, HTMLStencilElement {
     }
     var HTMLElsaPagerElement: {
@@ -697,12 +706,6 @@ declare global {
         prototype: HTMLElsaWidgetsElement;
         new (): HTMLElsaWidgetsElement;
     };
-    interface HTMLElsaWorkflowDefinitionActivitySettingsElement extends Components.ElsaWorkflowDefinitionActivitySettings, HTMLStencilElement {
-    }
-    var HTMLElsaWorkflowDefinitionActivitySettingsElement: {
-        prototype: HTMLElsaWorkflowDefinitionActivitySettingsElement;
-        new (): HTMLElsaWorkflowDefinitionActivitySettingsElement;
-    };
     interface HTMLElsaWorkflowDefinitionBrowserElement extends Components.ElsaWorkflowDefinitionBrowser, HTMLStencilElement {
     }
     var HTMLElsaWorkflowDefinitionBrowserElement: {
@@ -732,6 +735,12 @@ declare global {
     var HTMLElsaWorkflowDefinitionEditorToolboxActivitiesElement: {
         prototype: HTMLElsaWorkflowDefinitionEditorToolboxActivitiesElement;
         new (): HTMLElsaWorkflowDefinitionEditorToolboxActivitiesElement;
+    };
+    interface HTMLElsaWorkflowDefinitionInputOutputSettingsElement extends Components.ElsaWorkflowDefinitionInputOutputSettings, HTMLStencilElement {
+    }
+    var HTMLElsaWorkflowDefinitionInputOutputSettingsElement: {
+        prototype: HTMLElsaWorkflowDefinitionInputOutputSettingsElement;
+        new (): HTMLElsaWorkflowDefinitionInputOutputSettingsElement;
     };
     interface HTMLElsaWorkflowDefinitionPickerInputElement extends Components.ElsaWorkflowDefinitionPickerInput, HTMLStencilElement {
     }
@@ -829,6 +838,7 @@ declare global {
         "elsa-multi-line-input": HTMLElsaMultiLineInputElement;
         "elsa-multi-text-input": HTMLElsaMultiTextInputElement;
         "elsa-notifications-manager": HTMLElsaNotificationsManagerElement;
+        "elsa-output-picker-input": HTMLElsaOutputPickerInputElement;
         "elsa-pager": HTMLElsaPagerElement;
         "elsa-panel": HTMLElsaPanelElement;
         "elsa-radio-list-input": HTMLElsaRadioListInputElement;
@@ -844,12 +854,12 @@ declare global {
         "elsa-variables-editor": HTMLElsaVariablesEditorElement;
         "elsa-variables-viewer": HTMLElsaVariablesViewerElement;
         "elsa-widgets": HTMLElsaWidgetsElement;
-        "elsa-workflow-definition-activity-settings": HTMLElsaWorkflowDefinitionActivitySettingsElement;
         "elsa-workflow-definition-browser": HTMLElsaWorkflowDefinitionBrowserElement;
         "elsa-workflow-definition-editor": HTMLElsaWorkflowDefinitionEditorElement;
         "elsa-workflow-definition-editor-toolbar": HTMLElsaWorkflowDefinitionEditorToolbarElement;
         "elsa-workflow-definition-editor-toolbox": HTMLElsaWorkflowDefinitionEditorToolboxElement;
         "elsa-workflow-definition-editor-toolbox-activities": HTMLElsaWorkflowDefinitionEditorToolboxActivitiesElement;
+        "elsa-workflow-definition-input-output-settings": HTMLElsaWorkflowDefinitionInputOutputSettingsElement;
         "elsa-workflow-definition-picker-input": HTMLElsaWorkflowDefinitionPickerInputElement;
         "elsa-workflow-definition-properties-editor": HTMLElsaWorkflowDefinitionPropertiesEditorElement;
         "elsa-workflow-definition-version-history": HTMLElsaWorkflowDefinitionVersionHistoryElement;
@@ -1025,6 +1035,9 @@ declare namespace LocalJSX {
     interface ElsaNotificationsManager {
         "modalState"?: boolean;
     }
+    interface ElsaOutputPickerInput {
+        "inputContext"?: ActivityInputContext;
+    }
     interface ElsaPager {
         "onPaginated"?: (event: ElsaPagerCustomEvent<PagerData>) => void;
         "page"?: number;
@@ -1085,12 +1098,6 @@ declare namespace LocalJSX {
     interface ElsaWidgets {
         "widgets"?: Array<Widget>;
     }
-    interface ElsaWorkflowDefinitionActivitySettings {
-        "inputs"?: Array<InputDefinition>;
-        "onInputsChanged"?: (event: ElsaWorkflowDefinitionActivitySettingsCustomEvent<Array<InputDefinition>>) => void;
-        "onOutputsChanged"?: (event: ElsaWorkflowDefinitionActivitySettingsCustomEvent<Array<OutputDefinition>>) => void;
-        "outputs"?: Array<OutputDefinition>;
-    }
     interface ElsaWorkflowDefinitionBrowser {
         "onNewWorkflowDefinitionSelected"?: (event: ElsaWorkflowDefinitionBrowserCustomEvent<any>) => void;
         "onWorkflowDefinitionSelected"?: (event: ElsaWorkflowDefinitionBrowserCustomEvent<WorkflowDefinitionSummary>) => void;
@@ -1109,6 +1116,12 @@ declare namespace LocalJSX {
     }
     interface ElsaWorkflowDefinitionEditorToolboxActivities {
         "graph"?: Graph;
+    }
+    interface ElsaWorkflowDefinitionInputOutputSettings {
+        "inputs"?: Array<InputDefinition>;
+        "onInputsChanged"?: (event: ElsaWorkflowDefinitionInputOutputSettingsCustomEvent<Array<InputDefinition>>) => void;
+        "onOutputsChanged"?: (event: ElsaWorkflowDefinitionInputOutputSettingsCustomEvent<Array<OutputDefinition>>) => void;
+        "outputs"?: Array<OutputDefinition>;
     }
     interface ElsaWorkflowDefinitionPickerInput {
         "inputContext"?: ActivityInputContext;
@@ -1192,6 +1205,7 @@ declare namespace LocalJSX {
         "elsa-multi-line-input": ElsaMultiLineInput;
         "elsa-multi-text-input": ElsaMultiTextInput;
         "elsa-notifications-manager": ElsaNotificationsManager;
+        "elsa-output-picker-input": ElsaOutputPickerInput;
         "elsa-pager": ElsaPager;
         "elsa-panel": ElsaPanel;
         "elsa-radio-list-input": ElsaRadioListInput;
@@ -1207,12 +1221,12 @@ declare namespace LocalJSX {
         "elsa-variables-editor": ElsaVariablesEditor;
         "elsa-variables-viewer": ElsaVariablesViewer;
         "elsa-widgets": ElsaWidgets;
-        "elsa-workflow-definition-activity-settings": ElsaWorkflowDefinitionActivitySettings;
         "elsa-workflow-definition-browser": ElsaWorkflowDefinitionBrowser;
         "elsa-workflow-definition-editor": ElsaWorkflowDefinitionEditor;
         "elsa-workflow-definition-editor-toolbar": ElsaWorkflowDefinitionEditorToolbar;
         "elsa-workflow-definition-editor-toolbox": ElsaWorkflowDefinitionEditorToolbox;
         "elsa-workflow-definition-editor-toolbox-activities": ElsaWorkflowDefinitionEditorToolboxActivities;
+        "elsa-workflow-definition-input-output-settings": ElsaWorkflowDefinitionInputOutputSettings;
         "elsa-workflow-definition-picker-input": ElsaWorkflowDefinitionPickerInput;
         "elsa-workflow-definition-properties-editor": ElsaWorkflowDefinitionPropertiesEditor;
         "elsa-workflow-definition-version-history": ElsaWorkflowDefinitionVersionHistory;
@@ -1259,6 +1273,7 @@ declare module "@stencil/core" {
             "elsa-multi-line-input": LocalJSX.ElsaMultiLineInput & JSXBase.HTMLAttributes<HTMLElsaMultiLineInputElement>;
             "elsa-multi-text-input": LocalJSX.ElsaMultiTextInput & JSXBase.HTMLAttributes<HTMLElsaMultiTextInputElement>;
             "elsa-notifications-manager": LocalJSX.ElsaNotificationsManager & JSXBase.HTMLAttributes<HTMLElsaNotificationsManagerElement>;
+            "elsa-output-picker-input": LocalJSX.ElsaOutputPickerInput & JSXBase.HTMLAttributes<HTMLElsaOutputPickerInputElement>;
             "elsa-pager": LocalJSX.ElsaPager & JSXBase.HTMLAttributes<HTMLElsaPagerElement>;
             "elsa-panel": LocalJSX.ElsaPanel & JSXBase.HTMLAttributes<HTMLElsaPanelElement>;
             "elsa-radio-list-input": LocalJSX.ElsaRadioListInput & JSXBase.HTMLAttributes<HTMLElsaRadioListInputElement>;
@@ -1274,12 +1289,12 @@ declare module "@stencil/core" {
             "elsa-variables-editor": LocalJSX.ElsaVariablesEditor & JSXBase.HTMLAttributes<HTMLElsaVariablesEditorElement>;
             "elsa-variables-viewer": LocalJSX.ElsaVariablesViewer & JSXBase.HTMLAttributes<HTMLElsaVariablesViewerElement>;
             "elsa-widgets": LocalJSX.ElsaWidgets & JSXBase.HTMLAttributes<HTMLElsaWidgetsElement>;
-            "elsa-workflow-definition-activity-settings": LocalJSX.ElsaWorkflowDefinitionActivitySettings & JSXBase.HTMLAttributes<HTMLElsaWorkflowDefinitionActivitySettingsElement>;
             "elsa-workflow-definition-browser": LocalJSX.ElsaWorkflowDefinitionBrowser & JSXBase.HTMLAttributes<HTMLElsaWorkflowDefinitionBrowserElement>;
             "elsa-workflow-definition-editor": LocalJSX.ElsaWorkflowDefinitionEditor & JSXBase.HTMLAttributes<HTMLElsaWorkflowDefinitionEditorElement>;
             "elsa-workflow-definition-editor-toolbar": LocalJSX.ElsaWorkflowDefinitionEditorToolbar & JSXBase.HTMLAttributes<HTMLElsaWorkflowDefinitionEditorToolbarElement>;
             "elsa-workflow-definition-editor-toolbox": LocalJSX.ElsaWorkflowDefinitionEditorToolbox & JSXBase.HTMLAttributes<HTMLElsaWorkflowDefinitionEditorToolboxElement>;
             "elsa-workflow-definition-editor-toolbox-activities": LocalJSX.ElsaWorkflowDefinitionEditorToolboxActivities & JSXBase.HTMLAttributes<HTMLElsaWorkflowDefinitionEditorToolboxActivitiesElement>;
+            "elsa-workflow-definition-input-output-settings": LocalJSX.ElsaWorkflowDefinitionInputOutputSettings & JSXBase.HTMLAttributes<HTMLElsaWorkflowDefinitionInputOutputSettingsElement>;
             "elsa-workflow-definition-picker-input": LocalJSX.ElsaWorkflowDefinitionPickerInput & JSXBase.HTMLAttributes<HTMLElsaWorkflowDefinitionPickerInputElement>;
             "elsa-workflow-definition-properties-editor": LocalJSX.ElsaWorkflowDefinitionPropertiesEditor & JSXBase.HTMLAttributes<HTMLElsaWorkflowDefinitionPropertiesEditorElement>;
             "elsa-workflow-definition-version-history": LocalJSX.ElsaWorkflowDefinitionVersionHistory & JSXBase.HTMLAttributes<HTMLElsaWorkflowDefinitionVersionHistoryElement>;

--- a/src/designer/elsa-workflows-designer/src/components/inputs/output-picker.tsx
+++ b/src/designer/elsa-workflows-designer/src/components/inputs/output-picker.tsx
@@ -1,0 +1,57 @@
+import {Component, Prop, h} from '@stencil/core';
+import {LiteralExpression, SyntaxNames, Variable} from "../../models";
+import {ActivityInputContext} from "../../services/activity-input-driver";
+import {getInputPropertyValue, getPropertyValue} from "../../utils";
+import {FormEntry} from "../shared/forms/form-entry";
+import WorkflowDefinitionTunnel from "../../modules/workflow-definitions/state";
+import {OutputDefinition} from "../../modules/workflow-definitions/models/entities";
+import {ExpressionChangedArs} from "../shared/input-control-switch/input-control-switch";
+
+@Component({
+  tag: 'elsa-output-picker-input',
+  shadow: false
+})
+export class OutputPicker {
+  @Prop() public inputContext: ActivityInputContext;
+
+  public render() {
+    const inputContext = this.inputContext;
+    const inputDescriptor = inputContext.inputDescriptor;
+    const fieldName = inputDescriptor.name;
+    const fieldId = inputDescriptor.name;
+    const displayName = inputDescriptor.displayName;
+    const description = inputDescriptor.description;
+    const input = getInputPropertyValue(inputContext);
+    const value = (input?.expression as LiteralExpression)?.value;
+    const syntax = input?.expression?.type ?? inputDescriptor.defaultSyntax;
+
+    return (
+      <WorkflowDefinitionTunnel.Consumer>
+        {({workflowDefinition}) => {
+          let outputs: OutputDefinition[] = workflowDefinition?.outputs ?? [];
+          outputs = [null, ...outputs];
+          return <elsa-input-control-switch label={displayName} hint={description} syntax={syntax} expression={value} onExpressionChanged={this.onExpressionChanged}>
+            <select id={fieldId} name={fieldName} onChange={e => this.onChange(e)}>
+              {outputs.map((output: OutputDefinition) => {
+                const outputName = output?.name;
+                const displayName = output?.displayName ?? '';
+                const isSelected = outputName == value;
+                return <option value={outputName} selected={isSelected}>{displayName}</option>;
+              })}
+            </select>
+          </elsa-input-control-switch>
+        }}
+      </WorkflowDefinitionTunnel.Consumer>
+    );
+  }
+
+  private onExpressionChanged = (e: CustomEvent<ExpressionChangedArs>) => {
+    this.inputContext.inputChanged(e.detail.expression, e.detail.syntax);
+  }
+
+  private onChange = (e: Event) => {
+    const inputElement = e.target as HTMLSelectElement;
+    const outputName = inputElement.value;
+    this.inputContext.inputChanged(outputName, SyntaxNames.Literal);
+  }
+}

--- a/src/designer/elsa-workflows-designer/src/components/inputs/variable-picker.tsx
+++ b/src/designer/elsa-workflows-designer/src/components/inputs/variable-picker.tsx
@@ -30,10 +30,10 @@ export class VariablePickerInput {
     return (
       <WorkflowDefinitionTunnel.Consumer>
         {({workflowDefinition}) => {
-          let  variables: Variable[] = workflowDefinition?.variables ?? [];
+          let variables: Variable[] = workflowDefinition?.variables ?? [];
           variables = [null, ...variables];
           return <FormEntry fieldId={fieldId} label={displayName} hint={description}>
-          <select id={fieldId} name={fieldName} onChange={e => this.onChange(e)}>
+            <select id={fieldId} name={fieldName} onChange={e => this.onChange(e)}>
               {variables.map((variable: Variable) => {
                 const variableName = variable?.name;
                 const isSelected = variableName == currentValue?.name;

--- a/src/designer/elsa-workflows-designer/src/modules/workflow-definitions/components/properties/input-output-settings.tsx
+++ b/src/designer/elsa-workflows-designer/src/modules/workflow-definitions/components/properties/input-output-settings.tsx
@@ -6,10 +6,10 @@ import {InputDefinition, OutputDefinition} from "../../models/entities";
 import {DeleteIcon, EditIcon} from "../../../../components/icons/tooling";
 
 @Component({
-  tag: 'elsa-workflow-definition-activity-settings',
+  tag: 'elsa-workflow-definition-input-output-settings',
   shadow: false
 })
-export class ActivitySettings {
+export class InputOutputSettings {
   private readonly modalDialogService: ModalDialogService;
   private readonly inputSaveAction: ModalActionDefinition;
   private readonly outputSaveAction: ModalActionDefinition;

--- a/src/designer/elsa-workflows-designer/src/modules/workflow-definitions/components/properties/properties.tsx
+++ b/src/designer/elsa-workflows-designer/src/modules/workflow-definitions/components/properties/properties.tsx
@@ -190,12 +190,12 @@ export class WorkflowDefinitionPropertiesEditor {
       }
     }
 
-    const activityTabModel: TabModel = {
-      name: 'activity',
+    const inputOutputTabModel: TabModel = {
+      name: 'input-output',
       tab: {
-        displayText: 'Activity',
+        displayText: 'Input/output',
         order: 15,
-        content: () => this.renderActivitySettingsTab()
+        content: () => this.renderInputOutputTab()
       }
     }
 
@@ -208,10 +208,7 @@ export class WorkflowDefinitionPropertiesEditor {
       }
     }
 
-    model.tabModels = [propertiesTabModel, variablesTabModel, settingsTabModel, versionHistoryTabModel];
-
-    if(workflowDefinition.usableAsActivity)
-      model.tabModels.push(activityTabModel);
+    model.tabModels = [propertiesTabModel, variablesTabModel, settingsTabModel, versionHistoryTabModel, inputOutputTabModel];
 
     const args: WorkflowPropertiesEditorDisplayingArgs = {model};
 
@@ -230,12 +227,12 @@ export class WorkflowDefinitionPropertiesEditor {
     </div>
   };
 
-  private renderActivitySettingsTab = () => {
+  private renderInputOutputTab = () => {
     const inputs: Array<InputDefinition> = this.workflowDefinition?.inputs ?? [];
     const outputs: Array<OutputDefinition> = this.workflowDefinition?.outputs ?? [];
 
     return <div>
-      <elsa-workflow-definition-activity-settings
+      <elsa-workflow-definition-input-output-settings
         inputs={inputs}
         outputs={outputs}
         onInputsChanged={e => this.onInputsUpdated(e)}

--- a/src/designer/elsa-workflows-designer/src/services/input-control-registry.tsx
+++ b/src/designer/elsa-workflows-designer/src/services/input-control-registry.tsx
@@ -20,6 +20,7 @@ export class InputControlRegistry {
     this.add('checkbox', c => <elsa-checkbox-input inputContext={c}/>);
     this.add('variable-picker', c => <elsa-variable-picker-input inputContext={c}/>);
     this.add('type-picker', c => <elsa-type-picker-input inputContext={c}/>);
+    this.add('output-picker', c => <elsa-output-picker-input inputContext={c}/>);
   }
 
   public add(uiHint: UIHint, control: RenderActivityPropInputControl) {

--- a/src/modules/Elsa.JavaScript/Activities/RunJavaScript.cs
+++ b/src/modules/Elsa.JavaScript/Activities/RunJavaScript.cs
@@ -6,7 +6,7 @@ using IJavaScriptEvaluator = Elsa.JavaScript.Contracts.IJavaScriptEvaluator;
 
 namespace Elsa.JavaScript.Activities;
 
-[Activity("Elsa", "Scripting", "Executes JavaScript code")]
+[Activity("Elsa", "Scripting", "Executes JavaScript code", DisplayName = "Run JavaScript")]
 public class RunJavaScript : CodeActivity<object?>
 {
     [JsonConstructor]

--- a/src/modules/Elsa.Workflows.Designer/package-lock.json
+++ b/src/modules/Elsa.Workflows.Designer/package-lock.json
@@ -5,7 +5,7 @@
     "packages": {
         "": {
             "devDependencies": {
-                "@elsa-workflows/elsa-workflows-designer": "^3.0.2-preview.52",
+                "@elsa-workflows/elsa-workflows-designer": "^3.0.2-preview.53",
                 "copy-webpack-plugin": "^11.0.0",
                 "cross-env": "^7.0.3",
                 "monaco-editor": "^0.34.1",
@@ -115,9 +115,9 @@
             }
         },
         "node_modules/@elsa-workflows/elsa-workflows-designer": {
-            "version": "3.0.2-preview.52",
-            "resolved": "https://registry.npmjs.org/@elsa-workflows/elsa-workflows-designer/-/elsa-workflows-designer-3.0.2-preview.52.tgz",
-            "integrity": "sha512-bnf3qFUbMtxZ2vYVSMp0ZUZwFzJC1mkl8GiQRTauVthxIHREEVvQLyfeuGTg+/MCSQgzCFys+OgkWQHC5FbeXQ==",
+            "version": "3.0.2-preview.53",
+            "resolved": "https://registry.npmjs.org/@elsa-workflows/elsa-workflows-designer/-/elsa-workflows-designer-3.0.2-preview.53.tgz",
+            "integrity": "sha512-Qd+ZJhTMjoqAP5yuYM3eOffVKmqj3LwehAo51sXNo5fYSc25nOMEUmMjKnWRrrv9LsLJsHoVIxwZ47w+5NpCuQ==",
             "dev": true,
             "dependencies": {
                 "@antv/layout": "^0.3.11",
@@ -2425,9 +2425,9 @@
             "dev": true
         },
         "@elsa-workflows/elsa-workflows-designer": {
-            "version": "3.0.2-preview.52",
-            "resolved": "https://registry.npmjs.org/@elsa-workflows/elsa-workflows-designer/-/elsa-workflows-designer-3.0.2-preview.52.tgz",
-            "integrity": "sha512-bnf3qFUbMtxZ2vYVSMp0ZUZwFzJC1mkl8GiQRTauVthxIHREEVvQLyfeuGTg+/MCSQgzCFys+OgkWQHC5FbeXQ==",
+            "version": "3.0.2-preview.53",
+            "resolved": "https://registry.npmjs.org/@elsa-workflows/elsa-workflows-designer/-/elsa-workflows-designer-3.0.2-preview.53.tgz",
+            "integrity": "sha512-Qd+ZJhTMjoqAP5yuYM3eOffVKmqj3LwehAo51sXNo5fYSc25nOMEUmMjKnWRrrv9LsLJsHoVIxwZ47w+5NpCuQ==",
             "dev": true,
             "requires": {
                 "@antv/layout": "^0.3.11",

--- a/src/modules/Elsa.Workflows.Designer/package.json
+++ b/src/modules/Elsa.Workflows.Designer/package.json
@@ -6,7 +6,7 @@
         "build:debug": "cross-env webpack --mode=development --env configuration=Debug"
     },
     "devDependencies": {
-        "@elsa-workflows/elsa-workflows-designer": "^3.0.2-preview.52",
+        "@elsa-workflows/elsa-workflows-designer": "^3.0.2-preview.53",
         "copy-webpack-plugin": "^11.0.0",
         "cross-env": "^7.0.3",
         "monaco-editor": "^0.34.1",

--- a/src/modules/Elsa.Workflows.Management/Activities/SetWorkflowOutput.cs
+++ b/src/modules/Elsa.Workflows.Management/Activities/SetWorkflowOutput.cs
@@ -3,6 +3,7 @@ using Elsa.Extensions;
 using Elsa.Workflows.Core.Attributes;
 using Elsa.Workflows.Core.Models;
 using Elsa.Workflows.Management.Extensions;
+using Elsa.Workflows.Management.Models;
 using Elsa.Workflows.Management.Services;
 using JetBrains.Annotations;
 
@@ -18,7 +19,10 @@ public class SetWorkflowOutput : CodeActivity
     /// <summary>
     /// The name of the output to assign.
     /// </summary>
-    [Input(Description = "The output to assign.")]
+    [Input(
+        Description = "The output to assign.",
+        UIHint = InputUIHints.OutputPicker
+    )]
     public Input<string> OutputName { get; set; } = default!;
 
     /// <summary>

--- a/src/modules/Elsa.Workflows.Management/Models/InputUIHints.cs
+++ b/src/modules/Elsa.Workflows.Management/Models/InputUIHints.cs
@@ -16,5 +16,6 @@ public static class InputUIHints
     public const string VariablePicker = "variable-picker";
     public const string TypePicker = "type-picker";
     public const string WorkflowDefinitionPicker = "workflow-definition-picker";
+    public const string OutputPicker = "output-picker";
     public const string JsonEditor = "json-editor";
 }


### PR DESCRIPTION
This PR adds an output picker control for the SetWorkflowOutput activity, which is fed from the output definitions of the current workflow definition. This replaces the free form text field that was used originally.