### PR TITLE
UnscheduleCron triggers

### DIFF
--- a/src/modules/Elsa.Scheduling/Services/DefaultTriggerScheduler.cs
+++ b/src/modules/Elsa.Scheduling/Services/DefaultTriggerScheduler.cs
@@ -92,8 +92,11 @@ public class DefaultTriggerScheduler : ITriggerScheduler
         // Select all StartAt triggers.
         var startAtTriggers = triggerList.Filter<StartAt>().ToList();
 
+        // Select all Cron triggers.
+        var cronTriggers = triggerList.Filter<Cron>().ToList();
+
         // Concatenate the filtered triggers.
-        var filteredTriggers = timerTriggers.Concat(startAtTriggers).ToList();
+        var filteredTriggers = timerTriggers.Concat(startAtTriggers).Concat(cronTriggers).ToList();
 
         // Unschedule each trigger.
         foreach (var trigger in filteredTriggers)


### PR DESCRIPTION
The Cron triggers were not unscheduled, this resulted in multiple executions upon the publishing and unpublishing of workflows.