### PR TITLE
make NewtonsoftJson and System.Text.Json works side by side.

### DIFF
--- a/src/server/Elsa.Server.Api/Attributes/NewtonsoftJsonFormatterAttribute.cs
+++ b/src/server/Elsa.Server.Api/Attributes/NewtonsoftJsonFormatterAttribute.cs
@@ -1,0 +1,110 @@
+using Elsa.Server.Api.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ApplicationModels;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.ObjectPool;
+using Microsoft.Extensions.Options;
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Elsa.Server.Api.Attributes
+{
+    /// <summary>
+    /// mark a controller to use Newtonsoft as the formatter
+    /// </summary>
+    public class NewtonsoftJsonFormatterAttribute : ActionFilterAttribute, IControllerModelConvention, IActionModelConvention
+    {
+        public void Apply(ControllerModel controller)
+        {
+            foreach (var action in controller.Actions)
+            {
+                Apply(action);
+            }
+        }
+
+        public void Apply(ActionModel action)
+        {
+            // Set the model binder to NewtonsoftJsonBodyModelBinder for parameters that are bound to the request body.
+            var parameters = action.Parameters.Where(p => p.BindingInfo?.BindingSource == BindingSource.Body);
+            foreach (var p in parameters)
+            {
+                p.BindingInfo.BinderType = typeof(NewtonsoftJsonBodyModelBinder);
+            }
+        }
+
+        public override void OnActionExecuted(ActionExecutedContext context)
+        {
+            if (context.Result is ObjectResult objectResult)
+            {
+                var jsonOptions = context.HttpContext.RequestServices.GetService<IEndpointContentSerializerSettingsProvider>();
+
+                objectResult.Formatters.RemoveType<SystemTextJsonOutputFormatter>();
+                objectResult.Formatters.Add(new NewtonsoftJsonOutputFormatter(
+                    jsonOptions?.GetSettings(),
+                    context.HttpContext.RequestServices.GetRequiredService<ArrayPool<char>>(),
+                    context.HttpContext.RequestServices.GetRequiredService<IOptions<MvcOptions>>().Value));
+            }
+            //for JsonResult, there is no way to change the formatter, so change them to Object result
+            else if (context.Result is JsonResult jr)
+            {
+                ObjectResult obj = new ObjectResult(jr.Value);
+                var jsonOptions = context.HttpContext.RequestServices.GetService<IEndpointContentSerializerSettingsProvider>();
+
+                obj.Formatters.RemoveType<SystemTextJsonOutputFormatter>();
+                obj.Formatters.Add(new NewtonsoftJsonOutputFormatter(
+                    jsonOptions?.GetSettings(),
+                    context.HttpContext.RequestServices.GetRequiredService<ArrayPool<char>>(),
+                    context.HttpContext.RequestServices.GetRequiredService<IOptions<MvcOptions>>().Value));
+                context.Result = obj;
+            }
+            else
+            {
+                base.OnActionExecuted(context);
+            }
+        }
+    }
+
+    public class NewtonsoftJsonBodyModelBinder : BodyModelBinder
+    {
+        public NewtonsoftJsonBodyModelBinder(
+            ILoggerFactory loggerFactory,
+            ArrayPool<char> charPool,
+            IHttpRequestStreamReaderFactory readerFactory,
+            ObjectPoolProvider objectPoolProvider,
+            IOptions<MvcOptions> mvcOptions,
+            IOptions<MvcNewtonsoftJsonOptions> jsonOptions)
+            : base(GetInputFormatters(loggerFactory, charPool, objectPoolProvider, mvcOptions, jsonOptions), readerFactory)
+        {
+        }
+
+        private static IInputFormatter[] GetInputFormatters(
+            ILoggerFactory loggerFactory,
+            ArrayPool<char> charPool,
+            ObjectPoolProvider objectPoolProvider,
+            IOptions<MvcOptions> mvcOptions,
+            IOptions<MvcNewtonsoftJsonOptions> jsonOptions)
+        {
+            var jsonOptionsValue = jsonOptions.Value;
+            return new IInputFormatter[]
+            {
+            new NewtonsoftJsonInputFormatter(
+                loggerFactory.CreateLogger<NewtonsoftJsonBodyModelBinder>(),
+                jsonOptionsValue.SerializerSettings,
+                charPool,
+                objectPoolProvider,
+                mvcOptions.Value,
+                jsonOptionsValue)
+            };
+        }
+    }
+}

--- a/src/server/Elsa.Server.Api/Extensions/ElsaNewtonsoftJsonConvention.cs
+++ b/src/server/Elsa.Server.Api/Extensions/ElsaNewtonsoftJsonConvention.cs
@@ -1,0 +1,42 @@
+using Elsa.Server.Api.Attributes;
+using Microsoft.AspNetCore.Mvc.ApplicationModels;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Elsa.Server.Api.Extensions
+{
+    /// <summary>
+    /// Auto apply NewtonsoftJsonFormatterAttribute to all controllers in Elsa.Server.Api
+    /// </summary>
+    public class ElsaNewtonsoftJsonConvention : IControllerModelConvention
+    {
+
+        public ElsaNewtonsoftJsonConvention()
+        {
+        }
+
+        public void Apply(ControllerModel controller)
+        {
+            if (ShouldApplyConvention(controller))
+            {
+                var formatterAttribute = new NewtonsoftJsonFormatterAttribute();
+
+                // The attribute itself also implements IControllerModelConvention so we have to call that one as well.
+                // This way, the NewtonsoftJsonBodyModelBinder will be properly connected to the controller actions.
+                formatterAttribute.Apply(controller);
+
+                controller.Filters.Add(formatterAttribute);
+            }
+        }
+
+        private bool ShouldApplyConvention(ControllerModel controller)
+        {
+            return controller?.ControllerType?.FullName?.StartsWith("Elsa.Server.Api")==true &&
+                !controller.Attributes.Any(x => x.GetType() == typeof(NewtonsoftJsonFormatterAttribute));
+        }
+    }
+}

--- a/src/server/Elsa.Server.Api/Extensions/ServiceCollectionExtensions.cs
+++ b/src/server/Elsa.Server.Api/Extensions/ServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using Elsa;
 using Elsa.Models;
 using Elsa.Server.Api;
+using Elsa.Server.Api.Extensions;
 using Elsa.Server.Api.Extensions.SchemaFilters;
 using Elsa.Server.Api.Mapping;
 using Elsa.Server.Api.Services;
@@ -30,7 +31,8 @@ namespace Microsoft.Extensions.DependencyInjection
 
             var setupNewtonsoftJson = apiOptions.SetupNewtonsoftJson ?? (_ => { });
 
-            services.AddControllers().AddNewtonsoftJson(setupNewtonsoftJson);
+            //don't set Newtonsoft globally
+            services.AddControllers();//.AddNewtonsoftJson(setupNewtonsoftJson);
             services.AddRouting(options => { options.LowercaseUrls = true; });
 
             services.AddVersionedApiExplorer(o =>
@@ -54,7 +56,11 @@ namespace Microsoft.Extensions.DependencyInjection
                 .AddSingleton<IEndpointContentSerializerSettingsProvider, EndpointContentSerializerSettingsProvider>()
                 .AddAutoMapperProfile<AutoMapperProfile>()
                 .AddSignalR();
-                
+            services.AddMvc(options =>
+            {
+                //use this convertion to set ElsaNewtonsoftJsonConvention to all controllers in Elsa.Server.Api
+                options.Conventions.Add(new ElsaNewtonsoftJsonConvention());
+            });
             return services;
         }
 
@@ -65,7 +71,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 {
                     c.SwaggerDoc("v1", new OpenApiInfo { Title = "Elsa", Version = "v1" });
                     c.EnableAnnotations();
-                    c.ExampleFilters();
+                    //c.ExampleFilters(); I don't know why, this line will make swagger error
                     c.MapType<VersionOptions?>(() => new OpenApiSchema
                     {
                         Type = PrimitiveType.String.ToString().ToLower(),
@@ -83,7 +89,6 @@ namespace Microsoft.Extensions.DependencyInjection
 
                     //Allow enums to be displayed
                     c.SchemaFilter<XEnumNamesSchemaFilter>();
-
                     configure?.Invoke(c);
                 });
     }

--- a/src/server/Elsa.Server.Api/Extensions/ServiceCollectionExtensions.cs
+++ b/src/server/Elsa.Server.Api/Extensions/ServiceCollectionExtensions.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             var setupNewtonsoftJson = apiOptions.SetupNewtonsoftJson ?? (_ => { });
 
-            //don't set Newtonsoft globally
+            //Don't set Newtonsoft globally
             services.AddControllers();//.AddNewtonsoftJson(setupNewtonsoftJson);
             services.AddRouting(options => { options.LowercaseUrls = true; });
 
@@ -58,7 +58,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 .AddSignalR();
             services.AddMvc(options =>
             {
-                //use this convertion to set ElsaNewtonsoftJsonConvention to all controllers in Elsa.Server.Api
+                //Use this conventions to set ElsaNewtonsoftJsonConvention to all controllers in Elsa.Server.Api
                 options.Conventions.Add(new ElsaNewtonsoftJsonConvention());
             });
             return services;


### PR DESCRIPTION
The idea is instead of using AddNewtonsoftJson to all controllers,make an attribute to use Newtensoft as Object result's formatter, and apply this attribute to all controllers that in Elsa.Server.Api namespace.