### PR TITLE
Cleanup schedulers

### DIFF
--- a/src/modules/Elsa.Scheduling/Services/DefaultBookmarkScheduler.cs
+++ b/src/modules/Elsa.Scheduling/Services/DefaultBookmarkScheduler.cs
@@ -25,19 +25,17 @@ public class DefaultBookmarkScheduler : IBookmarkScheduler
     /// <inheritdoc />
     public async Task ScheduleAsync(IEnumerable<StoredBookmark> bookmarks, CancellationToken cancellationToken = default)
     {
-        var bookmarkList = bookmarks.ToList();
-
         // Select all Delay bookmarks.
-        var delayBookmarks = bookmarkList.Filter<Delay>().ToList();
+        var delayBookmarks = bookmarks.Filter<Delay>();
 
         // Select all StartAt bookmarks.
-        var startAtBookmarks = bookmarkList.Filter<StartAt>().ToList();
+        var startAtBookmarks = bookmarks.Filter<StartAt>();
 
         // Select all Timer bookmarks.
-        var timerBookmarks = bookmarkList.Filter<Activities.Timer>().ToList();
+        var timerBookmarks = bookmarks.Filter<Activities.Timer>();
 
         // Select all Cron bookmarks.
-        var cronBookmarks = bookmarkList.Filter<Cron>().ToList();
+        var cronBookmarks = bookmarks.Filter<Cron>();
 
         // Schedule each Delay bookmark.
         foreach (var bookmark in delayBookmarks)
@@ -83,19 +81,17 @@ public class DefaultBookmarkScheduler : IBookmarkScheduler
     /// <inheritdoc />
     public async Task ScheduleAsync(string workflowInstanceId, IEnumerable<Bookmark> bookmarks, CancellationToken cancellationToken = default)
     {
-        var bookmarkList = bookmarks.ToList();
-
         // Select all Delay bookmarks.
-        var delayBookmarks = bookmarkList.Filter<Delay>().ToList();
+        var delayBookmarks = bookmarks.Filter<Delay>();
 
         // Select all StartAt bookmarks.
-        var startAtBookmarks = bookmarkList.Filter<StartAt>().ToList();
+        var startAtBookmarks = bookmarks.Filter<StartAt>();
 
         // Select all Timer bookmarks.
-        var timerBookmarks = bookmarkList.Filter<Activities.Timer>().ToList();
+        var timerBookmarks = bookmarks.Filter<Activities.Timer>();
 
         // Select all Cron bookmarks.
-        var cronBookmarks = bookmarkList.Filter<Cron>().ToList();
+        var cronBookmarks = bookmarks.Filter<Cron>();
 
         // Schedule each Delay bookmark.
         foreach (var bookmark in delayBookmarks)

--- a/src/modules/Elsa.Scheduling/Services/DefaultTriggerScheduler.cs
+++ b/src/modules/Elsa.Scheduling/Services/DefaultTriggerScheduler.cs
@@ -25,12 +25,10 @@ public class DefaultTriggerScheduler : ITriggerScheduler
     /// <inheritdoc />
     public async Task ScheduleAsync(IEnumerable<StoredTrigger> triggers, CancellationToken cancellationToken = default)
     {
-        var triggerList = triggers.ToList();
-
         // Select Timer, StartAt and Cron triggers.
-        var timerTriggers = triggerList.Filter<Activities.Timer>().ToList();
-        var startAtTriggers = triggerList.Filter<StartAt>().ToList();
-        var cronTriggers = triggerList.Filter<Cron>().ToList();
+        var timerTriggers = triggers.Filter<Activities.Timer>();
+        var startAtTriggers = triggers.Filter<StartAt>();
+        var cronTriggers = triggers.Filter<Cron>();
 
         // Schedule each Timer trigger.
         foreach (var trigger in timerTriggers)
@@ -84,19 +82,17 @@ public class DefaultTriggerScheduler : ITriggerScheduler
     /// <inheritdoc />
     public async Task UnscheduleAsync(IEnumerable<StoredTrigger> triggers, CancellationToken cancellationToken = default)
     {
-        var triggerList = triggers.ToList();
-
         // Select all Timer triggers.
-        var timerTriggers = triggerList.Filter<Activities.Timer>().ToList();
+        var timerTriggers = triggers.Filter<Activities.Timer>();
 
         // Select all StartAt triggers.
-        var startAtTriggers = triggerList.Filter<StartAt>().ToList();
+        var startAtTriggers = triggers.Filter<StartAt>();
 
         // Select all Cron triggers.
-        var cronTriggers = triggerList.Filter<Cron>().ToList();
+        var cronTriggers = triggers.Filter<Cron>();
 
         // Concatenate the filtered triggers.
-        var filteredTriggers = timerTriggers.Concat(startAtTriggers).Concat(cronTriggers).ToList();
+        var filteredTriggers = timerTriggers.Concat(startAtTriggers).Concat(cronTriggers);
 
         // Unschedule each trigger.
         foreach (var trigger in filteredTriggers)


### PR DESCRIPTION
As discussed in pull request #4149 The ToList and list variable are unnecessary.

So this pull request cleans up both DefaultTriggerScheduler and DefaultBookmarkScheduler by removing both the variable and the ToList actions.