### PR TITLE
Fix credential manager in designer.

### DIFF
--- a/src/designer/elsa-workflows-studio/src/modules/credential-manager/elsa-secret-editor-modal/elsa-secret-editor-modal.tsx
+++ b/src/designer/elsa-workflows-studio/src/modules/credential-manager/elsa-secret-editor-modal/elsa-secret-editor-modal.tsx
@@ -62,16 +62,16 @@ export class ElsaSecretEditorModal {
     if (!this.secretModel) {
       return false;
     }
-    const grantType = this.secretModel.properties.find(x => x.name === 'GrantType').expressions[SyntaxNames.Literal];
+    const grantType = this.secretModel.properties.find(x => x.name === 'GrantType')?.expressions[SyntaxNames.Literal];
     const isTokenMissing = this.secretModel.properties.findIndex(x => x.name === 'Token') === -1;
     return grantType === 'authorization_code' && isTokenMissing;
   }
 
   get isAuthorizeButtonDisabled() {
-    const authUrl = this.secretModel.properties.find(x => x.name === 'AuthorizationUrl').expressions[SyntaxNames.Literal];
-    const tokenUrl = this.secretModel.properties.find(x => x.name === 'AccessTokenUrl').expressions[SyntaxNames.Literal];
-    const clientId = this.secretModel.properties.find(x => x.name === 'ClientId').expressions[SyntaxNames.Literal];
-    const clientSecret = this.secretModel.properties.find(x => x.name === 'ClientSecret').expressions[SyntaxNames.Literal];
+    const authUrl = this.secretModel.properties.find(x => x.name === 'AuthorizationUrl')?.expressions[SyntaxNames.Literal];
+    const tokenUrl = this.secretModel.properties.find(x => x.name === 'AccessTokenUrl')?.expressions[SyntaxNames.Literal];
+    const clientId = this.secretModel.properties.find(x => x.name === 'ClientId')?.expressions[SyntaxNames.Literal];
+    const clientSecret = this.secretModel.properties.find(x => x.name === 'ClientSecret')?.expressions[SyntaxNames.Literal];
 
     return !authUrl || !tokenUrl || !clientId || !clientSecret;
   }

--- a/src/designer/elsa-workflows-studio/src/modules/credential-manager/pages/credential-manager-items-list.tsx
+++ b/src/designer/elsa-workflows-studio/src/modules/credential-manager/pages/credential-manager-items-list.tsx
@@ -62,4 +62,4 @@ export class CredentialManagerItemsList {
     );
   }
 }
-Tunnel.injectProps(CredentialManagerItemsList, ['culture', 'basePath', 'serverUrl']);
+Tunnel.injectProps(CredentialManagerItemsList, ['culture', 'basePath', 'serverUrl', 'monacoLibPath']);


### PR DESCRIPTION
Fixes two issues:
1. Fix the `elsa-credential-manager-items-list` failing to open from the Elsa dashboard due to the `monacoLibPath` not being injected from the tunnel.
2. Fixes the `elsa-secret-editor-modal` throwing errors for secrets that don't have any of the following properties:
   1. `GrantType`
   2. `AuthorizationUrl`
   3. `AccessTokenUrl`
   4. `ClientId`
   5. `ClientSecret`