### PR TITLE
Undefined json element value fix

### DIFF
--- a/src/modules/Elsa.Workflows.Management/Serialization/Converters/InputJsonConverter.cs
+++ b/src/modules/Elsa.Workflows.Management/Serialization/Converters/InputJsonConverter.cs
@@ -39,6 +39,9 @@ public class InputJsonConverter<T> : JsonConverter<Input<T>>
 
             if (!expressionElement.TryGetProperty("type", out var expressionTypeNameElement))
                 return default!;
+            
+            if (!expressionElement.TryGetProperty("value", out _))
+                return default!;
 
             var expressionTypeName = expressionTypeNameElement.GetString() ?? "Literal";
             var expressionSyntaxDescriptor = _expressionSyntaxRegistry.Find(expressionTypeName);


### PR DESCRIPTION
Currently, when you try to execute a workflow that has a HttpEndpoint activity, it throws the following error:
InvalidOperationException: Operation is not valid due to the current state of the object.

The issue is caused by the undefined value of Policy on HttpEndpoint. This PR fixes it by excluding the Inputs thas have no value from the activity.