### PR TITLE
Support serialization of non(de)serializable values

### DIFF
--- a/src/modules/Elsa.EntityFrameworkCore.MySql/Modules/Management/Extensions.cs
+++ b/src/modules/Elsa.EntityFrameworkCore.MySql/Modules/Management/Extensions.cs
@@ -23,7 +23,7 @@ public static partial class Extensions
         return feature;
     }
 
-    public static EFCoreWorkflowManagementPersistenceFeature UseMySql(this EFCoreWorkflowManagementPersistenceFeature feature, string connectionString, ElsaDbContextOptions? options = default)
+    public static WorkflowManagementPersistenceFeature UseMySql(this WorkflowManagementPersistenceFeature feature, string connectionString, ElsaDbContextOptions? options = default)
     {
         feature.DbContextOptionsBuilder = (_, db) => db.UseElsaMySql(connectionString, options);
         return feature;

--- a/src/modules/Elsa.EntityFrameworkCore.PostgreSql/Modules/Management/Extensions.cs
+++ b/src/modules/Elsa.EntityFrameworkCore.PostgreSql/Modules/Management/Extensions.cs
@@ -23,7 +23,7 @@ public static partial class Extensions
         return feature;
     }
     
-    public static EFCoreWorkflowManagementPersistenceFeature UsePostgreSql(this EFCoreWorkflowManagementPersistenceFeature feature, string connectionString, ElsaDbContextOptions? options = default)
+    public static WorkflowManagementPersistenceFeature UsePostgreSql(this WorkflowManagementPersistenceFeature feature, string connectionString, ElsaDbContextOptions? options = default)
     {
         feature.DbContextOptionsBuilder = (_, db) => db.UseElsaPostgreSql(connectionString, options);
         return feature;

--- a/src/modules/Elsa.EntityFrameworkCore.SqlServer/Modules/Management/Extensions.cs
+++ b/src/modules/Elsa.EntityFrameworkCore.SqlServer/Modules/Management/Extensions.cs
@@ -20,7 +20,7 @@ public static partial class Extensions
         return feature;
     }
     
-    public static EFCoreWorkflowManagementPersistenceFeature UseSqlServer(this EFCoreWorkflowManagementPersistenceFeature feature, string connectionString, ElsaDbContextOptions? options = default)
+    public static WorkflowManagementPersistenceFeature UseSqlServer(this WorkflowManagementPersistenceFeature feature, string connectionString, ElsaDbContextOptions? options = default)
     {
         feature.DbContextOptionsBuilder = (_, db) => db.UseElsaSqlServer(connectionString, options);
         return feature;

--- a/src/modules/Elsa.EntityFrameworkCore.Sqlite/Modules/Management/Extensions.cs
+++ b/src/modules/Elsa.EntityFrameworkCore.Sqlite/Modules/Management/Extensions.cs
@@ -21,7 +21,7 @@ public static partial class Extensions
         return feature;
     }
     
-    public static EFCoreWorkflowManagementPersistenceFeature UseSqlite(this EFCoreWorkflowManagementPersistenceFeature feature, string connectionString = Constants.DefaultConnectionString, ElsaDbContextOptions? options = default)
+    public static WorkflowManagementPersistenceFeature UseSqlite(this WorkflowManagementPersistenceFeature feature, string connectionString = Constants.DefaultConnectionString, ElsaDbContextOptions? options = default)
     {
         feature.DbContextOptionsBuilder = (_, db) => db.UseElsaSqlite(connectionString, options);
         return feature;

--- a/src/modules/Elsa.EntityFrameworkCore/Modules/Management/Extensions.cs
+++ b/src/modules/Elsa.EntityFrameworkCore/Modules/Management/Extensions.cs
@@ -28,7 +28,7 @@ public static class WorkflowManagementFeatureExtensions
     /// <summary>
     /// Sets up the EF Core persistence provider. 
     /// </summary>
-    public static WorkflowManagementFeature UseEntityFrameworkCore(this WorkflowManagementFeature feature, Action<EFCoreWorkflowManagementPersistenceFeature>? configure = default)
+    public static WorkflowManagementFeature UseEntityFrameworkCore(this WorkflowManagementFeature feature, Action<WorkflowManagementPersistenceFeature>? configure = default)
     {
         feature.Module.Configure(configure);
         return feature;

--- a/src/modules/Elsa.EntityFrameworkCore/Modules/Management/WorkflowManagementPersistenceFeature.cs
+++ b/src/modules/Elsa.EntityFrameworkCore/Modules/Management/WorkflowManagementPersistenceFeature.cs
@@ -15,10 +15,10 @@ namespace Elsa.EntityFrameworkCore.Modules.Management;
 [DependsOn(typeof(WorkflowInstancesFeature))]
 [DependsOn(typeof(WorkflowDefinitionsFeature))]
 [PublicAPI]
-public class EFCoreWorkflowManagementPersistenceFeature : PersistenceFeatureBase<ManagementElsaDbContext>
+public class WorkflowManagementPersistenceFeature : PersistenceFeatureBase<ManagementElsaDbContext>
 {
     /// <inheritdoc />
-    public EFCoreWorkflowManagementPersistenceFeature(IModule module) : base(module)
+    public WorkflowManagementPersistenceFeature(IModule module) : base(module)
     {
     }
 

--- a/src/modules/Elsa.EntityFrameworkCore/Modules/Runtime/ActivityExecutionLogStore.cs
+++ b/src/modules/Elsa.EntityFrameworkCore/Modules/Runtime/ActivityExecutionLogStore.cs
@@ -53,7 +53,7 @@ public class EFCoreActivityExecutionStore : IActivityExecutionStore
     private async ValueTask OnSaveAsync(RuntimeElsaDbContext dbContext, ActivityExecutionRecord entity, CancellationToken cancellationToken)
     {
         dbContext.Entry(entity).Property("SerializedActivityState").CurrentValue = entity.ActivityState != null ? (await _activityStateSerializer.SerializeAsync(entity.ActivityState, cancellationToken)).ToString() : default;
-        dbContext.Entry(entity).Property("SerializedOutputs").CurrentValue = entity.ActivityState != null ? (await _activityStateSerializer.SerializeAsync(entity.Outputs, cancellationToken)).ToString() : default;
+        dbContext.Entry(entity).Property("SerializedOutputs").CurrentValue = entity.Outputs != null ? (await _activityStateSerializer.SerializeAsync(entity.Outputs, cancellationToken)).ToString() : default;
         dbContext.Entry(entity).Property("SerializedException").CurrentValue = entity.Exception != null ? _payloadSerializer.Serialize(entity.Exception) : default;
         dbContext.Entry(entity).Property("SerializedPayload").CurrentValue = entity.Payload != null ? _payloadSerializer.Serialize(entity.Payload) : default;
     }

--- a/src/modules/Elsa.Workflows.Core/Serialization/Converters/PolymorphicObjectConverter.cs
+++ b/src/modules/Elsa.Workflows.Core/Serialization/Converters/PolymorphicObjectConverter.cs
@@ -6,6 +6,7 @@ using System.Dynamic;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
 
 namespace Elsa.Workflows.Core.Serialization.Converters;
 
@@ -42,7 +43,16 @@ public class PolymorphicObjectConverter : JsonConverter<object>
         var isEnumerable = typeof(IEnumerable).IsAssignableFrom(targetType);
 
         if (!isEnumerable)
-            return JsonSerializer.Deserialize(ref reader, targetType, newOptions)!;
+        {
+            try
+            {
+                return JsonSerializer.Deserialize(ref reader, targetType, newOptions)!;
+            }
+            catch (NotSupportedException e)
+            {
+                return default!;
+            }
+        }
 
         // If the target type is a Newtonsoft.JObject, parse the JSON island.
         var isNewtonsoftObject = targetType == typeof(JObject);

--- a/src/modules/Elsa.Workflows.Core/Serialization/Converters/SafeDictionaryConverter.cs
+++ b/src/modules/Elsa.Workflows.Core/Serialization/Converters/SafeDictionaryConverter.cs
@@ -1,0 +1,51 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Elsa.Workflows.Core.Serialization.Converters;
+
+/// <summary>
+/// A JSON converter that safely serializes a dictionary of objects, even if some of the objects are not serializable.
+/// In that case, the converter will serialize a fallback object that contains the type name of the original object.
+/// </summary>
+public class SafeDictionaryConverter : JsonConverter<IDictionary<string, object>>
+{
+    /// <inheritdoc />
+    public override IDictionary<string, object> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        // For simplicity, I'm assuming you're using the default deserialization for dictionaries.
+        // If you need custom deserialization logic, you can implement it here.
+        return JsonSerializer.Deserialize<IDictionary<string, object>>(ref reader, options)!;
+    }
+
+    /// <inheritdoc />
+    public override void Write(Utf8JsonWriter writer, IDictionary<string, object> value, JsonSerializerOptions options)
+    {
+        writer.WriteStartObject();
+
+        foreach (var kvp in value)
+        {
+            if (kvp.Value == null!) continue; // Skip null values
+
+            writer.WritePropertyName(kvp.Key);
+
+            try
+            {
+                // Serialize the value to a temporary string.
+                var serializedValue = JsonSerializer.Serialize(kvp.Value, options);
+            
+                // Use the serialized string value to write to the main writer.
+                using var doc = JsonDocument.Parse(serializedValue);
+                doc.WriteTo(writer);
+            }
+            catch
+            {
+                // If serialization fails, write the fallback object.
+                writer.WriteStartObject();
+                writer.WriteString("TypeName", kvp.Value.GetType().FullName);
+                writer.WriteEndObject();
+            }
+        }
+
+        writer.WriteEndObject();
+    }
+}

--- a/src/modules/Elsa.Workflows.Core/Serialization/Converters/SafeDictionaryConverterFactory.cs
+++ b/src/modules/Elsa.Workflows.Core/Serialization/Converters/SafeDictionaryConverterFactory.cs
@@ -1,0 +1,26 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Elsa.Workflows.Core.Serialization.Converters;
+
+/// <summary>
+/// A JSON converter factory that creates <see cref="SafeDictionaryConverter"/> instances.
+/// </summary>
+public class SafeDictionaryConverterFactory : JsonConverterFactory
+{
+    /// <inheritdoc />
+    public override bool CanConvert(Type typeToConvert)
+    {
+        // Check if the type is assignable to IDictionary<string, object>
+        return typeof(IDictionary<string, object>).IsAssignableFrom(typeToConvert);
+    }
+
+    /// <inheritdoc />
+    public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (CanConvert(typeToConvert))
+            return new SafeDictionaryConverter();
+
+        throw new InvalidOperationException($"Cannot convert {typeToConvert}");
+    }
+}


### PR DESCRIPTION
### === auto-pr-body ===


Summary:
This pull request updates the logic for setting up persistence for the EF Core database provider. It also adds a new class `SafeDictionaryConverter` and updates the `BasicSerializationProvider` class.

List of changes:
- Updated `OnSaveAsync()` and `OnLoadAsync()` to use the IActivityStateSerializer interface and JsonSerializer, respectively.
- Added a new class `SafeDictionaryConverter` that safely serializes a dictionary of objects, even if some of the objects are not serializable.
- Added a new class `SafeDictionaryConverterFactory` that creates instances of `SafeDictionaryConverter`. 
- Updated `BasicSerializationProvider` to add the SafeDictionaryConverterFactory to the list of converters, and to enable reference handling. 
- Changed the EF Core workflow instance and management persistence feature methods to use Elsa database options.
- Updated the workflow management feature and EF Core workflow management persistence feature names.
- Added logic to the activity execution log store to save activity execution records to the database.

Refactoring Target:
- Refactor `OnSaveAsync()` and `OnLoadAsync()` into a single method to improve code readability.
- Refactor exception handling for the PolymorphicObjectConverter for robustness.