### PR TITLE
Refactor proto files and fix snapshot loading of running workflows grain

### DIFF
--- a/src/bundles/Elsa.WorkflowServer.Web/Elsa.WorkflowServer.Web.csproj
+++ b/src/bundles/Elsa.WorkflowServer.Web/Elsa.WorkflowServer.Web.csproj
@@ -9,6 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\..\modules\Elsa.EntityFrameworkCore.SqlServer\Elsa.EntityFrameworkCore.SqlServer.csproj" />
         <ProjectReference Include="..\Elsa\Elsa.csproj" />
         <ProjectReference Include="..\..\modules\Elsa.Elasticsearch\Elsa.Elasticsearch.csproj" />
         <ProjectReference Include="..\..\modules\Elsa.Email\Elsa.Email.csproj" />
@@ -34,6 +35,7 @@
     <ItemGroup>
         <PackageReference Include="Azure.Identity" Version="1.8.2" />
         <PackageReference Include="Proto.Persistence.Sqlite" Version="1.1.0" />
+        <PackageReference Include="Proto.Persistence.SqlServer" Version="1.3.1-alpha.0.2" />
     </ItemGroup>
 
 </Project>

--- a/src/modules/Elsa.EntityFrameworkCore.SqlServer/Modules/Runtime/Extensions.cs
+++ b/src/modules/Elsa.EntityFrameworkCore.SqlServer/Modules/Runtime/Extensions.cs
@@ -6,6 +6,12 @@ namespace Elsa.EntityFrameworkCore.Extensions;
 
 public static partial class Extensions
 {
+    public static EFCoreWorkflowRuntimePersistenceFeature UseSqlServer(this EFCoreWorkflowRuntimePersistenceFeature feature, string connectionString, ElsaDbContextOptions? options = default)
+    {
+        feature.DbContextOptionsBuilder = (_, db) => db.UseElsaSqlServer(connectionString, options);
+        return feature;
+    }
+    
     public static EFCoreDefaultWorkflowRuntimePersistenceFeature UseSqlServer(this EFCoreDefaultWorkflowRuntimePersistenceFeature feature, string connectionString, ElsaDbContextOptions? options = default)
     {
         feature.DbContextOptionsBuilder = (_, db) => db.UseElsaSqlServer(connectionString, options);

--- a/src/modules/Elsa.EntityFrameworkCore.Sqlite/Modules/Runtime/Extensions.cs
+++ b/src/modules/Elsa.EntityFrameworkCore.Sqlite/Modules/Runtime/Extensions.cs
@@ -11,8 +11,8 @@ public static partial class Extensions
     {
         feature.DbContextOptionsBuilder = (_, db) => db.UseElsaSqlite(connectionString, options);
         return feature;
-        
     }
+    
     public static EFCoreDefaultWorkflowRuntimePersistenceFeature UseSqlite(this EFCoreDefaultWorkflowRuntimePersistenceFeature feature, string connectionString = Constants.DefaultConnectionString, ElsaDbContextOptions? options = default)
     {
         feature.DbContextOptionsBuilder = (_, db) => db.UseElsaSqlite(connectionString, options);

--- a/src/modules/Elsa.ProtoActor/Elsa.ProtoActor.csproj
+++ b/src/modules/Elsa.ProtoActor/Elsa.ProtoActor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <Import Project="..\..\..\common.props" />
-    <Import Project="..\..\..\configureawait.props" />
+    <Import Project="..\..\..\common.props"/>
+    <Import Project="..\..\..\configureawait.props"/>
 
     <PropertyGroup>
         <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
@@ -12,31 +12,35 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Google.Protobuf" Version="3.23.4" />
+        <PackageReference Include="Google.Protobuf" Version="3.23.4"/>
         <PackageReference Include="Grpc.Tools" Version="2.51.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0"/>
     </ItemGroup>
 
     <ItemGroup Label="ProtoActor">
-        <PackageReference Include="Proto.Actor" Version="1.3.0" />
-        <PackageReference Include="Proto.Cluster" Version="1.3.0" />
-        <PackageReference Include="Proto.Cluster.CodeGen" Version="1.3.0" />
-        <PackageReference Include="Proto.Cluster.TestProvider" Version="1.3.0" />
-        <PackageReference Include="Proto.Persistence" Version="1.3.0" />
-        <PackageReference Include="Proto.Remote" Version="1.3.0" />
+        <PackageReference Include="Proto.Actor" Version="1.3.0"/>
+        <PackageReference Include="Proto.Cluster" Version="1.3.0"/>
+        <PackageReference Include="Proto.Cluster.CodeGen" Version="1.3.0"/>
+        <PackageReference Include="Proto.Cluster.TestProvider" Version="1.3.0"/>
+        <PackageReference Include="Proto.Persistence" Version="1.3.0"/>
+        <PackageReference Include="Proto.Remote" Version="1.3.0"/>
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Elsa.Workflows.Core\Elsa.Workflows.Core.csproj" />
-        <ProjectReference Include="..\Elsa.Workflows.Runtime\Elsa.Workflows.Runtime.csproj" />
+        <ProjectReference Include="..\Elsa.Workflows.Core\Elsa.Workflows.Core.csproj"/>
+        <ProjectReference Include="..\Elsa.Workflows.Runtime\Elsa.Workflows.Runtime.csproj"/>
     </ItemGroup>
 
-    <ItemGroup Label="Protos">
-        <Protobuf Include="Protos\Messages.proto" />
-        <ProtoGrain Include="Protos\Grains.proto" AdditionalImportDirs="Protos" />
+    <ItemGroup Label="Proto">
+        <Protobuf Include="Proto\Shared.proto" AdditionalImportDirs="./Proto"/>
+        <Protobuf Include="Proto\RunningWorkflows.Messages.proto" AdditionalImportDirs="./Proto"/>
+        <Protobuf Include="Proto\WorkflowInstance.Messages.proto" AdditionalImportDirs="./Proto"/>
+        <ProtoGrain Include="Proto\RunningWorkflows.proto" AdditionalImportDirs="./Proto"/>
+        <ProtoGrain Include="Proto\WorkflowInstance.proto" AdditionalImportDirs="./Proto"/>
     </ItemGroup>
+
 
 </Project>

--- a/src/modules/Elsa.ProtoActor/Extensions/ClusterExtensions.cs
+++ b/src/modules/Elsa.ProtoActor/Extensions/ClusterExtensions.cs
@@ -1,5 +1,5 @@
 using Elsa.ProtoActor.Grains;
-using Elsa.ProtoActor.Protos;
+using Elsa.ProtoActor.ProtoBuf;
 using Proto.Cluster;
 
 // ReSharper disable once CheckNamespace
@@ -7,6 +7,6 @@ namespace Elsa.Extensions;
 
 internal static class ClusterExtensions
 {
-    public static RunningWorkflowsGrainClient GetNamedRunningWorkflowsGrain(this Cluster cluster) => cluster.GetRunningWorkflowsGrain(nameof(RunningWorkflowsGrain));
-    public static WorkflowGrainClient GetNamedWorkflowGrain(this Cluster cluster, string workflowInstanceId) => cluster.GetWorkflowGrain($"{nameof(WorkflowGrain)}-{workflowInstanceId}");
+    public static RunningWorkflowsClient GetNamedRunningWorkflowsGrain(this Cluster cluster) => cluster.GetRunningWorkflows(nameof(RunningWorkflows));
+    public static WorkflowInstanceClient GetNamedWorkflowGrain(this Cluster cluster, string workflowInstanceId) => cluster.GetWorkflowInstance($"{nameof(WorkflowInstance)}-{workflowInstanceId}");
 }

--- a/src/modules/Elsa.ProtoActor/Extensions/ProtoInputExtensions.cs
+++ b/src/modules/Elsa.ProtoActor/Extensions/ProtoInputExtensions.cs
@@ -1,5 +1,5 @@
 using System.Text.Json;
-using Elsa.ProtoActor.Protos;
+using Elsa.ProtoActor.ProtoBuf;
 using Elsa.Workflows.Core.Serialization.Converters;
 
 namespace Elsa.ProtoActor.Extensions;

--- a/src/modules/Elsa.ProtoActor/Handlers/StopRunningWorkflows.cs
+++ b/src/modules/Elsa.ProtoActor/Handlers/StopRunningWorkflows.cs
@@ -1,6 +1,6 @@
 using Elsa.Extensions;
 using Elsa.Mediator.Contracts;
-using Elsa.ProtoActor.Protos;
+using Elsa.ProtoActor.ProtoBuf;
 using Elsa.Workflows.Management.Notifications;
 using JetBrains.Annotations;
 using Proto.Cluster;

--- a/src/modules/Elsa.ProtoActor/Handlers/UpdateRunningWorkflows.cs
+++ b/src/modules/Elsa.ProtoActor/Handlers/UpdateRunningWorkflows.cs
@@ -2,7 +2,7 @@ using Elsa.Extensions;
 using Elsa.Mediator.Contracts;
 using Elsa.ProtoActor.Extensions;
 using Elsa.ProtoActor.Grains;
-using Elsa.ProtoActor.Protos;
+using Elsa.ProtoActor.ProtoBuf;
 using Elsa.Workflows.Core.Notifications;
 using JetBrains.Annotations;
 using Proto.Cluster;
@@ -11,7 +11,7 @@ using WorkflowStatus = Elsa.Workflows.Core.WorkflowStatus;
 namespace Elsa.ProtoActor.Handlers;
 
 /// <summary>
-/// Updates the <see cref="RunningWorkflowsGrain"/> with running workflow instances.
+/// Updates the <see cref="RunningWorkflows"/> with running workflow instances.
 /// </summary>
 [PublicAPI]
 internal class UpdateRunningWorkflows : INotificationHandler<WorkflowExecuted>

--- a/src/modules/Elsa.ProtoActor/Mappers/BookmarkMapper.cs
+++ b/src/modules/Elsa.ProtoActor/Mappers/BookmarkMapper.cs
@@ -1,7 +1,7 @@
 using Elsa.ProtoActor.Extensions;
 using Elsa.Workflows.Core.Contracts;
 using Elsa.Workflows.Core.Models;
-using ProtoBookmark = Elsa.ProtoActor.Protos.Bookmark;
+using ProtoBookmark = Elsa.ProtoActor.ProtoBuf.Bookmark;
 
 namespace Elsa.ProtoActor.Mappers;
 

--- a/src/modules/Elsa.ProtoActor/Mappers/ExceptionMapper.cs
+++ b/src/modules/Elsa.ProtoActor/Mappers/ExceptionMapper.cs
@@ -1,5 +1,5 @@
 using Elsa.Workflows.Core.State;
-using ProtoException = Elsa.ProtoActor.Protos.ExceptionState;
+using ProtoException = Elsa.ProtoActor.ProtoBuf.ExceptionState;
 
 namespace Elsa.ProtoActor.Mappers;
 

--- a/src/modules/Elsa.ProtoActor/Mappers/WorkflowExecutionResultMapper.cs
+++ b/src/modules/Elsa.ProtoActor/Mappers/WorkflowExecutionResultMapper.cs
@@ -1,6 +1,6 @@
 using Elsa.ProtoActor.Extensions;
 using Elsa.Workflows.Runtime.Contracts;
-using ProtoWorkflowExecutionResponse = Elsa.ProtoActor.Protos.WorkflowExecutionResponse;
+using ProtoWorkflowExecutionResponse = Elsa.ProtoActor.ProtoBuf.WorkflowExecutionResponse;
 
 namespace Elsa.ProtoActor.Mappers;
 

--- a/src/modules/Elsa.ProtoActor/Mappers/WorkflowFaultStateMapper.cs
+++ b/src/modules/Elsa.ProtoActor/Mappers/WorkflowFaultStateMapper.cs
@@ -1,5 +1,5 @@
 using Elsa.Workflows.Core.State;
-using ProtoWorkflowFault = Elsa.ProtoActor.Protos.WorkflowFault;
+using ProtoWorkflowFault = Elsa.ProtoActor.ProtoBuf.WorkflowFault;
 
 namespace Elsa.ProtoActor.Mappers;
 

--- a/src/modules/Elsa.ProtoActor/Mappers/WorkflowStatusMapper.cs
+++ b/src/modules/Elsa.ProtoActor/Mappers/WorkflowStatusMapper.cs
@@ -1,5 +1,5 @@
 using Elsa.Workflows.Core;
-using ProtoWorkflowStatus = Elsa.ProtoActor.Protos.WorkflowStatus;
+using ProtoWorkflowStatus = Elsa.ProtoActor.ProtoBuf.WorkflowStatus;
 
 namespace Elsa.ProtoActor.Mappers;
 

--- a/src/modules/Elsa.ProtoActor/Mappers/WorkflowSubStatusMapper.cs
+++ b/src/modules/Elsa.ProtoActor/Mappers/WorkflowSubStatusMapper.cs
@@ -1,5 +1,5 @@
 using Elsa.Workflows.Core;
-using ProtoWorkflowSubStatus = Elsa.ProtoActor.Protos.WorkflowSubStatus;
+using ProtoWorkflowSubStatus = Elsa.ProtoActor.ProtoBuf.WorkflowSubStatus;
 
 namespace Elsa.ProtoActor.Mappers;
 

--- a/src/modules/Elsa.ProtoActor/Models/RunningWorkflowInstanceEntry.cs
+++ b/src/modules/Elsa.ProtoActor/Models/RunningWorkflowInstanceEntry.cs
@@ -1,0 +1,10 @@
+namespace Elsa.ProtoActor.Models;
+
+/// <summary>
+/// A snapshot of information about a running workflow instance.
+/// </summary>
+/// <param name="DefinitionId">The workflow definition id.</param>
+/// <param name="Version">The workflow definition version.</param>
+/// <param name="InstanceId">The workflow instance ID.</param>
+/// <param name="CorrelationId">The workflow instance correlation ID.</param>
+public record RunningWorkflowInstanceEntry(string DefinitionId, int Version, string InstanceId, string? CorrelationId);

--- a/src/modules/Elsa.ProtoActor/Proto/RunningWorkflows.Messages.proto
+++ b/src/modules/Elsa.ProtoActor/Proto/RunningWorkflows.Messages.proto
@@ -1,0 +1,27 @@
+syntax = "proto3";
+option csharp_namespace = "Elsa.ProtoActor.ProtoBuf";
+package Elsa.ProtoActor.ProtoBuf;
+
+import "google/protobuf/empty.proto";
+import "Shared.proto";
+
+message RegisterRunningWorkflowRequest {
+  string DefinitionId = 1;
+  int32 Version = 2;
+  string InstanceId = 3;
+  optional string CorrelationId = 6;
+}
+
+message UnregisterRunningWorkflowRequest {
+  string InstanceId = 1;
+}
+
+message CountRunningWorkflowsRequest {
+  string DefinitionId = 1;
+  int32 Version = 2;
+  optional string CorrelationId = 3;
+}
+
+message CountRunningWorkflowsResponse {
+  optional int32 Count = 1;
+}

--- a/src/modules/Elsa.ProtoActor/Proto/RunningWorkflows.proto
+++ b/src/modules/Elsa.ProtoActor/Proto/RunningWorkflows.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+option csharp_namespace = "Elsa.ProtoActor.ProtoBuf";
+package Elsa.ProtoActor.ProtoBuf;
+
+import "google/protobuf/empty.proto";
+import "Shared.proto";
+import "RunningWorkflows.Messages.proto";
+
+service RunningWorkflows {
+  rpc Register(RegisterRunningWorkflowRequest) returns (google.protobuf.Empty);
+  rpc Unregister(UnregisterRunningWorkflowRequest) returns (google.protobuf.Empty);
+  rpc Count (CountRunningWorkflowsRequest) returns (CountRunningWorkflowsResponse);
+}

--- a/src/modules/Elsa.ProtoActor/Proto/Shared.proto
+++ b/src/modules/Elsa.ProtoActor/Proto/Shared.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+option csharp_namespace = "Elsa.ProtoActor.ProtoBuf";
+package Elsa.ProtoActor.ProtoBuf;
+
+import "google/protobuf/empty.proto";
+import "google/protobuf/wrappers.proto";
+
+// Shared.
+message Json {
+  string text = 1;
+}
+
+message Input {
+  map<string, Json> Data = 1;
+}

--- a/src/modules/Elsa.ProtoActor/Proto/WorkflowInstance.Messages.proto
+++ b/src/modules/Elsa.ProtoActor/Proto/WorkflowInstance.Messages.proto
@@ -1,19 +1,11 @@
 syntax = "proto3";
+option csharp_namespace = "Elsa.ProtoActor.ProtoBuf";
+package Elsa.ProtoActor.ProtoBuf;
+
 import "google/protobuf/empty.proto";
 import "google/protobuf/wrappers.proto";
-package Elsa.ProtoActor.Protos;
-option csharp_namespace = "Elsa.ProtoActor.Protos";
+import "Shared.proto";
 
-// Shared.
-message Json {
-  string text = 1;
-}
-
-message Input {
-  map<string, Json> Data = 1;
-}
-
-// WorkflowGrain.
 message CanStartWorkflowResponse {
   bool CanStart = 1;
 }
@@ -102,26 +94,4 @@ message Bookmark {
   optional bool AutoBurn = 8;
   optional string CallbackMethodName = 9;
   string CreatedAt = 10; // ISO 8601
-}
-
-// RunningWorkflowsGrain.
-message RegisterRunningWorkflowRequest {
-  string DefinitionId = 1;
-  int32 Version = 2;
-  string InstanceId = 3;
-  optional string CorrelationId = 6;
-}
-
-message UnregisterRunningWorkflowRequest {
-  string InstanceId = 1;
-}
-
-message CountRunningWorkflowsRequest {
-  string DefinitionId = 1;
-  int32 Version = 2;
-  optional string CorrelationId = 3;
-}
-
-message CountRunningWorkflowsResponse {
-  optional int32 Count = 1;
 }

--- a/src/modules/Elsa.ProtoActor/Proto/WorkflowInstance.proto
+++ b/src/modules/Elsa.ProtoActor/Proto/WorkflowInstance.proto
@@ -1,21 +1,17 @@
 syntax = "proto3";
-
-option csharp_namespace = "Elsa.ProtoActor.Protos";
+option csharp_namespace = "Elsa.ProtoActor.ProtoBuf";
+package Elsa.ProtoActor.ProtoBuf;
 
 import "google/protobuf/empty.proto";
-import "Messages.proto";
+import "google/protobuf/wrappers.proto";
+import "Shared.proto";
+import "WorkflowInstance.Messages.proto";
 
-service WorkflowGrain {
+service WorkflowInstance {
   rpc CanStart (StartWorkflowRequest) returns (CanStartWorkflowResponse);
   rpc Start (StartWorkflowRequest) returns (WorkflowExecutionResponse);
   rpc Stop (Empty) returns (Empty);
   rpc Resume (ResumeWorkflowRequest) returns (WorkflowExecutionResponse);
   rpc ExportState(ExportWorkflowStateRequest) returns (ExportWorkflowStateResponse);
   rpc ImportState(ImportWorkflowStateRequest) returns (ImportWorkflowStateResponse);
-}
-
-service RunningWorkflowsGrain {
-  rpc Register(RegisterRunningWorkflowRequest) returns (google.protobuf.Empty);
-  rpc Unregister(UnregisterRunningWorkflowRequest) returns (google.protobuf.Empty);
-  rpc Count (CountRunningWorkflowsRequest) returns (CountRunningWorkflowsResponse);
 }

--- a/src/modules/Elsa.ProtoActor/Services/ProtoActorWorkflowRuntime.cs
+++ b/src/modules/Elsa.ProtoActor/Services/ProtoActorWorkflowRuntime.cs
@@ -2,7 +2,7 @@ using Elsa.Common.Models;
 using Elsa.Extensions;
 using Elsa.ProtoActor.Extensions;
 using Elsa.ProtoActor.Mappers;
-using Elsa.ProtoActor.Protos;
+using Elsa.ProtoActor.ProtoBuf;
 using Elsa.Workflows.Core.Contracts;
 using Elsa.Workflows.Core.State;
 using Elsa.Workflows.Management.Contracts;
@@ -11,12 +11,12 @@ using Elsa.Workflows.Runtime.Entities;
 using Elsa.Workflows.Runtime.Filters;
 using Proto.Cluster;
 using Bookmark = Elsa.Workflows.Core.Models.Bookmark;
-using ProtoWorkflowStatus = Elsa.ProtoActor.Protos.WorkflowStatus;
-using ProtoWorkflowSubStatus = Elsa.ProtoActor.Protos.WorkflowSubStatus;
-using ProtoWorkflowFault = Elsa.ProtoActor.Protos.WorkflowFault;
-using ProtoException = Elsa.ProtoActor.Protos.ExceptionState;
-using ProtoWorkflowExecutionResponse = Elsa.ProtoActor.Protos.WorkflowExecutionResponse;
-using ProtoBookmark = Elsa.ProtoActor.Protos.Bookmark;
+using ProtoWorkflowStatus = Elsa.ProtoActor.ProtoBuf.WorkflowStatus;
+using ProtoWorkflowSubStatus = Elsa.ProtoActor.ProtoBuf.WorkflowSubStatus;
+using ProtoWorkflowFault = Elsa.ProtoActor.ProtoBuf.WorkflowFault;
+using ProtoException = Elsa.ProtoActor.ProtoBuf.ExceptionState;
+using ProtoWorkflowExecutionResponse = Elsa.ProtoActor.ProtoBuf.WorkflowExecutionResponse;
+using ProtoBookmark = Elsa.ProtoActor.ProtoBuf.Bookmark;
 
 namespace Elsa.ProtoActor.Services;
 

--- a/src/modules/Elsa.ProtoActor/Snapshots.cs
+++ b/src/modules/Elsa.ProtoActor/Snapshots.cs
@@ -1,8 +1,8 @@
-using Elsa.ProtoActor.Grains;
+using Elsa.ProtoActor.Models;
 using Elsa.Workflows.Core.State;
 
 namespace Elsa.ProtoActor;
 
-internal record WorkflowSnapshot(string DefinitionId, string InstanceId, int Version, WorkflowState WorkflowState, IDictionary<string, object>? Input);
+internal record WorkflowSnapshot(string DefinitionId, string InstanceId, int Version, WorkflowState WorkflowState, Dictionary<string, object>? Input);
 
-internal record WorkflowRegistrySnapshot(ICollection<WorkflowInstanceEntry> Entries);
+internal record RunningWorkflowsSnapshot(List<RunningWorkflowInstanceEntry> Entries);

--- a/src/samples/aspnet/Elsa.Samples.AspNet.ProtoActorRuntime.AzureContainerApps/Program.cs
+++ b/src/samples/aspnet/Elsa.Samples.AspNet.ProtoActorRuntime.AzureContainerApps/Program.cs
@@ -3,7 +3,7 @@ using Elsa.EntityFrameworkCore.Modules.Labels;
 using Elsa.EntityFrameworkCore.Modules.Management;
 using Elsa.EntityFrameworkCore.Modules.Runtime;
 using Elsa.Extensions;
-using Elsa.ProtoActor.Protos;
+using Elsa.ProtoActor.ProtoBuf;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.Data.Sqlite;
 using Proto.Cluster.AzureContainerApps;
@@ -69,7 +69,7 @@ services
                 protoActor.RemoteConfig = _ => GrpcNetRemoteConfig
                     .BindTo(advertisedHost)
                     .WithProtoMessages(EmptyReflection.Descriptor)
-                    .WithProtoMessages(MessagesReflection.Descriptor)
+                    .WithProtoMessages(SharedReflection.Descriptor)
                     .WithLogLevelForDeserializationErrors(LogLevel.Critical)
                     .WithRemoteDiagnostics(true); // required by proto.actor dashboard
 


### PR DESCRIPTION
This PR fixes an issue with the Running Workflows grain by implementing snapshot recovery.

### === auto-pr-body ===



Summary: 
This Pull Request updates imports and references for ProtoActor. It adds ExportState() and ImportState() RPCs to WorkflowInstance and renames WorkflowGrain to WorkflowInstance. It also adds several new messages, records, and handlers to allow for managing existing workflow instances. 

List of changes: 
- Imported google/protobuf/empty.proto and google/protobuf/wrappers.proto packages
- Moved Json message and Input message from Elsa.ProtoActor.Protos to Shared.proto
- Modified option csharp_namespace to Elsa.ProtoActor.ProtoBuf
- Added ExportState() and ImportState() RPCs to WorkflowInstance service
- Renamed WorkflowGrain service to WorkflowInstance
- Renamed WorkflowRegistrySnapshot to RunningWorkflowsSnapshot
- Imported Elsa.ProtoActor.Protos messages in ProtoActorWorkflowRuntime.cs
- Imported Elsa.ProtoActor.ProtoBuf messages in Program.cs
- Replaced the MessagesReflection.Descriptor with SharedReflection.Descriptor in the RemoteConfig
- Set LogLevel for deserialization to LogLevel.Critical
- Enabled RemoteDiagnostics for proto.actor dashboard
- Added reference to Elsa.EntityFrameworkCore.SqlServer in the Elsa.WorkflowServer.Web csproj
- Added using Elsa.EntityFrameworkCore.Extensions; in Program.cs
- UseSqlite/UseElsaSqlServer/UseSqlServer added to Elsa configuration to use either Sqlite/ElsaSqlServer/SqlServer
- Added additional support for Proto.Persistence.SqlServer in program.cs
- Added extensions for EFCoreWorkflowRuntimePersistenceFeature and EFCoreDefaultWorkflowRuntimePersistenceFeature to support SqlServer

Suggested Refactoring: 
- Improve readability, structure, and comments in Program.cs to make it easier to understand all of the changes
- Use the `using static` directive to make sure constants of the same type do not need to be fully qualified
- Use the `string?` syntax instead of `string` for nullable parameters in the WorkflowInstance constructor
- Ensure consistent naming conventions
- Add documentation comments to newly added methods and/or types
- Consider using constants for timeouts and events per snapshot
- Create an enumeration for the kind names
- Consider moving CountRunningWorkflows request/response and Register/Unregister Running Workflow Request/Response into their own respective services instead of bundling them into one service to improve readability
- Provide separate files for WorkflowGrain, RunningWorkflowsGrain and Shared.proto messages