### PR TITLE
Send HTTP error when workflow faults

### DIFF
--- a/src/common/Elsa.Testing.Shared/ServiceProviderExtensions.cs
+++ b/src/common/Elsa.Testing.Shared/ServiceProviderExtensions.cs
@@ -62,13 +62,13 @@ public static class ServiceProviderExtensions
         while (bookmarks.TryPop(out var bookmark))
         {
             var resumeOptions = new ResumeWorkflowRuntimeOptions(BookmarkId: bookmark.Id);
-            var resumeResult = await workflowRuntime.ResumeWorkflowAsync(result.InstanceId, resumeOptions);
+            var resumeResult = await workflowRuntime.ResumeWorkflowAsync(result.WorkflowInstanceId, resumeOptions);
 
             foreach (var newBookmark in resumeResult.Bookmarks)
                 bookmarks.Push(newBookmark);
         }
 
         // Return the workflow state.
-        return (await workflowRuntime.ExportWorkflowStateAsync(result.InstanceId))!;
+        return (await workflowRuntime.ExportWorkflowStateAsync(result.WorkflowInstanceId))!;
     }
 }

--- a/src/modules/Elsa.Http/Contracts/IHttpBookmarkProcessor.cs
+++ b/src/modules/Elsa.Http/Contracts/IHttpBookmarkProcessor.cs
@@ -1,3 +1,4 @@
+using Elsa.Workflows.Core.State;
 using Elsa.Workflows.Runtime.Contracts;
 
 namespace Elsa.Http.Contracts;
@@ -10,7 +11,7 @@ public interface IHttpBookmarkProcessor
     /// <summary>
     /// Processes the specified <see cref="executionResults"/> by resuming each HTTP bookmark while we are in an HTTP context.
     /// </summary>
-    Task ProcessBookmarks(
+    Task<IEnumerable<WorkflowState>> ProcessBookmarks(
         IEnumerable<WorkflowExecutionResult> executionResults,
         string? correlationId,
         IDictionary<string, object>? input,

--- a/src/modules/Elsa.Http/Handlers/DefaultHttpEndpointWorkflowFaultHandler.cs
+++ b/src/modules/Elsa.Http/Handlers/DefaultHttpEndpointWorkflowFaultHandler.cs
@@ -26,22 +26,16 @@ public class DefaultHttpEndpointWorkflowFaultHandler : IHttpEndpointWorkflowFaul
     public virtual async ValueTask HandleAsync(HttpEndpointFaultedWorkflowContext context)
     {
         var httpContext = context.HttpContext;
-        var workflowInstance = context.WorkflowInstance;
-        var fault = workflowInstance.WorkflowState.Fault!;
+        var workflowState = context.WorkflowState;
+        var fault = workflowState.Fault!;
 
         httpContext.Response.ContentType = MediaTypeNames.Application.Json;
         httpContext.Response.StatusCode = StatusCodes.Status500InternalServerError;
 
         var faultedResponse = _apiSerializer.Serialize(new
         {
-            errorMessage = $"Workflow faulted at {workflowInstance.FaultedAt!} with error: {fault.Message}",
-            exception = fault?.Exception,
-            workflow = new
-            {
-                name = workflowInstance.Name,
-                version = workflowInstance.Version,
-                instanceId = workflowInstance.Id
-            }
+            errorMessage = $"Workflow faulted with error: {fault.Message}",
+            workflow = workflowState
         });
 
         await httpContext.Response.WriteAsync(faultedResponse, context.CancellationToken);

--- a/src/modules/Elsa.Http/Handlers/DefaultHttpEndpointWorkflowFaultHandler.cs
+++ b/src/modules/Elsa.Http/Handlers/DefaultHttpEndpointWorkflowFaultHandler.cs
@@ -35,7 +35,7 @@ public class DefaultHttpEndpointWorkflowFaultHandler : IHttpEndpointWorkflowFaul
         var faultedResponse = _apiSerializer.Serialize(new
         {
             errorMessage = $"Workflow faulted with error: {fault.Message}",
-            workflow = workflowState
+            workflowState = workflowState
         });
 
         await httpContext.Response.WriteAsync(faultedResponse, context.CancellationToken);

--- a/src/modules/Elsa.Http/Models/HttpEndpointFaultedWorkflowContext.cs
+++ b/src/modules/Elsa.Http/Models/HttpEndpointFaultedWorkflowContext.cs
@@ -1,6 +1,12 @@
-using Elsa.Workflows.Management.Entities;
+using Elsa.Workflows.Core.State;
 using Microsoft.AspNetCore.Http;
 
 namespace Elsa.Http.Models;
 
-public record HttpEndpointFaultedWorkflowContext(HttpContext HttpContext, WorkflowInstance WorkflowInstance, Exception? Exception, CancellationToken CancellationToken);
+/// <summary>
+/// Provides context about the faulted workflow.
+/// </summary>
+/// <param name="HttpContext">The HTTP context.</param>
+/// <param name="WorkflowState">The faulted workflow state.</param>
+/// <param name="CancellationToken">The cancellation token.</param>
+public record HttpEndpointFaultedWorkflowContext(HttpContext HttpContext, WorkflowState WorkflowState, CancellationToken CancellationToken);

--- a/src/modules/Elsa.Http/Services/HttpBookmarkProcessor.cs
+++ b/src/modules/Elsa.Http/Services/HttpBookmarkProcessor.cs
@@ -51,7 +51,7 @@ public class HttpBookmarkProcessor : IHttpBookmarkProcessor
             from executionResult in executionResults
             from bookmark in executionResult.Bookmarks
             where bookmark.Name == writeHttpResponseTypeName || bookmark.Name == httpEndpointTypeName
-            select (executionResult.InstanceId, bookmark.Id);
+            select (InstanceId: executionResult.WorkflowInstanceId, bookmark.Id);
 
         var workflowExecutionResults = new Stack<(string InstanceId, string BookmarkId)>(query);
 

--- a/src/modules/Elsa.ProtoActor/Extensions/ProtoStringExtensions.cs
+++ b/src/modules/Elsa.ProtoActor/Extensions/ProtoStringExtensions.cs
@@ -3,5 +3,5 @@ namespace Elsa.ProtoActor.Extensions;
 internal static class ProtoStringExtensions
 {
     public static string EmptyIfNull(this string? value) => value ?? "";
-    public static string? NullIfEmpty(this string value) => value == "" ? default : value;
+    public static string? NullIfEmpty(this string? value) => value == "" ? default : value;
 }

--- a/src/modules/Elsa.ProtoActor/Mappers/BookmarkMapper.cs
+++ b/src/modules/Elsa.ProtoActor/Mappers/BookmarkMapper.cs
@@ -1,0 +1,46 @@
+using Elsa.ProtoActor.Extensions;
+using Elsa.Workflows.Core.Contracts;
+using Elsa.Workflows.Core.Models;
+using ProtoBookmark = Elsa.ProtoActor.Protos.Bookmark;
+
+namespace Elsa.ProtoActor.Mappers;
+
+public class BookmarkMapper
+{
+    private readonly IBookmarkPayloadSerializer _bookmarkPayloadSerializer;
+
+    public BookmarkMapper(IBookmarkPayloadSerializer bookmarkPayloadSerializer)
+    {
+        _bookmarkPayloadSerializer = bookmarkPayloadSerializer;
+    }
+    
+    public Bookmark Map(ProtoBookmark bookmark) =>
+        new(bookmark.Id, bookmark.Name, bookmark.Hash, bookmark.Payload, bookmark.ActivityNodeId, bookmark.ActivityInstanceId, bookmark.AutoBurn, bookmark.CallbackMethodName);
+
+    
+    public IEnumerable<ProtoBookmark> Map(IEnumerable<Bookmark> source) =>   
+        source.Select(x =>
+            new ProtoBookmark
+            {
+                Id = x.Id,
+                Name = x.Name,
+                Hash = x.Hash,
+                Payload = x.Payload != null ? _bookmarkPayloadSerializer.Serialize(x.Payload) : default,
+                ActivityNodeId = x.ActivityNodeId,
+                ActivityInstanceId = x.ActivityInstanceId,
+                AutoBurn = x.AutoBurn,
+                CallbackMethodName = x.CallbackMethodName.NullIfEmpty()
+            });
+    
+    public IEnumerable<Bookmark> Map(IEnumerable<ProtoBookmark> source) =>
+        source.Select(x =>
+            new Bookmark(
+                x.Id,
+                x.Name,
+                x.Hash,
+                x.Payload.NullIfEmpty(),
+                x.ActivityNodeId,
+                x.ActivityInstanceId,
+                x.AutoBurn,
+                x.CallbackMethodName.NullIfEmpty()));
+}

--- a/src/modules/Elsa.ProtoActor/Mappers/BookmarkMapper.cs
+++ b/src/modules/Elsa.ProtoActor/Mappers/BookmarkMapper.cs
@@ -5,10 +5,16 @@ using ProtoBookmark = Elsa.ProtoActor.Protos.Bookmark;
 
 namespace Elsa.ProtoActor.Mappers;
 
+/// <summary>
+/// Maps between <see cref="Bookmark"/> and <see cref="ProtoBookmark"/>.
+/// </summary>
 public class BookmarkMapper
 {
     private readonly IBookmarkPayloadSerializer _bookmarkPayloadSerializer;
 
+    /// <summary>
+    /// Initializes a new instance of <see cref="BookmarkMapper"/>.
+    /// </summary>
     public BookmarkMapper(IBookmarkPayloadSerializer bookmarkPayloadSerializer)
     {
         _bookmarkPayloadSerializer = bookmarkPayloadSerializer;
@@ -25,7 +31,7 @@ public class BookmarkMapper
                 Id = x.Id,
                 Name = x.Name,
                 Hash = x.Hash,
-                Payload = x.Payload != null ? _bookmarkPayloadSerializer.Serialize(x.Payload) : default,
+                Payload = x.Payload != null ? _bookmarkPayloadSerializer.Serialize(x.Payload) : string.Empty,
                 ActivityNodeId = x.ActivityNodeId,
                 ActivityInstanceId = x.ActivityInstanceId,
                 AutoBurn = x.AutoBurn,

--- a/src/modules/Elsa.ProtoActor/Mappers/ExceptionMapper.cs
+++ b/src/modules/Elsa.ProtoActor/Mappers/ExceptionMapper.cs
@@ -1,0 +1,19 @@
+using Elsa.Workflows.Core.State;
+using ProtoException = Elsa.ProtoActor.Protos.ExceptionState;
+
+namespace Elsa.ProtoActor.Mappers;
+
+public class ExceptionMapper
+{
+    public ExceptionState Map(ProtoException exception) =>
+        new(Type.GetType(exception.Type)!, exception.Message, exception.StackTrace, exception.InnerException != null ? Map(exception.InnerException) : null);
+    
+    public ProtoException Map(ExceptionState exception) =>
+        new()
+        {
+            Type = exception.Type.AssemblyQualifiedName,
+            Message = exception.Message,
+            StackTrace = exception.StackTrace,
+            InnerException = exception.InnerException != null ? Map(exception.InnerException) : null
+        };
+}

--- a/src/modules/Elsa.ProtoActor/Mappers/WorkflowExecutionResultMapper.cs
+++ b/src/modules/Elsa.ProtoActor/Mappers/WorkflowExecutionResultMapper.cs
@@ -1,3 +1,4 @@
+using Elsa.ProtoActor.Extensions;
 using Elsa.Workflows.Runtime.Contracts;
 using ProtoWorkflowExecutionResponse = Elsa.ProtoActor.Protos.WorkflowExecutionResponse;
 
@@ -38,8 +39,8 @@ public class WorkflowExecutionResultMapper
          _workflowStatusMapper.Map(source.Status),
         _workflowSubStatusMapper.Map(source.SubStatus),
         _bookmarkMapper.Map(source.Bookmarks).ToList(),
-        source.TriggeredActivityId,
-        _workflowFaultStateMapper.Map(source.Fault));
+        source.TriggeredActivityId.NullIfEmpty(),
+        source.Fault != null ? _workflowFaultStateMapper.Map(source.Fault) : default);
     
     /// <summary>
     /// Maps a <see cref="WorkflowExecutionResult"/> to a <see cref="ProtoWorkflowExecutionResponse"/>.

--- a/src/modules/Elsa.ProtoActor/Mappers/WorkflowExecutionResultMapper.cs
+++ b/src/modules/Elsa.ProtoActor/Mappers/WorkflowExecutionResultMapper.cs
@@ -1,0 +1,58 @@
+using Elsa.Workflows.Runtime.Contracts;
+using ProtoWorkflowExecutionResponse = Elsa.ProtoActor.Protos.WorkflowExecutionResponse;
+
+namespace Elsa.ProtoActor.Mappers;
+
+/// <summary>
+/// Maps between <see cref="WorkflowExecutionResult"/> and <see cref="ProtoWorkflowExecutionResponse"/>.
+/// </summary>
+public class WorkflowExecutionResultMapper
+{
+    private readonly WorkflowStatusMapper _workflowStatusMapper;
+    private readonly WorkflowSubStatusMapper _workflowSubStatusMapper;
+    private readonly BookmarkMapper _bookmarkMapper;
+    private readonly WorkflowFaultStateMapper _workflowFaultStateMapper;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WorkflowExecutionResultMapper"/> class.
+    /// </summary>
+    public WorkflowExecutionResultMapper(
+        WorkflowStatusMapper workflowStatusMapper, 
+        WorkflowSubStatusMapper workflowSubStatusMapper,
+        BookmarkMapper bookmarkMapper, 
+        WorkflowFaultStateMapper workflowFaultStateMapper)
+    {
+        _workflowStatusMapper = workflowStatusMapper;
+        _workflowSubStatusMapper = workflowSubStatusMapper;
+        _bookmarkMapper = bookmarkMapper;
+        _workflowFaultStateMapper = workflowFaultStateMapper;
+    }
+    
+    /// <summary>
+    /// Maps a <see cref="ProtoWorkflowExecutionResponse"/> to a <see cref="WorkflowExecutionResult"/>.
+    /// </summary>
+    /// <param name="source">The source.</param>
+    /// <returns>The mapped <see cref="WorkflowExecutionResult"/>.</returns>
+    public WorkflowExecutionResult Map(ProtoWorkflowExecutionResponse source) => new(
+        source.WorkflowInstanceId,
+         _workflowStatusMapper.Map(source.Status),
+        _workflowSubStatusMapper.Map(source.SubStatus),
+        _bookmarkMapper.Map(source.Bookmarks).ToList(),
+        source.TriggeredActivityId,
+        _workflowFaultStateMapper.Map(source.Fault));
+    
+    /// <summary>
+    /// Maps a <see cref="WorkflowExecutionResult"/> to a <see cref="ProtoWorkflowExecutionResponse"/>.
+    /// </summary>
+    /// <param name="source">The source.</param>
+    /// <returns>The mapped <see cref="ProtoWorkflowExecutionResponse"/>.</returns>
+    public ProtoWorkflowExecutionResponse Map(WorkflowExecutionResult source) => new()
+    {
+        WorkflowInstanceId = source.WorkflowInstanceId,
+        Status = _workflowStatusMapper.Map(source.Status),
+        SubStatus = _workflowSubStatusMapper.Map(source.SubStatus),
+        Bookmarks = {_bookmarkMapper.Map(source.Bookmarks)},
+        TriggeredActivityId = source.TriggeredActivityId,
+        Fault = source.Fault != null ? _workflowFaultStateMapper.Map(source.Fault) : default
+    };
+}

--- a/src/modules/Elsa.ProtoActor/Mappers/WorkflowFaultStateMapper.cs
+++ b/src/modules/Elsa.ProtoActor/Mappers/WorkflowFaultStateMapper.cs
@@ -1,0 +1,41 @@
+using Elsa.Workflows.Core.State;
+using ProtoWorkflowFault = Elsa.ProtoActor.Protos.WorkflowFault;
+
+namespace Elsa.ProtoActor.Mappers;
+
+/// <summary>
+/// Maps between <see cref="WorkflowFaultState"/> and <see cref="ProtoWorkflowFault"/>.
+/// </summary>
+public class WorkflowFaultStateMapper
+{
+    private readonly ExceptionMapper _exceptionMapper;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WorkflowFaultStateMapper"/> class.
+    /// </summary>
+    public WorkflowFaultStateMapper(ExceptionMapper exceptionMapper)
+    {
+        _exceptionMapper = exceptionMapper;
+    }
+
+    /// <summary>
+    /// Maps a <see cref="ProtoWorkflowFault"/> to a <see cref="WorkflowFaultState"/>.
+    /// </summary>
+    /// <param name="source">The source.</param>
+    /// <returns>The mapped <see cref="WorkflowFaultState"/>.</returns>
+    public WorkflowFaultState Map(ProtoWorkflowFault source) =>
+        new(_exceptionMapper.Map(source.Exception), source.Message, source.FaultedActivityId);
+
+    /// <summary>
+    /// Maps a <see cref="WorkflowFaultState"/> to a <see cref="ProtoWorkflowFault"/>.
+    /// </summary>
+    /// <param name="source">The source.</param>
+    /// <returns>The mapped <see cref="ProtoWorkflowFault"/>.</returns>
+    public ProtoWorkflowFault Map(WorkflowFaultState source) =>
+        new()
+        {
+            Exception = source.Exception != null ? _exceptionMapper.Map(source.Exception) : default,
+            Message = source.Message,
+            FaultedActivityId = source.FaultedActivityId
+        };
+}

--- a/src/modules/Elsa.ProtoActor/Mappers/WorkflowStatusMapper.cs
+++ b/src/modules/Elsa.ProtoActor/Mappers/WorkflowStatusMapper.cs
@@ -1,0 +1,23 @@
+using Elsa.Workflows.Core.Models;
+using ProtoWorkflowStatus = Elsa.ProtoActor.Protos.WorkflowStatus;
+
+namespace Elsa.ProtoActor.Mappers;
+
+public class WorkflowStatusMapper
+{
+    public WorkflowStatus Map(ProtoWorkflowStatus status) =>
+        status switch
+        {
+            ProtoWorkflowStatus.Finished => WorkflowStatus.Finished,
+            ProtoWorkflowStatus.Running => WorkflowStatus.Running,
+            _ => throw new ArgumentOutOfRangeException(nameof(status), status, null)
+        };
+    
+    public ProtoWorkflowStatus Map(WorkflowStatus status) =>
+        status switch
+        {
+            WorkflowStatus.Finished => ProtoWorkflowStatus.Finished,
+            WorkflowStatus.Running => ProtoWorkflowStatus.Running,
+            _ => throw new ArgumentOutOfRangeException(nameof(status), status, null)
+        };
+}

--- a/src/modules/Elsa.ProtoActor/Mappers/WorkflowSubStatusMapper.cs
+++ b/src/modules/Elsa.ProtoActor/Mappers/WorkflowSubStatusMapper.cs
@@ -1,0 +1,29 @@
+using Elsa.Workflows.Core.Models;
+using ProtoWorkflowSubStatus = Elsa.ProtoActor.Protos.WorkflowSubStatus;
+
+namespace Elsa.ProtoActor.Mappers;
+
+public class WorkflowSubStatusMapper
+{
+    public WorkflowSubStatus Map(ProtoWorkflowSubStatus subStatus) =>
+        subStatus switch
+        {
+            ProtoWorkflowSubStatus.Faulted => WorkflowSubStatus.Faulted,
+            ProtoWorkflowSubStatus.Finished => WorkflowSubStatus.Finished,
+            ProtoWorkflowSubStatus.Cancelled => WorkflowSubStatus.Cancelled,
+            ProtoWorkflowSubStatus.Executing => WorkflowSubStatus.Executing,
+            ProtoWorkflowSubStatus.Suspended => WorkflowSubStatus.Suspended,
+            _ => throw new ArgumentOutOfRangeException(nameof(subStatus), subStatus, null)
+        };
+    
+    public ProtoWorkflowSubStatus Map(WorkflowSubStatus subStatus) =>
+        subStatus switch
+        {
+            WorkflowSubStatus.Faulted => ProtoWorkflowSubStatus.Faulted,
+            WorkflowSubStatus.Finished => ProtoWorkflowSubStatus.Finished,
+            WorkflowSubStatus.Cancelled => ProtoWorkflowSubStatus.Cancelled,
+            WorkflowSubStatus.Executing => ProtoWorkflowSubStatus.Executing,
+            WorkflowSubStatus.Suspended => ProtoWorkflowSubStatus.Suspended,
+            _ => throw new ArgumentOutOfRangeException(nameof(subStatus), subStatus, null)
+        };
+}

--- a/src/modules/Elsa.ProtoActor/Protos/Grains.proto
+++ b/src/modules/Elsa.ProtoActor/Protos/Grains.proto
@@ -7,8 +7,8 @@ import "Messages.proto";
 
 service WorkflowGrain {
   rpc CanStart (StartWorkflowRequest) returns (CanStartWorkflowResponse);
-  rpc Start (StartWorkflowRequest) returns (StartWorkflowResponse);
-  rpc Resume (ResumeWorkflowRequest) returns (ResumeWorkflowResponse);
+  rpc Start (StartWorkflowRequest) returns (WorkflowExecutionResponse);
+  rpc Resume (ResumeWorkflowRequest) returns (WorkflowExecutionResponse);
   rpc ExportState(ExportWorkflowStateRequest) returns (ExportWorkflowStateResponse);
   rpc ImportState(ImportWorkflowStateRequest) returns (ImportWorkflowStateResponse);
 }

--- a/src/modules/Elsa.ProtoActor/Protos/Messages.proto
+++ b/src/modules/Elsa.ProtoActor/Protos/Messages.proto
@@ -27,9 +27,40 @@ message StartWorkflowRequest {
   optional string TriggerActivityId = 6;
 }
 
-message StartWorkflowResponse {
-  RunWorkflowResult Result = 1;
-  repeated BookmarkDto Bookmarks = 2;
+message WorkflowExecutionResponse {
+  string WorkflowInstanceId = 1;
+  RunWorkflowResult Result = 2;
+  WorkflowStatus Status = 3;
+  WorkflowSubStatus SubStatus = 4;
+  repeated Bookmark Bookmarks = 5;
+  optional WorkflowFault Fault = 6;
+  optional string TriggeredActivityId = 7;
+}
+
+message WorkflowFault {
+  optional ExceptionState Exception = 1;
+  string Message = 2;
+  optional string FaultedActivityId = 3;
+}
+
+message ExceptionState {
+  string Type = 1;
+  string Message = 2;
+  optional string StackTrace = 3;
+  optional ExceptionState InnerException = 4;
+}
+
+enum WorkflowStatus {
+  WorkflowStatusRunning = 0;
+  WorkflowStatusFinished = 1;
+}
+
+enum WorkflowSubStatus {
+  WorkflowSubStatusExecuting = 0;
+  WorkflowSubStatusSuspended = 1;
+  WorkflowSubStatusFinished = 2;
+  WorkflowSubStatusCancelled = 3;
+  WorkflowSubStatusFaulted = 4;
 }
 
 message ResumeWorkflowRequest {
@@ -41,11 +72,6 @@ message ResumeWorkflowRequest {
   optional string ActivityInstanceId = 6;
   optional string ActivityHash = 7;
   optional Input input = 8;
-}
-
-message ResumeWorkflowResponse {
-  RunWorkflowResult Result = 1;
-  repeated BookmarkDto Bookmarks = 2;
 }
 
 message ExportWorkflowStateRequest {}
@@ -65,11 +91,11 @@ enum RunWorkflowResult {
   RunWorkflowResultSuspended = 1;
 }
 
-message BookmarkDto {
+message Bookmark {
   string Id = 1;
   string Name = 2;
   string Hash = 3;
-  optional string Data = 4;
+  optional string Payload = 4;
   string ActivityNodeId = 5;
   string ActivityInstanceId = 6;
   optional bool AutoBurn = 7;

--- a/src/modules/Elsa.Workflows.Runtime/Contracts/IWorkflowRuntime.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Contracts/IWorkflowRuntime.cs
@@ -1,4 +1,5 @@
 using Elsa.Common.Models;
+using Elsa.Workflows.Core.Activities;
 using Elsa.Workflows.Core.Helpers;
 using Elsa.Workflows.Core.Models;
 using Elsa.Workflows.Core.State;
@@ -46,7 +47,7 @@ public interface IWorkflowRuntime
     /// <param name="workflowInstanceId">The ID of the workflow instance to resume.</param>
     /// <param name="options"></param>
     /// <param name="cancellationToken"></param>
-    Task<ResumeWorkflowResult> ResumeWorkflowAsync(string workflowInstanceId, ResumeWorkflowRuntimeOptions options, CancellationToken cancellationToken = default);
+    Task<WorkflowExecutionResult> ResumeWorkflowAsync(string workflowInstanceId, ResumeWorkflowRuntimeOptions options, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Resumes all workflows that are bookmarked on the specified activity type. 
@@ -117,13 +118,11 @@ public record ResumeWorkflowRuntimeOptions(
 
 public record CanStartWorkflowResult(string? InstanceId, bool CanStart);
 
-public record ResumeWorkflowResult(ICollection<Bookmark> Bookmarks);
-
 public record TriggerWorkflowsRuntimeOptions(string? CorrelationId = default, string? WorkflowInstanceId = default, IDictionary<string, object>? Input = default);
 
 public record TriggerWorkflowsResult(ICollection<WorkflowExecutionResult> TriggeredWorkflows);
 
-public record WorkflowExecutionResult(string InstanceId, ICollection<Bookmark> Bookmarks, string? ActivityId = null);
+public record WorkflowExecutionResult(string WorkflowInstanceId, WorkflowStatus Status, WorkflowSubStatus SubStatus, ICollection<Bookmark> Bookmarks, string? TriggeredActivityId = null, WorkflowFaultState? Fault = default);
 
 public record UpdateBookmarksContext(string InstanceId, Diff<Bookmark> Diff, string? CorrelationId);
 


### PR DESCRIPTION
This PR updates the way HTTP responses are sent in case of a faulting workflow.
Before this change, HTTP responses would respond with HTTP OK. After this change, HTTP responses will now include error details and a 500 status code.

Fixes #3936