### PR TITLE
Refactor SendEmail inputs to support list of strings and single string

### DIFF
--- a/src/modules/Elsa.Email/Activities/SendEmail.cs
+++ b/src/modules/Elsa.Email/Activities/SendEmail.cs
@@ -43,7 +43,7 @@ public class SendEmail : Activity
     /// The recipients email addresses.
     /// </summary>
     [Input(Description = "The recipients email addresses.", UIHint = InputUIHints.MultiText)]
-    public Input<object> To { get; set; } = default!;
+    public Input<ICollection<string>> To { get; set; } = default!;
 
     /// <summary>
     /// The CC recipient email addresses.
@@ -52,7 +52,7 @@ public class SendEmail : Activity
         Description = "The CC recipient email addresses.",
         UIHint = InputUIHints.MultiText,
         Category = "More")]
-    public Input<object> Cc { get; set; } = default!;
+    public Input<ICollection<string>> Cc { get; set; } = default!;
 
     /// <summary>
     /// The BCC recipients email addresses.
@@ -61,7 +61,7 @@ public class SendEmail : Activity
         Description = "The BCC recipients email addresses.",
         UIHint = InputUIHints.MultiText,
         Category = "More")]
-    public Input<object> Bcc { get; set; } = default!;
+    public Input<ICollection<string>> Bcc { get; set; } = default!;
 
     /// <summary>
     /// The subject of the email message.
@@ -103,7 +103,7 @@ public class SendEmail : Activity
 
         message.Sender = MailboxAddress.Parse(from);
         message.From.Add(MailboxAddress.Parse(from));
-        message.Subject = Subject.GetOrDefault(context);
+        message.Subject = Subject.GetOrDefault(context) ?? "";
 
         var bodyBuilder = new BodyBuilder { HtmlBody = Body.GetOrDefault(context) };
         await AddAttachmentsAsync(context, bodyBuilder, cancellationToken);
@@ -129,19 +129,9 @@ public class SendEmail : Activity
 
     private async ValueTask OnErrorCompletedAsync(ActivityExecutionContext context, ActivityExecutionContext childContext) => await context.CompleteActivityAsync();
 
-    private static ICollection<string> GetAddresses(ActivityExecutionContext context, Input<object> input)
+    private static ICollection<string> GetAddresses(ActivityExecutionContext context, Input<ICollection<string>> input)
     {
-        var addresses = input.GetOrDefault(context);
-
-        if (addresses == null)
-            return new List<string>(0);
-
-        return addresses switch
-        {
-            string s => new[] { s },
-            IEnumerable<string> e => e.ToList(),
-            _ => new[] { addresses.ToString()! }
-        };
+        return input.GetOrDefault(context) ?? new List<string>(0);
     }
 
     private async Task AddAttachmentsAsync(ActivityExecutionContext context, BodyBuilder bodyBuilder, CancellationToken cancellationToken)

--- a/src/modules/Elsa.Expressions/Helpers/ObjectConverter.cs
+++ b/src/modules/Elsa.Expressions/Helpers/ObjectConverter.cs
@@ -145,6 +145,10 @@ public static class ObjectConverter
 
             if (underlyingTargetType == typeof(Type))
                 return converterOptions?.WellKnownTypeRegistry != null ? converterOptions.WellKnownTypeRegistry.GetTypeOrDefault(s) : Type.GetType(s);
+
+            // Perhaps it's a bit of a leap, but if the input is a string and the target type is IEnumerable<string>, then let's assume the string is a comma-separated list of strings.
+            if (typeof(IEnumerable<string>).IsAssignableFrom(underlyingTargetType))
+                return new[] { s };
         }
 
         if (value is IEnumerable enumerable)


### PR DESCRIPTION
This PR refactors the input types for the `To`, `Cc` and `Bcc` fields.

Before this change, these inputs accepted `object` types and had the activity figure out if the value was a list of strings or a single string. This logic missed arrays of objects, which is the materialized type when the designer creates the inputs.

Instead of changing that logic, I chose to instead revert the input type to be a collection of strings, which is easier to reason about also from the point of view of programmatic workflows.

From the designer's point of view, we can still provide a singular string value instead of an array, which is more user friendly. 

To make that work, I updated the ObjectConverter to make a small leap by assuming that if the source value is a string and the target type to convert into is a list of strings, the intent is to wrap the singular string into a list, rather than returning the individual characters of the string as a list.