### PR TITLE
Implement direct access to activity output and last result

### DIFF
--- a/Elsa.sln
+++ b/Elsa.sln
@@ -222,6 +222,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Dapper.Migrations", "s
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.WorkflowProviders.BlobStorage", "src\modules\Elsa.WorkflowProviders.BlobStorage\Elsa.WorkflowProviders.BlobStorage.csproj", "{A702DD84-B55C-4807-9C28-D8F5AC3CCA78}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Samples.ConsoleApp.ActivityOutput", "src\samples\console\Elsa.Samples.ConsoleApp.ActivityOutput\Elsa.Samples.ConsoleApp.ActivityOutput.csproj", "{9C9FEB8E-A253-4705-A344-49BFEFC9A516}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -552,6 +554,10 @@ Global
 		{A702DD84-B55C-4807-9C28-D8F5AC3CCA78}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A702DD84-B55C-4807-9C28-D8F5AC3CCA78}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A702DD84-B55C-4807-9C28-D8F5AC3CCA78}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9C9FEB8E-A253-4705-A344-49BFEFC9A516}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9C9FEB8E-A253-4705-A344-49BFEFC9A516}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9C9FEB8E-A253-4705-A344-49BFEFC9A516}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9C9FEB8E-A253-4705-A344-49BFEFC9A516}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{155227F0-A33B-40AA-A4B4-06F813EB921B} = {61017E64-6D00-49CB-9E81-5002DC8F7D5F}
@@ -652,5 +658,6 @@ Global
 		{D5905087-2E73-44AD-B3CC-70FE8AAA99A1} = {56C2FFB8-EA54-45B5-A095-4A78142EB4B5}
 		{A86DF0F0-24E9-470E-984B-9E7332544972} = {9B4F139F-7D26-435C-A561-89E65A67A8E5}
 		{A702DD84-B55C-4807-9C28-D8F5AC3CCA78} = {B08B4E00-C2AB-48F3-8389-449F42AEF179}
+		{9C9FEB8E-A253-4705-A344-49BFEFC9A516} = {873BFC3E-63C2-4495-A503-5EC05DCD84E4}
 	EndGlobalSection
 EndGlobal

--- a/src/designer/designer_packages/elsa-workflows-designer/src/utils/utils.ts
+++ b/src/designer/designer_packages/elsa-workflows-designer/src/utils/utils.ts
@@ -129,5 +129,5 @@ export function generateIdentity() {
 }
 
 export function formatTextWithLineBreaks(text: string) {
-  return text.replace(/\n/g, '<br />');
+  return text?.replace(/\n/g, '<br />');
 }

--- a/src/modules/Elsa.JavaScript/Extensions/WorkflowExecutionContextExtensions.cs
+++ b/src/modules/Elsa.JavaScript/Extensions/WorkflowExecutionContextExtensions.cs
@@ -1,0 +1,43 @@
+using Elsa.Extensions;
+using Elsa.Workflows.Core.Contracts;
+using Elsa.Workflows.Core.Models;
+
+namespace Elsa.JavaScript.Extensions;
+
+internal static class WorkflowExecutionContextExtensions
+{
+    public static IEnumerable<(IActivity Activity, ActivityDescriptor ActivityDescriptor)> GetActivitiesWithOutputs(this ActivityExecutionContext activityExecutionContext)
+    {
+        // Get current container.
+
+        var currentContainerNode = activityExecutionContext.FindParentWithVariableContainer()?.ActivityNode;
+
+        if (currentContainerNode == null)
+            yield break;
+
+        // Get all nodes in the current container
+        var workflowExecutionContext = activityExecutionContext.WorkflowExecutionContext;
+        var containedNodes = workflowExecutionContext.Nodes.Where(x => x.Parents.Contains(currentContainerNode)).Distinct().ToList();
+
+        // Select activities with outputs.
+        var activityRegistry = workflowExecutionContext.GetRequiredService<IActivityRegistry>();
+        var activitiesWithOutputs = containedNodes.GetActivitiesWithOutputs(activityRegistry);
+
+        foreach (var (activity, activityDescriptor) in activitiesWithOutputs)
+            yield return (activity, activityDescriptor);
+    }
+
+    public static IEnumerable<(IActivity Activity, ActivityDescriptor ActivityDescriptor)> GetActivitiesWithOutputs(this IEnumerable<ActivityNode> nodes, IActivityRegistry activityRegistry)
+    {
+        // Select activities with outputs.
+        var activitiesWithOutputs =
+            from node in nodes
+            let activity = node.Activity
+            let activityDescriptor = activityRegistry.Find(activity.Type, activity.Version)
+            where activityDescriptor.Outputs.Any()
+            select (activity, activityDescriptor);
+
+        foreach (var (activity, activityDescriptor) in activitiesWithOutputs)
+            yield return (activity, activityDescriptor);
+    }
+}

--- a/src/modules/Elsa.JavaScript/Features/JavaScriptFeature.cs
+++ b/src/modules/Elsa.JavaScript/Features/JavaScriptFeature.cs
@@ -47,6 +47,7 @@ public class JavaScriptFeature : FeatureBase
             .AddSingleton<ITypeDefinitionDocumentRenderer, TypeDefinitionDocumentRenderer>()
             .AddSingleton<ITypeAliasRegistry, TypeAliasRegistry>()
             .AddFunctionDefinitionProvider<CommonFunctionsDefinitionProvider>()
+            .AddFunctionDefinitionProvider<ActivityOutputFunctionsDefinitionProvider>()
             .AddTypeDefinitionProvider<CommonTypeDefinitionProvider>()
             .AddTypeDefinitionProvider<VariableTypeDefinitionProvider>()
             ;

--- a/src/modules/Elsa.JavaScript/TypeDefinitions/Providers/ActivityOutputFunctionsDefinitionProvider.cs
+++ b/src/modules/Elsa.JavaScript/TypeDefinitions/Providers/ActivityOutputFunctionsDefinitionProvider.cs
@@ -1,0 +1,42 @@
+using Elsa.Extensions;
+using Elsa.JavaScript.Extensions;
+using Elsa.JavaScript.TypeDefinitions.Abstractions;
+using Elsa.JavaScript.TypeDefinitions.Models;
+using Elsa.Workflows.Core.Contracts;
+using Humanizer;
+
+namespace Elsa.JavaScript.TypeDefinitions.Providers;
+
+/// <summary>
+/// Produces <see cref="FunctionDefinition"/>s for common functions.
+/// </summary>
+internal class ActivityOutputFunctionsDefinitionProvider : FunctionDefinitionProvider
+{
+    private readonly IActivityVisitor _activityVisitor;
+    private readonly IActivityRegistry _activityRegistry;
+
+    public ActivityOutputFunctionsDefinitionProvider(IActivityVisitor activityVisitor, IActivityRegistry activityRegistry)
+    {
+        _activityVisitor = activityVisitor;
+        _activityRegistry = activityRegistry;
+    }
+
+    protected override async ValueTask<IEnumerable<FunctionDefinition>> GetFunctionDefinitionsAsync(TypeDefinitionContext context)
+    {
+        // Output getters.
+        var nodes = (await _activityVisitor.VisitAsync(context.Workflow.Root, context.CancellationToken)).Flatten().Distinct().ToList();
+        var activitiesWithOutputs = nodes.GetActivitiesWithOutputs(_activityRegistry);
+        var definitions = new List<FunctionDefinition>();
+
+        foreach (var (activity, activityDescriptor) in activitiesWithOutputs)
+        {
+            definitions.AddRange(from output in activityDescriptor.Outputs
+                select output.Name.Pascalize()
+                into outputPascalName
+                let activityIdPascalName = activity.Id.Pascalize()
+                select CreateFunctionDefinition(builder => builder.Name($"get{outputPascalName}From{activityIdPascalName}").ReturnType("any")));
+        }
+
+        return definitions;
+    }
+}

--- a/src/modules/Elsa.JavaScript/TypeDefinitions/Providers/CommonFunctionsDefinitionProvider.cs
+++ b/src/modules/Elsa.JavaScript/TypeDefinitions/Providers/CommonFunctionsDefinitionProvider.cs
@@ -17,46 +17,56 @@ internal class CommonFunctionsDefinitionProvider : FunctionDefinitionProvider
     {
         _typeAliasRegistry = typeAliasRegistry;
     }
-    
+
     protected override IEnumerable<FunctionDefinition> GetFunctionDefinitions(TypeDefinitionContext context)
     {
         yield return CreateFunctionDefinition(builder => builder
             .Name("getWorkflowInstanceId")
             .ReturnType("string"));
-        
+
         yield return CreateFunctionDefinition(builder => builder
             .Name("getCorrelationId")
             .ReturnType("string"));
-        
+
         yield return CreateFunctionDefinition(builder => builder
             .Name("setCorrelationId")
             .Parameter("value", "string"));
-        
+
         yield return CreateFunctionDefinition(builder => builder
             .Name("setVariable")
             .Parameter("name", "string")
             .Parameter("value", "any"));
-        
+
         yield return CreateFunctionDefinition(builder => builder
             .Name("getVariable")
             .Parameter("name", "string")
             .ReturnType("any"));
-        
+
         yield return CreateFunctionDefinition(builder => builder
             .Name("getInput")
             .Parameter("name", "string")
             .ReturnType("any"));
+
+        yield return CreateFunctionDefinition(builder => builder
+            .Name("getOutputFrom")
+            .Parameter("activityId", "string")
+            .Parameter("outputName", "string", true)
+            .ReturnType("any"));
         
+        yield return CreateFunctionDefinition(builder => builder
+            .Name("getLastResult")
+            .ReturnType("any"));
+
         yield return CreateFunctionDefinition(builder => builder
             .Name("isNullOrWhiteSpace")
             .Parameter("value", "string")
             .ReturnType("boolean"));
-        
+
         yield return CreateFunctionDefinition(builder => builder
             .Name("isNullOrEmpty")
             .Parameter("value", "string")
             .ReturnType("boolean"));
-        
+
         yield return CreateFunctionDefinition(builder => builder
             .Name("parseGuid")
             .Parameter("value", "string")
@@ -78,7 +88,7 @@ internal class CommonFunctionsDefinitionProvider : FunctionDefinitionProvider
             .Name("toJson")
             .Parameter("value", "any")
             .ReturnType("string"));
-        
+
         // Variable getter and setters.
         foreach (var variable in context.Workflow.Variables)
         {
@@ -88,7 +98,7 @@ internal class CommonFunctionsDefinitionProvider : FunctionDefinitionProvider
 
             // get{Variable}.
             yield return CreateFunctionDefinition(builder => builder.Name($"get{pascalName}").ReturnType(typeAlias));
-            
+
             // set{Variable}.
             yield return CreateFunctionDefinition(builder => builder.Name($"set{pascalName}").Parameter("value", typeAlias));
         }

--- a/src/modules/Elsa.Liquid/Handlers/ConfigureLiquidEngine.cs
+++ b/src/modules/Elsa.Liquid/Handlers/ConfigureLiquidEngine.cs
@@ -43,7 +43,7 @@ internal class ConfigureLiquidEngine : INotificationHandler<RenderingLiquidTempl
         memberAccessStrategy.Register<ExpandoObject>();
         memberAccessStrategy.Register<LiquidPropertyAccessor, FluidValue>((x, name) => x.GetValueAsync(name));
         memberAccessStrategy.Register<ExpandoObject, object>((x, name) => ((IDictionary<string, object>)x!)[name]);
-        memberAccessStrategy.Register<ExpressionExecutionContext, LiquidPropertyAccessor>("Variables", x => new LiquidPropertyAccessor(name => ToFluidValue(x, name, options)));
+        memberAccessStrategy.Register<ExpressionExecutionContext, LiquidPropertyAccessor>("Variables", x => new LiquidPropertyAccessor(name => GetVariable(x, name, options)));
         memberAccessStrategy.Register<ExpressionExecutionContext, string?>("CorrelationId", x => x.GetWorkflowExecutionContext().CorrelationId);
 
         if (_fluidOptions.AllowConfigurationAccess)
@@ -62,7 +62,7 @@ internal class ConfigureLiquidEngine : INotificationHandler<RenderingLiquidTempl
     private ConfigurationSectionWrapper GetConfigurationValue(string name) => new(_configuration.GetSection(name));
     private Task<FluidValue> ToFluidValue(object? input, TemplateOptions options) => Task.FromResult(FluidValue.Create(input, options));
 
-    private Task<FluidValue> ToFluidValue(ExpressionExecutionContext context, string key, TemplateOptions options)
+    private Task<FluidValue> GetVariable(ExpressionExecutionContext context, string key, TemplateOptions options)
     {
         var value = GetVariableInScope(context, key);
         return Task.FromResult(value == null ? NilValue.Instance : FluidValue.Create(value, options));

--- a/src/modules/Elsa.Workflows.Core/Extensions/ActivityExecutionContextExtensions.cs
+++ b/src/modules/Elsa.Workflows.Core/Extensions/ActivityExecutionContextExtensions.cs
@@ -346,7 +346,7 @@ public static class ActivityExecutionContextExtensions
     }
     
     /// <summary>
-    /// Returns a the first context that is associated with a <see cref="IVariableContainer"/>.
+    /// Returns the first context that is associated with a <see cref="IVariableContainer"/>.
     /// </summary>
     public static ActivityExecutionContext? FindParentWithVariableContainer(this ActivityExecutionContext context)
     {

--- a/src/modules/Elsa.Workflows.Core/Models/ActivityOutputRegister.cs
+++ b/src/modules/Elsa.Workflows.Core/Models/ActivityOutputRegister.cs
@@ -1,0 +1,84 @@
+using Elsa.Extensions;
+
+namespace Elsa.Workflows.Core.Models;
+
+/// <summary>
+/// Stores activity output.
+/// </summary>
+public class ActivityOutputRegister
+{
+    /// <summary>
+    /// The default output name.
+    /// </summary>
+    public const string DefaultOutputName = "Result";
+    
+    private readonly Dictionary<string, IDictionary<string, object>> _nodeIdLookup = new();
+    private readonly Dictionary<string, IDictionary<string, object>> _activityIdLookup = new();
+    private readonly Dictionary<string, IDictionary<string, object>> _activityInstanceIdLookup = new();
+    
+    /// <summary>
+    /// Records an activity's output.
+    /// </summary>
+    /// <param name="activityExecutionContext">The activity execution context.</param>
+    /// <param name="outputValue">The output value.</param>
+    public void Record(ActivityExecutionContext activityExecutionContext, object? outputValue)
+    {
+        Record(activityExecutionContext, default, outputValue);
+    }
+    
+    /// <summary>
+    /// Records an activity's output.
+    /// </summary>
+    /// <param name="activityExecutionContext">The activity execution context.</param>
+    /// <param name="outputName">The name of the output. Defaults to "Result"</param>
+    /// <param name="outputValue">The output value.</param>
+    public void Record(ActivityExecutionContext activityExecutionContext, string? outputName, object? outputValue)
+    {
+        var nodeId = activityExecutionContext.NodeId;
+        var activityId = activityExecutionContext.Activity.Id;
+        var activityInstanceId = activityExecutionContext.Id;
+        var record = (_nodeIdLookup.TryGetValue(nodeId, out var value) ? value : default) ?? new Dictionary<string, object>();
+
+        record[outputName ?? DefaultOutputName] = outputValue!;
+        
+        _nodeIdLookup[nodeId] = record;
+        _activityIdLookup[activityId] = record;
+        _activityInstanceIdLookup[activityInstanceId] = record;
+    }
+
+    /// <summary>
+    /// Gets the output value for the specified node ID.
+    /// </summary>
+    /// <param name="nodeId">The node ID.</param>
+    /// <param name="outputName">Name of the output.</param>
+    /// <returns>The output value.</returns>
+    public object? FindOutputByNodeId(string nodeId, string? outputName = default)
+    {
+        var record = _nodeIdLookup.TryGetValue(nodeId, out var value) ? value : default;
+        return record?.GetValueOrDefault<object>(outputName ?? DefaultOutputName);
+    }
+
+    /// <summary>
+    /// Gets the output value for the specified activity ID.
+    /// </summary>
+    /// <param name="activityId">The activity ID.</param>
+    /// <param name="outputName">Name of the output.</param>
+    /// <returns>The output value.</returns>
+    public object? FindOutputByActivityId(string activityId, string? outputName = default)
+    {
+        var record = _activityIdLookup.TryGetValue(activityId, out var value) ? value : default;
+        return record?.GetValueOrDefault<object>(outputName ?? DefaultOutputName);
+    }
+
+    /// <summary>
+    /// Gets the output value for the specified activity instance ID.
+    /// </summary>
+    /// <param name="activityInstanceId">The activity instance ID.</param>
+    /// <param name="outputName"></param>
+    /// <returns>The output value.</returns>
+    public object? FindOutputByActivityInstanceId(string activityInstanceId, string? outputName = default)
+    {
+        var record = _activityInstanceIdLookup.TryGetValue(activityInstanceId, out var value) ? value : default;
+        return record?.GetValueOrDefault<object>(outputName ?? DefaultOutputName);
+    }
+}

--- a/src/samples/console/Elsa.Samples.ConsoleApp.ActivityOutput/Elsa.Samples.ConsoleApp.ActivityOutput.csproj
+++ b/src/samples/console/Elsa.Samples.ConsoleApp.ActivityOutput/Elsa.Samples.ConsoleApp.ActivityOutput.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net7.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\bundles\Elsa\Elsa.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/samples/console/Elsa.Samples.ConsoleApp.ActivityOutput/Program.cs
+++ b/src/samples/console/Elsa.Samples.ConsoleApp.ActivityOutput/Program.cs
@@ -1,0 +1,20 @@
+﻿using Elsa.Extensions;
+using Elsa.Samples.ConsoleApp.ActivityOutput.Workflows;
+using Elsa.Workflows.Core.Contracts;
+using Microsoft.Extensions.DependencyInjection;
+
+// Setup service container.
+var services = new ServiceCollection();
+
+// Add Elsa services.
+services.AddElsa();
+
+// Build service container.
+var serviceProvider = services.BuildServiceProvider();
+
+// Resolve a workflow runner to run the workflow.
+var workflowRunner = serviceProvider.GetRequiredService<IWorkflowRunner>();
+
+// Run workflows.
+await workflowRunner.RunAsync<TargetActivityOutputWorkflow>();
+await workflowRunner.RunAsync<LastResultWorkflow>();

--- a/src/samples/console/Elsa.Samples.ConsoleApp.ActivityOutput/Workflows/LastResultWorkflow.cs
+++ b/src/samples/console/Elsa.Samples.ConsoleApp.ActivityOutput/Workflows/LastResultWorkflow.cs
@@ -1,0 +1,36 @@
+using Elsa.Extensions;
+using Elsa.Workflows.Core.Abstractions;
+using Elsa.Workflows.Core.Activities;
+using Elsa.Workflows.Core.Contracts;
+
+namespace Elsa.Samples.ConsoleApp.ActivityOutput.Workflows;
+
+/// <summary>
+/// Demonstrates accessing the last result of a given activity.
+/// </summary>
+public class LastResultWorkflow : WorkflowBase
+{
+    protected override void Build(IWorkflowBuilder builder)
+    {
+        builder.Root = new Sequence
+        {
+            // Setup the sequence of activities to run.
+            Activities =
+            {
+                new WriteLine("===================================="),
+                new WriteLine("Last Result Workflow"),
+                new WriteLine("===================================="),
+                new WriteLine("Please tell me your age:"),
+                new ReadLine(),
+                new If
+                {
+                    // If aged 18 or up, beer is provided, soda otherwise.
+                    Condition = new(context => context.GetLastResult<int>() < 18),
+                    Then = new WriteLine("Enjoy your soda!"),
+                    Else = new WriteLine("Enjoy your beer!")
+                },
+                new WriteLine("Come again!")
+            }
+        };
+    }
+}

--- a/src/samples/console/Elsa.Samples.ConsoleApp.ActivityOutput/Workflows/TargetActivityOutputWorkflow.cs
+++ b/src/samples/console/Elsa.Samples.ConsoleApp.ActivityOutput/Workflows/TargetActivityOutputWorkflow.cs
@@ -1,0 +1,39 @@
+using Elsa.Extensions;
+using Elsa.Workflows.Core.Abstractions;
+using Elsa.Workflows.Core.Activities;
+using Elsa.Workflows.Core.Contracts;
+
+namespace Elsa.Samples.ConsoleApp.ActivityOutput.Workflows;
+
+/// <summary>
+/// Demonstrates accessing the output of a given activity.
+/// </summary>
+public class TargetActivityOutputWorkflow : WorkflowBase
+{
+    protected override void Build(IWorkflowBuilder builder)
+    {
+        // Create a variable to reference the activity so that we can reference its output.
+        var readLine = new ReadLine();
+
+        builder.Root = new Sequence
+        {
+            // Setup the sequence of activities to run.
+            Activities =
+            {
+                new WriteLine("===================================="),
+                new WriteLine("Target Activity Output Workflow"),
+                new WriteLine("===================================="),
+                new WriteLine("Please tell me your age:"),
+                readLine,
+                new If
+                {
+                    // If aged 18 or up, beer is provided, soda otherwise.
+                    Condition = new(context => readLine.GetResult<int>(context) < 18),
+                    Then = new WriteLine("Enjoy your soda!"),
+                    Else = new WriteLine("Enjoy your beer!")
+                },
+                new WriteLine("Come again!")
+            }
+        };
+    }
+}


### PR DESCRIPTION
This PR adds a couple of APIs to access a given activity's output as well as the last result.

A console sample project was added to demonstrate how to do this for programmatic workflows.
When using the designer, we use JS expressions.

For example:

```javascript
// Generic form:
getOutputFrom("SomeActivityId");

// Generic form accepting a second argument in case an activity provides output named other than "Result":
getOutputFrom("SomeActivityId", "SomeOutputName");

// Typed form:
getResultFromHttpEndpoint1();
getSomeOutputNameFromSomeActivityId();
```

One improvement to be made is to generate a typescript definition that takes into account the output types.