### PR TITLE
Allow the user to select the start activty when calling through the api

### DIFF
--- a/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/Dispatch/Endpoint.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/Dispatch/Endpoint.cs
@@ -41,6 +41,7 @@ internal class Endpoint : ElsaEndpoint<Request, Response>
 
         var instanceId = request.InstanceId ?? _identityGenerator.GenerateId();
         var correlationId = request.CorrelationId;
+        var triggerActivityId = request.TriggerActivityId;
         var input = (IDictionary<string, object>?)request.Input;
         var dispatchRequest = new DispatchWorkflowDefinitionRequest
         {
@@ -48,7 +49,8 @@ internal class Endpoint : ElsaEndpoint<Request, Response>
             VersionOptions = VersionOptions.Published,
             Input = input,
             InstanceId = instanceId,
-            CorrelationId = correlationId
+            CorrelationId = correlationId,
+            TriggerActivityId = triggerActivityId
         };
 
         await _workflowDispatcher.DispatchAsync(dispatchRequest, cancellationToken);

--- a/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/Dispatch/Models.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/Dispatch/Models.cs
@@ -8,6 +8,7 @@ internal class Request
     public string DefinitionId { get; set; } = default!;
     public string? InstanceId { get; set; }
     public string? CorrelationId { get; set; }
+    public string? TriggerActivityId { get; set; }
 
     [JsonConverter(typeof(ExpandoObjectConverterFactory))]
     public object? Input { get; set; }

--- a/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/Execute/Endpoint.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/Execute/Endpoint.cs
@@ -54,7 +54,7 @@ internal class Execute : ElsaEndpoint<Request, Response>
 
         var correlationId = request.CorrelationId;
         var input = (IDictionary<string, object>?)request.Input;
-        var startWorkflowOptions = new StartWorkflowRuntimeOptions(correlationId, input, VersionOptions.Published);
+        var startWorkflowOptions = new StartWorkflowRuntimeOptions(correlationId, input, VersionOptions.Published, request.TriggerActivityId);
         var result = await _workflowRuntime.StartWorkflowAsync(definitionId, startWorkflowOptions, cancellationToken);
 
         // If a workflow fault occurred, respond appropriately with a 500 internal server error.

--- a/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/Execute/Models.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/Execute/Models.cs
@@ -8,7 +8,8 @@ internal class Request
 {
     public string DefinitionId { get; set; } = default!;
     public string? CorrelationId { get; set; }
-    
+    public string? TriggerActivityId { get; set; }
+
     [JsonConverter(typeof(ExpandoObjectConverterFactory))]
     public object? Input { get; set; }
 }


### PR DESCRIPTION
Allow the user to select which activity should start with from the ones marked with 'Can start workflow'. This is useful when calling the workflow through the /execute or /dispatch endpoint.