### PR TITLE
Added ability to externalize MongoClient creation

### DIFF
--- a/src/persistence/Elsa.Persistence.MongoDb/Options/ElsaMongoDbOptions.cs
+++ b/src/persistence/Elsa.Persistence.MongoDb/Options/ElsaMongoDbOptions.cs
@@ -1,3 +1,6 @@
+using MongoDB.Driver;
+using System;
+
 namespace Elsa.Persistence.MongoDb.Options
 {
     public class ElsaMongoDbOptions
@@ -7,7 +10,7 @@ namespace Elsa.Persistence.MongoDb.Options
 
         /// <summary>
         /// This parameter to opt-out automatic registration of
-        /// <see cref="Elsa.Persistence.MongoDb.Serializers.VariablesSerializer"/>
+        /// <see cref="Serializers.VariablesSerializer"/>
         /// </summary>
         public bool DoNotRegisterVariablesSerializer { get; set; }
 
@@ -16,6 +19,19 @@ namespace Elsa.Persistence.MongoDb.Options
         /// it has some breaking changes, so it is preferibly to enable only if you are really sure
         /// that it works without any problem in your project.
         /// </summary>
+        [Obsolete("Prefer to use the ConfigureMongoClientSettings")]
         public bool UseNewLinq3Provider { get; set; }
+
+        /// <summary>
+        /// Let the caller configure MongoClientSettings.
+        /// </summary>
+        public Action<MongoClientSettings> ConfigureMongoClientSettings { get; set; } = _ => { };
+
+        /// <summary>
+        /// As a general rule of thumb we should avoid creating more than one instance of MongoClient, the problem
+        /// is that each instance has a Connection Pool and can put eccessive strain for the server. Giving the
+        /// user the ability to create the MongoClient instance we can avoid this problem.
+        /// </summary>
+        public Func<MongoClientSettings, MongoUrl, IMongoClient> MongoClientFactory { get; set; } = (settings, _) => new MongoClient(settings);
     }
 }

--- a/src/persistence/Elsa.Persistence.MongoDb/Services/ElsaMongoDbDriverHelpers.cs
+++ b/src/persistence/Elsa.Persistence.MongoDb/Services/ElsaMongoDbDriverHelpers.cs
@@ -8,22 +8,29 @@ namespace Elsa.Persistence.MongoDb.Services
     public static class ElsaMongoDbDriverHelpers
     {
         /// <summary>
-        /// Avoid creating too much instances for MongoClient.
+        /// Avoid creating too much instances for MongoClient, usually caller program should
+        /// implmenent a singleton to avoid creating too much Client instance, but actually we
+        /// implement a simple cache to avoid this problem.
         /// </summary>
-        private static readonly ConcurrentDictionary<string, MongoClient> _clients = new();
+        private static readonly ConcurrentDictionary<string, IMongoClient> _clients = new();
 
-        public static MongoClient CreateClient(ElsaMongoDbOptions options)
+        public static IMongoClient CreateClient(ElsaMongoDbOptions options)
         {
             if (string.IsNullOrEmpty(options.ConnectionString)) throw new ArgumentException("Connection string is required.", nameof(options.ConnectionString));
-            if (!_clients.TryGetValue(options.ConnectionString, out MongoClient client))
+            if (!_clients.TryGetValue(options.ConnectionString, out IMongoClient client))
             {
                 var connectionString = options.ConnectionString;
+                var mongoUrl = new MongoUrl(connectionString);
                 var clientSettings = MongoClientSettings.FromConnectionString(connectionString);
-                if (options.UseNewLinq3Provider == false)
+
+                //This will be removed in a future version, we started deprecation
+                if (!options.UseNewLinq3Provider)
                 {
                     clientSettings.LinqProvider = MongoDB.Driver.Linq.LinqProvider.V2;
                 }
-                client = new MongoClient(clientSettings);
+
+                options.ConfigureMongoClientSettings(clientSettings);
+                client = options.MongoClientFactory(clientSettings, mongoUrl);
                 _clients[options.ConnectionString] = client;
             }
 


### PR DESCRIPTION
Best practice for usage of MongoClient is creating a **single instance** for the entire process. (or a single instance for each different connection string). 

Actual code create a new MongoClient and uses a local cache to limit the number of client, but with this commit we allow the caller to redefine the function to create MongoClient and use an external cache (or use decorators, etc).