### PR TITLE
Fix HTTP triggers not being updated

### DIFF
--- a/src/bundles/Elsa.WorkflowServer.Web/Program.cs
+++ b/src/bundles/Elsa.WorkflowServer.Web/Program.cs
@@ -3,6 +3,7 @@ using Elsa.Extensions;
 using Elsa.EntityFrameworkCore.Modules.Labels;
 using Elsa.EntityFrameworkCore.Modules.Management;
 using Elsa.EntityFrameworkCore.Modules.Runtime;
+using Elsa.Http.Handlers;
 using Elsa.JavaScript.Options;
 using Elsa.WorkflowServer.Web;
 
@@ -46,7 +47,7 @@ services
         .UseWorkflowsApi(api => api.AddFastEndpointsAssembly<Program>())
         .UseJavaScript()
         .UseLiquid()
-        .UseHttp()
+        .UseHttp(http => http.HttpEndpointAuthorizationHandler = sp => sp.GetRequiredService<AllowAnonymousHttpEndpointAuthorizationHandler>())
         .UseEmail(email => email.ConfigureOptions = options => configuration.GetSection("Smtp").Bind(options))
     );
 

--- a/src/modules/Elsa.Http/Contracts/IHttpEndpointAuthorizationHandler.cs
+++ b/src/modules/Elsa.Http/Contracts/IHttpEndpointAuthorizationHandler.cs
@@ -2,7 +2,15 @@ using Elsa.Http.Models;
 
 namespace Elsa.Http.Contracts;
 
+/// <summary>
+/// A handler that is invoked when authorizing an inbound HTTP request.
+/// </summary>
 public interface IHttpEndpointAuthorizationHandler
 {
+    /// <summary>
+    /// Authorizes an inbound HTTP request.
+    /// </summary>
+    /// <param name="context">The context.</param>
+    /// <returns>True if the request is authorized, otherwise false.</returns>
     ValueTask<bool> AuthorizeAsync(AuthorizeHttpEndpointContext context);
 }

--- a/src/modules/Elsa.Http/Features/HttpFeature.cs
+++ b/src/modules/Elsa.Http/Features/HttpFeature.cs
@@ -43,12 +43,12 @@ public class HttpFeature : FeatureBase
     /// <summary>
     /// A delegate that is invoked when authorizing an inbound HTTP request.
     /// </summary>
-    public Func<IServiceProvider, IHttpEndpointAuthorizationHandler> HttpEndpointAuthorizationHandler { get; set; } = ActivatorUtilities.GetServiceOrCreateInstance<AllowAnonymousHttpEndpointAuthorizationHandler>;
+    public Func<IServiceProvider, IHttpEndpointAuthorizationHandler> HttpEndpointAuthorizationHandler { get; set; } = sp => sp.GetRequiredService<AllowAnonymousHttpEndpointAuthorizationHandler>();
 
     /// <summary>
     /// A delegate that is invoked when an HTTP workflow faults. 
     /// </summary>
-    public Func<IServiceProvider, IHttpEndpointWorkflowFaultHandler> HttpEndpointWorkflowFaultHandler { get; set; } = ActivatorUtilities.GetServiceOrCreateInstance<DefaultHttpEndpointWorkflowFaultHandler>;
+    public Func<IServiceProvider, IHttpEndpointWorkflowFaultHandler> HttpEndpointWorkflowFaultHandler { get; set; } = sp => sp.GetRequiredService<DefaultHttpEndpointWorkflowFaultHandler>();
 
     /// <summary>
     /// A delegate to configure the <see cref="HttpClient"/> used when by the <see cref="FlowSendHttpRequest"/> activity.
@@ -123,7 +123,10 @@ public class HttpFeature : FeatureBase
             // Port resolvers.
             .AddSingleton<IActivityPortResolver, SendHttpRequestActivityPortResolver>()
 
-            // Add Http endpoint handlers.
+            // Add HTTP endpoint handlers.
+            .AddSingleton<AuthenticationBasedHttpEndpointAuthorizationHandler>()
+            .AddSingleton<AllowAnonymousHttpEndpointAuthorizationHandler>()
+            .AddSingleton<DefaultHttpEndpointWorkflowFaultHandler>()
             .AddSingleton(HttpEndpointWorkflowFaultHandler)
             .AddSingleton(HttpEndpointAuthorizationHandler)
             

--- a/src/modules/Elsa.Http/Handlers/AllowAnonymousHttpEndpointAuthorizationHandler.cs
+++ b/src/modules/Elsa.Http/Handlers/AllowAnonymousHttpEndpointAuthorizationHandler.cs
@@ -3,7 +3,11 @@ using Elsa.Http.Models;
 
 namespace Elsa.Http.Handlers;
 
+/// <summary>
+/// A default <see cref="IHttpEndpointAuthorizationHandler"/> that allows all requests.
+/// </summary>
 public class AllowAnonymousHttpEndpointAuthorizationHandler : IHttpEndpointAuthorizationHandler
 {
+    /// <inheritdoc />
     public ValueTask<bool> AuthorizeAsync(AuthorizeHttpEndpointContext context) => new(true);
 }

--- a/src/modules/Elsa.Http/Handlers/AuthenticationBasedHttpEndpointAuthorizationHandler.cs
+++ b/src/modules/Elsa.Http/Handlers/AuthenticationBasedHttpEndpointAuthorizationHandler.cs
@@ -1,14 +1,24 @@
 using Elsa.Http.Contracts;
 using Elsa.Http.Models;
+using JetBrains.Annotations;
 using Microsoft.AspNetCore.Authorization;
 
 namespace Elsa.Http.Handlers;
 
+/// <summary>
+/// An <see cref="IHttpEndpointAuthorizationHandler"/> that uses the <see cref="IAuthorizationService"/> to authorize an inbound HTTP request.
+/// </summary>
+[PublicAPI]
 public class AuthenticationBasedHttpEndpointAuthorizationHandler : IHttpEndpointAuthorizationHandler
 {
     private readonly IAuthorizationService _authorizationService;
+    
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AuthenticationBasedHttpEndpointAuthorizationHandler"/> class.
+    /// </summary>
     public AuthenticationBasedHttpEndpointAuthorizationHandler(IAuthorizationService authorizationService) => _authorizationService = authorizationService;
 
+    /// <inheritdoc />
     public async ValueTask<bool> AuthorizeAsync(AuthorizeHttpEndpointContext context)
     {
         var httpContext = context.HttpContext;

--- a/src/modules/Elsa.Workflows.Core/Serialization/Converters/TypeJsonConverter.cs
+++ b/src/modules/Elsa.Workflows.Core/Serialization/Converters/TypeJsonConverter.cs
@@ -1,13 +1,18 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Elsa.Expressions.Contracts;
+using Elsa.Expressions.Options;
+using Elsa.Expressions.Services;
 using Elsa.Extensions;
+using JetBrains.Annotations;
+using Microsoft.Extensions.Options;
 
 namespace Elsa.Workflows.Core.Serialization.Converters;
 
 /// <summary>
 /// Serializes <see cref="Type"/> objects to a simple alias representing the type.
 /// </summary>
+[PublicAPI]
 public class TypeJsonConverter : JsonConverter<Type>
 {
     private readonly IWellKnownTypeRegistry _wellKnownTypeRegistry;
@@ -44,7 +49,7 @@ public class TypeJsonConverter : JsonConverter<Type>
     public override void Write(Utf8JsonWriter writer, Type value, JsonSerializerOptions options)
     {
         // Handle collection types.
-        if (value.IsGenericType && value.GenericTypeArguments.Length == 1)
+        if (value is { IsGenericType: true, GenericTypeArguments.Length: 1 })
         {
             var elementType = value.GenericTypeArguments.First();
             var typedEnumerable = typeof(IEnumerable<>).MakeGenericType(elementType);

--- a/src/modules/Elsa.Workflows.Core/Services/BookmarkHasher.cs
+++ b/src/modules/Elsa.Workflows.Core/Services/BookmarkHasher.cs
@@ -39,5 +39,5 @@ public class BookmarkHasher : IBookmarkHasher
         return hash;
     }
 
-    private string? Serialize(object payload) => JsonSerializer.Serialize(payload, payload.GetType(), _settings);
+    private string Serialize(object payload) => JsonSerializer.Serialize(payload, payload.GetType(), _settings);
 }

--- a/src/modules/Elsa.Workflows.Runtime/Comparers/WorkflowTriggerEqualityComparer.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Comparers/WorkflowTriggerEqualityComparer.cs
@@ -1,0 +1,56 @@
+using System.Text.Json;
+using Elsa.Expressions.Services;
+using Elsa.Workflows.Core.Serialization.Converters;
+using Elsa.Workflows.Runtime.Entities;
+
+namespace Elsa.Workflows.Runtime.Comparers;
+
+/// <summary>
+/// Compares two <see cref="StoredTrigger"/> instances for equality.
+/// </summary>
+public class WorkflowTriggerEqualityComparer : IEqualityComparer<StoredTrigger>
+{
+    private readonly JsonSerializerOptions _settings;
+    
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WorkflowTriggerEqualityComparer"/> class.
+    /// </summary>
+    public WorkflowTriggerEqualityComparer()
+    {
+        _settings = new JsonSerializerOptions
+        {
+            // Enables serialization of ValueTuples, which use fields instead of properties.
+            IncludeFields = true,
+            PropertyNameCaseInsensitive = true
+        };
+        
+        _settings.Converters.Add(new TypeJsonConverter(WellKnownTypeRegistry.CreateDefault()));
+    }
+
+    /// <inheritdoc />
+    public bool Equals(StoredTrigger? x, StoredTrigger? y)
+    {
+        var xJson = x != null ? Serialize(x) : null;
+        var yJson = y != null ? Serialize(y) : null;
+        return xJson == yJson;
+    }
+
+    /// <inheritdoc />
+    public int GetHashCode(StoredTrigger obj)
+    {
+        var json = Serialize(obj);
+        return json.GetHashCode();
+    }
+
+    private string Serialize(StoredTrigger storedTrigger)
+    {
+        var input = new
+        {
+            storedTrigger.Payload,
+            storedTrigger.Name,
+            storedTrigger.ActivityId,
+            storedTrigger.WorkflowDefinitionId
+        };
+        return JsonSerializer.Serialize(input, _settings);
+    }
+}

--- a/src/modules/Elsa.Workflows.Runtime/Comparers/WorkflowTriggerHashEqualityComparer.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Comparers/WorkflowTriggerHashEqualityComparer.cs
@@ -1,9 +1,0 @@
-using Elsa.Workflows.Runtime.Entities;
-
-namespace Elsa.Workflows.Runtime.Comparers;
-
-public class WorkflowTriggerHashEqualityComparer : IEqualityComparer<StoredTrigger>
-{
-    public bool Equals(StoredTrigger? x, StoredTrigger? y) => x?.Hash?.Equals(y?.Hash) ?? false;
-    public int GetHashCode(StoredTrigger obj) => obj.Hash?.GetHashCode() ?? "".GetHashCode();
-}

--- a/src/modules/Elsa.Workflows.Runtime/Services/TriggerIndexer.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Services/TriggerIndexer.cs
@@ -75,7 +75,7 @@ public class TriggerIndexer : ITriggerIndexer
             : new List<StoredTrigger>(0);
 
         // Diff triggers.
-        var diff = Diff.For(currentTriggers, newTriggers, new WorkflowTriggerHashEqualityComparer());
+        var diff = Diff.For(currentTriggers, newTriggers, new WorkflowTriggerEqualityComparer());
 
         // Replace triggers for the specified workflow.
         await _triggerStore.ReplaceAsync(diff.Removed, diff.Added, cancellationToken);
@@ -96,7 +96,7 @@ public class TriggerIndexer : ITriggerIndexer
         var currentTriggers = await GetCurrentTriggersAsync(workflowDefinitionIds, cancellationToken).ToList();
 
         // Diff triggers.
-        var diff = Diff.For(currentTriggers, emptyTriggerList, new WorkflowTriggerHashEqualityComparer());
+        var diff = Diff.For(currentTriggers, emptyTriggerList, new WorkflowTriggerEqualityComparer());
 
         // Replace triggers for the specified workflow.
         await _triggerStore.ReplaceAsync(diff.Removed, diff.Added, cancellationToken);


### PR DESCRIPTION
This PR fixes an issue where triggers would not be updated under certain conditions.

In the case of HTTP Endpoint, the issue was that the `Authorize` field is excluded from the Hash computation (as it should) - but because trigger comparison relied on this hash, changing only the Authorize value would not change the hash, and therefore the trigger would not be replaced.