### PR TITLE
Handle exceptions generated from ActivityTypeProviders

### DIFF
--- a/src/core/Elsa.Core/Services/Bookmarks/BookmarkIndexer.cs
+++ b/src/core/Elsa.Core/Services/Bookmarks/BookmarkIndexer.cs
@@ -146,23 +146,26 @@ namespace Elsa.Services.Bookmarks
 
             foreach (var blockingActivity in blockingActivities)
             {
-                var activityExecutionContext = new ActivityExecutionContext(_serviceProvider, workflowExecutionContext, blockingActivity, null, false, cancellationToken);
-                var activityType = activityTypes[blockingActivity.Type];
-                var providerContext = new BookmarkProviderContext(activityExecutionContext, activityType, BookmarkIndexingMode.WorkflowInstance);
-                var providers = await FilterProvidersAsync(providerContext).ToListAsync(cancellationToken);
-
-                foreach (var provider in providers)
+                if(activityTypes.ContainsKey(blockingActivity.Type))
                 {
-                    var bookmarkResults = (await provider.GetBookmarksAsync(providerContext, cancellationToken)).ToList();
+                    var activityExecutionContext = new ActivityExecutionContext(_serviceProvider, workflowExecutionContext, blockingActivity, null, false, cancellationToken);
+                    var activityType = activityTypes[blockingActivity.Type];
+                    var providerContext = new BookmarkProviderContext(activityExecutionContext, activityType, BookmarkIndexingMode.WorkflowInstance);
+                    var providers = await FilterProvidersAsync(providerContext).ToListAsync(cancellationToken);
 
-                    bookmarkedWorkflows.AddRange(bookmarkResults.Select(bookmarkResult => new BookmarkedWorkflow
+                    foreach (var provider in providers)
                     {
-                        WorkflowBlueprint = workflowBlueprint,
-                        WorkflowInstanceId = workflowInstance.Id,
-                        ActivityType = bookmarkResult.ActivityTypeName ?? blockingActivity.Type,
-                        ActivityId = blockingActivity.Id,
-                        Bookmark = bookmarkResult.Bookmark
-                    }));
+                        var bookmarkResults = (await provider.GetBookmarksAsync(providerContext, cancellationToken)).ToList();
+
+                        bookmarkedWorkflows.AddRange(bookmarkResults.Select(bookmarkResult => new BookmarkedWorkflow
+                        {
+                            WorkflowBlueprint = workflowBlueprint,
+                            WorkflowInstanceId = workflowInstance.Id,
+                            ActivityType = bookmarkResult.ActivityTypeName ?? blockingActivity.Type,
+                            ActivityId = blockingActivity.Id,
+                            Bookmark = bookmarkResult.Bookmark
+                        }));
+                    }
                 }
             }
 

--- a/src/core/Elsa.Core/Services/Triggers/TriggersForActivityBlueprintAndWorkflowProvider.cs
+++ b/src/core/Elsa.Core/Services/Triggers/TriggersForActivityBlueprintAndWorkflowProvider.cs
@@ -39,19 +39,26 @@ namespace Elsa.Services.Triggers
             IDictionary<string, ActivityType> activityTypes,
             CancellationToken cancellationToken = default)
         {
-            var bookmarkProviderContext = GetBookmarkProviderContext(activityBlueprint, workflowExecutionContext, cancellationToken, activityTypes);
-            var supportedBookmarkProviders = await GetSupportedBookmarkProvidersForContextAsync(bookmarkProviderContext)
-                .ToListAsync(cancellationToken);
+            if (activityTypes.ContainsKey(activityBlueprint.Type))
+            {
+                var bookmarkProviderContext = GetBookmarkProviderContext(activityBlueprint, workflowExecutionContext, cancellationToken, activityTypes);
+                var supportedBookmarkProviders = await GetSupportedBookmarkProvidersForContextAsync(bookmarkProviderContext)
+                    .ToListAsync(cancellationToken);
 
-            var tasksOfListsOfTriggers = supportedBookmarkProviders
-                .Select(bookmarkProvider => GetTriggersForBookmarkProvider(bookmarkProvider,
-                    bookmarkProviderContext,
-                    activityBlueprint,
-                    workflowExecutionContext.WorkflowBlueprint,
-                    cancellationToken));
-            return (await Task.WhenAll(tasksOfListsOfTriggers))
-                .SelectMany(x => x)
-                .ToList();
+                var tasksOfListsOfTriggers = supportedBookmarkProviders
+                    .Select(bookmarkProvider => GetTriggersForBookmarkProvider(bookmarkProvider,
+                        bookmarkProviderContext,
+                        activityBlueprint,
+                        workflowExecutionContext.WorkflowBlueprint,
+                        cancellationToken));
+                return (await Task.WhenAll(tasksOfListsOfTriggers))
+                    .SelectMany(x => x)
+                    .ToList();
+            }
+            else
+            {
+                return Enumerable.Empty<WorkflowTrigger>();
+            }
         }
 
         private BookmarkProviderContext GetBookmarkProviderContext(


### PR DESCRIPTION
If an ActivityType provider generates an exception it will cause the /activities endpoint to fail and the missing triggers will cause the runtime to stop.

This attempts to handle those exceptions that may be caused by external dependencies and improve the engine robustness.