### PR TITLE
Fixed IsNameUnique for InMemory WorkflowDefinition store

### DIFF
--- a/src/modules/Elsa.Dapper/Modules/Management/Services/DapperWorkflowDefinitionStore.cs
+++ b/src/modules/Elsa.Dapper/Modules/Management/Services/DapperWorkflowDefinitionStore.cs
@@ -154,13 +154,15 @@ public class DapperWorkflowDefinitionStore : IWorkflowDefinitionStore
     /// <inheritdoc />
     public async Task<bool> GetIsNameUnique(string name, string? definitionId = default, CancellationToken cancellationToken = default)
     {
-        return await _store.AnyAsync(query =>
+        var exists = await _store.AnyAsync(query =>
         {
             query.Is(nameof(WorkflowDefinition.Name), name);
 
             if (definitionId != null)
                 query.IsNot(nameof(WorkflowDefinition.DefinitionId), definitionId);
         }, cancellationToken);
+
+        return !exists;
     }
 
     private void ApplyFilter(ParameterizedQuery query, WorkflowDefinitionFilter filter)

--- a/src/modules/Elsa.EntityFrameworkCore/Modules/Management/WorkflowDefinitionStore.cs
+++ b/src/modules/Elsa.EntityFrameworkCore/Modules/Management/WorkflowDefinitionStore.cs
@@ -146,7 +146,8 @@ public class EFCoreWorkflowDefinitionStore : IWorkflowDefinitionStore
     /// <inheritdoc />
     public async Task<bool> GetIsNameUnique(string name, string? definitionId = default, CancellationToken cancellationToken = default)
     {
-        return await _store.AnyAsync(x => x.Name == name && x.DefinitionId != definitionId, cancellationToken);
+        var exists = await _store.AnyAsync(x => x.Name == name && x.DefinitionId != definitionId, cancellationToken);
+        return !exists;
     }
 
     private ValueTask OnSaveAsync(ManagementElsaDbContext managementElsaDbContext, WorkflowDefinition entity, CancellationToken cancellationToken)

--- a/src/modules/Elsa.MongoDb/Modules/Management/WorkflowDefinitionStore.cs
+++ b/src/modules/Elsa.MongoDb/Modules/Management/WorkflowDefinitionStore.cs
@@ -132,7 +132,8 @@ public class MongoWorkflowDefinitionStore : IWorkflowDefinitionStore
     /// <inheritdoc />
     public async Task<bool> GetIsNameUnique(string name, string? definitionId = default, CancellationToken cancellationToken = default)
     {
-        return await _mongoDbStore.AnyAsync(x => x.Name == name && x.DefinitionId != definitionId, cancellationToken);
+        var exists = await _mongoDbStore.AnyAsync(x => x.Name == name && x.DefinitionId != definitionId, cancellationToken);
+        return !exists;
     }
 
     private IMongoQueryable<WorkflowDefinition> Filter(IMongoQueryable<WorkflowDefinition> queryable, WorkflowDefinitionFilter filter) =>

--- a/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/IsNameUnique/Endpoint.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/IsNameUnique/Endpoint.cs
@@ -25,8 +25,8 @@ internal class IsNameUnique : ElsaEndpoint<Request>
 
     public override async Task HandleAsync(Request request, CancellationToken cancellationToken)
     {
-        var exists = await _store.GetIsNameUnique(request.Name.Trim(), request.DefinitionId, cancellationToken);
-        var response = new Response(!exists);
+        var isUnique = await _store.GetIsNameUnique(request.Name.Trim(), request.DefinitionId, cancellationToken);
+        var response = new Response(isUnique);
         
         await SendOkAsync(response, cancellationToken);
     }


### PR DESCRIPTION
IWorkflowDefinitionStore GetIsNameUnique only inverted the result in the InMemoryStore, and it was inverted again in the endpoint. 

I changed the GetIsNameUnique to return false when the name already exists, and removed the invert in the endpoint. 

This should fix the issue seen in elsa-workflows/elsa-studio#29
