### PR TITLE
Take latest version if none specified

### DIFF
--- a/src/modules/Elsa.Workflows.Management/Activities/WorkflowDefinitionActivity/WorkflowDefinitionActivity.cs
+++ b/src/modules/Elsa.Workflows.Management/Activities/WorkflowDefinitionActivity/WorkflowDefinitionActivity.cs
@@ -23,7 +23,7 @@ public class WorkflowDefinitionActivity : Composite, IInitializable
     public string WorkflowDefinitionId { get; set; } = default!;
 
     /// <summary>
-    /// the latest published version number set by the provider. This is used by tooling to let the user know that a newer version is available.
+    /// The latest published version number set by the provider. This is used by tooling to let the user know that a newer version is available.
     /// </summary>
     public int LatestAvailablePublishedVersion { get; set; }
 

--- a/src/modules/Elsa.Workflows.Management/Serialization/SerializationOptionsConfigurator.cs
+++ b/src/modules/Elsa.Workflows.Management/Serialization/SerializationOptionsConfigurator.cs
@@ -5,15 +5,22 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Elsa.Workflows.Management.Serialization;
 
+/// <summary>
+/// Configures the JSON serialization options with support for serializing and deserializing activities and expressions.
+/// </summary>
 public class SerializationOptionsConfigurator : ISerializationOptionsConfigurator
 {
     private readonly IServiceProvider _serviceProvider;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SerializationOptionsConfigurator"/> class.
+    /// </summary>
     public SerializationOptionsConfigurator(IServiceProvider serviceProvider)
     {
         _serviceProvider = serviceProvider;
     }
 
+    /// <inheritdoc />
     public void Configure(JsonSerializerOptions options)
     {
         options.Converters.Add(Create<ActivityJsonConverterFactory>());


### PR DESCRIPTION
This PR improves the handling of activity descriptors that were initially missing, and then later restored. Think of importing consuming workflows of composite activities not yet added to the system. Before this change, not specifying a version number would take version 1 of the dependency workflow, even if there is a newer version available.
Now, it will always take the latest version of no explicit version number was provided.