### PR TITLE
Allow saving the Workflow Version Name for the instance list endpoint

### DIFF
--- a/src/core/Elsa.Core/Services/Workflows/WorkflowFactory.cs
+++ b/src/core/Elsa.Core/Services/Workflows/WorkflowFactory.cs
@@ -28,6 +28,7 @@ namespace Elsa.Services.Workflows
             var workflowInstance = new WorkflowInstance
             {
                 Id = _idGenerator.Generate(),
+                Name = workflowBlueprint.Name,
                 DefinitionId = workflowBlueprint.Id,
                 TenantId = tenantId ?? workflowBlueprint.TenantId,
                 Version = workflowBlueprint.Version,


### PR DESCRIPTION
Currently, when using the endpoint /v1/workflow-instances the property "Name" is always null.

Added a mapping to the Workflow Factory that allows saving the "Name" of the executed workflow definition for retrieval later in the /v1/workflow-instances endpoint.

Example of the current output of the endpoint /v1/workflow-instances endpoint:
![image](https://github.com/elsa-workflows/elsa-core/assets/7645736/b1eb9324-2617-48a6-96b1-768b50404ffb)
