### PR TITLE
Update output selector with support for activity instances

### DIFF
--- a/src/modules/Elsa.Workflows.Core/Extensions/ActivityExtensions.cs
+++ b/src/modules/Elsa.Workflows.Core/Extensions/ActivityExtensions.cs
@@ -68,9 +68,8 @@ public static class ActivityExtensions
     public static object? GetOutput(this IActivity activity, ExpressionExecutionContext context, string? outputName = default)
     {
         var workflowExecutionContext = context.GetWorkflowExecutionContext();
-        var activityNode = workflowExecutionContext.FindNodeByActivity(activity);
         var outputRegister = workflowExecutionContext.GetActivityOutputRegister();
-        var output = outputRegister.FindOutputByNodeId(activityNode.NodeId, outputName);
+        var output = outputRegister.FindOutputByActivityInstanceId(context.GetActivityExecutionContext().Id, outputName);
         return output;
     }
 

--- a/src/modules/Elsa.Workflows.Core/Models/ActivityOutputRecord.cs
+++ b/src/modules/Elsa.Workflows.Core/Models/ActivityOutputRecord.cs
@@ -1,0 +1,11 @@
+namespace Elsa.Workflows.Core.Models;
+
+/// <summary>
+/// Represents a record of an activity's output.
+/// </summary>
+/// <param name="ContainerId">The ID of the container that contains the activity.</param>
+/// <param name="ActivityId">The ID of the activity.</param>
+/// <param name="ActivityInstanceId">The ID of the activity instance.</param>
+/// <param name="OutputName">The name of the output.</param>
+/// <param name="Value">The output value.</param>
+public record ActivityOutputRecord(string ContainerId, string ActivityId, string ActivityInstanceId, string OutputName, object? Value);

--- a/test/unit/Elsa.Workflows.Core.UnitTests/ExpressionExecutionContextExtensionsTests.cs
+++ b/test/unit/Elsa.Workflows.Core.UnitTests/ExpressionExecutionContextExtensionsTests.cs
@@ -71,14 +71,18 @@ public class ExpressionExecutionContextExtensionsTests
     }
 
     [Fact]
-    public void SetVariable_ThrowsException_WhenVariableDoesNotExist()
+    public void SetVariable_CreatesVariable_WhenVariableDoesNotExist()
     {
         // Arrange
         var memoryRegister = new MemoryRegister(new Dictionary<string, MemoryBlock>());
         var context = new ExpressionExecutionContext(null!, memoryRegister);
 
-        // Act & Assert
-        Assert.Throws<Exception>(() => context.SetVariable("nonexistent", 10));
+        // Act
+        context.CreateVariable("newVariable", 10);
+
+        // Assert
+        var variable = context.GetVariable<int>("newVariable");
+        Assert.Equal(10, variable);
     }
 
     [Fact]


### PR DESCRIPTION
### === auto-pr-body ===



Summary:
This Pull Request contains various refactoring and modification changes to the codebase, including changing the signature of GetConfiguredEngine(), adding logic to filter the output of output records based on container IDs, removing unused code from CreateVariableAccessors(), changing the signature of the GetVariableInScope() method, changing the logic to find an output value by ActivityInstanceId, and making the SetVariable method create a variable when it does not exist. 

List of Changes:
- Changed the signature of GetConfiguredEngine() to return an object instead of Engine
- Added logic in GetConfiguredEngine() to filter the output of output records based on container IDs
- Changed the signature of GetVariableInScope() to return an object instead of the original IEnumerable or string
- Removed unused code from CreateVariableAccessors()
- Changed GetOutputs() to find the output in the ActivityOutputRegister by ActivityInstanceId instead of NodeId
- Added ActivityOutputRecord class to represent a record of an activity's output
- Changed the logic to find an output value by ActivityId or ActivityInstanceId in the Record class
- Changed the logic so that the SetVariable method now creates a variable when it does not exist, rather than throwing an exception 

Refactoring Target:
- Consider making the variable type generic, so that the value returned by the FindOutputByActivityId and FindOutputByActivityInstanceId methods is of the same type as the variable stored
- Add a unit test to ensure that the variable is updated correctly when the SetVariable method is used