### PR TITLE
Change RunTask Payload from ActivityOutput to ActivityInput

### DIFF
--- a/src/activities/Elsa.Activities.Conductor/Activities/RunTask.cs
+++ b/src/activities/Elsa.Activities.Conductor/Activities/RunTask.cs
@@ -30,7 +30,10 @@ namespace Elsa.Activities.Conductor
         )]
         public string TaskName { get; set; } = default!;
 
-        [ActivityOutput(Hint = "Any input to send along with the task to your application.")]
+        [ActivityInput(
+            Hint = "Any input to send along with the task to your application.",
+            SupportedSyntaxes = new[] { SyntaxNames.JavaScript, SyntaxNames.Liquid }
+        )]
         public object? Payload { get; set; }
         
         [ActivityOutput(Hint = "Any input that was received along with the task completion.")]


### PR DESCRIPTION
The `Payload` property of the `Elsa.Activities.Conductor.RunTask` is annotated as an `ActivityOutput`. This seems to be wrong as it is used in the `OnExecuteAsync` method, where it is always set to `null` with this annotation. Annotating it to be an `ActivityInput` solves that problem.