### PR TITLE
V3 Add to ConfigureHttpClient access to the service provider

### DIFF
--- a/src/clients/Elsa.Api.Client/Extensions/DependencyInjectionExtensions.cs
+++ b/src/clients/Elsa.Api.Client/Extensions/DependencyInjectionExtensions.cs
@@ -71,7 +71,7 @@ public static class DependencyInjectionExtensions
     {
         var options = serviceProvider.GetRequiredService<IOptions<ElsaClientOptions>>().Value;
         httpClient.BaseAddress = options.BaseAddress;
-        options.ConfigureHttpClient?.Invoke(httpClient);
+        options.ConfigureHttpClient?.Invoke(serviceProvider, httpClient);
     }
     
     private static RefitSettings CreateRefitSettings(IServiceProvider serviceProvider)

--- a/src/clients/Elsa.Api.Client/Options/ElsaClientOptions.cs
+++ b/src/clients/Elsa.Api.Client/Options/ElsaClientOptions.cs
@@ -18,5 +18,5 @@ public class ElsaClientOptions
     /// <summary>
     /// Gets or sets a delegate that can be used to configure the HTTP client.
     /// </summary>
-    public Action<HttpClient>? ConfigureHttpClient { get; set; }
+    public Action<IServiceProvider, HttpClient>? ConfigureHttpClient { get; set; }
 }


### PR DESCRIPTION
Sometimes, when configuring the HttpClient, it may be necessary to access the ServiceProvider.

For example, for authentication, I use BearerToken and to get it I need to access other services:
```
        services.AddElsaClient(options =>
        {
            options.BaseAddress = new Uri(elsaServerUrl + "elsa/api");
            options.ConfigureHttpClient = (provider, client) =>
            {
                IClientAccessTokenCache? clientAccessTokenCache = provider.GetService<IClientAccessTokenCache>();
                ClientAccessToken? clientToken = clientAccessTokenCache?
                    .GetAsync("m2m", new ClientAccessTokenParameters())
                    .GetAwaiter()
                    .GetResult();

                client.SetBearerToken(clientToken?.AccessToken);
            };
        });
```