### PR TITLE
Have hangfire ignore exception when workflow is singleton and already running

### DIFF
--- a/src/activities/Elsa.Activities.Temporal.Hangfire/Jobs/RunHangfireWorkflowDefinitionJob.cs
+++ b/src/activities/Elsa.Activities.Temporal.Hangfire/Jobs/RunHangfireWorkflowDefinitionJob.cs
@@ -8,6 +8,6 @@ namespace Elsa.Activities.Temporal.Hangfire.Jobs
     {
         private readonly IWorkflowDefinitionDispatcher _workflowDefinitionDispatcher;
         public RunHangfireWorkflowDefinitionJob(IWorkflowDefinitionDispatcher workflowDefinitionDispatcher) => _workflowDefinitionDispatcher = workflowDefinitionDispatcher;
-        public async Task ExecuteAsync(RunHangfireWorkflowDefinitionJobModel data) => await _workflowDefinitionDispatcher.DispatchAsync(new ExecuteWorkflowDefinitionRequest(data.WorkflowDefinitionId, data.ActivityId));
+        public async Task ExecuteAsync(RunHangfireWorkflowDefinitionJobModel data) => await _workflowDefinitionDispatcher.DispatchAsync(new ExecuteWorkflowDefinitionRequest(data.WorkflowDefinitionId, data.ActivityId, IgnoreAlreadyRunningAndSingleton: true));
     }
 }

--- a/src/core/Elsa.Abstractions/Exceptions/WorkflowAlreadyRunningException.cs
+++ b/src/core/Elsa.Abstractions/Exceptions/WorkflowAlreadyRunningException.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Elsa.Exceptions
+{
+    public class WorkflowAlreadyRunningException : WorkflowException
+    {
+        public WorkflowAlreadyRunningException(string message) 
+            : base(message)
+        {
+        }
+        public WorkflowAlreadyRunningException(string message, Exception innerException) 
+            : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/core/Elsa.Abstractions/Services/Dispatch/Models.cs
+++ b/src/core/Elsa.Abstractions/Services/Dispatch/Models.cs
@@ -1,10 +1,10 @@
-﻿using Elsa.Models;
+using Elsa.Models;
 
 namespace Elsa.Services
 {
     public record TriggerWorkflowsRequest(string ActivityType, IBookmark Bookmark, WorkflowInput? Input = default, string? CorrelationId = default, string? WorkflowInstanceId = default, string? ContextId = default, string? TenantId = default);
 
-    public record ExecuteWorkflowDefinitionRequest(string WorkflowDefinitionId, string? ActivityId = default, WorkflowInput? Input = default, string? CorrelationId = default, string? ContextId = default, string? TenantId = default);
+    public record ExecuteWorkflowDefinitionRequest(string WorkflowDefinitionId, string? ActivityId = default, WorkflowInput? Input = default, string? CorrelationId = default, string? ContextId = default, string? TenantId = default, bool IgnoreAlreadyRunningAndSingleton = false);
 
     public record ExecuteWorkflowInstanceRequest(string WorkflowInstanceId, string? ActivityId = default, WorkflowInput? Input = default);
 }

--- a/src/core/Elsa.Abstractions/Services/Workflows/IWorkflowLaunchpad.cs
+++ b/src/core/Elsa.Abstractions/Services/Workflows/IWorkflowLaunchpad.cs
@@ -37,17 +37,17 @@ namespace Elsa.Services
         /// <summary>
         /// Creates a new workflow instance with execution pending for the specified workflow blueprint using the specified starting activity ID.
         /// </summary>
-        Task<StartableWorkflow?> FindStartableWorkflowAsync(IWorkflowBlueprint workflowBlueprint, string? activityId = default, string? correlationId = default, string? contextId = default, string? tenantId = default, CancellationToken cancellationToken = default);
+        Task<StartableWorkflow?> FindStartableWorkflowAsync(IWorkflowBlueprint workflowBlueprint, string? activityId = default, string? correlationId = default, string? contextId = default, string? tenantId = default, bool throwIfRunningAndSingleton = false, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Collects and executes the specified startable workflow.
         /// </summary>
-        Task FindAndExecuteStartableWorkflowAsync(string workflowDefinitionId, string? activityId = default, string? correlationId = default, string? contextId = default, WorkflowInput? input = default, string? tenantId = default, CancellationToken cancellationToken = default);
+        Task FindAndExecuteStartableWorkflowAsync(string workflowDefinitionId, string? activityId = default, string? correlationId = default, string? contextId = default, WorkflowInput? input = default, string? tenantId = default, bool throwIfRunningAndSingleton = false, CancellationToken cancellationToken = default);
         
         /// <summary>
         /// Collects and executes the specified startable workflow.
         /// </summary>
-        Task<RunWorkflowResult> FindAndExecuteStartableWorkflowAsync(IWorkflowBlueprint workflowBlueprint, string? activityId = default, string? correlationId = default, string? contextId = default, WorkflowInput? input = default, CancellationToken cancellationToken = default);
+        Task<RunWorkflowResult> FindAndExecuteStartableWorkflowAsync(IWorkflowBlueprint workflowBlueprint, string? activityId = default, string? correlationId = default, string? contextId = default, WorkflowInput? input = default, bool throwIfRunningAndSingleton = false, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Executes a list of pending workflows.

--- a/src/core/Elsa.Core/Services/Workflows/WorkflowLaunchpad.cs
+++ b/src/core/Elsa.Core/Services/Workflows/WorkflowLaunchpad.cs
@@ -101,7 +101,7 @@ namespace Elsa.Services.Workflows
             if (workflowBlueprint == null || workflowBlueprint.IsDisabled)
                 return null;
 
-            return await FindStartableWorkflowAsync(workflowBlueprint, activityId, correlationId, contextId, tenantId, cancellationToken);
+            return await FindStartableWorkflowAsync(workflowBlueprint, activityId, correlationId, contextId, tenantId, false, cancellationToken);
         }
 
         public async Task<StartableWorkflow?> FindStartableWorkflowAsync(
@@ -118,7 +118,7 @@ namespace Elsa.Services.Workflows
             if (workflowBlueprint == null || workflowBlueprint.IsDisabled)
                 return null;
 
-            return await FindStartableWorkflowAsync(workflowBlueprint, activityId, correlationId, contextId, tenantId, cancellationToken);
+            return await FindStartableWorkflowAsync(workflowBlueprint, activityId, correlationId, contextId, tenantId, false, cancellationToken);
         }
 
         public async Task<StartableWorkflow?> FindStartableWorkflowAsync(
@@ -127,11 +127,12 @@ namespace Elsa.Services.Workflows
             string? correlationId = default,
             string? contextId = default,
             string? tenantId = default,
+            bool throwIfRunningAndSingleton = false,
             CancellationToken cancellationToken = default)
         {
             async Task<StartableWorkflow?> CollectWorkflows()
             {
-                var startableWorkflowDefinition = await CollectStartableWorkflowInternalAsync(workflowBlueprint, activityId, correlationId, contextId, tenantId, cancellationToken);
+                var startableWorkflowDefinition = await CollectStartableWorkflowInternalAsync(workflowBlueprint, activityId, correlationId, contextId, tenantId, throwIfRunningAndSingleton, cancellationToken);
                 return startableWorkflowDefinition != null ? await InstantiateStartableWorkflow(startableWorkflowDefinition, cancellationToken) : default;
             }
 
@@ -150,6 +151,7 @@ namespace Elsa.Services.Workflows
             string? contextId = default,
             WorkflowInput? input = default,
             string? tenantId = default,
+            bool throwIfRunningAndSingleton = false,
             CancellationToken cancellationToken = default)
         {
             var workflowBlueprint = await _workflowRegistry.FindAsync(workflowDefinitionId, VersionOptions.Published, tenantId, cancellationToken);
@@ -160,7 +162,7 @@ namespace Elsa.Services.Workflows
                 return;
             }
 
-            await FindAndExecuteStartableWorkflowAsync(workflowBlueprint, activityId, correlationId, contextId, input, cancellationToken);
+            await FindAndExecuteStartableWorkflowAsync(workflowBlueprint, activityId, correlationId, contextId, input, throwIfRunningAndSingleton, cancellationToken);
         }
 
         public async Task<RunWorkflowResult> FindAndExecuteStartableWorkflowAsync(
@@ -169,12 +171,13 @@ namespace Elsa.Services.Workflows
             string? correlationId = default,
             string? contextId = default,
             WorkflowInput? input = default,
+            bool throwIfRunningAndSingleton = false,
             CancellationToken cancellationToken = default)
         {
             var workflowDefinitionId = workflowBlueprint.Id;
             var tenantId = workflowBlueprint.TenantId;
 
-            var startableWorkflow = await FindStartableWorkflowAsync(workflowBlueprint, activityId, correlationId, contextId, tenantId, cancellationToken);
+            var startableWorkflow = await FindStartableWorkflowAsync(workflowBlueprint, activityId, correlationId, contextId, tenantId, throwIfRunningAndSingleton, cancellationToken);
 
             if (startableWorkflow == null)
                 throw new WorkflowException($"Could not start workflow with ID {workflowDefinitionId}");
@@ -276,7 +279,7 @@ namespace Elsa.Services.Workflows
                     continue;
                 }
 
-                var startableWorkflow = await CollectStartableWorkflowInternalAsync(workflowBlueprint, trigger.ActivityId, query.CorrelationId!, query.ContextId, query.TenantId, cancellationToken);
+                var startableWorkflow = await CollectStartableWorkflowInternalAsync(workflowBlueprint, trigger.ActivityId, query.CorrelationId!, query.ContextId, query.TenantId, false, cancellationToken);
 
                 if (startableWorkflow != null)
                     startableWorkflows.Add(startableWorkflow);
@@ -291,6 +294,7 @@ namespace Elsa.Services.Workflows
             string? correlationId,
             string? contextId = default,
             string? tenantId = default,
+            bool throwIfRunningAndSingleton = false,
             CancellationToken cancellationToken = default)
         {
             var workflowDefinitionId = workflowBlueprint.Id;
@@ -307,6 +311,8 @@ namespace Elsa.Services.Workflows
                 if (await GetWorkflowIsAlreadyExecutingAsync(tenantId, workflowDefinitionId))
                 {
                     _logger.LogDebug("Workflow {WorkflowDefinitionId} is a singleton workflow and is already running", workflowDefinitionId);
+                    if (throwIfRunningAndSingleton)
+                        throw new WorkflowAlreadyRunningException($"Workflow {workflowDefinitionId} is a singleton workflow and is already running");
                     return null;
                 }
             }

--- a/src/server/Elsa.Server.Orleans/Grains/WorkflowDefinitionGrain.cs
+++ b/src/server/Elsa.Server.Orleans/Grains/WorkflowDefinitionGrain.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading;
+using System.Threading;
 using System.Threading.Tasks;
 using Elsa.Server.Orleans.Grains.Contracts;
 using Elsa.Services;
@@ -14,6 +14,6 @@ namespace Elsa.Server.Orleans.Grains
         public WorkflowDefinitionGrain(IWorkflowLaunchpad workflowLaunchpad) => _workflowLaunchpad = workflowLaunchpad;
 
         public async Task ExecuteWorkflowAsync(ExecuteWorkflowDefinitionRequest request, CancellationToken cancellationToken = default) =>
-            await _workflowLaunchpad.FindAndExecuteStartableWorkflowAsync(request.WorkflowDefinitionId, request.ActivityId, request.CorrelationId, request.ContextId, request.Input, request.TenantId, cancellationToken);
+            await _workflowLaunchpad.FindAndExecuteStartableWorkflowAsync(request.WorkflowDefinitionId, request.ActivityId, request.CorrelationId, request.ContextId, request.Input, request.TenantId, request.IgnoreAlreadyRunningAndSingleton, cancellationToken);
     }
 }


### PR DESCRIPTION
This fixes the issue raised in #4213. After further diagnosing, the issue is related to hangfire trying to start a workflow while there is an existing background job running for the workflow. (AKA workflow is still running) If the workflow is set as singleton, the `WorkflowLaunchpad` would throw an error that it can't start the workflow. Hangfire would then keep retrying the failed job to start the workflow. I added parameters where needed to have the launchpad throw a new specific `WorkflowAlreadyRunningException`, so that it can be caught when needed and ignored. It now will wait for the next triggered time to start the workflow, if it is already running. This functionality is only applied for WorkflowDefinition jobs, and not WorkflowInstance jobs.

I'm not sure if this same issue exists when using Quartz for temporal jobs. The easiest way to test, is to create a singleton workflow that starts every 15 seconds via a cron activity, then an activity that suspends the workflow for 45 seconds. Within that 45 seconds is when hangfire would attempt to start the workflow 2 additional times, even though it was a singleton.

closes #4213