### PR TITLE
Fix WriteHttpResponse when NoContent

### DIFF
--- a/src/modules/Elsa.Http/Activities/WriteHttpResponse.cs
+++ b/src/modules/Elsa.Http/Activities/WriteHttpResponse.cs
@@ -85,7 +85,8 @@ public class WriteHttpResponse : Activity
     private async Task WriteResponseAsync(ActivityExecutionContext context, HttpResponse response)
     {
         // Set status code.
-        response.StatusCode = (int)context.Get(StatusCode);
+        var statusCode = StatusCode.GetOrDefault(context, () => HttpStatusCode.OK);
+        response.StatusCode = (int)statusCode;
 
         // Add headers.
         var headers = context.GetHeaders(ResponseHeaders);
@@ -110,7 +111,8 @@ public class WriteHttpResponse : Activity
         response.ContentType = httpContent.Headers.ContentType?.ToString() ?? contentType;
 
         // Write content.
-        await httpContent.CopyToAsync(response.Body);
+        if(statusCode != HttpStatusCode.NoContent)
+            await httpContent.CopyToAsync(response.Body);
         
         // Complete activity.
         await context.CompleteActivityAsync();

--- a/src/modules/Elsa.Workflows.Core/Extensions/InputExtensions.cs
+++ b/src/modules/Elsa.Workflows.Core/Extensions/InputExtensions.cs
@@ -6,10 +6,48 @@ using Elsa.Workflows.Core.Models;
 // ReSharper disable once CheckNamespace
 namespace Elsa.Extensions;
 
+/// <summary>
+/// Provides extensions on <see cref="ExpressionExecutionContext"/> and <see cref="ActivityExecutionContext"/>
+/// </summary>
 public static class InputExtensions
 {
-    public static T? GetOrDefault<T>(this Input<T>? input, ActivityExecutionContext context) => context.Get(input);
-    public static T? GetOrDefault<T>(this Input<T>? input, ExpressionExecutionContext context) => context.Get(input);
+    /// <summary>
+    /// Returns the value of the specified input, or a default value if the input is not found.
+    /// </summary>
+    public static T? GetOrDefault<T>(this Input<T>? input, ActivityExecutionContext context, Func<T>? defaultValue = default)
+    {
+        var value = context.Get(input);
+        return value != null ? value : defaultValue != null ? defaultValue.Invoke() : default;
+    }
+
+    /// <summary>
+    /// Returns the value of the specified input, or a default value if the input is not found.
+    /// </summary>
+    public static T? GetOrDefault<T>(this Input<T>? input, ExpressionExecutionContext context, Func<T>? defaultValue = default)
+    {
+        var value = context.Get(input);
+        return value != null ? value : defaultValue != null ? defaultValue.Invoke() : default;
+    }
+
+    /// <summary>
+    /// Returns the value of the specified input.
+    /// </summary>
+    /// <param name="input">The input.</param>
+    /// <param name="context">The context.</param>
+    /// <param name="inputName">The name of the input.</param>
+    /// <typeparam name="T">The type of the input.</typeparam>
+    /// <returns>The value of the specified input.</returns>
+    /// <exception cref="Exception">Throws an exception if the input is not found.</exception>
     public static T Get<T>(this Input<T>? input, ActivityExecutionContext context, [CallerArgumentExpression("input")]string? inputName = default) => context.Get(input) ?? throw new Exception($"{inputName} is required.");
+    
+    /// <summary>
+    /// Returns the value of the specified input.
+    /// </summary>
+    /// <param name="input">The input.</param>
+    /// <param name="context">The context.</param>
+    /// <param name="inputName">The name of the input.</param>
+    /// <typeparam name="T">The type of the input.</typeparam>
+    /// <returns>The value of the specified input.</returns>
+    /// <exception cref="Exception">Throws an exception if the input is not found.</exception>
     public static T Get<T>(this Input<T>? input, ExpressionExecutionContext context, [CallerArgumentExpression("input")]string? inputName = default) => context.Get(input) ?? throw new Exception($"{inputName} is required.");
 }


### PR DESCRIPTION
### === auto-pr-body ===

 List of changes:
- Added logic to use `StatusCode` input as HTTP response status
- Added logic to omit content writing when status code is set to `HttpStatusCode.NoContent`
- Created extension methods for `ActivityExecutionContext` and `ExpressionExecutionContext` to get input values, with additional overloads to support retrieving a default value when not present.

### Refactoring Target:
Aiming to reduce complexity by consolidating duplicated code from existing methods.