### PR TITLE
Upgrade MediatR to 12.0.1 fixing issue #3775

### DIFF
--- a/src/core/Elsa.Abstractions/Elsa.Abstractions.csproj
+++ b/src/core/Elsa.Abstractions/Elsa.Abstractions.csproj
@@ -16,7 +16,7 @@
     <ItemGroup>
         <PackageReference Include="DistributedLock.Core" Version="1.0.4" />
         <PackageReference Include="LinqKit.Core" Version="1.1.27" />
-        <PackageReference Include="MediatR" Version="10.0.1" />
+        <PackageReference Include="MediatR" Version="12.0.1" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />

--- a/src/core/Elsa.Core/Elsa.Core.csproj
+++ b/src/core/Elsa.Core/Elsa.Core.csproj
@@ -20,8 +20,7 @@
         <PackageReference Include="DistributedLock.Core" Version="1.0.4" />
         <PackageReference Include="DistributedLock.FileSystem" Version="1.0.1" />
         <PackageReference Include="Humanizer.Core" Version="2.13.14" />
-        <PackageReference Include="MediatR" Version="10.0.1" />
-        <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="10.0.1" />
+        <PackageReference Include="MediatR" Version="12.0.1" />
         <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="7.0.0" />
         <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
         <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />

--- a/src/core/Elsa.Core/Extensions/ElsaServiceCollectionExtensions.cs
+++ b/src/core/Elsa.Core/Extensions/ElsaServiceCollectionExtensions.cs
@@ -36,7 +36,6 @@ using Elsa.Services.WorkflowContexts;
 using Elsa.Services.Workflows;
 using Elsa.Services.WorkflowStorage;
 using Elsa.StartupTasks;
-using MediatR;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Newtonsoft.Json;
@@ -254,8 +253,12 @@ namespace Microsoft.Extensions.DependencyInjection
                 .AddBookmarkProvider<RunWorkflowBookmarkProvider>();
 
             // Mediator.
-            services
-                .AddMediatR(mediatr => mediatr.AsScoped(), typeof(IActivity), typeof(LogWorkflowExecution));
+            services.AddMediatR(cfg =>
+            {
+                cfg.Lifetime = ServiceLifetime.Scoped;
+                cfg.RegisterServicesFromAssemblyContaining<IActivity>();
+                cfg.RegisterServicesFromAssemblyContaining<LogWorkflowExecution>();
+            });
 
             // Service Bus.
             services

--- a/src/core/Elsa.Core/Extensions/MessageHandlerServiceCollectionExtensions.cs
+++ b/src/core/Elsa.Core/Extensions/MessageHandlerServiceCollectionExtensions.cs
@@ -20,8 +20,10 @@ namespace Elsa
         
         public static IServiceCollection AddNotificationHandlers(this IServiceCollection services, params Type[] markerTypes)
         {
-            var assemblies = markerTypes.Select(x => x.GetTypeInfo().Assembly);
-            ServiceRegistrar.AddMediatRClasses(services, assemblies, new MediatRServiceConfiguration());
+            var assemblies = markerTypes.Select(x => x.GetTypeInfo().Assembly).ToArray();
+            var serviceConfiguration = new MediatRServiceConfiguration();
+            serviceConfiguration.RegisterServicesFromAssemblies(assemblies);
+            ServiceRegistrar.AddMediatRClasses(services, serviceConfiguration);
             return services;
         }
     }

--- a/src/indexing/Elsa.Indexing.Abstractions/Extensions/ElsaIndexingOptionsExtensions.cs
+++ b/src/indexing/Elsa.Indexing.Abstractions/Extensions/ElsaIndexingOptionsExtensions.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Reflection;
 using Elsa.Options;
-using MediatR;
 using MediatR.Registration;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Elsa.Indexing.Extensions
 {
@@ -13,7 +13,9 @@ namespace Elsa.Indexing.Extensions
             var indexingOptions = new ElsaIndexingOptions(options.Services);
             configure.Invoke(indexingOptions);
 
-            ServiceRegistrar.AddMediatRClasses(options.Services, new[] { Assembly.GetExecutingAssembly() }, new MediatRServiceConfiguration());
+            var serviceConfiguration = new MediatRServiceConfiguration();
+            serviceConfiguration.RegisterServicesFromAssembly(Assembly.GetExecutingAssembly());
+            ServiceRegistrar.AddMediatRClasses(options.Services, serviceConfiguration);
 
             return options;
         }

--- a/src/samples/aspnet/Elsa.Samples.InProcessBackgroundMediator/Elsa.Samples.InProcessBackgroundMediator.csproj
+++ b/src/samples/aspnet/Elsa.Samples.InProcessBackgroundMediator/Elsa.Samples.InProcessBackgroundMediator.csproj
@@ -5,9 +5,9 @@
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>
-    
+
     <ItemGroup>
-        <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="10.0.1" />
+      <PackageReference Include="MediatR" Version="12.0.1" />
     </ItemGroup>
 
 </Project>

--- a/src/samples/aspnet/Elsa.Samples.InProcessBackgroundMediator/Program.cs
+++ b/src/samples/aspnet/Elsa.Samples.InProcessBackgroundMediator/Program.cs
@@ -8,7 +8,7 @@ var builder = WebApplication.CreateBuilder(args);
 var services = builder.Services;
 
 services
-    .AddMediatR(typeof(DependencyInjectionExtensions))
+    .AddMediatR(cfg => cfg.RegisterServicesFromAssembly(typeof(DependencyInjectionExtensions).Assembly))
     .AddSingleton<IBackgroundEventPublisher, BackgroundEventPublisher>()
     .AddHostedService<BackgroundEventPublisherHostedService>()
     .CreateChannel<INotification>();


### PR DESCRIPTION
MediatR.Extensions.Microsoft.DependencyInjection is also replaced with the main MediatR package since it is deprecated.