### PR TITLE
Refactor store APIs

### DIFF
--- a/src/bundles/Elsa.WorkflowServer.Web/appsettings.json
+++ b/src/bundles/Elsa.WorkflowServer.Web/appsettings.json
@@ -1,9 +1,10 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Debug",
+      "Default": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information",
       "Microsoft.EntityFrameworkCore": "Warning",
-      "Microsoft.AspNetCore": "Debug"
+      "Microsoft.AspNetCore": "Warning"
     }
   },
   "AllowedHosts": "*",
@@ -14,8 +15,8 @@
     "CreateDefaultAdmin": true,
     "Tokens": {
       "SigningKey": "secret-signing-key",
-      "AccessTokenLifetime": "1:00:00",
-      "RefreshTokenLifetime": "1:10:00"
+      "AccessTokenLifetime": "1:00:00:00",
+      "RefreshTokenLifetime": "1:00:10:00"
     }
   }
 }

--- a/src/common/Elsa.Api.Common/Extensions/WebApplicationExtensions.cs
+++ b/src/common/Elsa.Api.Common/Extensions/WebApplicationExtensions.cs
@@ -40,7 +40,8 @@ public static class WebApplicationExtensions
 
     private static Task SerializeRequestAsync(HttpResponse httpResponse, object? dto, string contentType, JsonSerializerContext? serializerContext, CancellationToken cancellationToken)
     {
-        var serializerOptionsProvider = httpResponse.HttpContext.RequestServices.GetRequiredService<SerializerOptionsProvider>();
+        var services = httpResponse.HttpContext.RequestServices;
+        var serializerOptionsProvider = services.GetRequiredService<SerializerOptionsProvider>();
         var options = serializerOptionsProvider.CreateApiOptions();
 
         httpResponse.ContentType = contentType;

--- a/src/designer/elsa-workflows-designer/src/models/api.ts
+++ b/src/designer/elsa-workflows-designer/src/models/api.ts
@@ -1,5 +1,3 @@
-import {WorkflowState} from "./core";
-
 export enum WorkflowStatus {
   Running = 'Running',
   Finished = 'Finished'

--- a/src/designer/elsa-workflows-designer/src/models/core.ts
+++ b/src/designer/elsa-workflows-designer/src/models/core.ts
@@ -38,7 +38,6 @@ export interface Workflow extends Activity {
 export interface Variable {
   name: string;
   typeName: string;
-
   isArray: boolean;
   value?: any;
   storageDriverTypeName?: string;

--- a/src/designer/elsa-workflows-designer/src/modules/workflow-definitions/components/workflow-properties/activity-input-editor-dialog-content.tsx
+++ b/src/designer/elsa-workflows-designer/src/modules/workflow-definitions/components/workflow-properties/activity-input-editor-dialog-content.tsx
@@ -82,8 +82,8 @@ export class ActivityInputEditorDialogContent {
                 </select>
               </FormEntry>
 
-              <CheckboxFormEntry fieldId="variableIsArray" label="This variable is an array" hint="Check if the variable holds an array of the selected type.">
-                <input type="checkbox" name="variableIsArray" id="variableIsArray" value="true" checked={input.isArray}/>
+              <CheckboxFormEntry fieldId="inputIsArray" label="This input is an array" hint="Check if the input holds an array of the selected type.">
+                <input type="checkbox" name="inputIsArray" id="inputIsArray" value="true" checked={input.isArray}/>
               </CheckboxFormEntry>
 
               <FormEntry fieldId="inputDisplayName" label="Display name" hint="The user friendly display name of the input.">
@@ -129,6 +129,7 @@ export class ActivityInputEditorDialogContent {
     const description = formData.get('inputDescription') as string;
     const category = formData.get('inputCategory') as string;
     const uiHint = formData.get('inputUIHint') as string;
+    const isArray = formData.get('inputIsArray') as string === 'true';
     const input = this.input;
 
     input.name = name;
@@ -137,6 +138,7 @@ export class ActivityInputEditorDialogContent {
     input.category = category;
     input.description = description;
     input.uiHint = uiHint;
+    input.isArray = isArray;
 
     return input;
   };

--- a/src/designer/elsa-workflows-designer/src/modules/workflow-definitions/components/workflow-properties/activity-input-editor-dialog-content.tsx
+++ b/src/designer/elsa-workflows-designer/src/modules/workflow-definitions/components/workflow-properties/activity-input-editor-dialog-content.tsx
@@ -3,7 +3,7 @@ import {groupBy} from 'lodash';
 import descriptorsStore from '../../../../data/descriptors-store';
 import {VariableDescriptor} from "../../../../services/api-client/variable-descriptors-api";
 import {InputDefinition} from "../../models/entities";
-import {FormEntry} from "../../../../components/shared/forms/form-entry";
+import {CheckboxFormEntry, FormEntry} from "../../../../components/shared/forms/form-entry";
 
 @Component({
   tag: 'elsa-activity-input-editor-dialog-content',
@@ -21,7 +21,7 @@ export class ActivityInputEditorDialogContent {
   }
 
   render() {
-    const input: InputDefinition = this.input ?? {name: '', type: 'Object'};
+    const input: InputDefinition = this.input ?? {name: '', type: 'Object', isArray: false};
     const inputTypeName = input.type;
     const availableTypes: Array<VariableDescriptor> = descriptorsStore.variableDescriptors;
     const groupedTypes = groupBy(availableTypes, x => x.category);
@@ -82,6 +82,10 @@ export class ActivityInputEditorDialogContent {
                 </select>
               </FormEntry>
 
+              <CheckboxFormEntry fieldId="variableIsArray" label="This variable is an array" hint="Check if the variable holds an array of the selected type.">
+                <input type="checkbox" name="variableIsArray" id="variableIsArray" value="true" checked={input.isArray}/>
+              </CheckboxFormEntry>
+
               <FormEntry fieldId="inputDisplayName" label="Display name" hint="The user friendly display name of the input.">
                 <input type="text" name="inputDisplayName" id="inputDisplayName" value={input.displayName}/>
               </FormEntry>
@@ -94,7 +98,7 @@ export class ActivityInputEditorDialogContent {
                 <input type="text" name="inputCategory" id="inputCategory" value={input.category}/>
               </FormEntry>
 
-              <FormEntry fieldId="inputUIHint" label="Category" hint="A custom category.">
+              <FormEntry fieldId="inputUIHint" label="Control" hint="The control to use for this input.">
                 <select name="inputUIHint" id="inputUIHint">
                   {uiHints.map(uiHint => {
                     const isSelected = uiHint.value == selectedUIHint;

--- a/src/designer/elsa-workflows-designer/src/modules/workflow-definitions/components/workflow-properties/activity-output-editor-dialog-content.tsx
+++ b/src/designer/elsa-workflows-designer/src/modules/workflow-definitions/components/workflow-properties/activity-output-editor-dialog-content.tsx
@@ -21,7 +21,7 @@ export class ActivityOutputEditorDialogContent {
   }
 
   render() {
-    const output: OutputDefinition = this.output ?? {name: '', type: 'Object'};
+    const output: OutputDefinition = this.output ?? {name: '', type: 'Object', isArray: false};
     const outputTypeName = output.type;
     const availableTypes: Array<VariableDescriptor> = descriptorsStore.variableDescriptors;
     const groupedTypes = groupBy(availableTypes, x => x.category);

--- a/src/designer/elsa-workflows-designer/src/modules/workflow-definitions/components/workflow-properties/input-output-settings.tsx
+++ b/src/designer/elsa-workflows-designer/src/modules/workflow-definitions/components/workflow-properties/input-output-settings.tsx
@@ -198,14 +198,14 @@ export class InputOutputSettings {
 
   private onAddInputClick = async () => {
     const newName = this.generateNewInputName();
-    const input: InputDefinition = {name: newName, type: 'Object', displayName: newName};
+    const input: InputDefinition = {name: newName, type: 'Object', displayName: newName, isArray: false};
 
     this.modalDialogInstance = this.modalDialogService.show(() => <elsa-activity-input-editor-dialog-content input={input}/>, {actions: [this.inputSaveAction]})
   };
 
   private onAddOutputClick = async () => {
     const newName = this.generateNewOutputName();
-    const output: OutputDefinition = {name: newName, type: 'Object', displayName: newName};
+    const output: OutputDefinition = {name: newName, type: 'Object', displayName: newName, isArray: false};
 
     this.modalDialogInstance = this.modalDialogService.show(() => <elsa-activity-output-editor-dialog-content output={output}/>, {actions: [this.outputSaveAction]})
   };

--- a/src/designer/elsa-workflows-designer/src/modules/workflow-definitions/models/entities.ts
+++ b/src/designer/elsa-workflows-designer/src/modules/workflow-definitions/models/entities.ts
@@ -32,6 +32,7 @@ export interface WorkflowOptions {
 
 export interface ArgumentDefinition {
   type: Type;
+  isArray: boolean;
   name: string;
   displayName?: string;
   description?: string;

--- a/src/modules/Elsa.Common/Entities/OrderDefinition.cs
+++ b/src/modules/Elsa.Common/Entities/OrderDefinition.cs
@@ -1,0 +1,9 @@
+using System.Linq.Expressions;
+
+namespace Elsa.Common.Entities;
+
+public class OrderDefinition<T, TProp>
+{
+    public OrderDirection Direction { get; set; }
+    public Expression<Func<T, TProp>> KeySelector { get; set; }
+}

--- a/src/modules/Elsa.Common/Extensions/QueryableExtensions.cs
+++ b/src/modules/Elsa.Common/Extensions/QueryableExtensions.cs
@@ -1,4 +1,5 @@
 using System.Linq.Expressions;
+using Elsa.Common.Entities;
 using Elsa.Common.Models;
 
 // ReSharper disable once CheckNamespace
@@ -16,13 +17,26 @@ public static class QueryableExtensions
         return Page.Of(results, count);
     }
 
-    public static Page<T> Paginate<T>(this IQueryable<T> queryable, PageArgs? pageArgs = default)
+    public static Page<T> ToPage<T>(this IQueryable<T> queryable, PageArgs? pageArgs = default)
     {
         if (pageArgs?.Offset != null) queryable = queryable.Skip(pageArgs.Offset.Value);
         if (pageArgs?.Limit != null) queryable = queryable.Take(pageArgs.Limit.Value);
-
+    
         var count = queryable.Count();
         var results = queryable.ToList();
         return Page.Of(results, count);
     }
+    
+    public static IQueryable<T> Paginate<T>(this IQueryable<T> queryable, PageArgs pageArgs)
+    {
+        if (pageArgs?.Offset != null) queryable = queryable.Skip(pageArgs.Offset.Value);
+        if (pageArgs?.Limit != null) queryable = queryable.Take(pageArgs.Limit.Value);
+
+        return queryable;
+    }
+
+    public static IQueryable<T> OrderBy<T, TOrderBy>(this IQueryable<T> queryable, OrderDefinition<T, TOrderBy> order) =>
+        order.Direction == OrderDirection.Ascending 
+            ? queryable.OrderBy(order.KeySelector) 
+            : queryable.OrderByDescending(order.KeySelector);
 }

--- a/src/modules/Elsa.Common/Models/PageArgs.cs
+++ b/src/modules/Elsa.Common/Models/PageArgs.cs
@@ -4,4 +4,6 @@ public record PageArgs(int? Page, int? PageSize)
 {
     public int? Offset => Page * PageSize;
     public int? Limit => PageSize;
+
+    public PageArgs Next() => this with { Page = Page + 1 };
 }

--- a/src/modules/Elsa.Elasticsearch/Modules/Management/WorkflowInstanceStore.cs
+++ b/src/modules/Elsa.Elasticsearch/Modules/Management/WorkflowInstanceStore.cs
@@ -1,8 +1,10 @@
+using System.IO.MemoryMappedFiles;
 using Elastic.Clients.Elasticsearch;
 using Elastic.Clients.Elasticsearch.QueryDsl;
 using Elsa.Common.Entities;
 using Elsa.Common.Models;
 using Elsa.Elasticsearch.Common;
+using Elsa.Extensions;
 using Elsa.Workflows.Management.Entities;
 using Elsa.Workflows.Management.Models;
 using Elsa.Workflows.Management.Services;
@@ -15,7 +17,7 @@ namespace Elsa.Elasticsearch.Modules.Management;
 public class ElasticWorkflowInstanceStore : IWorkflowInstanceStore
 {
     private readonly ElasticStore<WorkflowInstance> _store;
-    
+
     /// <summary>
     /// Constructor.
     /// </summary>
@@ -25,107 +27,129 @@ public class ElasticWorkflowInstanceStore : IWorkflowInstanceStore
     }
 
     /// <inheritdoc />
-    public async Task<WorkflowInstance?> FindByIdAsync(string id, CancellationToken cancellationToken = default)
+    public async Task<WorkflowInstance?> FindAsync(WorkflowInstanceFilter filter, CancellationToken cancellationToken = default)
     {
-        var instances = await _store
-            .SearchAsync(desc => desc
-                .Query(q => q
-                    .Match(m => m
-                        .Field(f => f.Id)
-                        .Query(id))), default, cancellationToken);
-
-        return instances.Items.MaxBy(x => x.LastExecutedAt);
+        var result = await _store.SearchAsync(d => Filter(d, filter), new PageArgs(0, 1), cancellationToken);
+        return result.Items.FirstOrDefault();
     }
 
     /// <inheritdoc />
-    public async Task SaveAsync(WorkflowInstance record, CancellationToken cancellationToken = default) => 
+    public async Task<Page<WorkflowInstance>> FindManyAsync(WorkflowInstanceFilter filter, PageArgs pageArgs, CancellationToken cancellationToken = default) =>
+        await _store.SearchAsync(d => Filter(d, filter), pageArgs, cancellationToken);
+
+    /// <inheritdoc />
+    public async Task<Page<WorkflowInstance>> FindManyAsync<TOrderBy>(WorkflowInstanceFilter filter, PageArgs pageArgs, WorkflowInstanceOrder<TOrderBy> order, CancellationToken cancellationToken = default) =>
+        await _store.SearchAsync(d => Sort(Filter(d, filter), order), pageArgs, cancellationToken);
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<WorkflowInstance>> FindManyAsync(WorkflowInstanceFilter filter, CancellationToken cancellationToken = default) =>
+        await _store.SearchAsync(d => Filter(d, filter), cancellationToken);
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<WorkflowInstance>> FindManyAsync<TOrderBy>(WorkflowInstanceFilter filter, WorkflowInstanceOrder<TOrderBy> order, CancellationToken cancellationToken = default)
+    {
+        return await _store.SearchAsync(d => Sort(Filter(d, filter), order), cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<Page<WorkflowInstanceSummary>> SummarizeManyAsync(WorkflowInstanceFilter filter, PageArgs pageArgs, CancellationToken cancellationToken = default)
+    {
+        var results = await _store.SearchAsync(d => Summarize(Filter(d, filter)), pageArgs, cancellationToken);
+        var summaries = results.Items.Select(WorkflowInstanceSummary.FromInstance).ToList();
+        return new(summaries, results.TotalCount);
+    }
+
+    /// <inheritdoc />
+    public async Task<Page<WorkflowInstanceSummary>> SummarizeManyAsync<TOrderBy>(WorkflowInstanceFilter filter, PageArgs pageArgs, WorkflowInstanceOrder<TOrderBy> order, CancellationToken cancellationToken = default)
+    {
+        var results = await _store.SearchAsync(d => Summarize(Sort(Filter(d, filter), order)), pageArgs, cancellationToken);
+        var summaries = results.Items.Select(WorkflowInstanceSummary.FromInstance).ToList();
+        return new(summaries, results.TotalCount);
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<WorkflowInstanceSummary>> SummarizeManyAsync(WorkflowInstanceFilter filter, CancellationToken cancellationToken = default)
+    {
+        var results = await _store.SearchAsync(d => Summarize(Filter(d, filter)), cancellationToken);
+        return results.Select(WorkflowInstanceSummary.FromInstance).ToList();
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<WorkflowInstanceSummary>> SummarizeManyAsync<TOrder>(WorkflowInstanceFilter filter, WorkflowInstanceOrder<TOrder> order, CancellationToken cancellationToken = default)
+    {
+        var results = await _store.SearchAsync(d => Summarize(Sort(Filter(d, filter), order)), cancellationToken);
+        return results.Select(WorkflowInstanceSummary.FromInstance).ToList();
+    }
+
+    /// <inheritdoc />
+    public async Task SaveAsync(WorkflowInstance record, CancellationToken cancellationToken = default) =>
         await _store.SaveAsync(record, cancellationToken);
 
     /// <inheritdoc />
-    public async Task SaveManyAsync(IEnumerable<WorkflowInstance> records, CancellationToken cancellationToken = default) => 
+    public async Task SaveManyAsync(IEnumerable<WorkflowInstance> records, CancellationToken cancellationToken = default) =>
         await _store.SaveManyAsync(records, cancellationToken);
 
     /// <inheritdoc />
-    public async Task<bool> DeleteAsync(string id, CancellationToken cancellationToken = default)
+    public async Task<bool> DeleteAsync(WorkflowInstanceFilter filter, CancellationToken cancellationToken = default)
     {
-        var result = await _store.DeleteByQueryAsync(desc => desc
-                .Query(q => q
-                    .Term(t => t
-                        .Field(f => f.Id)
-                        .Value(id))), 
-            cancellationToken);
+        var result = await _store.DeleteByQueryAsync(d => Filter(d, filter), cancellationToken);
         return result > 0;
     }
 
     /// <inheritdoc />
-    public async Task<int> DeleteManyAsync(IEnumerable<string> ids, CancellationToken cancellationToken = default)
+    public async Task<int> DeleteManyAsync(WorkflowInstanceFilter filter, CancellationToken cancellationToken = default)
     {
-        var result = await _store.DeleteByQueryAsync(desc => desc
-                .Query(q => q
-                    .Terms(t => t
-                        .Field(f => f.Id)
-                        .Terms(new TermsQueryField(ids.Select(FieldValue.String).ToList()))
-                    )),
-            cancellationToken);
+        var result = await _store.DeleteByQueryAsync(d => Filter(d, filter), cancellationToken);
         return (int)result;
     }
-
-    /// <inheritdoc />
-    public async Task DeleteManyByDefinitionIdAsync(string definitionId, CancellationToken cancellationToken = default) =>
-        await _store.DeleteByQueryAsync(desc => desc
-                .Query(q => q
-                    .Term(t => t
-                        .Field(f => f.DefinitionId)
-                        .Value(definitionId))), 
-            cancellationToken);
-
-    /// <inheritdoc />
-    public async Task<Page<WorkflowInstanceSummary>> FindManyAsync(FindWorkflowInstancesArgs args, CancellationToken cancellationToken = default)
+    
+    private static SearchRequestDescriptor<WorkflowInstance> Sort<TProp>(SearchRequestDescriptor<WorkflowInstance> descriptor, WorkflowInstanceOrder<TProp> order)
     {
         var sortDescriptor = new SortOptionsDescriptor<WorkflowInstance>();
+        var propName = order.KeySelector.GetProperty()!.Name;
+        var sortOrder = order.Direction == OrderDirection.Ascending ? SortOrder.Asc : SortOrder.Desc;
+        sortDescriptor.Field(propName, f => f.Order(sortOrder));
 
-        var (searchTerm, definitionId, version, correlationId, workflowStatus, workflowSubStatus, pageArgs, orderBy,
-            orderDirection) = args;
-
-        sortDescriptor = orderBy switch
-        {
-            OrderBy.Finished => orderDirection == OrderDirection.Ascending
-                ? sortDescriptor.Field(f => f.FinishedAt!, cfg => cfg.Order(SortOrder.Asc))
-                : sortDescriptor.Field(f => f.FinishedAt!, cfg => cfg.Order(SortOrder.Desc)),
-            OrderBy.LastExecuted => orderDirection == OrderDirection.Ascending
-                ? sortDescriptor.Field(f => f.LastExecutedAt!, cfg => cfg.Order(SortOrder.Asc))
-                : sortDescriptor.Field(f => f.LastExecutedAt!, cfg => cfg.Order(SortOrder.Desc)),
-            OrderBy.Created => orderDirection == OrderDirection.Ascending
-                ? sortDescriptor.Field(f => f.CreatedAt, cfg => cfg.Order(SortOrder.Asc))
-                : sortDescriptor.Field(f => f.CreatedAt, cfg => cfg.Order(SortOrder.Desc)),
-            _ => sortDescriptor
-        };
-
-        var result = await _store.SearchAsync(s =>
-        {
-            if (!string.IsNullOrWhiteSpace(definitionId))
-                s.Query(q => q.Match(m => m.Field(f => f.DefinitionId).Query(definitionId)));
-
-            if (version != null)
-                s.Query(q => q.Match(m => m.Field(f => f.Version).Query(version.ToString()!)));
-
-            if (!string.IsNullOrWhiteSpace(correlationId))
-                s.Query(q => q.Match(m => m.Field(f => f.CorrelationId).Query(correlationId)));
-
-            if (workflowStatus != null)
-                s.Query(q => q.Match(m => m.Field(f => f.Status).Query(workflowStatus.ToString()!)));
-
-            if (workflowSubStatus != null)
-                s.Query(q => q.Match(m => m.Field(f => f.SubStatus).Query(workflowSubStatus.ToString()!)));
-            
-            if(!string.IsNullOrWhiteSpace(searchTerm))
-                s.Query(q => q
-                    .QueryString(c => c
-                        .Query(searchTerm)));
-
-            s.Sort(sortDescriptor);
-        }, args.PageArgs, cancellationToken);
-        return new Page<WorkflowInstanceSummary>(result.Items.Select(WorkflowInstanceSummary.FromInstance).ToList(),
-            result.TotalCount);
+        descriptor.Sort(sortDescriptor);
+        return descriptor;
     }
+
+    private static SearchRequestDescriptor<WorkflowInstance> Filter(SearchRequestDescriptor<WorkflowInstance> descriptor, WorkflowInstanceFilter filter) => descriptor.Query(query => Filter(query, filter));
+    private static DeleteByQueryRequestDescriptor<WorkflowInstance> Filter(DeleteByQueryRequestDescriptor<WorkflowInstance> descriptor, WorkflowInstanceFilter filter) => descriptor.Query(query => Filter(query, filter));
+
+    private static QueryDescriptor<WorkflowInstance> Filter(QueryDescriptor<WorkflowInstance> descriptor, WorkflowInstanceFilter filter)
+    {
+        // TODO: Implement remaining filters.
+
+        if (!string.IsNullOrWhiteSpace(filter.DefinitionId)) descriptor = descriptor.Match(m => m.Field(f => f.DefinitionId).Query(filter.DefinitionId));
+        if (filter.Version != null) descriptor = descriptor.Match(m => m.Field(f => f.Version).Query(filter.Version.ToString()!));
+        if (!string.IsNullOrWhiteSpace(filter.CorrelationId)) descriptor = descriptor.Match(m => m.Field(f => f.CorrelationId).Query(filter.CorrelationId));
+        if (filter.WorkflowStatus != null) descriptor = descriptor.Match(m => m.Field(f => f.Status).Query(filter.WorkflowStatus.ToString()!));
+        if (filter.WorkflowSubStatus != null) descriptor = descriptor.Match(m => m.Field(f => f.SubStatus).Query(filter.WorkflowSubStatus.ToString()!));
+
+        if (!string.IsNullOrWhiteSpace(filter.SearchTerm))
+            descriptor = descriptor
+                .QueryString(c => c
+                    .Query(filter.SearchTerm));
+
+        return descriptor;
+    }
+
+    private static SearchRequestDescriptor<WorkflowInstance> Summarize(SearchRequestDescriptor<WorkflowInstance> descriptor) =>
+        descriptor.Fields(
+            field => field.Field(f => f.Id),
+            field => field.Field(f => f.DefinitionId),
+            field => field.Field(f => f.Status),
+            field => field.Field(f => f.SubStatus),
+            field => field.Field(f => f.Version),
+            field => field.Field(f => f.CorrelationId),
+            field => field.Field(f => f.Version),
+            field => field.Field(f => f.Name),
+            field => field.Field(f => f.CreatedAt),
+            field => field.Field(f => f.CancelledAt),
+            field => field.Field(f => f.FaultedAt),
+            field => field.Field(f => f.FinishedAt),
+            field => field.Field(f => f.DefinitionVersionId),
+            field => field.Field(f => f.LastExecutedAt)
+        );
 }

--- a/src/modules/Elsa.EntityFrameworkCore/Modules/Management/WorkflowDefinitionStore.cs
+++ b/src/modules/Elsa.EntityFrameworkCore/Modules/Management/WorkflowDefinitionStore.cs
@@ -1,15 +1,13 @@
-using System.Data.Entity;
-using System.Linq.Expressions;
 using System.Text.Json;
 using Elsa.Common.Models;
 using Elsa.EntityFrameworkCore.Common;
-using Elsa.EntityFrameworkCore.Extensions;
 using Elsa.Extensions;
 using Elsa.Workflows.Core.Models;
 using Elsa.Workflows.Core.Serialization;
 using Elsa.Workflows.Management.Entities;
 using Elsa.Workflows.Management.Models;
 using Elsa.Workflows.Management.Services;
+using Microsoft.EntityFrameworkCore;
 using Open.Linq.AsyncExtensions;
 
 namespace Elsa.EntityFrameworkCore.Modules.Management;

--- a/src/modules/Elsa.EntityFrameworkCore/Modules/Management/WorkflowDefinitionStore.cs
+++ b/src/modules/Elsa.EntityFrameworkCore/Modules/Management/WorkflowDefinitionStore.cs
@@ -127,20 +127,7 @@ public class EFCoreWorkflowDefinitionStore : IWorkflowDefinitionStore
         return entity;
     }
 
-    private IQueryable<WorkflowDefinition> Filter(IQueryable<WorkflowDefinition> queryable, WorkflowDefinitionFilter filter)
-    {
-        if (filter.DefinitionId != null) queryable = queryable.Where(x => x.DefinitionId == filter.DefinitionId);
-        if (filter.DefinitionIds != null) queryable = queryable.Where(x => filter.DefinitionIds.Contains(x.DefinitionId));
-        if (filter.Id != null) queryable = queryable.Where(x => x.Id == filter.Id);
-        if (filter.Ids != null) queryable = queryable.Where(x => filter.Ids.Contains(x.Id));
-        if (filter.VersionOptions != null) queryable = queryable.WithVersion(filter.VersionOptions.Value);
-        if (filter.MaterializerName != null) queryable = queryable.Where(x => x.MaterializerName == filter.MaterializerName);
-        if (filter.Name != null) queryable = queryable.Where(x => x.Name == filter.Name);
-        if (filter.Names != null) queryable = queryable.Where(x => filter.Names.Contains(x.Name));
-        if (filter.UsableAsActivity != null) queryable = queryable.Where(x => x.UsableAsActivity == filter.UsableAsActivity);
-
-        return queryable;
-    }
+    private IQueryable<WorkflowDefinition> Filter(IQueryable<WorkflowDefinition> queryable, WorkflowDefinitionFilter filter) => filter.Apply(queryable);
 
     private IQueryable<WorkflowDefinition> Paginate(IQueryable<WorkflowDefinition> queryable, PageArgs? pageArgs)
     {

--- a/src/modules/Elsa.EntityFrameworkCore/Modules/Management/WorkflowInstanceStore.cs
+++ b/src/modules/Elsa.EntityFrameworkCore/Modules/Management/WorkflowInstanceStore.cs
@@ -1,6 +1,5 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using Elsa.Common.Entities;
 using Elsa.Common.Models;
 using Elsa.EntityFrameworkCore.Common;
 using Elsa.Extensions;
@@ -133,30 +132,5 @@ public class EFCoreWorkflowInstanceStore : IWorkflowInstanceStore
         return entity;
     }
 
-    private IQueryable<WorkflowInstance> Filter(IQueryable<WorkflowInstance> query, WorkflowInstanceFilter filter)
-    {
-        if (!string.IsNullOrWhiteSpace(filter.Id)) query = query.Where(x => x.Id == filter.Id);
-        if (filter.Ids != null) query = query.Where(x => filter.Ids.Contains(x.Id));
-        if (!string.IsNullOrWhiteSpace(filter.DefinitionId)) query = query.Where(x => x.DefinitionId == filter.DefinitionId);
-        if (filter.DefinitionIds != null) query = query.Where(x => filter.DefinitionIds.Contains(x.DefinitionId));
-        if (filter.Version != null) query = query.Where(x => x.Version == filter.Version);
-        if (!string.IsNullOrWhiteSpace(filter.CorrelationId)) query = query.Where(x => x.CorrelationId == filter.CorrelationId);
-        if (filter.CorrelationIds != null) query = query.Where(x => filter.CorrelationIds.Contains(x.CorrelationId!));
-        if (filter.WorkflowStatus != null) query = query.Where(x => x.Status == filter.WorkflowStatus);
-        if (filter.WorkflowSubStatus != null) query = query.Where(x => x.SubStatus == filter.WorkflowSubStatus);
-
-        var searchTerm = filter.SearchTerm;
-        if (!string.IsNullOrWhiteSpace(searchTerm))
-        {
-            query =
-                from instance in query
-                where instance.Name!.Contains(searchTerm)
-                      || instance.Id.Contains(searchTerm)
-                      || instance.DefinitionId.Contains(searchTerm)
-                      || instance.CorrelationId!.Contains(searchTerm)
-                select instance;
-        }
-
-        return query;
-    }
+    private static IQueryable<WorkflowInstance> Filter(IQueryable<WorkflowInstance> query, WorkflowInstanceFilter filter) => filter.Apply(query);
 }

--- a/src/modules/Elsa.EntityFrameworkCore/Modules/Runtime/BookmarkStore.cs
+++ b/src/modules/Elsa.EntityFrameworkCore/Modules/Runtime/BookmarkStore.cs
@@ -4,6 +4,9 @@ using Elsa.Workflows.Runtime.Services;
 
 namespace Elsa.EntityFrameworkCore.Modules.Runtime;
 
+/// <summary>
+/// An EF Core implementation of <see cref="IBookmarkStore"/>.
+/// </summary>
 public class EFCoreBookmarkStore : IBookmarkStore
 {
     private readonly Store<RuntimeElsaDbContext, StoredBookmark> _store;
@@ -17,26 +20,8 @@ public class EFCoreBookmarkStore : IBookmarkStore
     public async ValueTask SaveAsync(StoredBookmark record, CancellationToken cancellationToken = default) => await _store.SaveAsync(record, s => s.BookmarkId, cancellationToken);
 
     /// <inheritdoc />
-    public async ValueTask<IEnumerable<StoredBookmark>> FindByWorkflowInstanceAsync(string workflowInstanceId, CancellationToken cancellationToken = default) =>
-        await _store.FindManyAsync(x => x.WorkflowInstanceId == workflowInstanceId, cancellationToken);
+    public async ValueTask<IEnumerable<StoredBookmark>> FindManyAsync(BookmarkFilter filter, CancellationToken cancellationToken = default) => await _store.QueryAsync(filter.Apply, cancellationToken);
 
     /// <inheritdoc />
-    public async ValueTask<IEnumerable<StoredBookmark>> FindByHashAsync(string hash, CancellationToken cancellationToken = default) =>
-        await _store.FindManyAsync(x => x.Hash == hash, cancellationToken);
-
-    /// <inheritdoc />
-    public async ValueTask<IEnumerable<StoredBookmark>> FindByWorkflowInstanceAndHashAsync(string workflowInstanceId, string hash, CancellationToken cancellationToken) => 
-        await _store.FindManyAsync(x => x.WorkflowInstanceId == workflowInstanceId && x.Hash == hash, cancellationToken);
-
-    /// <inheritdoc />
-    public async ValueTask<IEnumerable<StoredBookmark>> FindByCorrelationAndHashAsync(string correlationId, string hash, CancellationToken cancellationToken) => 
-        await _store.FindManyAsync(x => x.CorrelationId == correlationId && x.Hash == hash, cancellationToken);
-
-    /// <inheritdoc />
-    public async ValueTask<IEnumerable<StoredBookmark>> FindByActivityTypeAsync(string activityType, CancellationToken cancellationToken = default) => 
-        await _store.FindManyAsync(x => x.ActivityTypeName == activityType, cancellationToken);
-
-    /// <inheritdoc />
-    public async ValueTask DeleteAsync(string hash, string workflowInstanceId, CancellationToken cancellationToken = default) =>
-        await _store.DeleteWhereAsync(x => x.WorkflowInstanceId == workflowInstanceId && x.Hash == hash, cancellationToken);
+    public async ValueTask<long> DeleteAsync(BookmarkFilter filter, CancellationToken cancellationToken = default) => await _store.DeleteWhereAsync(filter.Apply, cancellationToken);
 }

--- a/src/modules/Elsa.Expressions/Implementations/WellKnownTypeRegistry.cs
+++ b/src/modules/Elsa.Expressions/Implementations/WellKnownTypeRegistry.cs
@@ -39,6 +39,15 @@ public class WellKnownTypeRegistry : IWellKnownTypeRegistry
     {
         _typeAliasDictionary[type] = alias;
         _aliasTypeDictionary[alias] = type;
+
+        if (type.IsPrimitive || type.IsValueType && Nullable.GetUnderlyingType(type) == null)
+        {
+            var nullableType = typeof(Nullable<>).MakeGenericType(type);
+            var nullableAlias = alias + "?";
+            _typeAliasDictionary[nullableType] = nullableAlias;
+            _aliasTypeDictionary[nullableAlias] = nullableType;
+        }
+            
     }
 
     /// <inheritdoc />

--- a/src/modules/Elsa.Labels/Endpoints/WorkflowDefinitionLabels/List/Endpoint.cs
+++ b/src/modules/Elsa.Labels/Endpoints/WorkflowDefinitionLabels/List/Endpoint.cs
@@ -2,11 +2,13 @@ using Elsa.Labels.Services;
 using Elsa.Workflows.Core.Serialization;
 using Elsa.Workflows.Management.Services;
 using FastEndpoints;
+using JetBrains.Annotations;
 using Open.Linq.AsyncExtensions;
 
 namespace Elsa.Labels.Endpoints.WorkflowDefinitionLabels.List;
 
-public class List : Endpoint<Request, Response>
+[PublicAPI]
+internal class List : Endpoint<Request, Response>
 {
     private readonly IWorkflowDefinitionStore _workflowDefinitionStore;
     private readonly IWorkflowDefinitionLabelStore _workflowDefinitionLabelStore;
@@ -28,7 +30,7 @@ public class List : Endpoint<Request, Response>
 
     public override async Task HandleAsync(Request request, CancellationToken cancellationToken)
     {
-        var workflowDefinition = await _workflowDefinitionStore.FindByIdAsync(request.Id, cancellationToken);
+        var workflowDefinition = await _workflowDefinitionStore.FindAsync(new WorkflowDefinitionFilter { Id = request.Id }, cancellationToken);
 
         if (workflowDefinition == null)
         {

--- a/src/modules/Elsa.Labels/Endpoints/WorkflowDefinitionLabels/Update/Endpoint.cs
+++ b/src/modules/Elsa.Labels/Endpoints/WorkflowDefinitionLabels/Update/Endpoint.cs
@@ -5,11 +5,13 @@ using Elsa.Workflows.Core.Serialization;
 using Elsa.Workflows.Core.Services;
 using Elsa.Workflows.Management.Services;
 using FastEndpoints;
+using JetBrains.Annotations;
 using Open.Linq.AsyncExtensions;
 
 namespace Elsa.Labels.Endpoints.WorkflowDefinitionLabels.Update;
 
-public class Update : Endpoint<Request, Response>
+[PublicAPI]
+internal class Update : Endpoint<Request, Response>
 {
     private readonly ILabelStore _labelStore;
     private readonly IWorkflowDefinitionStore _workflowDefinitionStore;
@@ -46,7 +48,7 @@ public class Update : Endpoint<Request, Response>
 
     public override async Task HandleAsync(Request request, CancellationToken cancellationToken)
     {
-        var workflowDefinition = await _workflowDefinitionStore.FindByIdAsync(request.Id, cancellationToken);
+        var workflowDefinition = await _workflowDefinitionStore.FindAsync(new WorkflowDefinitionFilter{ Id = request.Id}, cancellationToken);
 
         if (workflowDefinition == null)
         {

--- a/src/modules/Elsa.Labels/Implementations/InMemoryLabelStore.cs
+++ b/src/modules/Elsa.Labels/Implementations/InMemoryLabelStore.cs
@@ -6,29 +6,38 @@ using Elsa.Labels.Services;
 
 namespace Elsa.Labels.Implementations;
 
+/// <summary>
+/// An in-memory store of labels.
+/// </summary>
 public class InMemoryLabelStore : ILabelStore
 {
     private readonly MemoryStore<Label> _labelStore;
     private readonly MemoryStore<WorkflowDefinitionLabel> _workflowDefinitionLabelStore;
 
+    /// <summary>
+    /// Constructor.
+    /// </summary>
     public InMemoryLabelStore(MemoryStore<Label> labelStore, MemoryStore<WorkflowDefinitionLabel> workflowDefinitionLabelStore)
     {
         _labelStore = labelStore;
         _workflowDefinitionLabelStore = workflowDefinitionLabelStore;
     }
 
+    /// <inheritdoc />
     public Task SaveAsync(Label record, CancellationToken cancellationToken = default)
     {
         _labelStore.Save(record, x => x.Id);
         return Task.CompletedTask;
     }
 
+    /// <inheritdoc />
     public Task SaveManyAsync(IEnumerable<Label> records, CancellationToken cancellationToken = default)
     {
         _labelStore.SaveMany(records, x => x.Id);
         return Task.CompletedTask;
     }
 
+    /// <inheritdoc />
     public Task<bool> DeleteAsync(string id, CancellationToken cancellationToken = default)
     {
         _workflowDefinitionLabelStore.DeleteWhere(x => x.LabelId == id);
@@ -36,6 +45,7 @@ public class InMemoryLabelStore : ILabelStore
         return Task.FromResult(result);
     }
 
+    /// <inheritdoc />
     public Task<int> DeleteManyAsync(IEnumerable<string> ids, CancellationToken cancellationToken = default)
     {
         var idList = ids.ToList();
@@ -44,12 +54,14 @@ public class InMemoryLabelStore : ILabelStore
         return Task.FromResult(result);
     }
 
+    /// <inheritdoc />
     public Task<Label?> FindByIdAsync(string id, CancellationToken cancellationToken = default)
     {
         var record = _labelStore.Find(x => x.Id == id);
         return Task.FromResult(record);
     }
 
+    /// <inheritdoc />
     public Task<Page<Label>> ListAsync(PageArgs? pageArgs = default, CancellationToken cancellationToken = default)
     {
         var query = _labelStore.List().AsQueryable().OrderBy(x => x.Name);
@@ -57,6 +69,7 @@ public class InMemoryLabelStore : ILabelStore
         return Task.FromResult(page);
     }
 
+    /// <inheritdoc />
     public Task<IEnumerable<Label>> FindManyByIdAsync(IEnumerable<string> ids, CancellationToken cancellationToken)
     {
         var idList = ids.ToList();

--- a/src/modules/Elsa.Labels/Implementations/InMemoryLabelStore.cs
+++ b/src/modules/Elsa.Labels/Implementations/InMemoryLabelStore.cs
@@ -53,7 +53,7 @@ public class InMemoryLabelStore : ILabelStore
     public Task<Page<Label>> ListAsync(PageArgs? pageArgs = default, CancellationToken cancellationToken = default)
     {
         var query = _labelStore.List().AsQueryable().OrderBy(x => x.Name);
-        var page = query.Paginate(pageArgs);
+        var page = query.ToPage(pageArgs);
         return Task.FromResult(page);
     }
 

--- a/src/modules/Elsa.Labels/Implementations/InMemoryWorkflowDefinitionLabelStore.cs
+++ b/src/modules/Elsa.Labels/Implementations/InMemoryWorkflowDefinitionLabelStore.cs
@@ -4,45 +4,50 @@ using Elsa.Labels.Services;
 
 namespace Elsa.Labels.Implementations;
 
+/// <summary>
+/// An in-memory store of workflow-label associations.
+/// </summary>
 public class InMemoryWorkflowDefinitionLabelStore : IWorkflowDefinitionLabelStore
 {
     private readonly MemoryStore<WorkflowDefinitionLabel> _store;
 
+    /// <summary>
+    /// Constructor.
+    /// </summary>
     public InMemoryWorkflowDefinitionLabelStore(MemoryStore<WorkflowDefinitionLabel> store)
     {
         _store = store;
     }
 
+    /// <inheritdoc />
     public Task SaveAsync(WorkflowDefinitionLabel record, CancellationToken cancellationToken = default)
     {
         _store.Save(record, x => x.Id);
         return Task.CompletedTask;
     }
 
+    /// <inheritdoc />
     public Task SaveManyAsync(IEnumerable<WorkflowDefinitionLabel> records, CancellationToken cancellationToken = default)
     {
         _store.SaveMany(records, x => x.Id);
         return Task.CompletedTask;
     }
 
+    /// <inheritdoc />
     public Task<bool> DeleteAsync(string id, CancellationToken cancellationToken = default)
     {
         var result = _store.Delete(id);
         return Task.FromResult(result);
     }
-
-    public Task<int> DeleteManyAsync(IEnumerable<string> ids, CancellationToken cancellationToken = default)
-    {
-        var result = _store.DeleteMany(ids);
-        return Task.FromResult(result);
-    }
-
+    
+    /// <inheritdoc />
     public Task<IEnumerable<WorkflowDefinitionLabel>> FindByWorkflowDefinitionVersionIdAsync(string workflowDefinitionVersionId, CancellationToken cancellationToken = default)
     {
         var result = _store.FindMany(x => x.WorkflowDefinitionVersionId == workflowDefinitionVersionId);
         return Task.FromResult(result);
     }
 
+    /// <inheritdoc />
     public Task ReplaceAsync(IEnumerable<WorkflowDefinitionLabel> removed, IEnumerable<WorkflowDefinitionLabel> added, CancellationToken cancellationToken = default)
     {
         _store.DeleteMany(removed, x => x.Id);
@@ -50,18 +55,21 @@ public class InMemoryWorkflowDefinitionLabelStore : IWorkflowDefinitionLabelStor
         return Task.CompletedTask;
     }
 
+    /// <inheritdoc />
     public Task<int> DeleteByWorkflowDefinitionIdAsync(string workflowDefinitionId, CancellationToken cancellationToken = default)
     {
         var result = _store.DeleteWhere(x => x.WorkflowDefinitionId == workflowDefinitionId);
         return Task.FromResult(result);
     }
 
+    /// <inheritdoc />
     public Task<int> DeleteByWorkflowDefinitionVersionIdAsync(string workflowDefinitionVersionId, CancellationToken cancellationToken = default)
     {
         var result = _store.DeleteWhere(x => x.WorkflowDefinitionVersionId == workflowDefinitionVersionId);
         return Task.FromResult(result);
     }
 
+    /// <inheritdoc />
     public Task<int> DeleteByWorkflowDefinitionIdsAsync(IEnumerable<string> workflowDefinitionIds, CancellationToken cancellationToken = default)
     {
         var ids = workflowDefinitionIds.ToList();
@@ -69,10 +77,18 @@ public class InMemoryWorkflowDefinitionLabelStore : IWorkflowDefinitionLabelStor
         return Task.FromResult(result);
     }
 
+    /// <inheritdoc />
     public Task<int> DeleteByWorkflowDefinitionVersionIdsAsync(IEnumerable<string> workflowDefinitionVersionIds, CancellationToken cancellationToken = default)
     {
         var ids = workflowDefinitionVersionIds.ToList();
         var result = _store.DeleteWhere(x => ids.Contains(x.WorkflowDefinitionVersionId));
         return Task.FromResult(result);
     }
+    
+    private Task<int> DeleteManyAsync(IEnumerable<string> ids, CancellationToken cancellationToken = default)
+    {
+        var result = _store.DeleteMany(ids);
+        return Task.FromResult(result);
+    }
+
 }

--- a/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/BulkRetract/Endpoint.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/BulkRetract/Endpoint.cs
@@ -1,10 +1,12 @@
 using Elsa.Abstractions;
 using Elsa.Common.Models;
 using Elsa.Workflows.Management.Services;
+using JetBrains.Annotations;
 
 namespace Elsa.Workflows.Api.Endpoints.WorkflowDefinitions.BulkRetract;
 
-public class BulkRetract : ElsaEndpoint<Request, Response>
+[PublicAPI]
+internal class BulkRetract : ElsaEndpoint<Request, Response>
 {
     private readonly IWorkflowDefinitionStore _store;
     private readonly IWorkflowDefinitionPublisher _workflowDefinitionPublisher;
@@ -29,7 +31,11 @@ public class BulkRetract : ElsaEndpoint<Request, Response>
 
         foreach (var definitionId in request.DefinitionIds)
         {
-            var definition = (await _store.FindManyByDefinitionIdAsync(definitionId, VersionOptions.Latest, cancellationToken)).FirstOrDefault();
+            var definition = (await _store.FindManyAsync(new WorkflowDefinitionFilter
+            {
+                DefinitionId = definitionId,
+                VersionOptions = VersionOptions.Latest
+            }, cancellationToken: cancellationToken)).FirstOrDefault();
 
             if (definition == null)
             {

--- a/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/Dispatch/Endpoint.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/Dispatch/Endpoint.cs
@@ -3,10 +3,12 @@ using Elsa.Common.Models;
 using Elsa.Workflows.Management.Services;
 using Elsa.Workflows.Runtime.Models;
 using Elsa.Workflows.Runtime.Services;
+using JetBrains.Annotations;
 
 namespace Elsa.Workflows.Api.Endpoints.WorkflowDefinitions.Dispatch;
 
-public class Endpoint : ElsaEndpoint<Request, Response>
+[PublicAPI]
+internal class Endpoint : ElsaEndpoint<Request, Response>
 {
     private readonly IWorkflowDefinitionStore _store;
     private readonly IWorkflowDispatcher _workflowDispatcher;
@@ -25,7 +27,7 @@ public class Endpoint : ElsaEndpoint<Request, Response>
 
     public override async Task HandleAsync(Request request, CancellationToken cancellationToken)
     {
-        var exists = await _store.GetExistsAsync(request.DefinitionId, VersionOptions.Published, cancellationToken);
+        var exists = await _store.AnyAsync(new WorkflowDefinitionFilter{ DefinitionId = request.DefinitionId, VersionOptions = VersionOptions.Published}, cancellationToken);
 
         if (!exists)
         {

--- a/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/Execute/Endpoint.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/Execute/Endpoint.cs
@@ -37,7 +37,7 @@ public class Execute : ElsaEndpoint<Request, Response>
     public override async Task HandleAsync(Request request, CancellationToken cancellationToken)
     {
         var definitionId = request.DefinitionId;
-        var exists = await _store.GetExistsAsync(definitionId, VersionOptions.Published, cancellationToken);
+        var exists = await _store.AnyAsync(new WorkflowDefinitionFilter { DefinitionId = definitionId, VersionOptions = VersionOptions.Published }, cancellationToken);
 
         if (!exists)
         {

--- a/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/Execute/Endpoint.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/Execute/Endpoint.cs
@@ -1,5 +1,6 @@
 using Elsa.Abstractions;
 using Elsa.Common.Models;
+using Elsa.Extensions;
 using Elsa.Http.Services;
 using Elsa.Workflows.Management.Services;
 using Elsa.Workflows.Runtime.Services;
@@ -45,7 +46,8 @@ public class Execute : ElsaEndpoint<Request, Response>
         }
 
         var correlationId = request.CorrelationId;
-        var startWorkflowOptions = new StartWorkflowRuntimeOptions(correlationId, VersionOptions: VersionOptions.Published);
+        var input = (IDictionary<string, object>?)request.Input;
+        var startWorkflowOptions = new StartWorkflowRuntimeOptions(correlationId, input, VersionOptions.Published);
         var result = await _workflowRuntime.StartWorkflowAsync(definitionId, startWorkflowOptions, cancellationToken);
 
         // Resume any HTTP bookmarks.

--- a/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/Execute/Models.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/Execute/Models.cs
@@ -1,9 +1,15 @@
+using System.Text.Json.Serialization;
+using Elsa.Workflows.Core.Serialization.Converters;
+
 namespace Elsa.Workflows.Api.Endpoints.WorkflowDefinitions.Execute;
 
 public class Request
 {
     public string DefinitionId { get; set; } = default!;
     public string? CorrelationId { get; set; }
+    
+    [JsonConverter(typeof(ExpandoObjectConverter))]
+    public object? Input { get; set; }
 }
 
 public class Response

--- a/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/Export/Endpoint.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/Export/Endpoint.cs
@@ -45,7 +45,7 @@ public class Export : ElsaEndpoint<Request>
     {
         var serializerOptions = _serializerOptionsProvider.CreateApiOptions();
         var versionOptions = request.VersionOptions != null ? VersionOptions.FromString(request.VersionOptions) : VersionOptions.Latest;
-        var definition = (await _store.FindManyByDefinitionIdAsync(request.DefinitionId, versionOptions, cancellationToken)).FirstOrDefault();
+        var definition = (await _store.FindManyAsync(new WorkflowDefinitionFilter{ DefinitionId = request.DefinitionId, VersionOptions = versionOptions}, cancellationToken: cancellationToken)).FirstOrDefault();
 
         if (definition == null)
         {

--- a/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/Get/Endpoint.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/Get/Endpoint.cs
@@ -24,7 +24,14 @@ internal class Get : ElsaEndpoint<Request, WorkflowDefinitionResponse, WorkflowD
     public override async Task HandleAsync(Request request, CancellationToken cancellationToken)
     {
         var versionOptions = request.VersionOptions != null ? VersionOptions.FromString(request.VersionOptions) : VersionOptions.Latest;
-        var definition = (await _store.FindManyByDefinitionIdAsync(request.DefinitionId, versionOptions, cancellationToken)).FirstOrDefault();
+        
+        var filter = new WorkflowDefinitionFilter
+        {
+            DefinitionId = request.DefinitionId,
+            VersionOptions = versionOptions
+        };
+        
+        var definition = (await _store.FindManyAsync(filter, cancellationToken: cancellationToken)).FirstOrDefault();
 
         if (definition == null)
         {

--- a/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/Get/Endpoint.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/Get/Endpoint.cs
@@ -32,7 +32,7 @@ internal class Get : ElsaEndpoint<Request, WorkflowDefinitionResponse, WorkflowD
             return;
         }
 
-        var response = await Map.FromEntityAsync(definition);
+        var response = await Map.FromEntityAsync(definition, cancellationToken);
         await SendOkAsync(response, cancellationToken);
     }
 }

--- a/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/Publish/Endpoint.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/Publish/Endpoint.cs
@@ -25,7 +25,13 @@ internal class Publish : ElsaEndpoint<Request, WorkflowDefinitionResponse, Workf
 
     public override async Task HandleAsync(Request request, CancellationToken cancellationToken)
     {
-        var definition = (await _store.FindManyByDefinitionIdAsync(request.DefinitionId, VersionOptions.Latest, cancellationToken)).FirstOrDefault();
+        var filter = new WorkflowDefinitionFilter
+        {
+            DefinitionId = request.DefinitionId,
+            VersionOptions = VersionOptions.Latest
+        };
+        
+        var definition = await _store.FindAsync(filter, cancellationToken);
 
         if (definition == null)
         {
@@ -42,7 +48,7 @@ internal class Publish : ElsaEndpoint<Request, WorkflowDefinitionResponse, Workf
 
         await _workflowDefinitionPublisher.PublishAsync(definition, cancellationToken);
 
-        var response = await Map.FromEntityAsync(definition);
+        var response = await Map.FromEntityAsync(definition, cancellationToken);
         await SendOkAsync(response, cancellationToken);
     }
 }

--- a/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/Retract/Endpoint.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/Retract/Endpoint.cs
@@ -25,7 +25,13 @@ internal class Retract : ElsaEndpoint<Request, WorkflowDefinitionResponse, Workf
 
     public override async Task HandleAsync(Request request, CancellationToken cancellationToken)
     {
-        var definition = (await _store.FindManyByDefinitionIdAsync(request.DefinitionId, VersionOptions.LatestOrPublished, cancellationToken)).FirstOrDefault();
+        var filter = new WorkflowDefinitionFilter
+        {
+            DefinitionId = request.DefinitionId,
+            VersionOptions = VersionOptions.LatestOrPublished
+        };
+        
+        var definition = await _store.FindAsync(filter, cancellationToken);
 
         if (definition == null)
         {
@@ -41,7 +47,7 @@ internal class Retract : ElsaEndpoint<Request, WorkflowDefinitionResponse, Workf
         }
 
         await _workflowDefinitionPublisher.RetractAsync(definition, cancellationToken);
-        var response = await Map.FromEntityAsync(definition);
+        var response = await Map.FromEntityAsync(definition, cancellationToken);
         await SendOkAsync(response, cancellationToken);
     }
 }

--- a/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowInstances/BulkDelete/Endpoint.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowInstances/BulkDelete/Endpoint.cs
@@ -1,9 +1,11 @@
 using Elsa.Abstractions;
 using Elsa.Workflows.Management.Services;
+using JetBrains.Annotations;
 
 namespace Elsa.Workflows.Api.Endpoints.WorkflowInstances.BulkDelete;
 
-public class BulkDelete : ElsaEndpoint<Request, Response>
+[PublicAPI]
+internal class BulkDelete : ElsaEndpoint<Request, Response>
 {
     private readonly IWorkflowInstanceStore _store;
 
@@ -20,7 +22,8 @@ public class BulkDelete : ElsaEndpoint<Request, Response>
 
     public override async Task<Response> ExecuteAsync(Request request, CancellationToken cancellationToken)
     {
-        var count = await _store.DeleteManyAsync(request.Ids, cancellationToken);
+        var filter = new WorkflowInstanceFilter { Ids = request.Ids };
+        var count = await _store.DeleteManyAsync(filter, cancellationToken);
 
         return new Response(count);   
     }

--- a/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowInstances/Delete/Endpoint.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowInstances/Delete/Endpoint.cs
@@ -1,9 +1,11 @@
 using Elsa.Abstractions;
 using Elsa.Workflows.Management.Services;
+using JetBrains.Annotations;
 
 namespace Elsa.Workflows.Api.Endpoints.WorkflowInstances.Delete;
 
-public class Delete : ElsaEndpoint<Request>
+[PublicAPI]
+internal class Delete : ElsaEndpoint<Request>
 {
     private readonly IWorkflowInstanceStore _store;
     public Delete(IWorkflowInstanceStore store) => _store = store;
@@ -16,7 +18,8 @@ public class Delete : ElsaEndpoint<Request>
 
     public override async Task HandleAsync(Request request, CancellationToken cancellationToken)
     {
-        var deleted = await _store.DeleteAsync(request.Id, cancellationToken);
+        var filter = new WorkflowInstanceFilter { Id = request.Id };
+        var deleted = await _store.DeleteAsync(filter, cancellationToken);
 
         if (deleted)
             await SendNoContentAsync(cancellationToken);

--- a/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowInstances/Get/Endpoint.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowInstances/Get/Endpoint.cs
@@ -1,9 +1,11 @@
 using Elsa.Abstractions;
 using Elsa.Workflows.Management.Services;
+using JetBrains.Annotations;
 
 namespace Elsa.Workflows.Api.Endpoints.WorkflowInstances.Get;
 
-public class Get : ElsaEndpoint<Request, Response, WorkflowInstanceMapper>
+[PublicAPI]
+internal class Get : ElsaEndpoint<Request, Response, WorkflowInstanceMapper>
 {
     private readonly IWorkflowInstanceStore _store;
 
@@ -20,7 +22,8 @@ public class Get : ElsaEndpoint<Request, Response, WorkflowInstanceMapper>
 
     public override async Task HandleAsync(Request request, CancellationToken cancellationToken)
     {
-        var workflowInstance = await _store.FindByIdAsync(request.Id, cancellationToken);
+        var filter = new WorkflowInstanceFilter { Id = request.Id };
+        var workflowInstance = await _store.FindAsync(filter, cancellationToken);
 
         if (workflowInstance == null)
             await SendNotFoundAsync(cancellationToken);

--- a/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowInstances/List/Endpoint.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowInstances/List/Endpoint.cs
@@ -1,11 +1,14 @@
 using Elsa.Abstractions;
 using Elsa.Common.Entities;
 using Elsa.Common.Models;
+using Elsa.Workflows.Management.Models;
 using Elsa.Workflows.Management.Services;
+using JetBrains.Annotations;
 
 namespace Elsa.Workflows.Api.Endpoints.WorkflowInstances.List;
 
-public class List : ElsaEndpoint<Request, Response>
+[PublicAPI]
+internal class List : ElsaEndpoint<Request, Response>
 {
     private readonly IWorkflowInstanceStore _store;
 
@@ -24,18 +27,56 @@ public class List : ElsaEndpoint<Request, Response>
     {
         var pageArgs = new PageArgs(request.Page, request.PageSize);
 
-        var args = new FindWorkflowInstancesArgs(
-            request.SearchTerm,
-            request.DefinitionId,
-            request.Version,
-            request.CorrelationId,
-            request.Status,
-            request.SubStatus,
-            pageArgs,
-            request.OrderBy ?? OrderBy.Created,
-            request.OrderDirection ?? OrderDirection.Ascending);
+        var filter = new WorkflowInstanceFilter
+        {
+            SearchTerm = request.SearchTerm,
+            DefinitionId = request.DefinitionId,
+            Version = request.Version,
+            CorrelationId = request.CorrelationId,
+            WorkflowStatus = request.Status,
+            WorkflowSubStatus = request.SubStatus
+        };
 
-        var summaries = await _store.FindManyAsync(args, cancellationToken);
+        var direction = request.OrderDirection == OrderDirection.Ascending ? OrderDirection.Ascending : OrderDirection.Descending;
+        var summaries = await FindAsync(request, filter, pageArgs, direction, cancellationToken);
         return new Response(summaries.Items, summaries.TotalCount);
+    }
+
+    private async Task<Page<WorkflowInstanceSummary>> FindAsync(Request request, WorkflowInstanceFilter filter, PageArgs pageArgs, OrderDirection direction, CancellationToken cancellationToken)
+    {
+        switch (request.OrderBy ?? OrderBy.Created)
+        {
+            default:
+            case OrderBy.Created:
+            {
+                var o = new WorkflowInstanceOrder<DateTimeOffset>
+                {
+                    KeySelector = p => p.CreatedAt,
+                    Direction = direction
+                };
+
+                return await _store.SummarizeManyAsync(filter, pageArgs, o, cancellationToken);
+            }
+            case OrderBy.LastExecuted:
+            {
+                var o = new WorkflowInstanceOrder<DateTimeOffset?>
+                {
+                    KeySelector = p => p.LastExecutedAt,
+                    Direction = direction
+                };
+
+                return await _store.SummarizeManyAsync(filter, pageArgs, o, cancellationToken);
+            }
+            case OrderBy.Finished:
+            {
+                var o = new WorkflowInstanceOrder<DateTimeOffset?>
+                {
+                    KeySelector = p => p.FinishedAt,
+                    Direction = direction
+                };
+
+                return await _store.SummarizeManyAsync(filter, pageArgs, o, cancellationToken);
+            }
+        }
     }
 }

--- a/src/modules/Elsa.Workflows.Api/Features/WorkflowsApiFeature.cs
+++ b/src/modules/Elsa.Workflows.Api/Features/WorkflowsApiFeature.cs
@@ -3,6 +3,8 @@ using Elsa.Features.Abstractions;
 using Elsa.Features.Attributes;
 using Elsa.Features.Services;
 using Elsa.JavaScript.Features;
+using Elsa.Workflows.Api.Serialization;
+using Elsa.Workflows.Core.Services;
 using Elsa.Workflows.Management.Features;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.DependencyInjection;
@@ -37,6 +39,7 @@ public class WorkflowsApiFeature : FeatureBase
     public override void Apply()
     {
         Services.AddAuthorization(auth => auth.AddPolicy("CompleteTask", CompleteTaskPolicy));
+        Services.AddSingleton<ISerializationOptionsConfigurator, SerializationConfigurator>();
         Module.AddFastEndpointsFromModule();
     }
 }

--- a/src/modules/Elsa.Workflows.Api/Serialization/ArgumentJsonConverter.cs
+++ b/src/modules/Elsa.Workflows.Api/Serialization/ArgumentJsonConverter.cs
@@ -1,0 +1,54 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using Elsa.Expressions.Extensions;
+using Elsa.Expressions.Services;
+using Elsa.Extensions;
+using Elsa.Workflows.Management.Models;
+
+namespace Elsa.Workflows.Api.Serialization;
+
+/// <summary>
+/// Converts <see cref="ArgumentDefinition"/> derivatives from and to JSON
+/// </summary>
+public class ArgumentJsonConverter : JsonConverter<ArgumentDefinition>
+{
+    private readonly IWellKnownTypeRegistry _wellKnownTypeRegistry;
+
+    /// <inheritdoc />
+    public ArgumentJsonConverter(IWellKnownTypeRegistry wellKnownTypeRegistry)
+    {
+        _wellKnownTypeRegistry = wellKnownTypeRegistry;
+    }
+    
+    /// <inheritdoc />
+    public override void Write(Utf8JsonWriter writer, ArgumentDefinition value, JsonSerializerOptions options)
+    {
+        var newOptions = new JsonSerializerOptions(options);
+        newOptions.Converters.RemoveWhere(x => x is ArgumentJsonConverterFactory);
+        
+        var jsonObject = (JsonObject)JsonSerializer.SerializeToNode(value, newOptions)!;
+        jsonObject["isArray"] = value.Type.IsCollectionType();
+
+        JsonSerializer.Serialize(writer, jsonObject, newOptions);
+    }
+
+    /// <inheritdoc />
+    public override ArgumentDefinition Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var jsonObject = (JsonObject)JsonNode.Parse(ref reader)!;
+        var isArray = jsonObject["isArray"]?.GetValue<bool>() ?? false;
+        var typeName = jsonObject["type"]!.GetValue<string>();
+        var type = _wellKnownTypeRegistry.GetTypeOrDefault(typeName);
+
+        if (isArray)
+            type = type.MakeCollectionType();
+
+        var newOptions = new JsonSerializerOptions(options);
+        newOptions.Converters.RemoveWhere(x => x is ArgumentJsonConverterFactory);
+        var inputDefinition = (ArgumentDefinition)jsonObject.Deserialize(typeToConvert, newOptions)!;
+        inputDefinition.Type = type;
+
+        return inputDefinition;
+    }
+}

--- a/src/modules/Elsa.Workflows.Api/Serialization/ArgumentJsonConverter.cs
+++ b/src/modules/Elsa.Workflows.Api/Serialization/ArgumentJsonConverter.cs
@@ -27,8 +27,10 @@ public class ArgumentJsonConverter : JsonConverter<ArgumentDefinition>
         var newOptions = new JsonSerializerOptions(options);
         newOptions.Converters.RemoveWhere(x => x is ArgumentJsonConverterFactory);
         
-        var jsonObject = (JsonObject)JsonSerializer.SerializeToNode(value, newOptions)!;
-        jsonObject["isArray"] = value.Type.IsCollectionType();
+        var jsonObject = (JsonObject)JsonSerializer.SerializeToNode(value, value.GetType(), newOptions)!;
+        var isArray = value.Type.IsCollectionType();
+        jsonObject["isArray"] = isArray;
+        jsonObject["type"] = _wellKnownTypeRegistry.GetAliasOrDefault(isArray ? value.Type.GetCollectionElementType() : value.Type);
 
         JsonSerializer.Serialize(writer, jsonObject, newOptions);
     }

--- a/src/modules/Elsa.Workflows.Api/Serialization/ArgumentJsonConverterFactory.cs
+++ b/src/modules/Elsa.Workflows.Api/Serialization/ArgumentJsonConverterFactory.cs
@@ -1,0 +1,23 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Elsa.Expressions.Services;
+using Elsa.Workflows.Management.Models;
+
+namespace Elsa.Workflows.Api.Serialization;
+
+internal class ArgumentJsonConverterFactory : JsonConverterFactory
+{
+    private readonly IWellKnownTypeRegistry _wellKnownTypeRegistry;
+
+    public ArgumentJsonConverterFactory(IWellKnownTypeRegistry wellKnownTypeRegistry)
+    {
+        _wellKnownTypeRegistry = wellKnownTypeRegistry;
+    }
+    
+    public override bool CanConvert(Type typeToConvert) => typeToConvert.IsAssignableTo(typeof(ArgumentDefinition));
+
+    public override JsonConverter? CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+    {
+        return new ArgumentJsonConverter(_wellKnownTypeRegistry);
+    }
+}

--- a/src/modules/Elsa.Workflows.Api/Serialization/SerializationConfigurator.cs
+++ b/src/modules/Elsa.Workflows.Api/Serialization/SerializationConfigurator.cs
@@ -1,0 +1,20 @@
+using System.Text.Json;
+using Elsa.Workflows.Core.Services;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Elsa.Workflows.Api.Serialization;
+
+internal class SerializationConfigurator : ISerializationOptionsConfigurator
+{
+    private readonly IServiceProvider _serviceProvider;
+
+    public SerializationConfigurator(IServiceProvider serviceProvider)
+    {
+        _serviceProvider = serviceProvider;
+    }
+    
+    public void Configure(JsonSerializerOptions options)
+    {
+        options.Converters.Add(ActivatorUtilities.GetServiceOrCreateInstance<ArgumentJsonConverterFactory>(_serviceProvider));
+    }
+}

--- a/src/modules/Elsa.Workflows.Management/Activities/SetWorkflowOutput.cs
+++ b/src/modules/Elsa.Workflows.Management/Activities/SetWorkflowOutput.cs
@@ -57,7 +57,10 @@ public class SetWorkflowOutput : CodeActivity
     {
         var workflowDefinitionStore = context.GetRequiredService<IWorkflowDefinitionStore>();
         var workflowDefinitionActivity = (WorkflowDefinitionActivity)workflowDefinitionActivityContext.Activity;
-        var workflowDefinition = await workflowDefinitionStore.FindByDefinitionIdAsync(workflowDefinitionActivity.WorkflowDefinitionId, VersionOptions.SpecificVersion(workflowDefinitionActivity.Version));
+        var definitionId = workflowDefinitionActivity.WorkflowDefinitionId;
+        var versionOptions = VersionOptions.SpecificVersion(workflowDefinitionActivity.Version);
+        var filter = new WorkflowDefinitionFilter { DefinitionId = definitionId, VersionOptions = versionOptions};
+        var workflowDefinition = await workflowDefinitionStore.FindAsync(filter, context.CancellationToken);
 
         if (workflowDefinition == null)
             return;

--- a/src/modules/Elsa.Workflows.Management/Activities/WorkflowDefinitionActivity.cs
+++ b/src/modules/Elsa.Workflows.Management/Activities/WorkflowDefinitionActivity.cs
@@ -18,7 +18,7 @@ namespace Elsa.Workflows.Management.Activities;
 public class WorkflowDefinitionActivity : Activity, IInitializable
 {
     internal IActivity Root { get; set; } = default!;
-    
+
     /// <summary>
     /// The definition ID of the workflow to schedule for execution.
     /// </summary>
@@ -50,13 +50,13 @@ public class WorkflowDefinitionActivity : Activity, IInitializable
                 return;
 
             // If there's a block with the same name as the output property, we need to read its value and bind it against our output.
-            if (!context.ExpressionExecutionContext.Memory.HasBlock(outputDescriptor.Name)) 
+            if (!context.ExpressionExecutionContext.Memory.HasBlock(outputDescriptor.Name))
                 continue;
-            
+
             var outputValue = context.ExpressionExecutionContext.Memory.Blocks[outputDescriptor.Name].Value;
             context.Set(output, outputValue);
         }
-        
+
         await context.CompleteActivityAsync();
     }
 
@@ -66,7 +66,8 @@ public class WorkflowDefinitionActivity : Activity, IInitializable
         var cancellationToken = context.CancellationToken;
         var workflowDefinitionStore = serviceProvider.GetRequiredService<IWorkflowDefinitionStore>();
         var versionOptions = VersionOptions.SpecificVersion(Version);
-        var workflowDefinition = await workflowDefinitionStore.FindByDefinitionIdAsync(WorkflowDefinitionId, versionOptions, cancellationToken);
+        var filter = new WorkflowDefinitionFilter { DefinitionId = WorkflowDefinitionId, VersionOptions = versionOptions };
+        var workflowDefinition = await workflowDefinitionStore.FindAsync(filter, cancellationToken);
 
         if (workflowDefinition == null)
             throw new Exception($"Workflow definition {WorkflowDefinitionId} not found");
@@ -74,7 +75,7 @@ public class WorkflowDefinitionActivity : Activity, IInitializable
         // Construct the root activity stored in the activity definitions.
         var materializer = serviceProvider.GetRequiredService<IWorkflowMaterializer>();
         var root = await materializer.MaterializeAsync(workflowDefinition, cancellationToken);
-        
+
         Root = root;
     }
 }

--- a/src/modules/Elsa.Workflows.Management/Extensions/TypeExtensions.cs
+++ b/src/modules/Elsa.Workflows.Management/Extensions/TypeExtensions.cs
@@ -20,4 +20,14 @@ public static class TypeExtensions
     /// Returns the wrapped type of the specified nullable type.
     /// </summary>
     public static Type GetTypeOfNullable(this Type type) => type.GenericTypeArguments[0];
+
+    /// <summary>
+    /// Returns true if the specified type is a collection type, false otherwise.
+    /// </summary>
+    public static bool IsCollectionType(this Type type) => type.IsGenericType && typeof(ICollection<>).IsAssignableFrom(type.GetGenericTypeDefinition());
+
+    /// <summary>
+    /// Constructs a collection type from the specified type.
+    /// </summary>
+    public static Type MakeCollectionType(this Type type) => typeof(ICollection<>).MakeGenericType(type);
 }

--- a/src/modules/Elsa.Workflows.Management/Extensions/TypeExtensions.cs
+++ b/src/modules/Elsa.Workflows.Management/Extensions/TypeExtensions.cs
@@ -30,4 +30,9 @@ public static class TypeExtensions
     /// Constructs a collection type from the specified type.
     /// </summary>
     public static Type MakeCollectionType(this Type type) => typeof(ICollection<>).MakeGenericType(type);
+
+    /// <summary>
+    /// Returns the element type of the specified collection type.
+    /// </summary>
+    public static Type GetCollectionElementType(this Type type) => type.GenericTypeArguments[0];
 }

--- a/src/modules/Elsa.Workflows.Management/Implementations/MemoryWorkflowDefinitionStore.cs
+++ b/src/modules/Elsa.Workflows.Management/Implementations/MemoryWorkflowDefinitionStore.cs
@@ -2,7 +2,6 @@ using Elsa.Common.Implementations;
 using Elsa.Common.Models;
 using Elsa.Extensions;
 using Elsa.Workflows.Management.Entities;
-using Elsa.Workflows.Management.Extensions;
 using Elsa.Workflows.Management.Models;
 using Elsa.Workflows.Management.Services;
 
@@ -101,20 +100,7 @@ public class MemoryWorkflowDefinitionStore : IWorkflowDefinitionStore
         return Task.FromResult(exists);
     }
     
-    private IQueryable<WorkflowDefinition> Filter(IQueryable<WorkflowDefinition> queryable, WorkflowDefinitionFilter filter)
-    {
-        if (filter.DefinitionId != null) queryable = queryable.Where(x => x.DefinitionId == filter.DefinitionId);
-        if (filter.DefinitionIds != null) queryable = queryable.Where(x => filter.DefinitionIds.Contains(x.DefinitionId));
-        if (filter.Id != null) queryable = queryable.Where(x => x.Id == filter.Id);
-        if (filter.Ids != null) queryable = queryable.Where(x => filter.Ids.Contains(x.Id));
-        if (filter.VersionOptions != null) queryable = queryable.WithVersion(filter.VersionOptions.Value);
-        if (filter.MaterializerName != null) queryable = queryable.Where(x => x.MaterializerName == filter.MaterializerName);
-        if (filter.Name != null) queryable = queryable.Where(x => x.Name == filter.Name);
-        if (filter.Names != null) queryable = queryable.Where(x => filter.Names.Contains(x.Name));
-        if (filter.UsableAsActivity != null) queryable = queryable.Where(x => x.UsableAsActivity == filter.UsableAsActivity);
-        
-        return queryable;
-    }
+    private IQueryable<WorkflowDefinition> Filter(IQueryable<WorkflowDefinition> queryable, WorkflowDefinitionFilter filter) => filter.Apply(queryable);
 
     private string GetId(WorkflowDefinition workflowDefinition) => workflowDefinition.Id;
 }

--- a/src/modules/Elsa.Workflows.Management/Implementations/MemoryWorkflowDefinitionStore.cs
+++ b/src/modules/Elsa.Workflows.Management/Implementations/MemoryWorkflowDefinitionStore.cs
@@ -27,60 +27,47 @@ public class MemoryWorkflowDefinitionStore : IWorkflowDefinitionStore
     }
 
     /// <inheritdoc />
-    public Task<WorkflowDefinition?> FindByIdAsync(string id, CancellationToken cancellationToken = default)
+    public Task<WorkflowDefinition?> FindAsync(WorkflowDefinitionFilter filter, CancellationToken cancellationToken = default)
     {
-        var definition = _store.Find(x => x.Id == id);
-        return Task.FromResult(definition);
+        var result = _store.Query(query => Filter(query, filter)).FirstOrDefault();
+        return Task.FromResult(result);
     }
 
     /// <inheritdoc />
-    public Task<IEnumerable<WorkflowDefinition>> FindManyByDefinitionIdAsync(string definitionId, VersionOptions versionOptions, CancellationToken cancellationToken = default)
+    public Task<Page<WorkflowDefinition>> FindManyAsync(WorkflowDefinitionFilter filter, PageArgs pageArgs, CancellationToken cancellationToken = default)
     {
-        var definition = _store.FindMany(x => x.DefinitionId == definitionId && x.WithVersion(versionOptions));
-        return Task.FromResult(definition);
-    }
-
-    /// <inheritdoc />
-    public Task<WorkflowDefinition?> FindByDefinitionIdAsync(string definitionId, VersionOptions versionOptions, CancellationToken cancellationToken = default)
-    {
-        var definition = _store.Find(x => x.DefinitionId == definitionId && x.WithVersion(versionOptions));
-        return Task.FromResult(definition);
-    }
-
-    /// <inheritdoc />
-    public Task<WorkflowDefinition?> FindByNameAsync(string name, VersionOptions versionOptions, CancellationToken cancellationToken = default)
-    {
-        var definition = _store.Find(x => x.Name == name && x.WithVersion(versionOptions));
-        return Task.FromResult(definition);
-    }
-
-    /// <inheritdoc />
-    public Task<IEnumerable<WorkflowDefinition>> FindWithActivityBehaviorAsync(VersionOptions versionOptions, CancellationToken cancellationToken = default)
-    {
-        var definition = _store.FindMany(w => w.UsableAsActivity == true && w.WithVersion(versionOptions));
-        return Task.FromResult(definition);
-    }
-
-    /// <inheritdoc />
-    public Task<IEnumerable<WorkflowDefinitionSummary>> FindSummariesAsync(IEnumerable<string> definitionIds, VersionOptions? versionOptions = default, CancellationToken cancellationToken = default)
-    {
-        var query = _store.List();
-
-        if (versionOptions != null)
-            query = query.WithVersion(versionOptions.Value);
-
-        var definitionIdList = definitionIds.ToList();
-        query = query.Where(x => definitionIdList.Contains(x.Id));
-
-        var summaries = query.Select(WorkflowDefinitionSummary.FromDefinition).ToList().AsEnumerable();
-        return Task.FromResult(summaries);
+        var count = _store.Query(query => Filter(query, filter)).LongCount();
+        var result = _store.Query(query => Paginate(Filter(query, filter), pageArgs)).ToList();
+        return Task.FromResult(Page.Of(result, count));
     }
     
     /// <inheritdoc />
-    public Task<WorkflowDefinition?> FindLastVersionAsync(string definitionId, CancellationToken cancellationToken)
+    public Task<IEnumerable<WorkflowDefinition>> FindManyAsync(WorkflowDefinitionFilter filter, CancellationToken cancellationToken = default)
     {
-        var query = _store.List();
-        return Task.FromResult(query.Where(w => w.DefinitionId == definitionId).MaxBy(w => w.Version));
+        var result = _store.Query(query => Filter(query, filter)).ToList().AsEnumerable();
+        return Task.FromResult(result);
+    }
+
+    /// <inheritdoc />
+    public Task<Page<WorkflowDefinitionSummary>> FindSummariesAsync(WorkflowDefinitionFilter filter, PageArgs pageArgs, CancellationToken cancellationToken = default)
+    {
+        var count = _store.Query(query => Filter(query, filter)).LongCount();
+        var result = _store.Query(query => Paginate(Filter(query, filter), pageArgs)).Select(WorkflowDefinitionSummary.FromDefinition).ToList();
+        return Task.FromResult(Page.Of(result, count));
+    }
+    
+    /// <inheritdoc />
+    public Task<IEnumerable<WorkflowDefinitionSummary>> FindSummariesAsync(WorkflowDefinitionFilter filter, CancellationToken cancellationToken = default)
+    {
+        var result = _store.Query(query => Filter(query, filter)).Select(WorkflowDefinitionSummary.FromDefinition).ToList().AsEnumerable();
+        return Task.FromResult(result);
+    }
+
+    /// <inheritdoc />
+    public Task<WorkflowDefinition?> FindLastVersionAsync(WorkflowDefinitionFilter filter, CancellationToken cancellationToken)
+    {
+        var result = _store.Query(query => Filter(query, filter)).MaxBy(x => x.Version);
+        return Task.FromResult(result);
     }
 
     /// <inheritdoc />
@@ -98,51 +85,41 @@ public class MemoryWorkflowDefinitionStore : IWorkflowDefinitionStore
     }
 
     /// <inheritdoc />
-    public Task<int> DeleteByDefinitionIdAsync(string definitionId, CancellationToken cancellationToken = default)
+    public Task<int> DeleteAsync(WorkflowDefinitionFilter filter, CancellationToken cancellationToken = default)
     {
-        _instanceStore.DeleteWhere(x => x.DefinitionId == definitionId);
-        var result = _store.DeleteWhere(x => x.DefinitionId == definitionId);
-        return Task.FromResult(result);
+        var workflowDefinitionIds = _store.Query(query => Filter(query, filter)).Select(x => x.DefinitionId).Distinct().ToList();
+        _instanceStore.DeleteWhere(x => workflowDefinitionIds.Contains(x.DefinitionId));
+        _store.DeleteWhere(x => workflowDefinitionIds.Contains(x.DefinitionId));
+        return Task.FromResult(workflowDefinitionIds.Count);
+    }
+
+    /// <inheritdoc />
+    public Task<bool> AnyAsync(WorkflowDefinitionFilter filter, CancellationToken cancellationToken = default)
+    {
+        var exists = _store.Query(query => Filter(query, filter)).Any();
+        return Task.FromResult(exists);
     }
     
-    /// <inheritdoc />
-    public Task<int> DeleteByDefinitionIdAndVersionAsync(string definitionId, int version, CancellationToken cancellationToken = default)
+    private IQueryable<WorkflowDefinition> Filter(IQueryable<WorkflowDefinition> queryable, WorkflowDefinitionFilter filter)
     {
-        _instanceStore.DeleteWhere(x => x.DefinitionId == definitionId && x.Version == version);
-        var result = _store.DeleteWhere(x => x.DefinitionId == definitionId && x.Version == version);
-        return Task.FromResult(result);
+        if (filter.DefinitionId != null) queryable = queryable.Where(x => x.DefinitionId == filter.DefinitionId);
+        if (filter.DefinitionIds != null) queryable = queryable.Where(x => filter.DefinitionIds.Contains(x.DefinitionId));
+        if (filter.Id != null) queryable = queryable.Where(x => x.Id == filter.Id);
+        if (filter.Ids != null) queryable = queryable.Where(x => filter.Ids.Contains(x.Id));
+        if (filter.VersionOptions != null) queryable = queryable.WithVersion(filter.VersionOptions.Value);
+        if (filter.MaterializerName != null) queryable = queryable.Where(x => x.MaterializerName == filter.MaterializerName);
+        if (filter.Name != null) queryable = queryable.Where(x => x.Name == filter.Name);
+        if (filter.Names != null) queryable = queryable.Where(x => filter.Names.Contains(x.Name));
+        if (filter.UsableAsActivity != null) queryable = queryable.Where(x => x.UsableAsActivity == filter.UsableAsActivity);
+        
+        return queryable;
     }
 
-    /// <inheritdoc />
-    public Task<int> DeleteByDefinitionIdsAsync(IEnumerable<string> definitionIds, CancellationToken cancellationToken = default)
+    private IQueryable<WorkflowDefinition> Paginate(IQueryable<WorkflowDefinition> queryable, PageArgs? pageArgs)
     {
-        var definitionIdList = definitionIds.ToList();
-        _instanceStore.DeleteWhere(x => definitionIdList.Contains(x.DefinitionId));
-        var result = _store.DeleteWhere(x => definitionIdList.Contains(x.DefinitionId));
-        return Task.FromResult(result);
-    }
-
-    /// <inheritdoc />
-    public Task<Page<WorkflowDefinitionSummary>> ListSummariesAsync(
-        VersionOptions? versionOptions = default,
-        string? materializerName = default,
-        PageArgs? pageArgs = default,
-        CancellationToken cancellationToken = default)
-    {
-        var query = _store.List().AsQueryable();
-
-        if (versionOptions != null) query = query.WithVersion(versionOptions.Value);
-        if (!string.IsNullOrWhiteSpace(materializerName)) query = query.Where(x => x.MaterializerName == materializerName);
-
-        var page = query.Paginate(x => WorkflowDefinitionSummary.FromDefinition(x), pageArgs);
-        return Task.FromResult(page);
-    }
-
-    /// <inheritdoc />
-    public Task<bool> GetExistsAsync(string definitionId, VersionOptions versionOptions, CancellationToken cancellationToken = default)
-    {
-        var exists = _store.AnyAsync(x => x.DefinitionId == definitionId && x.WithVersion(versionOptions));
-        return Task.FromResult(exists);
+        if (pageArgs?.Offset != null) queryable = queryable.Skip(pageArgs.Offset.Value);
+        if (pageArgs?.Limit != null) queryable = queryable.Take(pageArgs.Limit.Value);
+        return queryable;
     }
 
     private string GetId(WorkflowDefinition workflowDefinition) => workflowDefinition.Id;

--- a/src/modules/Elsa.Workflows.Management/Implementations/MemoryWorkflowDefinitionStore.cs
+++ b/src/modules/Elsa.Workflows.Management/Implementations/MemoryWorkflowDefinitionStore.cs
@@ -2,6 +2,7 @@ using Elsa.Common.Implementations;
 using Elsa.Common.Models;
 using Elsa.Extensions;
 using Elsa.Workflows.Management.Entities;
+using Elsa.Workflows.Management.Extensions;
 using Elsa.Workflows.Management.Models;
 using Elsa.Workflows.Management.Services;
 
@@ -37,7 +38,7 @@ public class MemoryWorkflowDefinitionStore : IWorkflowDefinitionStore
     public Task<Page<WorkflowDefinition>> FindManyAsync(WorkflowDefinitionFilter filter, PageArgs pageArgs, CancellationToken cancellationToken = default)
     {
         var count = _store.Query(query => Filter(query, filter)).LongCount();
-        var result = _store.Query(query => Paginate(Filter(query, filter), pageArgs)).ToList();
+        var result = _store.Query(query => Filter(query, filter).Paginate(pageArgs)).ToList();
         return Task.FromResult(Page.Of(result, count));
     }
     
@@ -52,7 +53,7 @@ public class MemoryWorkflowDefinitionStore : IWorkflowDefinitionStore
     public Task<Page<WorkflowDefinitionSummary>> FindSummariesAsync(WorkflowDefinitionFilter filter, PageArgs pageArgs, CancellationToken cancellationToken = default)
     {
         var count = _store.Query(query => Filter(query, filter)).LongCount();
-        var result = _store.Query(query => Paginate(Filter(query, filter), pageArgs)).Select(WorkflowDefinitionSummary.FromDefinition).ToList();
+        var result = _store.Query(query => Filter(query, filter).Paginate(pageArgs)).Select(WorkflowDefinitionSummary.FromDefinition).ToList();
         return Task.FromResult(Page.Of(result, count));
     }
     
@@ -112,13 +113,6 @@ public class MemoryWorkflowDefinitionStore : IWorkflowDefinitionStore
         if (filter.Names != null) queryable = queryable.Where(x => filter.Names.Contains(x.Name));
         if (filter.UsableAsActivity != null) queryable = queryable.Where(x => x.UsableAsActivity == filter.UsableAsActivity);
         
-        return queryable;
-    }
-
-    private IQueryable<WorkflowDefinition> Paginate(IQueryable<WorkflowDefinition> queryable, PageArgs? pageArgs)
-    {
-        if (pageArgs?.Offset != null) queryable = queryable.Skip(pageArgs.Offset.Value);
-        if (pageArgs?.Limit != null) queryable = queryable.Take(pageArgs.Limit.Value);
         return queryable;
     }
 

--- a/src/modules/Elsa.Workflows.Management/Implementations/MemoryWorkflowInstanceStore.cs
+++ b/src/modules/Elsa.Workflows.Management/Implementations/MemoryWorkflowInstanceStore.cs
@@ -1,108 +1,150 @@
 using Elsa.Common.Entities;
 using Elsa.Common.Implementations;
 using Elsa.Common.Models;
+using Elsa.Extensions;
 using Elsa.Workflows.Management.Entities;
 using Elsa.Workflows.Management.Models;
 using Elsa.Workflows.Management.Services;
 
 namespace Elsa.Workflows.Management.Implementations;
 
+/// <summary>
+/// A non-persistent memory store for saving and loading <see cref="WorkflowInstance"/> entities.
+/// </summary>
 public class MemoryWorkflowInstanceStore : IWorkflowInstanceStore
 {
     private readonly MemoryStore<WorkflowInstance> _store;
 
+    /// <summary>
+    /// Constructor.
+    /// </summary>
     public MemoryWorkflowInstanceStore(MemoryStore<WorkflowInstance> store)
     {
         _store = store;
     }
 
-    public Task<WorkflowInstance?> FindByIdAsync(string id, CancellationToken cancellationToken = default)
+    /// <inheritdoc />
+    public Task<WorkflowInstance?> FindAsync(WorkflowInstanceFilter filter, CancellationToken cancellationToken = default)
     {
-        var instance = _store.Find(x => x.Id == id);
-        return Task.FromResult(instance);
+        var entity = _store.Query(query => Filter(query, filter)).FirstOrDefault();
+        return Task.FromResult(entity);
     }
 
+    /// <inheritdoc />
+    public Task<Page<WorkflowInstance>> FindManyAsync(WorkflowInstanceFilter filter, PageArgs pageArgs, CancellationToken cancellationToken = default)
+    {
+        var count = _store.Query(query => Filter(query, filter)).LongCount();
+        var entities = _store.Query(query => Filter(query, filter).Paginate(pageArgs)).ToList();
+        var page = Page.Of(entities, count);
+        return Task.FromResult(page);
+    }
+
+    /// <inheritdoc />
+    public Task<Page<WorkflowInstance>> FindManyAsync<TOrderBy>(WorkflowInstanceFilter filter, PageArgs pageArgs, WorkflowInstanceOrder<TOrderBy> order, CancellationToken cancellationToken = default)
+    {
+        var count = _store.Query(query => Filter(query, filter)).LongCount();
+        var entities = _store.Query(query => Filter(query, filter).OrderBy(order).Paginate(pageArgs)).ToList();
+        var page = Page.Of(entities, count);
+        return Task.FromResult(page);
+    }
+
+    /// <inheritdoc />
+    public Task<IEnumerable<WorkflowInstance>> FindManyAsync(WorkflowInstanceFilter filter, CancellationToken cancellationToken = default)
+    {
+        var entities = _store.Query(query => Filter(query, filter)).ToList().AsEnumerable();
+        return Task.FromResult(entities);
+    }
+
+    /// <inheritdoc />
+    public Task<IEnumerable<WorkflowInstance>> FindManyAsync<TOrderBy>(WorkflowInstanceFilter filter, WorkflowInstanceOrder<TOrderBy> order, CancellationToken cancellationToken = default)
+    {
+        var entities = _store.Query(query => Filter(query, filter).OrderBy(order)).ToList().AsEnumerable();
+        return Task.FromResult(entities);
+    }
+
+    /// <inheritdoc />
+    public async Task<Page<WorkflowInstanceSummary>> SummarizeManyAsync(WorkflowInstanceFilter filter, PageArgs pageArgs, CancellationToken cancellationToken = default)
+    {
+        var page = await FindManyAsync(filter, pageArgs, cancellationToken);
+        return new(page.Items.Select(WorkflowInstanceSummary.FromInstance).ToList(), page.TotalCount);
+    }
+
+    /// <inheritdoc />
+    public async Task<Page<WorkflowInstanceSummary>> SummarizeManyAsync<TOrderBy>(WorkflowInstanceFilter filter, PageArgs pageArgs, WorkflowInstanceOrder<TOrderBy> order, CancellationToken cancellationToken = default)
+    {
+        var page = await FindManyAsync(filter, pageArgs, order, cancellationToken);
+        return new(page.Items.Select(WorkflowInstanceSummary.FromInstance).ToList(), page.TotalCount);
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<WorkflowInstanceSummary>> SummarizeManyAsync(WorkflowInstanceFilter filter, CancellationToken cancellationToken = default)
+    {
+        var entities = await FindManyAsync(filter, cancellationToken);
+        return entities.Select(WorkflowInstanceSummary.FromInstance);
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<WorkflowInstanceSummary>> SummarizeManyAsync<TOrderBy>(WorkflowInstanceFilter filter, WorkflowInstanceOrder<TOrderBy> order, CancellationToken cancellationToken = default)
+    {
+        var entities = await FindManyAsync(filter, order, cancellationToken);
+        return entities.Select(WorkflowInstanceSummary.FromInstance);
+    }
+
+    /// <inheritdoc />
     public Task SaveAsync(WorkflowInstance record, CancellationToken cancellationToken = default)
     {
         _store.Save(record, x => x.Id);
         return Task.CompletedTask;
     }
 
+    /// <inheritdoc />
     public Task SaveManyAsync(IEnumerable<WorkflowInstance> records, CancellationToken cancellationToken = default)
     {
         _store.SaveMany(records, GetId);
         return Task.CompletedTask;
     }
 
-    public Task<bool> DeleteAsync(string id, CancellationToken cancellationToken = default)
+    /// <inheritdoc />
+    public async Task<bool> DeleteAsync(WorkflowInstanceFilter filter, CancellationToken cancellationToken = default)
     {
-        var success = _store.Delete(id);
-        return Task.FromResult(success);
+        var count = await DeleteManyAsync(filter, cancellationToken);
+        return count > 0;
     }
 
-    public Task<int> DeleteManyAsync(IEnumerable<string> ids, CancellationToken cancellationToken = default)
+    /// <inheritdoc />
+    public Task<int> DeleteManyAsync(WorkflowInstanceFilter filter, CancellationToken cancellationToken = default)
     {
-        var count = _store.DeleteMany(ids);
+        var query = Filter(_store.List().AsQueryable(), filter);
+        var count = _store.DeleteMany(query, x => x.Id);
         return Task.FromResult(count);
     }
 
-    public Task DeleteManyByDefinitionIdAsync(string definitionId, CancellationToken cancellationToken = default)
+    private string GetId(WorkflowInstance workflowInstance) => workflowInstance.Id;
+
+    private IQueryable<WorkflowInstance> Filter(IQueryable<WorkflowInstance> query, WorkflowInstanceFilter filter)
     {
-        _store.DeleteWhere(x => x.DefinitionId == definitionId);
-        return Task.CompletedTask;
-    }
+        if (!string.IsNullOrWhiteSpace(filter.Id)) query = query.Where(x => x.Id == filter.Id);
+        if (filter.Ids != null) query = query.Where(x => filter.Ids.Contains(x.Id));
+        if (!string.IsNullOrWhiteSpace(filter.DefinitionId)) query = query.Where(x => x.DefinitionId == filter.DefinitionId);
+        if (filter.DefinitionIds != null) query = query.Where(x => filter.DefinitionIds.Contains(x.DefinitionId));
+        if (filter.Version != null) query = query.Where(x => x.Version == filter.Version);
+        if (!string.IsNullOrWhiteSpace(filter.CorrelationId)) query = query.Where(x => x.CorrelationId == filter.CorrelationId);
+        if (filter.CorrelationIds != null) query = query.Where(x => filter.CorrelationIds.Contains(x.CorrelationId!));
+        if (filter.WorkflowStatus != null) query = query.Where(x => x.Status == filter.WorkflowStatus);
+        if (filter.WorkflowSubStatus != null) query = query.Where(x => x.SubStatus == filter.WorkflowSubStatus);
 
-    public Task<Page<WorkflowInstanceSummary>> FindManyAsync(FindWorkflowInstancesArgs args, CancellationToken cancellationToken = default)
-    {
-        var query = _store.List().AsQueryable();
-        var (searchTerm, definitionId, version, correlationId, workflowStatus, workflowSubStatus, pageArgs, orderBy, orderDirection) = args;
-
-        if (!string.IsNullOrWhiteSpace(definitionId))
-            query = query.Where(x => x.DefinitionId == definitionId);
-
-        if (version != null)
-            query = query.Where(x => x.Version == version);
-
-        if (!string.IsNullOrWhiteSpace(correlationId))
-            query = query.Where(x => x.CorrelationId == correlationId);
-
-        if (workflowStatus != null)
-            query = query.Where(x => x.Status == workflowStatus);
-        
-        if (workflowSubStatus != null)
-            query = query.Where(x => x.SubStatus == workflowSubStatus);
-
+        var searchTerm = filter.SearchTerm;
         if (!string.IsNullOrWhiteSpace(searchTerm))
         {
-            const StringComparison comparison = StringComparison.InvariantCultureIgnoreCase;
-
             query =
                 from instance in query
-                where instance.Name != null && instance.Name.Contains(searchTerm, comparison) == true
-                      || instance.Id.Contains(searchTerm, comparison)
-                      || instance.DefinitionId.Contains(searchTerm, comparison)
-                      || instance.CorrelationId != null && instance.CorrelationId.Contains(searchTerm, comparison)
+                where instance.Name!.Contains(searchTerm)
+                      || instance.Id.Contains(searchTerm)
+                      || instance.DefinitionId.Contains(searchTerm)
+                      || instance.CorrelationId!.Contains(searchTerm)
                 select instance;
         }
 
-        query = orderBy switch
-        {
-            OrderBy.Finished => orderDirection == OrderDirection.Ascending ? query.OrderBy(x => x.FinishedAt) : query.OrderByDescending(x => x.FinishedAt),
-            OrderBy.LastExecuted => orderDirection == OrderDirection.Ascending ? query.OrderBy(x => x.LastExecutedAt) : query.OrderByDescending(x => x.LastExecutedAt),
-            OrderBy.Created => orderDirection == OrderDirection.Ascending ? query.OrderBy(x => x.CreatedAt) : query.OrderByDescending(x => x.CreatedAt),
-            _ => query
-        };
-
-        var totalCount = query.Count();
-
-        if (pageArgs?.Offset != null) query = query.Skip(pageArgs.Offset.Value);
-        if (pageArgs?.Limit != null) query = query.Take(pageArgs.Limit.Value);
-        
-        var entities = query.ToList();
-        var summaries = entities.Select(WorkflowInstanceSummary.FromInstance).ToList();
-        var pagedList = Page.Of(summaries, totalCount);
-        return Task.FromResult(pagedList);
+        return query;
     }
-
-    private string GetId(WorkflowInstance workflowInstance) => workflowInstance.Id;
 }

--- a/src/modules/Elsa.Workflows.Management/Implementations/MemoryWorkflowInstanceStore.cs
+++ b/src/modules/Elsa.Workflows.Management/Implementations/MemoryWorkflowInstanceStore.cs
@@ -119,32 +119,7 @@ public class MemoryWorkflowInstanceStore : IWorkflowInstanceStore
         return Task.FromResult(count);
     }
 
-    private string GetId(WorkflowInstance workflowInstance) => workflowInstance.Id;
+    private static string GetId(WorkflowInstance workflowInstance) => workflowInstance.Id;
 
-    private IQueryable<WorkflowInstance> Filter(IQueryable<WorkflowInstance> query, WorkflowInstanceFilter filter)
-    {
-        if (!string.IsNullOrWhiteSpace(filter.Id)) query = query.Where(x => x.Id == filter.Id);
-        if (filter.Ids != null) query = query.Where(x => filter.Ids.Contains(x.Id));
-        if (!string.IsNullOrWhiteSpace(filter.DefinitionId)) query = query.Where(x => x.DefinitionId == filter.DefinitionId);
-        if (filter.DefinitionIds != null) query = query.Where(x => filter.DefinitionIds.Contains(x.DefinitionId));
-        if (filter.Version != null) query = query.Where(x => x.Version == filter.Version);
-        if (!string.IsNullOrWhiteSpace(filter.CorrelationId)) query = query.Where(x => x.CorrelationId == filter.CorrelationId);
-        if (filter.CorrelationIds != null) query = query.Where(x => filter.CorrelationIds.Contains(x.CorrelationId!));
-        if (filter.WorkflowStatus != null) query = query.Where(x => x.Status == filter.WorkflowStatus);
-        if (filter.WorkflowSubStatus != null) query = query.Where(x => x.SubStatus == filter.WorkflowSubStatus);
-
-        var searchTerm = filter.SearchTerm;
-        if (!string.IsNullOrWhiteSpace(searchTerm))
-        {
-            query =
-                from instance in query
-                where instance.Name!.Contains(searchTerm)
-                      || instance.Id.Contains(searchTerm)
-                      || instance.DefinitionId.Contains(searchTerm)
-                      || instance.CorrelationId!.Contains(searchTerm)
-                select instance;
-        }
-
-        return query;
-    }
+    private static IQueryable<WorkflowInstance> Filter(IQueryable<WorkflowInstance> query, WorkflowInstanceFilter filter) => filter.Apply(query);
 }

--- a/src/modules/Elsa.Workflows.Management/Implementations/WorkflowDefinitionPublisher.cs
+++ b/src/modules/Elsa.Workflows.Management/Implementations/WorkflowDefinitionPublisher.cs
@@ -25,10 +25,10 @@ public class WorkflowDefinitionPublisher : IWorkflowDefinitionPublisher
     /// Constructor.
     /// </summary>
     public WorkflowDefinitionPublisher(
-        IWorkflowDefinitionStore workflowDefinitionStore, 
+        IWorkflowDefinitionStore workflowDefinitionStore,
         IEventPublisher eventPublisher,
-        IIdentityGenerator identityGenerator, 
-        SerializerOptionsProvider serializerOptionsProvider, 
+        IIdentityGenerator identityGenerator,
+        SerializerOptionsProvider serializerOptionsProvider,
         ISystemClock systemClock)
     {
         _workflowDefinitionStore = workflowDefinitionStore;
@@ -61,7 +61,8 @@ public class WorkflowDefinitionPublisher : IWorkflowDefinitionPublisher
     /// <inheritdoc />
     public async Task<WorkflowDefinition?> PublishAsync(string definitionId, CancellationToken cancellationToken = default)
     {
-        var definition = (await _workflowDefinitionStore.FindManyByDefinitionIdAsync(definitionId, VersionOptions.Latest, cancellationToken)).FirstOrDefault();
+        var filter = new WorkflowDefinitionFilter { DefinitionId = definitionId, VersionOptions = VersionOptions.Latest };
+        var definition = await _workflowDefinitionStore.FindAsync(filter, cancellationToken);
 
         if (definition == null)
             return null;
@@ -75,7 +76,8 @@ public class WorkflowDefinitionPublisher : IWorkflowDefinitionPublisher
         var definitionId = definition.DefinitionId;
 
         // Reset current latest and published definitions.
-        var publishedAndOrLatestWorkflows = await _workflowDefinitionStore.FindManyByDefinitionIdAsync(definitionId, VersionOptions.LatestAndPublished, cancellationToken);
+        var filter = new WorkflowDefinitionFilter { DefinitionId = definitionId, VersionOptions = VersionOptions.LatestAndPublished };
+        var publishedAndOrLatestWorkflows = await _workflowDefinitionStore.FindManyAsync(filter, cancellationToken);
 
         foreach (var publishedAndOrLatestWorkflow in publishedAndOrLatestWorkflows)
         {
@@ -97,7 +99,8 @@ public class WorkflowDefinitionPublisher : IWorkflowDefinitionPublisher
     /// <inheritdoc />
     public async Task<WorkflowDefinition?> RetractAsync(string definitionId, CancellationToken cancellationToken = default)
     {
-        var definition = (await _workflowDefinitionStore.FindManyByDefinitionIdAsync(definitionId, VersionOptions.Published, cancellationToken)).FirstOrDefault();
+        var filter = new WorkflowDefinitionFilter { DefinitionId = definitionId, VersionOptions = VersionOptions.Published };
+        var definition = await _workflowDefinitionStore.FindAsync(filter, cancellationToken);
 
         if (definition == null)
             return null;
@@ -123,7 +126,8 @@ public class WorkflowDefinitionPublisher : IWorkflowDefinitionPublisher
     /// <inheritdoc />
     public async Task<WorkflowDefinition?> GetDraftAsync(string definitionId, VersionOptions versionOptions, CancellationToken cancellationToken = default)
     {
-        var definition = (await _workflowDefinitionStore.FindManyByDefinitionIdAsync(definitionId, versionOptions, cancellationToken)).FirstOrDefault();
+        var filter = new WorkflowDefinitionFilter { DefinitionId = definitionId, VersionOptions = versionOptions };
+        var definition = await _workflowDefinitionStore.FindAsync(filter, cancellationToken);
 
         if (definition == null)
             return null;
@@ -145,7 +149,8 @@ public class WorkflowDefinitionPublisher : IWorkflowDefinitionPublisher
     {
         var draft = definition;
         var definitionId = definition.DefinitionId;
-        var latestVersion = (await _workflowDefinitionStore.FindManyByDefinitionIdAsync(definitionId, VersionOptions.Latest, cancellationToken)).FirstOrDefault();
+        var filter = new WorkflowDefinitionFilter { DefinitionId = definitionId, VersionOptions = VersionOptions.Latest };
+        var latestVersion = await _workflowDefinitionStore.FindAsync(filter, cancellationToken);
 
         if (latestVersion is { IsPublished: true, IsLatest: true })
         {

--- a/src/modules/Elsa.Workflows.Management/Mappers/VariableDefinitionMapper.cs
+++ b/src/modules/Elsa.Workflows.Management/Mappers/VariableDefinitionMapper.cs
@@ -58,7 +58,7 @@ public class VariableDefinitionMapper
     {
         var variableType = source.GetType();
         var valueType = variableType.IsConstructedGenericType ? variableType.GetGenericArguments().FirstOrDefault() ?? typeof(object) : typeof(object);
-        var isArray = valueType.IsGenericType && typeof(ICollection<>).IsAssignableFrom(valueType.GetGenericTypeDefinition());
+        var isArray = valueType.IsCollectionType();
         var elementValueType = isArray ? valueType.GenericTypeArguments[0] : valueType; 
         var value = source.Value;
         

--- a/src/modules/Elsa.Workflows.Management/Services/IWorkflowDefinitionStore.cs
+++ b/src/modules/Elsa.Workflows.Management/Services/IWorkflowDefinitionStore.cs
@@ -5,49 +5,35 @@ using Elsa.Workflows.Management.Models;
 namespace Elsa.Workflows.Management.Services;
 
 /// <summary>
+/// A specification to use when finding workflow definitions. Only non-null fields will be included in the conditional expression.
+/// </summary>
+public class WorkflowDefinitionFilter
+{
+    public string? Id { get; set; }
+    public ICollection<string>? Ids { get; set; }
+    public string? DefinitionId { get; set; }
+    public ICollection<string>? DefinitionIds { get; set; }
+    public VersionOptions? VersionOptions { get; set; }
+    public string? Name { get; set; }
+    public ICollection<string>? Names { get; set; }
+    public string? MaterializerName { get; set; }
+    public bool? UsableAsActivity { get; set; }
+}
+
+/// <summary>
 /// Represents a store of <see cref="WorkflowDefinition"/>s.
 /// </summary>
 public interface IWorkflowDefinitionStore
 {
-    /// <summary>
-    /// Finds a workflow definition by its unique version ID.
-    /// </summary>
-    Task<WorkflowDefinition?> FindByIdAsync(string id, CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Finds all workflow definitions by its logical definition ID and specified version options.
-    /// </summary>
-    Task<IEnumerable<WorkflowDefinition>> FindManyByDefinitionIdAsync(string definitionId, VersionOptions versionOptions, CancellationToken cancellationToken = default);
-    
-    /// <summary>
-    /// Finds the workflow definition by its logical definition ID and specified version options.
-    /// </summary>
-    Task<WorkflowDefinition?> FindByDefinitionIdAsync(string definitionId, VersionOptions versionOptions, CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Finds a workflow definition by name and specified version options.
-    /// </summary>
-    Task<WorkflowDefinition?> FindByNameAsync(string name, VersionOptions versionOptions, CancellationToken cancellationToken = default);
-    
-    /// <summary>
-    /// Returns all workflow definitions that can be used as activities.
-    /// </summary>
-    Task<IEnumerable<WorkflowDefinition>> FindWithActivityBehaviorAsync(VersionOptions versionOptions, CancellationToken cancellationToken = default);
-
-    Task<IEnumerable<WorkflowDefinitionSummary>> FindSummariesAsync(IEnumerable<string> definitionIds, VersionOptions? versionOptions = default, CancellationToken cancellationToken = default);
-    
-    Task<WorkflowDefinition?> FindLastVersionAsync(string definitionId, CancellationToken cancellationToken);
+    Task<WorkflowDefinition?> FindAsync(WorkflowDefinitionFilter filter, CancellationToken cancellationToken = default);
+    Task<Page<WorkflowDefinition>> FindManyAsync(WorkflowDefinitionFilter filter, PageArgs pageArgs, CancellationToken cancellationToken = default);
+    Task<IEnumerable<WorkflowDefinition>> FindManyAsync(WorkflowDefinitionFilter filter, CancellationToken cancellationToken = default);
+    Task<Page<WorkflowDefinitionSummary>> FindSummariesAsync(WorkflowDefinitionFilter filter, PageArgs pageArgs, CancellationToken cancellationToken = default);
+    Task<IEnumerable<WorkflowDefinitionSummary>> FindSummariesAsync(WorkflowDefinitionFilter filter, CancellationToken cancellationToken = default);
+    Task<WorkflowDefinition?> FindLastVersionAsync(WorkflowDefinitionFilter filter, CancellationToken cancellationToken);
     Task SaveAsync(WorkflowDefinition record, CancellationToken cancellationToken = default);
     Task SaveManyAsync(IEnumerable<WorkflowDefinition> records, CancellationToken cancellationToken = default);
-    Task<int> DeleteByDefinitionIdAsync(string definitionId, CancellationToken cancellationToken = default);
-    Task<int> DeleteByDefinitionIdAndVersionAsync(string definitionId, int version, CancellationToken cancellationToken = default);
-    Task<int> DeleteByDefinitionIdsAsync(IEnumerable<string> definitionIds, CancellationToken cancellationToken = default);
+    Task<int> DeleteAsync(WorkflowDefinitionFilter filter, CancellationToken cancellationToken = default);
 
-    Task<Page<WorkflowDefinitionSummary>> ListSummariesAsync(
-        VersionOptions? versionOptions = default,
-        string? materializerName = default,
-        PageArgs? pageArgs = default,
-        CancellationToken cancellationToken = default);
-
-    Task<bool> GetExistsAsync(string definitionId, VersionOptions versionOptions, CancellationToken cancellationToken = default);
+    Task<bool> AnyAsync(WorkflowDefinitionFilter filter, CancellationToken cancellationToken = default);
 }

--- a/src/modules/Elsa.Workflows.Management/Services/IWorkflowDefinitionStore.cs
+++ b/src/modules/Elsa.Workflows.Management/Services/IWorkflowDefinitionStore.cs
@@ -1,4 +1,5 @@
 using Elsa.Common.Models;
+using Elsa.Extensions;
 using Elsa.Workflows.Management.Entities;
 using Elsa.Workflows.Management.Models;
 
@@ -18,6 +19,22 @@ public class WorkflowDefinitionFilter
     public ICollection<string>? Names { get; set; }
     public string? MaterializerName { get; set; }
     public bool? UsableAsActivity { get; set; }
+
+    public IQueryable<WorkflowDefinition> Apply(IQueryable<WorkflowDefinition> queryable)
+    {
+        var filter = this;
+        if (filter.DefinitionId != null) queryable = queryable.Where(x => x.DefinitionId == filter.DefinitionId);
+        if (filter.DefinitionIds != null) queryable = queryable.Where(x => filter.DefinitionIds.Contains(x.DefinitionId));
+        if (filter.Id != null) queryable = queryable.Where(x => x.Id == filter.Id);
+        if (filter.Ids != null) queryable = queryable.Where(x => filter.Ids.Contains(x.Id));
+        if (filter.VersionOptions != null) queryable = queryable.WithVersion(filter.VersionOptions.Value);
+        if (filter.MaterializerName != null) queryable = queryable.Where(x => x.MaterializerName == filter.MaterializerName);
+        if (filter.Name != null) queryable = queryable.Where(x => x.Name == filter.Name);
+        if (filter.Names != null) queryable = queryable.Where(x => filter.Names.Contains(x.Name!));
+        if (filter.UsableAsActivity != null) queryable = queryable.Where(x => x.UsableAsActivity == filter.UsableAsActivity);
+        
+        return queryable;
+    }
 }
 
 /// <summary>

--- a/src/modules/Elsa.Workflows.Management/Services/IWorkflowInstanceStore.cs
+++ b/src/modules/Elsa.Workflows.Management/Services/IWorkflowInstanceStore.cs
@@ -6,28 +6,40 @@ using Elsa.Workflows.Management.Models;
 
 namespace Elsa.Workflows.Management.Services;
 
+public class WorkflowInstanceFilter
+{
+    public string? Id { get; set; }
+    public ICollection<string>? Ids { get; set; }
+    public string? SearchTerm { get; set; }
+    public string? DefinitionId { get; set; }
+    public ICollection<string>? DefinitionIds { get; set; }
+    public int? Version { get; set; }
+    public string? CorrelationId { get; set; }
+    public ICollection<string>? CorrelationIds { get; set; }
+    public WorkflowStatus? WorkflowStatus { get; set; }
+    public WorkflowSubStatus? WorkflowSubStatus { get; set; }
+}
+
+public class WorkflowInstanceOrder<TProp> : OrderDefinition<WorkflowInstance, TProp>
+{
+}
+
 /// <summary>
 /// Represents a store of workflow instances.
 /// </summary>
 public interface IWorkflowInstanceStore
 {
-    Task<WorkflowInstance?> FindByIdAsync(string id, CancellationToken cancellationToken = default);
+    Task<WorkflowInstance?> FindAsync(WorkflowInstanceFilter filter, CancellationToken cancellationToken = default);
+    Task<Page<WorkflowInstance>> FindManyAsync(WorkflowInstanceFilter filter, PageArgs pageArgs, CancellationToken cancellationToken = default);
+    Task<Page<WorkflowInstance>> FindManyAsync<TOrderBy>(WorkflowInstanceFilter filter, PageArgs pageArgs, WorkflowInstanceOrder<TOrderBy> order, CancellationToken cancellationToken = default);
+    Task<IEnumerable<WorkflowInstance>> FindManyAsync(WorkflowInstanceFilter filter, CancellationToken cancellationToken = default);
+    Task<IEnumerable<WorkflowInstance>> FindManyAsync<TOrderBy>(WorkflowInstanceFilter filter, WorkflowInstanceOrder<TOrderBy> order, CancellationToken cancellationToken = default);
+    Task<Page<WorkflowInstanceSummary>> SummarizeManyAsync(WorkflowInstanceFilter filter, PageArgs pageArgs, CancellationToken cancellationToken = default);
+    Task<Page<WorkflowInstanceSummary>> SummarizeManyAsync<TOrderBy>(WorkflowInstanceFilter filter, PageArgs pageArgs, WorkflowInstanceOrder<TOrderBy> order, CancellationToken cancellationToken = default);
+    Task<IEnumerable<WorkflowInstanceSummary>> SummarizeManyAsync(WorkflowInstanceFilter filter, CancellationToken cancellationToken = default);
+    Task<IEnumerable<WorkflowInstanceSummary>> SummarizeManyAsync<TOrder>(WorkflowInstanceFilter filter, WorkflowInstanceOrder<TOrder> order, CancellationToken cancellationToken = default);
     Task SaveAsync(WorkflowInstance record, CancellationToken cancellationToken = default);
     Task SaveManyAsync(IEnumerable<WorkflowInstance> records, CancellationToken cancellationToken = default);
-    Task<bool> DeleteAsync(string id, CancellationToken cancellationToken = default);
-    Task<int> DeleteManyAsync(IEnumerable<string> ids, CancellationToken cancellationToken = default);
-    Task DeleteManyByDefinitionIdAsync(string definitionId, CancellationToken cancellationToken = default);
-    Task<Page<WorkflowInstanceSummary>> FindManyAsync(FindWorkflowInstancesArgs args, CancellationToken cancellationToken = default);
+    Task<bool> DeleteAsync(WorkflowInstanceFilter filter, CancellationToken cancellationToken = default);
+    Task<int> DeleteManyAsync(WorkflowInstanceFilter filter, CancellationToken cancellationToken = default);
 }
-
-public record FindWorkflowInstancesArgs(
-    string? SearchTerm = default,
-    string? DefinitionId = default,
-    int? Version = default,
-    string? CorrelationId = default,
-    WorkflowStatus? WorkflowStatus = default,
-    WorkflowSubStatus? WorkflowSubStatus = default,
-    PageArgs? PageArgs = default,
-    OrderBy OrderBy = OrderBy.Created,
-    OrderDirection OrderDirection = OrderDirection.Ascending
-);

--- a/src/modules/Elsa.Workflows.Management/Services/IWorkflowInstanceStore.cs
+++ b/src/modules/Elsa.Workflows.Management/Services/IWorkflowInstanceStore.cs
@@ -18,6 +18,34 @@ public class WorkflowInstanceFilter
     public ICollection<string>? CorrelationIds { get; set; }
     public WorkflowStatus? WorkflowStatus { get; set; }
     public WorkflowSubStatus? WorkflowSubStatus { get; set; }
+
+    public IQueryable<WorkflowInstance> Apply(IQueryable<WorkflowInstance> query)
+    {
+        var filter = this;
+        if (!string.IsNullOrWhiteSpace(filter.Id)) query = query.Where(x => x.Id == filter.Id);
+        if (filter.Ids != null) query = query.Where(x => filter.Ids.Contains(x.Id));
+        if (!string.IsNullOrWhiteSpace(filter.DefinitionId)) query = query.Where(x => x.DefinitionId == filter.DefinitionId);
+        if (filter.DefinitionIds != null) query = query.Where(x => filter.DefinitionIds.Contains(x.DefinitionId));
+        if (filter.Version != null) query = query.Where(x => x.Version == filter.Version);
+        if (!string.IsNullOrWhiteSpace(filter.CorrelationId)) query = query.Where(x => x.CorrelationId == filter.CorrelationId);
+        if (filter.CorrelationIds != null) query = query.Where(x => filter.CorrelationIds.Contains(x.CorrelationId!));
+        if (filter.WorkflowStatus != null) query = query.Where(x => x.Status == filter.WorkflowStatus);
+        if (filter.WorkflowSubStatus != null) query = query.Where(x => x.SubStatus == filter.WorkflowSubStatus);
+
+        var searchTerm = filter.SearchTerm;
+        if (!string.IsNullOrWhiteSpace(searchTerm))
+        {
+            query =
+                from instance in query
+                where instance.Name!.Contains(searchTerm)
+                      || instance.Id.Contains(searchTerm)
+                      || instance.DefinitionId.Contains(searchTerm)
+                      || instance.CorrelationId!.Contains(searchTerm)
+                select instance;
+        }
+
+        return query;
+    }
 }
 
 public class WorkflowInstanceOrder<TProp> : OrderDefinition<WorkflowInstance, TProp>

--- a/src/modules/Elsa.Workflows.Runtime/Activities/RunTask.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Activities/RunTask.cs
@@ -35,7 +35,7 @@ public class RunTask : Activity<object>, IBookmarksPersistedHandler
     /// <summary>
     /// The name of the task being requested.
     /// </summary>
-    [Input(Description = "Any additional parameters to send to the task.")]
+    [Input(Description = "AnyAsync additional parameters to send to the task.")]
     public Input<object?> TaskParams { get; set; } = default!;
     
     /// <inheritdoc />

--- a/src/modules/Elsa.Workflows.Runtime/HostedServices/PopulateWorkflowDefinitionStore.cs
+++ b/src/modules/Elsa.Workflows.Runtime/HostedServices/PopulateWorkflowDefinitionStore.cs
@@ -30,6 +30,7 @@ public class PopulateWorkflowDefinitionStore : IHostedService
         _workflowDefinitionStore = workflowDefinitionStore;
     }
 
+    /// <inheritdoc />
     public async Task StartAsync(CancellationToken cancellationToken)
     {
         foreach (var provider in _workflowDefinitionProviders)
@@ -47,10 +48,13 @@ public class PopulateWorkflowDefinitionStore : IHostedService
     private async Task AddOrUpdateAsync(WorkflowDefinition definition, CancellationToken cancellationToken = default)
     {
         // Check if there's already a workflow definition by the definition ID and version.
-        var existingDefinition = (await _workflowDefinitionStore.FindManyByDefinitionIdAsync(
-            definition.DefinitionId,
-            VersionOptions.SpecificVersion(definition.Version),
-            cancellationToken)).FirstOrDefault();
+        var filter = new WorkflowDefinitionFilter
+        {
+            DefinitionId = definition.DefinitionId, 
+            VersionOptions = VersionOptions.SpecificVersion(definition.Version)
+        };
+        
+        var existingDefinition = await _workflowDefinitionStore.FindAsync(filter, cancellationToken);
 
         if (existingDefinition == null)
         {
@@ -73,5 +77,6 @@ public class PopulateWorkflowDefinitionStore : IHostedService
 
     private async Task IndexTriggersAsync(Workflow workflow, CancellationToken cancellationToken) => await _triggerIndexer.IndexTriggersAsync(workflow, cancellationToken);
 
+    /// <inheritdoc />
     public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 }

--- a/src/modules/Elsa.Workflows.Runtime/Implementations/AsyncWorkflowStateExporter.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Implementations/AsyncWorkflowStateExporter.cs
@@ -50,14 +50,15 @@ public class AsyncWorkflowStateExporter : IWorkflowStateExporter, ICommandHandle
         var definitionId = workflowState.DefinitionId;
         var version = workflowState.DefinitionVersion;
         var versionOptions = VersionOptions.SpecificVersion(version);
-        var filter = new WorkflowDefinitionFilter { DefinitionId = definitionId, VersionOptions = versionOptions };
-        var definition = await _workflowDefinitionStore.FindAsync(filter, cancellationToken);
+        var definitionFilter = new WorkflowDefinitionFilter { DefinitionId = definitionId, VersionOptions = versionOptions };
+        var definition = await _workflowDefinitionStore.FindAsync(definitionFilter, cancellationToken);
 
         if (definition == null)
             throw new Exception(
                 $"Can't find workflow definition with definition ID {definitionId} and version {version}");
 
-        var workflowInstance = await _workflowInstanceStore.FindByIdAsync(workflowState.Id, cancellationToken);
+        var instanceFilter = new WorkflowInstanceFilter { Id = workflowState.Id };
+        var workflowInstance = await _workflowInstanceStore.FindAsync(instanceFilter, cancellationToken);
         var now = _systemClock.UtcNow;
 
         workflowInstance ??= new WorkflowInstance

--- a/src/modules/Elsa.Workflows.Runtime/Implementations/AsyncWorkflowStateExporter.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Implementations/AsyncWorkflowStateExporter.cs
@@ -50,7 +50,8 @@ public class AsyncWorkflowStateExporter : IWorkflowStateExporter, ICommandHandle
         var definitionId = workflowState.DefinitionId;
         var version = workflowState.DefinitionVersion;
         var versionOptions = VersionOptions.SpecificVersion(version);
-        var definition = await _workflowDefinitionStore.FindByDefinitionIdAsync(definitionId, versionOptions, cancellationToken);
+        var filter = new WorkflowDefinitionFilter { DefinitionId = definitionId, VersionOptions = versionOptions };
+        var definition = await _workflowDefinitionStore.FindAsync(filter, cancellationToken);
 
         if (definition == null)
             throw new Exception(

--- a/src/modules/Elsa.Workflows.Runtime/Implementations/TriggerIndexer.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Implementations/TriggerIndexer.cs
@@ -91,8 +91,11 @@ public class TriggerIndexer : ITriggerIndexer
         return indexedWorkflow;
     }
 
-    private async Task<IEnumerable<StoredTrigger>> GetCurrentTriggersAsync(string workflowDefinitionId, CancellationToken cancellationToken) =>
-        await _triggerStore.FindByWorkflowDefinitionIdAsync(workflowDefinitionId, cancellationToken);
+    private async Task<IEnumerable<StoredTrigger>> GetCurrentTriggersAsync(string workflowDefinitionId, CancellationToken cancellationToken)
+    {
+        var filter = new TriggerFilter { WorkflowDefinitionId = workflowDefinitionId};
+        return await _triggerStore.FindManyAsync(filter, cancellationToken);
+    }
 
     private async IAsyncEnumerable<StoredTrigger> GetTriggersAsync(Workflow workflow, [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {

--- a/src/modules/Elsa.Workflows.Runtime/Implementations/WorkflowDefinitionService.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Implementations/WorkflowDefinitionService.cs
@@ -49,6 +49,9 @@ public class WorkflowDefinitionService : IWorkflowDefinitionService
     }
 
     /// <inheritdoc />
-    public async Task<WorkflowDefinition?> FindAsync(string definitionId, VersionOptions versionOptions, CancellationToken cancellationToken = default) =>
-        await _workflowDefinitionStore.FindByDefinitionIdAsync(definitionId, versionOptions, cancellationToken);
+    public async Task<WorkflowDefinition?> FindAsync(string definitionId, VersionOptions versionOptions, CancellationToken cancellationToken = default)
+    {
+        var filter = new WorkflowDefinitionFilter { DefinitionId = definitionId, VersionOptions = versionOptions };
+        return await _workflowDefinitionStore.FindAsync(filter, cancellationToken);
+    }
 }

--- a/src/modules/Elsa.Workflows.Runtime/Interpreters/TriggerWorkflowInstructionInterpreter.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Interpreters/TriggerWorkflowInstructionInterpreter.cs
@@ -65,5 +65,5 @@
 //         return new DispatchWorkflowInstructionResult();
 //     }
 //
-//     private async Task<bool> GetDefinitionExistsAsync(string definitionId, CancellationToken cancellationToken) => await _workflowDefinitionStore.GetExistsAsync(definitionId, VersionOptions.Published, cancellationToken);
+//     private async Task<bool> GetDefinitionExistsAsync(string definitionId, CancellationToken cancellationToken) => await _workflowDefinitionStore.AnyAsync(definitionId, VersionOptions.Published, cancellationToken);
 // }

--- a/src/modules/Elsa.Workflows.Runtime/Models/DispatchTriggerWorkflowsRequest.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Models/DispatchTriggerWorkflowsRequest.cs
@@ -4,7 +4,7 @@ namespace Elsa.Workflows.Runtime.Models;
 /// Represents a dispatch request to trigger all workflows using the provided information.
 /// </summary>
 /// <param name="ActivityTypeName">The type name of the activity to trigger.</param>
-/// <param name="BookmarkPayload">Any bookmark payload to use to find the workflows to trigger.</param>
-/// <param name="CorrelationId">Any correlation ID to use to find the workflows to trigger.</param>
-/// <param name="Input">Any input to send along.</param>
+/// <param name="BookmarkPayload">AnyAsync bookmark payload to use to find the workflows to trigger.</param>
+/// <param name="CorrelationId">AnyAsync correlation ID to use to find the workflows to trigger.</param>
+/// <param name="Input">AnyAsync input to send along.</param>
 public record DispatchTriggerWorkflowsRequest(string ActivityTypeName, object BookmarkPayload, string? CorrelationId = default, IDictionary<string, object>? Input = default);

--- a/src/modules/Elsa.Workflows.Runtime/Notifications/RunTaskRequest.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Notifications/RunTaskRequest.cs
@@ -7,5 +7,5 @@ namespace Elsa.Workflows.Runtime.Notifications;
 /// </summary>
 /// <param name="TaskId">A unique identifier for an individual task request.</param>
 /// <param name="TaskName">The name of the task requested to run.</param>
-/// <param name="TaskParams">Any parameters supplied by the requester of the task.</param>
+/// <param name="TaskParams">AnyAsync parameters supplied by the requester of the task.</param>
 public record RunTaskRequest(string TaskId, string TaskName, object? TaskParams) : INotification;

--- a/src/modules/Elsa.Workflows.Runtime/Services/IBookmarkStore.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Services/IBookmarkStore.cs
@@ -2,6 +2,25 @@ using Elsa.Workflows.Runtime.Models;
 
 namespace Elsa.Workflows.Runtime.Services;
 
+public class BookmarkFilter
+{
+    public string? WorkflowInstanceId { get; set; }
+    public string? Hash { get; set; }
+    public string? CorrelationId { get; set; }
+    public string? ActivityTypeName { get; set; }
+
+    public IQueryable<StoredBookmark> Apply(IQueryable<StoredBookmark> query)
+    {
+        var filter = this;
+        if (filter.CorrelationId != null) query = query.Where(x => x.CorrelationId == filter.CorrelationId);
+        if (filter.Hash != null) query = query.Where(x => x.Hash == filter.Hash);
+        if (filter.WorkflowInstanceId != null) query = query.Where(x => x.WorkflowInstanceId == filter.WorkflowInstanceId);
+        if (filter.ActivityTypeName != null) query = query.Where(x => x.ActivityTypeName == filter.ActivityTypeName);
+
+        return query;
+    }
+}
+
 /// <summary>
 /// Provides access to stored bookmarks.
 /// </summary>
@@ -11,34 +30,14 @@ public interface IBookmarkStore
     /// Adds or updates the specified bookmark. 
     /// </summary>
     ValueTask SaveAsync(StoredBookmark record, CancellationToken cancellationToken = default);
-    
+
     /// <summary>
-    /// Returns a set of bookmarks matching the specified workflow instance ID.
+    /// Returns a set of bookmarks matching the specified filter.
     /// </summary>
-    ValueTask<IEnumerable<StoredBookmark>> FindByWorkflowInstanceAsync(string workflowInstanceId, CancellationToken cancellationToken = default);
-    
+    ValueTask<IEnumerable<StoredBookmark>> FindManyAsync(BookmarkFilter filter, CancellationToken cancellationToken = default);
+
     /// <summary>
-    /// Returns a set of bookmarks matching the specified hash.
+    /// Deletes a set of bookmarks matching the specified filter.
     /// </summary>
-    ValueTask<IEnumerable<StoredBookmark>> FindByHashAsync(string hash, CancellationToken cancellationToken = default);
-    
-    /// <summary>
-    /// Returns a set of bookmarks matching the specified workflow instance ID and hash.
-    /// </summary>
-    ValueTask<IEnumerable<StoredBookmark>> FindByWorkflowInstanceAndHashAsync(string workflowInstanceId, string hash, CancellationToken cancellationToken = default);
-    
-    /// <summary>
-    /// Returns a set of bookmarks matching the specified correlation ID and hash.
-    /// </summary>
-    ValueTask<IEnumerable<StoredBookmark>> FindByCorrelationAndHashAsync(string correlationId, string hash, CancellationToken cancellationToken = default);
-    
-    /// <summary>
-    /// Deletes a set of bookmarks matching the specified workflow instance ID and hash.
-    /// </summary>
-    ValueTask DeleteAsync(string hash, string workflowInstanceId, CancellationToken cancellationToken = default);
-    
-    /// <summary>
-    /// Returns a set of bookmarks matching the specified activity type.
-    /// </summary>
-    ValueTask<IEnumerable<StoredBookmark>> FindByActivityTypeAsync(string activityType, CancellationToken cancellationToken = default);
+    ValueTask<long> DeleteAsync(BookmarkFilter filter, CancellationToken cancellationToken = default);
 }

--- a/src/modules/Elsa.Workflows.Runtime/Services/ITriggerStore.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Services/ITriggerStore.cs
@@ -2,6 +2,26 @@ using Elsa.Workflows.Runtime.Entities;
 
 namespace Elsa.Workflows.Runtime.Services;
 
+public class TriggerFilter
+{
+    public string? Id { get; set; }
+    public ICollection<string>? Ids { get; set; }
+    public string? WorkflowDefinitionId { get; set; }
+    public string? Name { get; set; }
+    public string? Hash { get; set; }
+
+    public IQueryable<StoredTrigger> Apply(IQueryable<StoredTrigger> queryable)
+    {
+        if (Id != null) queryable = queryable.Where(x => x.Id == Id);
+        if (Ids != null) queryable = queryable.Where(x => Ids.Contains(x.Id));
+        if (WorkflowDefinitionId != null) queryable = queryable.Where(x => x.WorkflowDefinitionId == WorkflowDefinitionId);
+        if (Name != null) queryable = queryable.Where(x => x.Name == Name);
+        if (Hash != null) queryable = queryable.Where(x => x.Hash == Hash);
+
+        return queryable;
+    }
+}
+
 /// <summary>
 /// Provides access to the underlying store of stored triggers.
 /// </summary>
@@ -11,34 +31,24 @@ public interface ITriggerStore
     /// Adds or updates the specified record.
     /// </summary>
     ValueTask SaveAsync(StoredTrigger record, CancellationToken cancellationToken = default);
-    
+
     /// <summary>
     /// Adds or updates the specified set of records. 
     /// </summary>
     ValueTask SaveManyAsync(IEnumerable<StoredTrigger> records, CancellationToken cancellationToken = default);
-    
+
     /// <summary>
-    /// Returns all records matching the specified hash value.
+    /// Returns all records matching the specified filter.
     /// </summary>
-    ValueTask<IEnumerable<StoredTrigger>> FindAsync(string hash, CancellationToken cancellationToken = default);
-    
-    /// <summary>
-    /// Returns all records matching the specified workflow definition ID. 
-    /// </summary>
-    ValueTask<IEnumerable<StoredTrigger>> FindByWorkflowDefinitionIdAsync(string workflowDefinitionId, CancellationToken cancellationToken = default);
+    ValueTask<IEnumerable<StoredTrigger>> FindManyAsync(TriggerFilter filter, CancellationToken cancellationToken = default);
     
     /// <summary>
     /// Replaces a set of records based on the specified removed and added records.
     /// </summary>
     ValueTask ReplaceAsync(IEnumerable<StoredTrigger> removed, IEnumerable<StoredTrigger> added, CancellationToken cancellationToken = default);
-    
+
     /// <summary>
-    /// Deletes all records with the specified set of IDs.
+    /// Deletes all records matching the specified filter.
     /// </summary>
-    ValueTask DeleteManyAsync(IEnumerable<string> ids, CancellationToken cancellationToken = default);
-    
-    /// <summary>
-    /// Returns a set of records matching the specified activity type.
-    /// </summary>
-    ValueTask<IEnumerable<StoredTrigger>> FindByActivityTypeAsync(string activityType, CancellationToken cancellationToken = default);
+    ValueTask<long> DeleteManyAsync(TriggerFilter filter, CancellationToken cancellationToken = default);
 }

--- a/test/Elsa.IntegrationTests/Activities/Fork/ForkTests.cs
+++ b/test/Elsa.IntegrationTests/Activities/Fork/ForkTests.cs
@@ -31,7 +31,7 @@ public class ForkTests
         Assert.Equal(new[]{ "Branch 3", "Branch 2", "Branch 1" }, lines);
     }
     
-    [Fact(DisplayName = "Wait Any causes workflow to continue")]
+    [Fact(DisplayName = "Wait AnyAsync causes workflow to continue")]
     public async Task Test2()
     {
         var workflow = await _workflowBuilderFactory.CreateBuilder().BuildWorkflowAsync<JoinAnyForkWorkflow>();


### PR DESCRIPTION
This PR refactors the store services by following a simple specification pattern. The specification is not open for extension, which has the advantage of keeping the store implementations simple and predictable. This is in contrast to the specifications implementation in V2, where it is more complicated to discover all the specifications that potentially need to be implemented by (custom) persistence providers.