### PR TITLE
Implement HTTP correlation ID selectors

### DIFF
--- a/src/common/Elsa.Features/Services/IFeature.cs
+++ b/src/common/Elsa.Features/Services/IFeature.cs
@@ -1,8 +1,11 @@
+using JetBrains.Annotations;
+
 namespace Elsa.Features.Services;
 
 /// <summary>
 /// Represents a feature.
 /// </summary>
+[UsedImplicitly(ImplicitUseTargetFlags.WithInheritors | ImplicitUseTargetFlags.Members)]
 public interface IFeature
 {
     /// <summary>

--- a/src/modules/Elsa.Http/Abstractions/HttpCorrelationIdSelectorBase.cs
+++ b/src/modules/Elsa.Http/Abstractions/HttpCorrelationIdSelectorBase.cs
@@ -1,0 +1,29 @@
+using Elsa.Http.Contracts;
+using Microsoft.AspNetCore.Http;
+
+namespace Elsa.Http.Abstractions;
+
+/// <summary>
+/// Provides a base class for implementing <see cref="IHttpCorrelationIdSelector"/>.
+/// </summary>
+public abstract class HttpCorrelationIdSelectorBase : IHttpCorrelationIdSelector
+{
+    /// <inheritdoc />
+    public virtual double Priority => 0;
+
+    /// <summary>
+    /// Override this method to return the correlation ID for the specified HTTP context, or <c>null</c> if no correlation ID could be found.
+    /// </summary>
+    protected virtual ValueTask<string?> GetCorrelationIdAsync(HttpContext httpContext, CancellationToken cancellationToken = default)
+    {
+        var correlationId = GetCorrelationId(httpContext);
+        return new(correlationId);
+    }
+
+    /// <summary>
+    /// Override this method to return the correlation ID for the specified HTTP context, or <c>null</c> if no correlation ID could be found.
+    /// </summary>
+    protected virtual string? GetCorrelationId(HttpContext httpContext) => null;
+
+    ValueTask<string?> IHttpCorrelationIdSelector.GetCorrelationIdAsync(HttpContext httpContext, CancellationToken cancellationToken) => GetCorrelationIdAsync(httpContext, cancellationToken);
+}

--- a/src/modules/Elsa.Http/Abstractions/HttpWorkflowInstanceIdSelectorBase.cs
+++ b/src/modules/Elsa.Http/Abstractions/HttpWorkflowInstanceIdSelectorBase.cs
@@ -1,0 +1,29 @@
+using Elsa.Http.Contracts;
+using Microsoft.AspNetCore.Http;
+
+namespace Elsa.Http.Abstractions;
+
+/// <summary>
+/// Provides a base class for implementing <see cref="IHttpCorrelationIdSelector"/>.
+/// </summary>
+public abstract class HttpWorkflowInstanceIdSelectorBase : IHttpWorkflowInstanceIdSelector
+{
+    /// <inheritdoc />
+    public virtual double Priority => 0;
+
+    /// <summary>
+    /// Override this method to return the workflow instance ID for the specified HTTP context, or <c>null</c> if no workflow instance ID could be found.
+    /// </summary>
+    protected virtual ValueTask<string?> GetWorkflowInstanceIdAsync(HttpContext httpContext, CancellationToken cancellationToken = default)
+    {
+        var workflowInstanceId = GetWorkflowInstanceId(httpContext);
+        return new(workflowInstanceId);
+    }
+
+    /// <summary>
+    /// Override this method to return the workflow instance ID for the specified HTTP context, or <c>null</c> if no workflow instance ID could be found.
+    /// </summary>
+    protected virtual string? GetWorkflowInstanceId(HttpContext httpContext) => null;
+
+    ValueTask<string?> IHttpWorkflowInstanceIdSelector.GetWorkflowInstanceIdAsync(HttpContext httpContext, CancellationToken cancellationToken) => GetWorkflowInstanceIdAsync(httpContext, cancellationToken);
+}

--- a/src/modules/Elsa.Http/Contracts/IHttpCorrelationIdSelector.cs
+++ b/src/modules/Elsa.Http/Contracts/IHttpCorrelationIdSelector.cs
@@ -1,0 +1,19 @@
+using Microsoft.AspNetCore.Http;
+
+namespace Elsa.Http.Contracts;
+
+/// <summary>
+/// Provides a way to select the correlation ID for a request.
+/// </summary>
+public interface IHttpCorrelationIdSelector
+{
+    /// <summary>
+    /// The priority of this selector. The selector with the highest priority will be used.
+    /// </summary>
+    double Priority { get; }
+    
+    /// <summary>
+    /// Returns the correlation ID for the specified HTTP context, or <c>null</c> if no correlation ID could be found.
+    /// </summary>
+    ValueTask<string?> GetCorrelationIdAsync(HttpContext httpContext, CancellationToken cancellationToken = default);
+}

--- a/src/modules/Elsa.Http/Contracts/IHttpWorkflowInstanceIdSelector.cs
+++ b/src/modules/Elsa.Http/Contracts/IHttpWorkflowInstanceIdSelector.cs
@@ -1,0 +1,19 @@
+using Microsoft.AspNetCore.Http;
+
+namespace Elsa.Http.Contracts;
+
+/// <summary>
+/// Provides a way to select the workflow instance ID for a request.
+/// </summary>
+public interface IHttpWorkflowInstanceIdSelector
+{
+    /// <summary>
+    /// The priority of this selector. The selector with the highest priority will be used.
+    /// </summary>
+    double Priority { get; }
+    
+    /// <summary>
+    /// Returns the workflow instance ID for the specified HTTP context, or <c>null</c> if no workflow instance ID could be found.
+    /// </summary>
+    ValueTask<string?> GetWorkflowInstanceIdAsync(HttpContext httpContext, CancellationToken cancellationToken = default);
+}

--- a/src/modules/Elsa.Http/Elsa.Http.csproj
+++ b/src/modules/Elsa.Http/Elsa.Http.csproj
@@ -29,4 +29,6 @@
         <ProjectReference Include="..\Elsa.JavaScript\Elsa.JavaScript.csproj" />
     </ItemGroup>
 
+
+
 </Project>

--- a/src/modules/Elsa.Http/Extensions/ServiceCollectionExtensions.cs
+++ b/src/modules/Elsa.Http/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,31 @@
+using Elsa.Http.Contracts;
+using JetBrains.Annotations;
+using Microsoft.Extensions.DependencyInjection;
+
+// ReSharper disable once CheckNamespace
+namespace Elsa.Extensions;
+
+/// <summary>
+/// Contains extension methods for the <see cref="IServiceCollection"/> interface.
+/// </summary>
+[PublicAPI]
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds a <see cref="IHttpCorrelationIdSelector"/> implementation to the service collection.
+    /// </summary>
+    public static IServiceCollection AddHttpCorrelationIdSelector<T>(this IServiceCollection services) where T : class, IHttpCorrelationIdSelector
+    {
+        services.AddSingleton<IHttpCorrelationIdSelector, T>();
+        return services;
+    }
+    
+    /// <summary>
+    /// Adds a <see cref="IHttpCorrelationIdSelector"/> implementation to the service collection.
+    /// </summary>
+    public static IServiceCollection AddHttpCorrelationIdSelector(this IServiceCollection services, Func<IServiceProvider, IHttpCorrelationIdSelector> factory)
+    {
+        services.AddSingleton(factory);
+        return services;
+    }
+}

--- a/src/modules/Elsa.Http/Selectors/HeaderHttpCorrelationIdSelector.cs
+++ b/src/modules/Elsa.Http/Selectors/HeaderHttpCorrelationIdSelector.cs
@@ -1,0 +1,16 @@
+using Elsa.Http.Abstractions;
+using Microsoft.AspNetCore.Http;
+
+namespace Elsa.Http.Selectors;
+
+/// <summary>
+/// Returns the correlation ID from the <c>X-Correlation-ID</c> header, if any.
+/// </summary>
+public class HeaderHttpCorrelationIdSelector : HttpCorrelationIdSelectorBase
+{
+    /// <inheritdoc />
+    protected override string? GetCorrelationId(HttpContext httpContext)
+    {
+        return httpContext.Request.Headers["X-Correlation-ID"].FirstOrDefault();
+    }
+}

--- a/src/modules/Elsa.Http/Selectors/HeaderHttpWorkflowInstanceIdSelector.cs
+++ b/src/modules/Elsa.Http/Selectors/HeaderHttpWorkflowInstanceIdSelector.cs
@@ -1,0 +1,16 @@
+using Elsa.Http.Abstractions;
+using Microsoft.AspNetCore.Http;
+
+namespace Elsa.Http.Selectors;
+
+/// <summary>
+/// Returns the workflow instance ID from the <c>X-Workflow-Instance-ID</c> header, if any.
+/// </summary>
+public class HeaderHttpWorkflowInstanceIdSelector : HttpWorkflowInstanceIdSelectorBase
+{
+    /// <inheritdoc />
+    protected override string? GetWorkflowInstanceId(HttpContext httpContext)
+    {
+        return httpContext.Request.Headers["X-Workflow-Instance-ID"].FirstOrDefault();
+    }
+}

--- a/src/modules/Elsa.Http/Selectors/QueryStringHttpCorrelationIdSelector.cs
+++ b/src/modules/Elsa.Http/Selectors/QueryStringHttpCorrelationIdSelector.cs
@@ -1,0 +1,16 @@
+using Elsa.Http.Abstractions;
+using Microsoft.AspNetCore.Http;
+
+namespace Elsa.Http.Selectors;
+
+/// <summary>
+/// Returns the correlation ID from the <c>correlationId</c> query string parameter.
+/// </summary>
+public class QueryStringHttpCorrelationIdSelector : HttpCorrelationIdSelectorBase
+{
+    /// <inheritdoc />
+    protected override string? GetCorrelationId(HttpContext httpContext)
+    {
+        return httpContext.Request.Query["correlationId"].FirstOrDefault();
+    }
+}

--- a/src/modules/Elsa.Http/Selectors/QueryStringHttpWorkflowInstanceIdSelector.cs
+++ b/src/modules/Elsa.Http/Selectors/QueryStringHttpWorkflowInstanceIdSelector.cs
@@ -1,0 +1,16 @@
+using Elsa.Http.Abstractions;
+using Microsoft.AspNetCore.Http;
+
+namespace Elsa.Http.Selectors;
+
+/// <summary>
+/// Returns the workflow instance ID from the <c>X-Workflow-Instance-ID</c> header, if any.
+/// </summary>
+public class QueryStringHttpWorkflowInstanceIdSelector : HttpWorkflowInstanceIdSelectorBase
+{
+    /// <inheritdoc />
+    protected override string? GetWorkflowInstanceId(HttpContext httpContext)
+    {
+        return httpContext.Request.Query["workflowInstanceId"].FirstOrDefault();
+    }
+}


### PR DESCRIPTION
This PR introduces enhancements to the Elsa HTTP module:

1. **Correlation ID Selectors**: A new abstraction, `IHttpCorrelationIdSelector`, has been added to allow for the extraction of correlation IDs from HTTP requests.
   
2. **Workflow Instance ID Selectors**: The `IHttpWorkflowInstanceIdSelector` interface provides a mechanism to extract workflow instance IDs from HTTP requests. This aids in associating specific workflow instances with incoming HTTP requests.

3. **Base Classes for Selectors**: To simplify the implementation of the above selectors, base classes `HttpCorrelationIdSelectorBase` and `HttpWorkflowInstanceIdSelectorBase` have been provided. These offer common functionalities and can be extended as needed.