### PR TITLE
Add option to check custom header when receiving http endpoint request

### DIFF
--- a/src/activities/Elsa.Activities.Http/Activities/HttpEndpoint/HttpEndpoint.cs
+++ b/src/activities/Elsa.Activities.Http/Activities/HttpEndpoint/HttpEndpoint.cs
@@ -74,7 +74,7 @@ namespace Elsa.Activities.Http
         /// Allow authenticated requests only
         /// </summary>
         [ActivityInput(
-            Hint = "Check to allow authenticated requests only",
+            Hint = "Check to only allow requests, which satisfy a specified policy",
             SupportedSyntaxes = new[] { SyntaxNames.Literal, SyntaxNames.JavaScript, SyntaxNames.Liquid },
             Category = "Security"
         )]
@@ -89,6 +89,25 @@ namespace Elsa.Activities.Http
             Category = "Security"
         )]
         public string? Policy { get; set; }
+        
+        [ActivityInput(
+            Hint = "Check to only allow requests, which has a specified header with a specified value",
+            SupportedSyntaxes = new[] { SyntaxNames.Literal, SyntaxNames.JavaScript, SyntaxNames.Liquid },
+            Category = "Security"
+        )]
+        public bool AuthorizeWithCustomHeader { get; set; }
+        
+        [ActivityInput(
+            SupportedSyntaxes = new[] { SyntaxNames.Literal, SyntaxNames.JavaScript, SyntaxNames.Liquid },
+            Category = "Security"
+        )]
+        public string? CustomHeaderName { get; set; }
+        
+        [ActivityInput(
+            SupportedSyntaxes = new[] { SyntaxNames.Literal, SyntaxNames.JavaScript, SyntaxNames.Liquid },
+            Category = "Security"
+        )]
+        public string? CustomHeaderValue { get; set; }
 
         /// <summary>
         /// The received HTTP request.

--- a/src/activities/Elsa.Activities.Http/Activities/HttpEndpoint/HttpEndpoint.cs
+++ b/src/activities/Elsa.Activities.Http/Activities/HttpEndpoint/HttpEndpoint.cs
@@ -91,7 +91,7 @@ namespace Elsa.Activities.Http
         public string? Policy { get; set; }
         
         [ActivityInput(
-            Hint = "Check to only allow requests, which has a specified header with a specified value",
+            Hint = "Check to only allow requests, which have a specified header with a specified value",
             SupportedSyntaxes = new[] { SyntaxNames.Literal, SyntaxNames.JavaScript, SyntaxNames.Liquid },
             Category = "Security"
         )]

--- a/src/activities/Elsa.Activities.Http/Activities/HttpEndpoint/HttpEndpointExtensions.cs
+++ b/src/activities/Elsa.Activities.Http/Activities/HttpEndpoint/HttpEndpointExtensions.cs
@@ -154,5 +154,21 @@ namespace Elsa.Activities.Http
         
         /// <inheritdoc cref="WithPolicy(ISetupActivity{HttpEndpoint}, Func{ActivityExecutionContext, ValueTask{string?}})"/>
         public static ISetupActivity<HttpEndpoint> WithPolicy(this ISetupActivity<HttpEndpoint> activity, string? value) => activity.Set(x => x.Policy, value);
+        
+        
+        /// <summary>
+        /// Sets whether or not this endpoint requires authorization with a custom header to use
+        /// </summary>
+        /// <param name="activity"></param>
+        /// <param name="value">Whether or not authorization with custom header is used.</param>
+        /// <param name="customHeaderName">The name of the custom header.</param>
+        /// <param name="customHeaderValue">The value of the custom header</param>
+        /// <returns>A <see cref="ISetupActivity"/> that can be used to further change properties of <see cref="HttpEndpoint"/></returns>
+        public static ISetupActivity<HttpEndpoint> WithAuthorizeWithCustomHeader(this ISetupActivity<HttpEndpoint> activity, bool value, string customHeaderName, string customHeaderValue)
+        {
+            return activity.Set(x => x.AuthorizeWithCustomHeader, value)
+                .Set(x => x.CustomHeaderName, customHeaderName)
+                .Set(x => x.CustomHeaderValue, customHeaderValue);
+        }
     }
 }

--- a/src/activities/Elsa.Activities.Http/Services/CustomHeaderAuthorizationHandler.cs
+++ b/src/activities/Elsa.Activities.Http/Services/CustomHeaderAuthorizationHandler.cs
@@ -1,0 +1,24 @@
+using System.Threading.Tasks;
+using Elsa.Activities.Http.Contracts;
+using Elsa.Activities.Http.Models;
+
+namespace Elsa.Activities.Http.Services
+{
+    public class CustomHeaderAuthorizationHandler : IHttpEndpointAuthorizationHandler
+    {
+        public async ValueTask<bool> AuthorizeAsync(AuthorizeHttpEndpointContext context)
+        {
+            var httpContext = context.HttpContext;
+
+            var cancellationToken = context.CancellationToken;
+            var httpEndpoint = context.HttpEndpointActivity;
+            var headerName = await httpEndpoint.EvaluatePropertyValueAsync(x => x.CustomHeaderName, cancellationToken);
+            var expectedHeaderValue = await httpEndpoint.EvaluatePropertyValueAsync(x => x.CustomHeaderValue, cancellationToken);
+
+            if (string.IsNullOrWhiteSpace(headerName) || string.IsNullOrWhiteSpace(expectedHeaderValue))
+                return true;
+
+            return httpContext.Request.Headers[headerName] == expectedHeaderValue;
+        }
+    }
+}

--- a/src/samples/aspnet/Elsa.Samples.HttpEndpointSecurity/Workflows/SecureHelloWorkflow.cs
+++ b/src/samples/aspnet/Elsa.Samples.HttpEndpointSecurity/Workflows/SecureHelloWorkflow.cs
@@ -22,6 +22,14 @@ namespace Elsa.Samples.HttpEndpointSecurity.Workflows
                         var user = httpContext.User;
                         return $"Hello {user.Identity!.Name}!";
                     }));
+            
+            builder
+                .HttpEndpoint(setup => setup
+                    .WithPath("/safe-hello-header")
+                    .WithMethod("GET")
+                    .WithAuthorizeWithCustomHeader(true, "api-key", "test-api-key"))
+                .WriteHttpResponse(setup => setup.WithStatusCode(HttpStatusCode.OK)
+                    .WithContent(() => "Hello header"));
         }
     }
 }


### PR DESCRIPTION
For HttpEndpoint activity we have to have the previous authorization work in parallel with the now new check for plain header (ApiKey or something like that). I feel like there could be a better solution, so I am open to suggestions.