### PR TITLE
Fix Default Workflow Runtime Race condition

### DIFF
--- a/src/clients/Elsa.Api.Client/Resources/ActivityExecutions/Models/ActivityExecutionRecord.cs
+++ b/src/clients/Elsa.Api.Client/Resources/ActivityExecutions/Models/ActivityExecutionRecord.cs
@@ -36,17 +36,17 @@ public class ActivityExecutionRecord : Entity
     /// <summary>
     /// The state of the activity at the time this record is created or last updated.
     /// </summary>
-    public IDictionary<string, object>? ActivityState { get; set; }
+    public IDictionary<string, object?>? ActivityState { get; set; }
     
     /// <summary>
     /// Any additional payload associated with the log record.
     /// </summary>
-    public IDictionary<string, object>? Payload { get; set; }
+    public IDictionary<string, object?>? Payload { get; set; }
     
     /// <summary>
     /// Any outputs provided by the activity.
     /// </summary>
-    public IDictionary<string, object>? Outputs { get; set; }
+    public IDictionary<string, object?>? Outputs { get; set; }
     
     /// <summary>
     /// Gets or sets the exception that occurred during the activity execution.

--- a/src/modules/Elsa.Telnyx/Activities/AnswerCallBase.cs
+++ b/src/modules/Elsa.Telnyx/Activities/AnswerCallBase.cs
@@ -26,12 +26,12 @@ public abstract class AnswerCallBase : Activity<CallAnsweredPayload>
     /// The call control ID to answer. Leave blank when the workflow is driven by an incoming call and you wish to pick up that one.
     /// </summary>
     [Input(DisplayName = "Call Control ID", Description = "The call control ID of the call to answer.", Category = "Advanced")]
-    public Input<string?>? CallControlId { get; set; }
+    public Input<string> CallControlId { get; set; } = default!;
 
     /// <inheritdoc />
     protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
     {
-        var callControlId = context.GetPrimaryCallControlId(CallControlId) ?? throw new Exception("CallControlId is required.");
+        var callControlId = CallControlId.Get(context);
 
         var request = new AnswerCallRequest
         {

--- a/src/modules/Elsa.Telnyx/Activities/BridgeCallsBase.cs
+++ b/src/modules/Elsa.Telnyx/Activities/BridgeCallsBase.cs
@@ -29,19 +29,19 @@ public abstract class BridgeCallsBase : Activity<BridgedCallsOutput>
     /// The source call control ID of one of the call to bridge with. Leave empty to use the ambient inbound call control Id, if there is one.
     /// </summary>
     [Input(DisplayName = "Call Control ID A", Description = "The source call control ID of one of the call to bridge with. Leave empty to use the ambient inbound call control Id, if there is one.")]
-    public Input<string?>? CallControlIdA { get; set; }
+    public Input<string> CallControlIdA { get; set; } = default!;
 
     /// <summary>
     /// The destination call control ID of the call you want to bridge with.
     /// </summary>
     [Input(DisplayName = "Call Control ID B", Description = "The destination call control ID of the call you want to bridge with.")]
-    public Input<string?>? CallControlIdB { get; set; }
+    public Input<string> CallControlIdB { get; set; } = default!;
 
     /// <inheritdoc />
     protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
     {
-        var callControlIdA = context.GetPrimaryCallControlId(CallControlIdA) ?? throw new Exception("CallControlA is required");
-        var callControlIdB = context.GetSecondaryCallControlId(CallControlIdB) ?? throw new Exception("CallControlB is required");
+        var callControlIdA = CallControlIdA.Get(context);
+        var callControlIdB = CallControlIdB.Get(context);
         var request = new BridgeCallsRequest(callControlIdB, ClientState: context.CreateCorrelatingClientState(context.Id));
         var telnyxClient = context.GetRequiredService<ITelnyxClient>();
 
@@ -80,8 +80,8 @@ public abstract class BridgeCallsBase : Activity<BridgedCallsOutput>
     private async ValueTask ResumeAsync(ActivityExecutionContext context)
     {
         var payload = context.GetInput<CallBridgedPayload>()!;
-        var callControlIdA = context.GetPrimaryCallControlId(CallControlIdA);
-        var callControlIdB = context.GetSecondaryCallControlId(CallControlIdB);
+        var callControlIdA = CallControlIdA.Get(context);
+        var callControlIdB = CallControlIdB.Get(context);;
 
         if (payload.CallControlId == callControlIdA) context.SetProperty("CallBridgedPayloadA", payload);
         if (payload.CallControlId == callControlIdB) context.SetProperty("CallBridgedPayloadB", payload);

--- a/src/modules/Elsa.Telnyx/Activities/GatherUsingAudio.cs
+++ b/src/modules/Elsa.Telnyx/Activities/GatherUsingAudio.cs
@@ -32,7 +32,7 @@ public class GatherUsingAudio : Activity<CallGatherEndedPayload>, IBookmarksPers
     /// The call control ID of the call from which to gather input. Leave empty to use the ambient call control ID, if there is any.
     /// </summary>
     [Input(DisplayName = "Call Control ID", Description = "The call control ID of the call from which to gather input. Leave empty to use the ambient call control ID, if there is any.", Category = "Advanced")]
-    public Input<string?> CallControlId { get; set; } = default!;
+    public Input<string> CallControlId { get; set; } = default!;
 
     /// <summary>
     /// The URL of a file to be played back at the beginning of each prompt. The URL can point to either a WAV or MP3 file.
@@ -127,7 +127,7 @@ public class GatherUsingAudio : Activity<CallGatherEndedPayload>, IBookmarksPers
             ValidDigits.Get(context).EmptyToNull()
         );
 
-        var callControlId = context.GetPrimaryCallControlId(CallControlId) ?? throw new Exception("CallControlId is required");
+        var callControlId = CallControlId.Get(context);
         var telnyxClient = context.GetRequiredService<ITelnyxClient>();
 
         try
@@ -144,7 +144,7 @@ public class GatherUsingAudio : Activity<CallGatherEndedPayload>, IBookmarksPers
     /// <inheritdoc />
     protected override void Execute(ActivityExecutionContext context)
     {
-        var callControlId = context.GetPrimaryCallControlId(CallControlId) ?? throw new Exception("CallControlId is required");
+        var callControlId = CallControlId.Get(context);
         context.CreateBookmark(new WebhookEventBookmarkPayload(WebhookEventTypes.CallGatherEnded, callControlId), ResumeAsync);
     }
 

--- a/src/modules/Elsa.Telnyx/Activities/GatherUsingSpeak.cs
+++ b/src/modules/Elsa.Telnyx/Activities/GatherUsingSpeak.cs
@@ -31,7 +31,7 @@ public class GatherUsingSpeak : Activity<CallGatherEndedPayload>
     /// The call control ID of the call from which to gather input. Leave empty to use the ambient call control ID, if there is any.
     /// </summary>
     [Input(DisplayName = "Call Control ID", Description = "The call control ID of the call from which to gather input. Leave empty to use the ambient call control ID, if there is any.", Category = "Advanced")]
-    public Input<string?> CallControlId { get; set; } = default!;
+    public Input<string> CallControlId { get; set; } = default!;
         
     /// <summary>
     /// The language you want spoken.
@@ -144,7 +144,7 @@ public class GatherUsingSpeak : Activity<CallGatherEndedPayload>
     /// <inheritdoc />
     protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
     {
-        var callControlId = context.GetPrimaryCallControlId(CallControlId) ?? throw new Exception("CallControlId is required");
+        var callControlId = CallControlId.Get(context);
         
         var request = new GatherUsingSpeakRequest(
             Language.Get(context) ?? throw new Exception("Language is required."),

--- a/src/modules/Elsa.Telnyx/Activities/HangupCallBase.cs
+++ b/src/modules/Elsa.Telnyx/Activities/HangupCallBase.cs
@@ -1,3 +1,4 @@
+using Elsa.Extensions;
 using Elsa.Telnyx.Client.Models;
 using Elsa.Telnyx.Client.Services;
 using Elsa.Telnyx.Extensions;
@@ -23,12 +24,12 @@ public abstract class HangupCallBase : Activity
     /// Unique identifier and token for controlling the call.
     /// </summary>
     [Input(DisplayName = "Call Control ID", Description = "Unique identifier and token for controlling the call.", Category = "Advanced")]
-    public Input<string?> CallControlId { get; set; } = default!;
+    public Input<string> CallControlId { get; set; } = default!;
 
     /// <inheritdoc />
     protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
     {
-        var callControlId = context.GetPrimaryCallControlId(CallControlId) ?? throw new Exception("CallControlId is required.");
+        var callControlId = CallControlId.Get(context);
         var request = new HangupCallRequest(ClientState: context.CreateCorrelatingClientState());
         var telnyxClient = context.GetRequiredService<ITelnyxClient>();
 

--- a/src/modules/Elsa.Telnyx/Activities/IncomingCall.cs
+++ b/src/modules/Elsa.Telnyx/Activities/IncomingCall.cs
@@ -26,7 +26,7 @@ public class IncomingCall : Trigger<CallInitiatedPayload>
     public IncomingCall([CallerFilePath] string? source = default, [CallerLineNumber] int? line = default) : base(source, line)
     {
     }
-    
+
     /// <summary>
     /// A list of destination numbers to respond to.
     /// </summary>
@@ -67,26 +67,18 @@ public class IncomingCall : Trigger<CallInitiatedPayload>
         var webhookModel = context.GetInput<TelnyxWebhook>(WebhookSerializerOptions.Create());
         var callInitiatedPayload = (CallInitiatedPayload)webhookModel.Data.Payload;
 
-        // Correlate workflow with call session ID.
-        // TODO: Add support for multiple correlation ID keys.
-        context.WorkflowExecutionContext.CorrelationId = callInitiatedPayload.CallSessionId;
-            
-        // Associate workflow with inbound call control ID and from number.
-        context.SetPrimaryCallControlId(callInitiatedPayload.CallControlId);
-        context.SetFrom(callInitiatedPayload.From);
-            
         // Store webhook payload as output.
-        context.Set(Result, callInitiatedPayload);
+        Result.Set(context, callInitiatedPayload);
 
         await context.CompleteActivityAsync();
     }
-        
+
     private IEnumerable<object> GetBookmarkPayloads(ExpressionExecutionContext context)
     {
         var from = context.Get(From) ?? ArraySegment<string>.Empty;
         var to = context.Get(To) ?? ArraySegment<string>.Empty;
         var catchAll = context.Get(CatchAll);
-                
+
         foreach (var phoneNumber in from) yield return new IncomingCallFromBookmarkPayload(phoneNumber);
         foreach (var phoneNumber in to) yield return new IncomingCallToBookmarkPayload(phoneNumber);
 

--- a/src/modules/Elsa.Telnyx/Activities/PlayAudioBase.cs
+++ b/src/modules/Elsa.Telnyx/Activities/PlayAudioBase.cs
@@ -34,7 +34,7 @@ public abstract class PlayAudioBase : Activity
         Description = "Unique identifier and token for controlling the call.",
         Category = "Advanced"
     )]
-    public Input<string?>? CallControlId { get; set; } = default!;
+    public Input<string> CallControlId { get; set; } = default!;
 
     /// <summary>
     /// The URL of a file to be played back at the beginning of each prompt. The URL can point to either a WAV or MP3 file.
@@ -89,7 +89,7 @@ public abstract class PlayAudioBase : Activity
             ClientState: context.CreateCorrelatingClientState(context.Id)
         );
 
-        var callControlId = context.GetPrimaryCallControlId(CallControlId) ?? throw new Exception("CallControlId is required.");
+        var callControlId = CallControlId.Get(context);
         var telnyxClient = context.GetRequiredService<ITelnyxClient>();
 
         try

--- a/src/modules/Elsa.Telnyx/Activities/SpeakTextBase.cs
+++ b/src/modules/Elsa.Telnyx/Activities/SpeakTextBase.cs
@@ -31,7 +31,7 @@ public abstract class SpeakTextBase : Activity
         Description = "Unique identifier and token for controlling the call.",
         Category = "Advanced"
     )]
-    public Input<string?> CallControlId { get; set; } = default!;
+    public Input<string> CallControlId { get; set; } = default!;
 
     /// <summary>
     /// The language you want spoken.
@@ -97,7 +97,7 @@ public abstract class SpeakTextBase : Activity
             ClientState: context.CreateCorrelatingClientState(context.Id)
         );
 
-        var callControlId = context.GetPrimaryCallControlId(CallControlId) ?? throw new Exception("CallControlId is required.");
+        var callControlId = CallControlId.Get(context);
         var telnyxClient = context.GetRequiredService<ITelnyxClient>();
 
         try

--- a/src/modules/Elsa.Telnyx/Activities/StartRecordingBase.cs
+++ b/src/modules/Elsa.Telnyx/Activities/StartRecordingBase.cs
@@ -32,7 +32,7 @@ public abstract class StartRecordingBase : Activity<CallRecordingSavedPayload>
         Description = "Unique identifier and token for controlling the call.",
         Category = "Advanced"
     )]
-    public Input<string?> CallControlId { get; set; } = default!;
+    public Input<string> CallControlId { get; set; } = default!;
 
     /// <summary>
     /// When 'dual', final audio file will be stereo recorded with the first leg on channel A, and the rest on channel B.
@@ -72,7 +72,7 @@ public abstract class StartRecordingBase : Activity<CallRecordingSavedPayload>
             ClientState: context.CreateCorrelatingClientState()
         );
 
-        var callControlId = context.GetPrimaryCallControlId(CallControlId) ?? throw new Exception("CallControlId is required.");
+        var callControlId = CallControlId.Get(context);
         var telnyxClient = context.GetRequiredService<ITelnyxClient>();
 
         try

--- a/src/modules/Elsa.Telnyx/Activities/StopAudioPlaybackBase.cs
+++ b/src/modules/Elsa.Telnyx/Activities/StopAudioPlaybackBase.cs
@@ -28,7 +28,7 @@ public abstract class StopAudioPlaybackBase : Activity
         Description = "Unique identifier and token for controlling the call.",
         Category = "Advanced"
     )]
-    public Input<string?> CallControlId { get; set; } = default!;
+    public Input<string> CallControlId { get; set; } = default!;
 
     /// <summary>
     /// Use 'current' to stop only the current audio or 'all' to stop all audios in the queue.
@@ -44,7 +44,7 @@ public abstract class StopAudioPlaybackBase : Activity
     protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
     {
         var request = new StopAudioPlaybackRequest(Stop.Get(context), context.CreateCorrelatingClientState(context.Id));
-        var callControlId = context.GetPrimaryCallControlId(CallControlId) ?? throw new Exception("CallControlId is required.");
+        var callControlId = CallControlId.Get(context);
         var telnyxClient = context.GetRequiredService<ITelnyxClient>();
 
         try

--- a/src/modules/Elsa.Telnyx/Activities/StopRecording.cs
+++ b/src/modules/Elsa.Telnyx/Activities/StopRecording.cs
@@ -31,13 +31,13 @@ public class StopRecording : Activity
         Description = "Unique identifier and token for controlling the call.",
         Category = "Advanced"
     )]
-    public Input<string?> CallControlId { get; set; } = default!;
+    public Input<string> CallControlId { get; set; } = default!;
 
     /// <inheritdoc />
     protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
     {
         var request = new StopRecordingRequest(context.CreateCorrelatingClientState());
-        var callControlId = context.GetPrimaryCallControlId(CallControlId) ?? throw new Exception("CallControlId is required");
+        var callControlId = CallControlId.Get(context);
         var telnyxClient = context.GetRequiredService<ITelnyxClient>();
 
         try

--- a/src/modules/Elsa.Telnyx/Activities/TransferCall.cs
+++ b/src/modules/Elsa.Telnyx/Activities/TransferCall.cs
@@ -35,7 +35,7 @@ public class TransferCall : Activity<CallPayload>
         Description = "Unique identifier and token for controlling the call.",
         Category = "Advanced"
     )]
-    public Input<string?> CallControlId { get; set; } = default!;
+    public Input<string> CallControlId { get; set; } = default!;
 
     /// <summary>
     /// The DID or SIP URI to dial out and bridge to the given call.
@@ -129,7 +129,7 @@ public class TransferCall : Activity<CallPayload>
 
     private async ValueTask TransferCallAsync(ActivityExecutionContext context)
     {
-        var callControlId = context.GetPrimaryCallControlId(CallControlId) ?? throw new Exception("CallControlId is required.");
+        var callControlId = CallControlId.Get(context);
         
         var request = new TransferCallRequest(
             To.Get(context) ?? throw new Exception("To is required."),

--- a/src/modules/Elsa.Telnyx/Extensions/ActivityExecutionExtensions.cs
+++ b/src/modules/Elsa.Telnyx/Extensions/ActivityExecutionExtensions.cs
@@ -1,7 +1,5 @@
-using Elsa.Extensions;
 using Elsa.Telnyx.Models;
 using Elsa.Workflows.Core;
-using Elsa.Workflows.Core.Models;
 
 namespace Elsa.Telnyx.Extensions;
 
@@ -10,24 +8,11 @@ namespace Elsa.Telnyx.Extensions;
 /// </summary>
 public static class ActivityExecutionExtensions
 {
-    private const string PrimaryCallControlIdKey = "telnyx:primary-callcontrol-id";
-    private const string SecondaryCallControlIdKey = "telnyx:secondary-callcontrol-id";
-    private const string FromKey = "telnyx:from";
-    
-    public static void SetPrimaryCallControlId(this ActivityExecutionContext context, string value) => context.WorkflowExecutionContext.SetProperty(PrimaryCallControlIdKey, value);
-    public static string? GetPrimaryCallControlId(this ActivityExecutionContext context) => context.WorkflowExecutionContext.GetProperty<string>(PrimaryCallControlIdKey);
-    public static string? GetPrimaryCallControlId(this ActivityExecutionContext context, string? callControlId) => string.IsNullOrWhiteSpace(callControlId) ? context.GetPrimaryCallControlId() : callControlId;
-    public static string? GetPrimaryCallControlId(this ActivityExecutionContext context, Input<string?>? callControlId) => context.GetPrimaryCallControlId(callControlId.GetOrDefault(context));
-    public static bool HasPrimaryCallControlId(this ActivityExecutionContext context) => context.WorkflowExecutionContext.HasProperty(PrimaryCallControlIdKey);
-    
-    public static void SetSecondaryCallControlId(this ActivityExecutionContext context, string value) => context.WorkflowExecutionContext.SetProperty(SecondaryCallControlIdKey, value);
-    public static string? GetSecondaryCallControlId(this ActivityExecutionContext context) => context.WorkflowExecutionContext.GetProperty<string>(SecondaryCallControlIdKey);
-    public static string? GetSecondaryCallControlId(this ActivityExecutionContext context, string? callControlId) => string.IsNullOrWhiteSpace(callControlId) ? context.GetSecondaryCallControlId() : callControlId;
-    public static string? GetSecondaryCallControlId(this ActivityExecutionContext context, Input<string?>? callControlId) => context.GetSecondaryCallControlId(callControlId.Get(context));
-    public static bool HasSecondaryCallControlId(this ActivityExecutionContext context) => context.WorkflowExecutionContext.HasProperty(SecondaryCallControlIdKey);
-    public static string CreateCorrelatingClientState(this ActivityExecutionContext context, string? activityInstanceId = default) => new ClientStatePayload(context.WorkflowExecutionContext.CorrelationId!, activityInstanceId).ToBase64();
-    
-    public static void SetFrom(this ActivityExecutionContext context, string value) => context.WorkflowExecutionContext.SetProperty(FromKey, value);
-    public static string? GetFrom(this ActivityExecutionContext context) => context.WorkflowExecutionContext.GetProperty<string>(FromKey);
-    public static bool HasFrom(this ActivityExecutionContext context) => context.WorkflowExecutionContext.HasProperty(FromKey);
+    /// <summary>
+    /// Creates a correlating client state.
+    /// </summary>
+    public static string CreateCorrelatingClientState(this ActivityExecutionContext context, string? activityInstanceId = default)
+    {
+        return new ClientStatePayload(context.WorkflowExecutionContext.Id, activityInstanceId).ToBase64();
+    }
 }

--- a/src/modules/Elsa.Telnyx/Extensions/PayloadExtensions.cs
+++ b/src/modules/Elsa.Telnyx/Extensions/PayloadExtensions.cs
@@ -10,33 +10,12 @@ namespace Elsa.Telnyx.Extensions;
 public static class PayloadExtensions
 {
     /// <summary>
-    /// Extracts a correlation ID from the specified <see cref="Payload"/>. If the payload carries client state, the correlation ID is taken from there.
-    /// Otherwise, if the payload is of type <see cref="CallPayload"/>, its <see cref="CallPayload.CallSessionId"/> is used. 
+    /// Extracts a <see cref="ClientStatePayload"/> from the specified <see cref="Payload"/>. 
     /// </summary>
-    public static string GetCorrelationId(this Payload payload)
+    public static ClientStatePayload? GetClientStatePayload(this Payload payload)
     {
-        if (!string.IsNullOrWhiteSpace(payload.ClientState))
-        {
-            var clientStatePayload = ClientStatePayload.FromBase64(payload.ClientState);
-            return clientStatePayload.CorrelationId;
-        }
-
-        if (payload is CallPayload callPayload)
-            return callPayload.CallSessionId;
-
-        throw new NotSupportedException($"The received payload type {payload.GetType().Name} is not supported yet.");
-    }
-    
-    /// <summary>
-    /// Extracts a correlation ID from the specified <see cref="Payload"/>. If the payload carries client state, the correlation ID is taken from there.
-    /// Otherwise, if the payload is of type <see cref="CallPayload"/>, its <see cref="CallPayload.CallSessionId"/> is used. 
-    /// </summary>
-    public static ClientStatePayload GetClientStatePayload(this Payload payload)
-    {
-        if (!string.IsNullOrWhiteSpace(payload.ClientState))
-            return ClientStatePayload.FromBase64(payload.ClientState);
-
-        var correlationId = payload.GetCorrelationId();
-        return new ClientStatePayload(correlationId);
+        return !string.IsNullOrWhiteSpace(payload.ClientState) 
+            ? ClientStatePayload.FromBase64(payload.ClientState) 
+            : default;
     }
 }

--- a/src/modules/Elsa.Telnyx/Handlers/TriggerAnswerCallActivities.cs
+++ b/src/modules/Elsa.Telnyx/Handlers/TriggerAnswerCallActivities.cs
@@ -37,8 +37,8 @@ internal class TriggerAnswerCallActivities : INotificationHandler<TelnyxWebhookR
             return;
 
         var clientStatePayload = callAnsweredPayload.GetClientStatePayload();
-        var correlationId = clientStatePayload.CorrelationId;
-        var activityInstanceId = clientStatePayload.ActivityInstanceId!;
+        var workflowInstanceId = clientStatePayload?.WorkflowInstanceId;
+        var activityInstanceId = clientStatePayload?.ActivityInstanceId!;
         var input = new Dictionary<string, object>().AddInput(callAnsweredPayload);
         var callControlId = callAnsweredPayload.CallControlId;
 
@@ -53,10 +53,10 @@ internal class TriggerAnswerCallActivities : INotificationHandler<TelnyxWebhookR
             // Trigger all workflows matching the activity type names and associated call control IDs.
             await _workflowInbox.SubmitAsync(new NewWorkflowInboxMessage
             {
+                WorkflowInstanceId = workflowInstanceId,
                 ActivityTypeName = activityTypeName,
                 ActivityInstanceId = activityInstanceId,
                 BookmarkPayload = new AnswerCallBookmarkPayload(callControlId),
-                CorrelationId = correlationId,
                 Input = input
             }, cancellationToken);
         }

--- a/src/modules/Elsa.Telnyx/Handlers/TriggerCallAnsweredActivities.cs
+++ b/src/modules/Elsa.Telnyx/Handlers/TriggerCallAnsweredActivities.cs
@@ -37,8 +37,8 @@ internal class TriggerCallAnsweredActivities : INotificationHandler<TelnyxWebhoo
             return;
 
         var clientStatePayload = callAnsweredPayload.GetClientStatePayload();
-        var correlationId = clientStatePayload.CorrelationId;
-        var activityInstanceId = clientStatePayload.ActivityInstanceId!;
+        var workflowInstanceId = clientStatePayload?.WorkflowInstanceId;
+        var activityInstanceId = clientStatePayload?.ActivityInstanceId!;
         var input = new Dictionary<string, object>().AddInput(callAnsweredPayload);
         var callControlId = callAnsweredPayload.CallControlId;
         
@@ -46,7 +46,7 @@ internal class TriggerCallAnsweredActivities : INotificationHandler<TelnyxWebhoo
         {
             ActivityTypeName = ActivityTypeNameHelper.GenerateTypeName<CallAnswered>(),
             BookmarkPayload = new CallAnsweredBookmarkPayload(callControlId),
-            CorrelationId = correlationId,
+            WorkflowInstanceId = workflowInstanceId,
             ActivityInstanceId = activityInstanceId,
             Input = input
         }, cancellationToken);

--- a/src/modules/Elsa.Telnyx/Handlers/TriggerCallBridgedActivities.cs
+++ b/src/modules/Elsa.Telnyx/Handlers/TriggerCallBridgedActivities.cs
@@ -37,7 +37,7 @@ internal class TriggerCallBridgedActivities : INotificationHandler<TelnyxWebhook
             return;
 
         var clientStatePayload = callBridgedPayload.GetClientStatePayload();
-        var correlationId = clientStatePayload.CorrelationId;
+        var workflowInstanceId = clientStatePayload?.WorkflowInstanceId;
         var input = new Dictionary<string, object>().AddInput(callBridgedPayload);
         var callControlId = callBridgedPayload.CallControlId;
         var activityTypeNames = new[]
@@ -52,7 +52,7 @@ internal class TriggerCallBridgedActivities : INotificationHandler<TelnyxWebhook
             {
                 ActivityTypeName = activityTypeName,
                 BookmarkPayload = new WebhookEventBookmarkPayload(WebhookEventTypes.CallBridged, callControlId),
-                CorrelationId = correlationId,
+                WorkflowInstanceId = workflowInstanceId,
                 Input = input
             }, cancellationToken);
         }

--- a/src/modules/Elsa.Telnyx/Handlers/TriggerCallHangupActivities.cs
+++ b/src/modules/Elsa.Telnyx/Handlers/TriggerCallHangupActivities.cs
@@ -37,7 +37,7 @@ internal class TriggerCallHangupActivities : INotificationHandler<TelnyxWebhookR
             return;
 
         var clientStatePayload = callHangupPayload.GetClientStatePayload();
-        var correlationId = clientStatePayload.CorrelationId;
+        var workflowInstanceId = clientStatePayload?.WorkflowInstanceId;
         var input = new Dictionary<string, object>().AddInput(callHangupPayload);
         var callControlId = callHangupPayload.CallControlId;
         
@@ -45,7 +45,7 @@ internal class TriggerCallHangupActivities : INotificationHandler<TelnyxWebhookR
         {
             ActivityTypeName = ActivityTypeNameHelper.GenerateTypeName<CallHangup>(),
             BookmarkPayload = new CallHangupBookmarkPayload(callControlId),
-            CorrelationId = correlationId,
+            WorkflowInstanceId = workflowInstanceId,
             Input = input
         }, cancellationToken);
     }

--- a/src/modules/Elsa.Telnyx/Handlers/TriggerIncomingCallActivities.cs
+++ b/src/modules/Elsa.Telnyx/Handlers/TriggerIncomingCallActivities.cs
@@ -3,7 +3,6 @@ using Elsa.Mediator.Contracts;
 using Elsa.Telnyx.Activities;
 using Elsa.Telnyx.Bookmarks;
 using Elsa.Telnyx.Events;
-using Elsa.Telnyx.Extensions;
 using Elsa.Telnyx.Payloads.Call;
 using Elsa.Workflows.Core.Helpers;
 using Elsa.Workflows.Runtime.Contracts;
@@ -39,8 +38,7 @@ internal class TriggerIncomingCallActivities : INotificationHandler<TelnyxWebhoo
         // Only trigger workflows for incoming calls.
         if (callInitiatedPayload.Direction != "incoming" || callInitiatedPayload.ClientState != null)
             return;
-
-        var correlationId = callInitiatedPayload.GetCorrelationId();
+        
         var activityTypeName = ActivityTypeNameHelper.GenerateTypeName<IncomingCall>();
         var input = new Dictionary<string, object>().AddInput(webhook);
 
@@ -52,7 +50,6 @@ internal class TriggerIncomingCallActivities : INotificationHandler<TelnyxWebhoo
         {
             ActivityTypeName = activityTypeName,
             BookmarkPayload = fromBookmarkPayload,
-            CorrelationId = correlationId,
             Input = input
         }, cancellationToken);
 
@@ -63,7 +60,6 @@ internal class TriggerIncomingCallActivities : INotificationHandler<TelnyxWebhoo
         {
             ActivityTypeName = activityTypeName,
             BookmarkPayload = toBookmarkPayload,
-            CorrelationId = correlationId,
             Input = input
         }, cancellationToken);
 
@@ -77,7 +73,6 @@ internal class TriggerIncomingCallActivities : INotificationHandler<TelnyxWebhoo
         {
             ActivityTypeName = activityTypeName,
             BookmarkPayload = catchallBookmarkPayload,
-            CorrelationId = correlationId,
             Input = input
         }, cancellationToken);
     }

--- a/src/modules/Elsa.Telnyx/Handlers/TriggerWebhookActivities.cs
+++ b/src/modules/Elsa.Telnyx/Handlers/TriggerWebhookActivities.cs
@@ -40,25 +40,16 @@ internal class TriggerWebhookActivities : INotificationHandler<TelnyxWebhookRece
         if (activityType == null)
             return;
 
-        var correlationId = ((Payload)webhook.Data.Payload).GetCorrelationId();
+        var workflowInstanceId = ((Payload)webhook.Data.Payload).GetClientStatePayload()?.WorkflowInstanceId;
         var callControlId = (webhook.Data.Payload as CallPayload)?.CallControlId;
         var bookmarkPayloadWithCallControl = new WebhookEventBookmarkPayload(eventType, callControlId);
-        var bookmarkPayload = new WebhookEventBookmarkPayload(eventType);
         var input = new Dictionary<string, object>().AddInput(webhook);
-
-        // await _workflowInbox.SubmitAsync(new NewWorkflowInboxMessage
-        // {
-        //     ActivityTypeName = activityType,
-        //     BookmarkPayload = bookmarkPayload,
-        //     CorrelationId = correlationId,
-        //     Input = input
-        // }, cancellationToken);
         
         await _workflowInbox.SubmitAsync(new NewWorkflowInboxMessage
         {
             ActivityTypeName = activityType,
             BookmarkPayload = bookmarkPayloadWithCallControl,
-            CorrelationId = correlationId,
+            WorkflowInstanceId = workflowInstanceId,
             Input = input
         }, cancellationToken);
     }

--- a/src/modules/Elsa.Telnyx/Handlers/TriggerWebhookDrivenActivities.cs
+++ b/src/modules/Elsa.Telnyx/Handlers/TriggerWebhookDrivenActivities.cs
@@ -39,9 +39,8 @@ internal class TriggerWebhookDrivenActivities : INotificationHandler<TelnyxWebho
         var input = new Dictionary<string, object>().AddInput(eventPayload.GetType().Name, eventPayload);
         var activityDescriptors = FindActivityDescriptors(eventType).ToList();
         var clientStatePayload = ((Payload)webhook.Data.Payload).GetClientStatePayload();
-        var activityInstanceId = clientStatePayload.ActivityInstanceId; 
-        var correlationId = clientStatePayload.CorrelationId;
-        var bookmarkPayload = new WebhookEventBookmarkPayload(eventType);
+        var activityInstanceId = clientStatePayload?.ActivityInstanceId;
+        var workflowInstanceId = clientStatePayload?.WorkflowInstanceId;
         var bookmarkPayloadWithCallControl = new WebhookEventBookmarkPayload(eventType, callControlId);
 
         foreach (var activityDescriptor in activityDescriptors)
@@ -50,7 +49,7 @@ internal class TriggerWebhookDrivenActivities : INotificationHandler<TelnyxWebho
             {
                 ActivityTypeName = activityDescriptor.TypeName,
                 BookmarkPayload = bookmarkPayloadWithCallControl,
-                CorrelationId = correlationId,
+                WorkflowInstanceId = workflowInstanceId,
                 ActivityInstanceId = activityInstanceId,
                 Input = input
             }, cancellationToken);

--- a/src/modules/Elsa.Telnyx/Models/ClientStatePayload.cs
+++ b/src/modules/Elsa.Telnyx/Models/ClientStatePayload.cs
@@ -6,9 +6,9 @@ namespace Elsa.Telnyx.Models;
 /// <summary>
 /// Represents the client state payload to correlate commands and events.
 /// </summary>
-/// <param name="CorrelationId">The correlation ID.</param>
+/// <param name="WorkflowInstanceId">The correlation ID.</param>
 /// <param name="ActivityInstanceId">An optional activity instance ID.</param>
-public record ClientStatePayload(string CorrelationId, string? ActivityInstanceId = default)
+public record ClientStatePayload(string WorkflowInstanceId, string? ActivityInstanceId = default)
 {
     /// <summary>
     /// Deserializes a <see cref="ClientStatePayload"/> from the specified base64 string.

--- a/src/modules/Elsa.Telnyx/Services/WebhookHandler.cs
+++ b/src/modules/Elsa.Telnyx/Services/WebhookHandler.cs
@@ -35,9 +35,7 @@ internal class WebhookHandler : IWebhookHandler
         var cancellationToken = httpContext.RequestAborted;
         var json = await ReadRequestBodyAsync(httpContext);
         var webhook = JsonSerializer.Deserialize<TelnyxWebhook>(json, SerializerSettings)!;
-        var correlationId = ((Payload)webhook.Data.Payload).GetCorrelationId();
-
-        using var loggingScope = _logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId });
+        
         _logger.LogDebug("Telnyx webhook payload received: {@Webhook}", webhook);
         await _notificationSender.SendAsync(new TelnyxWebhookReceived(webhook), NotificationStrategy.Background, cancellationToken);
     }

--- a/src/modules/Elsa.Workflows.Core/Activities/SetVariable.cs
+++ b/src/modules/Elsa.Workflows.Core/Activities/SetVariable.cs
@@ -101,6 +101,6 @@ public class SetVariable : CodeActivity
     protected override void Execute(ActivityExecutionContext context)
     {
         var value = context.Get(Value);
-        Variable.Set(context, value);
+        context.SetVariable(Variable.Name, value);
     }
 }

--- a/src/modules/Elsa.Workflows.Core/Extensions/InputExtensions.cs
+++ b/src/modules/Elsa.Workflows.Core/Extensions/InputExtensions.cs
@@ -38,8 +38,11 @@ public static class InputExtensions
     /// <typeparam name="T">The type of the input.</typeparam>
     /// <returns>The value of the specified input.</returns>
     /// <exception cref="Exception">Throws an exception if the input is not found.</exception>
-    public static T Get<T>(this Input<T>? input, ActivityExecutionContext context, [CallerArgumentExpression("input")]string? inputName = default) => context.Get(input) ?? throw new Exception($"{inputName} is required.");
-    
+    public static T Get<T>(this Input<T>? input, ActivityExecutionContext context, [CallerArgumentExpression("input")] string? inputName = default)
+    {
+        return context.Get(input) ?? throw new Exception($"{inputName} is required.");
+    }
+
     /// <summary>
     /// Returns the value of the specified input.
     /// </summary>
@@ -49,5 +52,8 @@ public static class InputExtensions
     /// <typeparam name="T">The type of the input.</typeparam>
     /// <returns>The value of the specified input.</returns>
     /// <exception cref="Exception">Throws an exception if the input is not found.</exception>
-    public static T Get<T>(this Input<T>? input, ExpressionExecutionContext context, [CallerArgumentExpression("input")]string? inputName = default) => context.Get(input) ?? throw new Exception($"{inputName} is required.");
+    public static T Get<T>(this Input<T>? input, ExpressionExecutionContext context, [CallerArgumentExpression("input")] string? inputName = default)
+    {
+        return context.Get(input) ?? throw new Exception($"{inputName} is required.");
+    }
 }


### PR DESCRIPTION
This PR fixes  race condition that can occur if a new workflow instance is started and is resumed in the meantime, e.g. as a side effect of the workflow executing and triggering external events, which in turn trigger workflow bookmarks. 