### PR TITLE
Feature/workflow execution status codes

### DIFF
--- a/src/modules/Elsa.Http/Features/HttpFeature.cs
+++ b/src/modules/Elsa.Http/Features/HttpFeature.cs
@@ -105,9 +105,12 @@ public class HttpFeature : FeatureBase
             .AddSingleton<IHttpContentFactory, JsonContentFactory>()
             .AddSingleton<IHttpContentFactory, XmlContentFactory>()
             .AddSingleton<IHttpContentFactory, FormUrlEncodedHttpContentFactory>()
-            
+
             // Activity property options providers.
             .AddSingleton<IActivityPropertyOptionsProvider, WriteHttpResponseContentTypeOptionsProvider>()
+
+            // Add Http endpoint handlers
+            .AddSingleton(HttpEndpointWorkflowFaultHandler)
             ;
     }
 }

--- a/src/modules/Elsa.Http/Handlers/DefaultHttpEndpointWorkflowFaultHandler.cs
+++ b/src/modules/Elsa.Http/Handlers/DefaultHttpEndpointWorkflowFaultHandler.cs
@@ -1,8 +1,9 @@
-using System.Net.Mime;
-using System.Text.Json;
 using Elsa.Http.Models;
 using Elsa.Http.Services;
+using Elsa.Workflows.Core.Serialization;
 using Microsoft.AspNetCore.Http;
+using System.Net.Mime;
+using System.Text.Json;
 
 namespace Elsa.Http.Handlers;
 
@@ -12,6 +13,13 @@ namespace Elsa.Http.Handlers;
 /// </summary>
 public class DefaultHttpEndpointWorkflowFaultHandler : IHttpEndpointWorkflowFaultHandler
 {
+    private readonly SerializerOptionsProvider _serializerOptionsProvider;
+
+    public DefaultHttpEndpointWorkflowFaultHandler(SerializerOptionsProvider serializerOptionsProvider)
+    {
+        _serializerOptionsProvider = serializerOptionsProvider;
+    }
+
     /// <inheritdoc />
     public virtual async ValueTask HandleAsync(HttpEndpointFaultedWorkflowContext context)
     {
@@ -25,14 +33,14 @@ public class DefaultHttpEndpointWorkflowFaultHandler : IHttpEndpointWorkflowFaul
         var faultedResponse = JsonSerializer.Serialize(new
         {
             errorMessage = $"Workflow faulted at {workflowInstance.FaultedAt!} with error: {fault.Message}",
-            exception = fault.Exception,
+            exception = fault?.Exception,
             workflow = new
             {
                 name = workflowInstance.Name,
                 version = workflowInstance.Version,
                 instanceId = workflowInstance.Id
             }
-        });
+        }, _serializerOptionsProvider.CreatePersistenceOptions());
 
         await httpContext.Response.WriteAsync(faultedResponse, context.CancellationToken);
     }

--- a/src/modules/Elsa.Http/Middleware/WorkflowsMiddleware.cs
+++ b/src/modules/Elsa.Http/Middleware/WorkflowsMiddleware.cs
@@ -1,14 +1,16 @@
-using System.Net;
-using System.Net.Mime;
-using System.Text.Json;
 using Elsa.Http.Models;
 using Elsa.Http.Options;
 using Elsa.Http.Services;
 using Elsa.Workflows.Core.Helpers;
+using Elsa.Workflows.Core.Models;
+using Elsa.Workflows.Management.Services;
 using Elsa.Workflows.Runtime.Services;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
+using System.Net;
+using System.Net.Mime;
+using System.Text.Json;
 
 namespace Elsa.Http.Middleware;
 
@@ -23,6 +25,8 @@ public class WorkflowsMiddleware
     private readonly IWorkflowHostFactory _workflowHostFactory;
     private readonly IWorkflowDefinitionService _workflowDefinitionService;
     private readonly IHttpBookmarkProcessor _httpBookmarkProcessor;
+    private readonly IWorkflowInstanceStore _workflowInstanceStore;
+    private readonly IHttpEndpointWorkflowFaultHandler _httpEndpointWorkflowFaultHandler;
     private readonly HttpActivityOptions _options;
     private readonly string _activityTypeName = ActivityTypeNameHelper.GenerateTypeName<HttpEndpoint>();
 
@@ -35,13 +39,17 @@ public class WorkflowsMiddleware
         IWorkflowHostFactory workflowHostFactory,
         IWorkflowDefinitionService workflowDefinitionService,
         IHttpBookmarkProcessor httpBookmarkProcessor,
-        IOptions<HttpActivityOptions> options)
+        IWorkflowInstanceStore workflowInstanceStore,
+        IOptions<HttpActivityOptions> options,
+        IHttpEndpointWorkflowFaultHandler httpEndpointWorkflowFaultHandler)
     {
         _next = next;
         _workflowRuntime = workflowRuntime;
         _workflowHostFactory = workflowHostFactory;
         _workflowDefinitionService = workflowDefinitionService;
         _httpBookmarkProcessor = httpBookmarkProcessor;
+        _workflowInstanceStore = workflowInstanceStore;
+        _httpEndpointWorkflowFaultHandler = httpEndpointWorkflowFaultHandler;
         _options = options.Value;
     }
 
@@ -88,6 +96,9 @@ public class WorkflowsMiddleware
             return;
 
         if (await HandleMultipleWorkflowsFoundAsync(httpContext, triggerResult.TriggeredWorkflows, cancellationToken))
+            return;
+
+        if (await HandleWorkflowFaultAsync(httpContext, triggerResult, cancellationToken))
             return;
 
         // Process the trigger result by resuming each HTTP bookmark, if any.
@@ -150,5 +161,21 @@ public class WorkflowsMiddleware
 
         await httpContext.Response.WriteAsync(responseContent, cancellationToken);
         return true;
+    }
+
+    private async Task<bool> HandleWorkflowFaultAsync(HttpContext httpContext, TriggerWorkflowsResult triggerResult, CancellationToken cancellationToken)
+    {
+        var instanceFilter = new WorkflowInstanceFilter { Id = triggerResult.TriggeredWorkflows.Single().InstanceId };
+        var workflowInstance = await _workflowInstanceStore.FindAsync(instanceFilter, cancellationToken);
+
+        if (workflowInstance is not null
+            && workflowInstance.SubStatus == WorkflowSubStatus.Faulted
+            && !httpContext.Response.HasStarted)
+        {
+            await _httpEndpointWorkflowFaultHandler.HandleAsync(new HttpEndpointFaultedWorkflowContext(httpContext, workflowInstance, null, cancellationToken));
+            return true;
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
Implemented error handling for calling a workflow using the path described in the HTTP endpoint activity:
- 404 status code if no workflow is found with that path
- 500 + message, if multiple workflows are found with the same path
- 500 + details, if the workflow execution failed

The logic was mostly ported from Elsa 2.