### PR TITLE
Add WithNamedWorkflow extension to RunWorkflow activity

### DIFF
--- a/src/core/Elsa.Core/Activities/Workflows/RunWorkflow/Extensions/RunWorkflowExtensions.cs
+++ b/src/core/Elsa.Core/Activities/Workflows/RunWorkflow/Extensions/RunWorkflowExtensions.cs
@@ -24,6 +24,15 @@ namespace Elsa.Activities.Workflows
                     var workflow = (await workflowRegistry.GetWorkflowAsync<T>())!;
                     return workflow.Id;
                 });
+
+        public static ISetupActivity<RunWorkflow> WithNamedWorkflow(this ISetupActivity<RunWorkflow> activity, string name) =>
+            activity.WithWorkflow(
+                async context => 
+                {
+                    var workflowRegistry = context.GetService<IWorkflowRegistry>();
+                    return (await workflowRegistry.FindByNameAsync(name, VersionOptions.Published).ConfigureAwait(continueOnCapturedContext: false))?.Id
+                        ?? throw new ArgumentOutOfRangeException(nameof(name));
+                });
         
         public static ISetupActivity<RunWorkflow> WithInput(this ISetupActivity<RunWorkflow> activity, Func<ActivityExecutionContext, ValueTask<object?>> value) => activity.Set(x => x.Input, value);
         public static ISetupActivity<RunWorkflow> WithInput(this ISetupActivity<RunWorkflow> activity, Func<ActivityExecutionContext, object?> value) => activity.Set(x => x.Input, value);


### PR DESCRIPTION
I'd like to propose an extension to the RunWorkflow activity which allows to run a workflow by its name. Currently it will throw an exception if the name is incorrect but I'm open to suggestions about a better solution.