### PR TITLE
Terminal Activities

### DIFF
--- a/src/clients/Elsa.Api.Client/Resources/ActivityDescriptors/Models/ActivityDescriptor.cs
+++ b/src/clients/Elsa.Api.Client/Resources/ActivityDescriptors/Models/ActivityDescriptor.cs
@@ -81,4 +81,9 @@ public record ActivityDescriptor
     /// Whether this activity type is selectable from activity pickers.
     /// </summary>
     public bool IsBrowsable { get; set; }
+
+    /// <summary>
+    /// Whether this activity type is a terminal activity.
+    /// </summary>
+    public bool IsTerminal { get; set; }
 }

--- a/src/modules/Elsa.Workflows.Core/Activities/Break.cs
+++ b/src/modules/Elsa.Workflows.Core/Activities/Break.cs
@@ -1,5 +1,6 @@
 using System.Runtime.CompilerServices;
 using Elsa.Extensions;
+using Elsa.Workflows.Core.Activities.Flowchart.Contracts;
 using Elsa.Workflows.Core.Attributes;
 using Elsa.Workflows.Core.Signals;
 using JetBrains.Annotations;
@@ -11,7 +12,7 @@ namespace Elsa.Workflows.Core.Activities;
 /// </summary>
 [Activity("Elsa", "Looping", "Break out of a loop.")]
 [PublicAPI]
-public class Break : CodeActivity
+public class Break : CodeActivity, ITerminalNode
 {
     /// <inheritdoc />
     public Break([CallerFilePath] string? source = default, [CallerLineNumber] int? line = default) : base(source, line)

--- a/src/modules/Elsa.Workflows.Core/Activities/Break.cs
+++ b/src/modules/Elsa.Workflows.Core/Activities/Break.cs
@@ -2,6 +2,7 @@ using System.Runtime.CompilerServices;
 using Elsa.Extensions;
 using Elsa.Workflows.Core.Activities.Flowchart.Contracts;
 using Elsa.Workflows.Core.Attributes;
+using Elsa.Workflows.Core.Contracts;
 using Elsa.Workflows.Core.Signals;
 using JetBrains.Annotations;
 

--- a/src/modules/Elsa.Workflows.Core/Activities/Break.cs
+++ b/src/modules/Elsa.Workflows.Core/Activities/Break.cs
@@ -1,6 +1,5 @@
 using System.Runtime.CompilerServices;
 using Elsa.Extensions;
-using Elsa.Workflows.Core.Activities.Flowchart.Contracts;
 using Elsa.Workflows.Core.Attributes;
 using Elsa.Workflows.Core.Contracts;
 using Elsa.Workflows.Core.Signals;

--- a/src/modules/Elsa.Workflows.Core/Activities/Complete.cs
+++ b/src/modules/Elsa.Workflows.Core/Activities/Complete.cs
@@ -2,8 +2,10 @@ using System.Runtime.CompilerServices;
 using System.Text.Json;
 using Elsa.Expressions.Models;
 using Elsa.Extensions;
+using Elsa.Workflows.Core.Activities.Flowchart.Contracts;
 using Elsa.Workflows.Core.Activities.Flowchart.Models;
 using Elsa.Workflows.Core.Attributes;
+using Elsa.Workflows.Core.Contracts;
 using Elsa.Workflows.Core.Models;
 using Elsa.Workflows.Core.Signals;
 using JetBrains.Annotations;
@@ -15,7 +17,7 @@ namespace Elsa.Workflows.Core.Activities;
 /// </summary>
 [Activity("Elsa", "Composition", "Signals the current composite activity to complete itself as a whole.")]
 [PublicAPI]
-public class Complete : Activity
+public class Complete : Activity, ITerminalNode
 {
     /// <inheritdoc />
     public Complete([CallerFilePath] string? source = default, [CallerLineNumber] int? line = default) : base(source, line)

--- a/src/modules/Elsa.Workflows.Core/Activities/Complete.cs
+++ b/src/modules/Elsa.Workflows.Core/Activities/Complete.cs
@@ -2,7 +2,6 @@ using System.Runtime.CompilerServices;
 using System.Text.Json;
 using Elsa.Expressions.Models;
 using Elsa.Extensions;
-using Elsa.Workflows.Core.Activities.Flowchart.Contracts;
 using Elsa.Workflows.Core.Activities.Flowchart.Models;
 using Elsa.Workflows.Core.Attributes;
 using Elsa.Workflows.Core.Contracts;

--- a/src/modules/Elsa.Workflows.Core/Activities/End.cs
+++ b/src/modules/Elsa.Workflows.Core/Activities/End.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
+using Elsa.Workflows.Core.Activities.Flowchart.Contracts;
 using Elsa.Workflows.Core.Attributes;
 using JetBrains.Annotations;
 
@@ -7,9 +8,9 @@ namespace Elsa.Workflows.Core.Activities;
 /// <summary>
 /// Marks the end of a flowchart, causing the flowchart to complete.
 /// </summary>
-[Activity("Elsa", "Flow", "A milestone activity that marks the start of a flowchart.", Kind = ActivityKind.Action)]
+[Activity("Elsa", "Flow", "A milestone activity that marks the end of a flowchart.", Kind = ActivityKind.Action)]
 [PublicAPI]
-public class End : CodeActivity
+public class End : CodeActivity, ITerminalNode
 {
     /// <inheritdoc />
     public End([CallerFilePath] string? source = default, [CallerLineNumber] int? line = default) : base(source, line)

--- a/src/modules/Elsa.Workflows.Core/Activities/End.cs
+++ b/src/modules/Elsa.Workflows.Core/Activities/End.cs
@@ -1,6 +1,7 @@
 using System.Runtime.CompilerServices;
 using Elsa.Workflows.Core.Activities.Flowchart.Contracts;
 using Elsa.Workflows.Core.Attributes;
+using Elsa.Workflows.Core.Contracts;
 using JetBrains.Annotations;
 
 namespace Elsa.Workflows.Core.Activities;

--- a/src/modules/Elsa.Workflows.Core/Activities/End.cs
+++ b/src/modules/Elsa.Workflows.Core/Activities/End.cs
@@ -1,5 +1,4 @@
 using System.Runtime.CompilerServices;
-using Elsa.Workflows.Core.Activities.Flowchart.Contracts;
 using Elsa.Workflows.Core.Attributes;
 using Elsa.Workflows.Core.Contracts;
 using JetBrains.Annotations;

--- a/src/modules/Elsa.Workflows.Core/Activities/Finish.cs
+++ b/src/modules/Elsa.Workflows.Core/Activities/Finish.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
+using Elsa.Workflows.Core.Activities.Flowchart.Contracts;
 using Elsa.Workflows.Core.Attributes;
 using JetBrains.Annotations;
 
@@ -9,7 +10,7 @@ namespace Elsa.Workflows.Core.Activities;
 /// </summary>
 [Activity("Elsa", "Primitives", "Mark the workflow as finished.")]
 [PublicAPI]
-public class Finish : Activity
+public class Finish : CodeActivity, ITerminalNode
 {
     /// <inheritdoc />
     public Finish([CallerFilePath] string? source = default, [CallerLineNumber] int? line = default) : base(source, line)

--- a/src/modules/Elsa.Workflows.Core/Activities/Finish.cs
+++ b/src/modules/Elsa.Workflows.Core/Activities/Finish.cs
@@ -1,6 +1,7 @@
 using System.Runtime.CompilerServices;
 using Elsa.Workflows.Core.Activities.Flowchart.Contracts;
 using Elsa.Workflows.Core.Attributes;
+using Elsa.Workflows.Core.Contracts;
 using JetBrains.Annotations;
 
 namespace Elsa.Workflows.Core.Activities;

--- a/src/modules/Elsa.Workflows.Core/Activities/Finish.cs
+++ b/src/modules/Elsa.Workflows.Core/Activities/Finish.cs
@@ -1,5 +1,4 @@
 using System.Runtime.CompilerServices;
-using Elsa.Workflows.Core.Activities.Flowchart.Contracts;
 using Elsa.Workflows.Core.Attributes;
 using Elsa.Workflows.Core.Contracts;
 using JetBrains.Annotations;

--- a/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Activities/FlowJoin.cs
+++ b/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Activities/FlowJoin.cs
@@ -12,7 +12,7 @@ namespace Elsa.Workflows.Core.Activities.Flowchart.Activities;
 /// <summary>
 /// Merge multiple branches into a single branch of execution.
 /// </summary>
-[Activity("Elsa", "Branching", "Merge multiple branches into a single branch of execution.")]
+[Activity("Elsa", "Branching", "Merge multiple branches into a single branch of execution.", DisplayName = "Join")]
 [PublicAPI]
 public class FlowJoin : Activity, IJoinNode
 {

--- a/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Activities/Flowchart.cs
+++ b/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Activities/Flowchart.cs
@@ -196,10 +196,10 @@ public class Flowchart : Container
 
         scope.RegisterActivityExecution(completedActivity);
 
-        // If the completed activity is an End or Break activity, complete the flowchart immediately.
-        if (completedActivity is End or Break)
+        // If the complete activity is a terminal node, complete the flowchart immediately.
+        if (completedActivity is ITerminalNode)
         {
-            logger.LogDebug("Completed activity {ActivityId} is an End or Break activity. Completing flowchart", completedActivity.Id);
+            logger.LogDebug("Completed activity {ActivityId} is a terminal activity. Completing flowchart", completedActivity.Id);
             await flowchartContext.CompleteActivityAsync();
         }
         else if (scheduleChildren)

--- a/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Contracts/ITerminalNode.cs
+++ b/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Contracts/ITerminalNode.cs
@@ -1,0 +1,8 @@
+namespace Elsa.Workflows.Core.Activities.Flowchart.Contracts;
+
+/// <summary>
+/// Marks an activity as a terminal activity.
+/// </summary>
+public interface ITerminalNode
+{
+}

--- a/src/modules/Elsa.Workflows.Core/Activities/Sequence.cs
+++ b/src/modules/Elsa.Workflows.Core/Activities/Sequence.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using Elsa.Extensions;
+using Elsa.Workflows.Core.Activities.Flowchart.Contracts;
 using Elsa.Workflows.Core.Attributes;
 using Elsa.Workflows.Core.Signals;
 using JetBrains.Annotations;
@@ -53,8 +54,8 @@ public class Sequence : Container
         var isBreaking = targetContext.GetIsBreaking();
         var completedActivity = childContext.Activity;
 
-        // If we are breaking, or the completed activity is an End or Break activity, complete the sequence immediately.
-        if (isBreaking || completedActivity is End or Break)
+        // If the complete activity is a terminal node, complete the sequence immediately.
+        if (isBreaking || completedActivity is ITerminalNode)
         {
             await targetContext.CompleteActivityAsync();
             return;

--- a/src/modules/Elsa.Workflows.Core/Activities/Sequence.cs
+++ b/src/modules/Elsa.Workflows.Core/Activities/Sequence.cs
@@ -3,6 +3,7 @@ using System.Runtime.CompilerServices;
 using Elsa.Extensions;
 using Elsa.Workflows.Core.Activities.Flowchart.Contracts;
 using Elsa.Workflows.Core.Attributes;
+using Elsa.Workflows.Core.Contracts;
 using Elsa.Workflows.Core.Signals;
 using JetBrains.Annotations;
 

--- a/src/modules/Elsa.Workflows.Core/Activities/Sequence.cs
+++ b/src/modules/Elsa.Workflows.Core/Activities/Sequence.cs
@@ -1,7 +1,6 @@
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using Elsa.Extensions;
-using Elsa.Workflows.Core.Activities.Flowchart.Contracts;
 using Elsa.Workflows.Core.Attributes;
 using Elsa.Workflows.Core.Contracts;
 using Elsa.Workflows.Core.Signals;

--- a/src/modules/Elsa.Workflows.Core/Contexts/WorkflowExecutionContext.cs
+++ b/src/modules/Elsa.Workflows.Core/Contexts/WorkflowExecutionContext.cs
@@ -10,7 +10,6 @@ using Elsa.Workflows.Core.Activities;
 using Elsa.Workflows.Core.Memory;
 using Elsa.Workflows.Core.Models;
 using Elsa.Workflows.Core.Options;
-using Elsa.Workflows.Core.State;
 using JetBrains.Annotations;
 
 namespace Elsa.Workflows.Core;

--- a/src/modules/Elsa.Workflows.Core/Contracts/ITerminalNode.cs
+++ b/src/modules/Elsa.Workflows.Core/Contracts/ITerminalNode.cs
@@ -1,4 +1,4 @@
-namespace Elsa.Workflows.Core.Activities.Flowchart.Contracts;
+namespace Elsa.Workflows.Core.Contracts;
 
 /// <summary>
 /// Marks an activity as a terminal activity.

--- a/src/modules/Elsa.Workflows.Core/Extensions/ActivityExecutionContextExtensions.cs
+++ b/src/modules/Elsa.Workflows.Core/Extensions/ActivityExecutionContextExtensions.cs
@@ -1,6 +1,5 @@
 using System.Linq.Expressions;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Text.Json;
 using Elsa.Common.Contracts;
 using Elsa.Expressions.Contracts;
@@ -14,7 +13,6 @@ using Elsa.Workflows.Core.Contracts;
 using Elsa.Workflows.Core.Memory;
 using Elsa.Workflows.Core.Models;
 using Elsa.Workflows.Core.Notifications;
-using Elsa.Workflows.Core.Services;
 using Elsa.Workflows.Core.Signals;
 using JetBrains.Annotations;
 using Microsoft.Extensions.Logging;

--- a/src/modules/Elsa.Workflows.Core/Models/ActivityDescriptor.cs
+++ b/src/modules/Elsa.Workflows.Core/Models/ActivityDescriptor.cs
@@ -96,6 +96,11 @@ public class ActivityDescriptor
     /// Whether this activity type is selectable from activity pickers.
     /// </summary>
     public bool IsBrowsable { get; set; } = true;
+
+    /// <summary>
+    /// Whether this activity type is a terminal activity.
+    /// </summary>
+    public bool IsTerminal { get; set; }
 }
 
 // TODO: Refactor this to remove the dependency on JsonElement and JsonSerializerOptions.

--- a/src/modules/Elsa.Workflows.Core/Services/ActivityDescriber.cs
+++ b/src/modules/Elsa.Workflows.Core/Services/ActivityDescriber.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Elsa.Extensions;
 using Elsa.Workflows.Core.Activities.Flowchart.Attributes;
+using Elsa.Workflows.Core.Activities.Flowchart.Contracts;
 using Elsa.Workflows.Core.Attributes;
 using Elsa.Workflows.Core.Contracts;
 using Elsa.Workflows.Core.Helpers;
@@ -71,6 +72,7 @@ public class ActivityDescriber : IActivityDescriber
         var outputProperties = GetOutputProperties(activityType).ToList();
         var isTrigger = activityType.IsAssignableTo(typeof(ITrigger));
         var browsableAttr = activityType.GetCustomAttribute<BrowsableAttribute>();
+        var isTerminal = activityType.FindInterfaces((type, criteria) => type == typeof(ITerminalNode), null).Any();
         var attributes = activityType.GetCustomAttributes(true).Cast<Attribute>().ToList();
 
         var descriptor = new ActivityDescriptor
@@ -88,6 +90,7 @@ public class ActivityDescriber : IActivityDescriber
             Outputs = (await DescribeOutputPropertiesAsync(outputProperties, cancellationToken)).ToList(),
             IsContainer = typeof(IContainer).IsAssignableFrom(activityType),
             IsBrowsable = browsableAttr == null || browsableAttr.Browsable,
+            IsTerminal = isTerminal,
             Attributes = attributes,
             Constructor = context =>
             {

--- a/src/modules/Elsa.Workflows.Core/Services/ActivityDescriber.cs
+++ b/src/modules/Elsa.Workflows.Core/Services/ActivityDescriber.cs
@@ -4,7 +4,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Elsa.Extensions;
 using Elsa.Workflows.Core.Activities.Flowchart.Attributes;
-using Elsa.Workflows.Core.Activities.Flowchart.Contracts;
 using Elsa.Workflows.Core.Attributes;
 using Elsa.Workflows.Core.Contracts;
 using Elsa.Workflows.Core.Helpers;

--- a/src/modules/Elsa.Workflows.Core/Services/WorkflowStateExtractor.cs
+++ b/src/modules/Elsa.Workflows.Core/Services/WorkflowStateExtractor.cs
@@ -1,6 +1,5 @@
 using Elsa.Extensions;
 using Elsa.Workflows.Core.Contracts;
-using Elsa.Workflows.Core.Models;
 using Elsa.Workflows.Core.State;
 
 namespace Elsa.Workflows.Core.Services;


### PR DESCRIPTION
Provides the ITerminalNode abstraction to allow activities to act as terminal nodes in a diagram, such as End, Break, Finish and Complete.

Terminal nodes will complete their parent Flowchart and Sequence activity immediately and do not have a Done outcome.

This PR also fixes an issue with the Finish activity not completing.

### === auto-pr-body ===

 
Summary: 
This pull request introduces changes to the ActivityDescriptor model, adds the ITerminalNode interface, updates the display name of the FlowJoin activity, and modifies global logging language to better reflect terminal activities.

List of Changes: 
- Added a new property to the `ActivityDescriptor` model named `IsTerminal`, which is intended to store whether this activity type is a terminal activity. 
- The `Break`, `Complete`, `End`, and `Finish` activity classes have all been modified to implement the `ITerminalNode` interface.
- The display name of the `FlowJoin` activity has been changed from "Flow Join" to just "Join". 
- Changed the logging language in the "Sequence.cs" file to better reflect terminal activities. 
- Removed the dependency of "WorkflowExecutionContext.cs" on the "WorkflowStateTracker.cs" file. 
- Removed the reference to the "System.Runtime.CompilerServices" namespace in "ActivityExecutionContextExtensions.cs" that was not needed. 
- Added a new condition to the "ActivityDescriber.cs" class to identify the activity as a terminal node. 
- Added a new condition to the "WorkflowStateExtractor.cs" class to identify the activity as a terminal node.

Suggestions for Refactoring: 
- Add comments to the new code added to each class to explain why the changes were needed. 
- Refactor the code in the class "ActivityDescriber.cs" to a more succinct structure. 
- Move the new boolean property "IsTerminal" to an inherited class or super class to avoid the need to add it to all new activity types when they are created.