### PR TITLE
HTTP File Response Improvements

### DIFF
--- a/src/modules/Elsa.Http/Features/HttpFeature.cs
+++ b/src/modules/Elsa.Http/Features/HttpFeature.cs
@@ -27,6 +27,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace Elsa.Http.Features;
 
@@ -71,9 +72,10 @@ public class HttpFeature : FeatureBase
     /// <summary>
     /// A delegate to configure the <see cref="IFileCacheStorageProvider"/>.
     /// </summary>
-    public Func<IServiceProvider, IFileCacheStorageProvider> FileCache { get; set; } = _ =>
+    public Func<IServiceProvider, IFileCacheStorageProvider> FileCache { get; set; } = sp =>
     {
-        var blobStorage = StorageFactory.Blobs.DirectoryFiles(Path.GetTempPath());
+        var options = sp.GetRequiredService<IOptions<HttpFileCacheOptions>>().Value;
+        var blobStorage = StorageFactory.Blobs.DirectoryFiles(options.LocalCacheDirectory);
         return new BlobFileCacheStorageProvider(blobStorage);
     };
 

--- a/src/modules/Elsa.Http/Options/HttpFileCacheOptions.cs
+++ b/src/modules/Elsa.Http/Options/HttpFileCacheOptions.cs
@@ -9,4 +9,9 @@ public class HttpFileCacheOptions
     /// The time to live for cached files.
     /// </summary>
     public TimeSpan TimeToLive { get; set; } = TimeSpan.FromDays(7);
+
+    /// <summary>
+    /// The local cache directory. Defaults to the system's temp directory.
+    /// </summary>
+    public string LocalCacheDirectory { get; set; } = Path.GetTempPath();
 }

--- a/src/modules/Elsa.Http/Services/ZipManager.cs
+++ b/src/modules/Elsa.Http/Services/ZipManager.cs
@@ -39,7 +39,7 @@ internal class ZipManager
         CancellationToken cancellationToken = default)
     {
         // Create a temporary file.
-        var tempFilePath = Path.GetTempFileName();
+        var tempFilePath = GetTempFilePath();
 
         // Create a zip archive from the downloadables.
         await CreateZipArchiveAsync(tempFilePath, downloadables, cancellationToken);
@@ -54,7 +54,7 @@ internal class ZipManager
         var zipStream = File.OpenRead(tempFilePath);
         return (zipBlob, zipStream, () => Cleanup(tempFilePath));
     }
-    
+
     /// <summary>
     /// Loads a cached zip blob for the specified download correlation ID.
     /// </summary>
@@ -172,6 +172,13 @@ internal class ZipManager
         downloadAsFilename = !string.IsNullOrWhiteSpace(downloadAsFilename) ? downloadAsFilename : "download.zip";
         
         return (downloadAsFilename, contentType);
+    }
+    
+    private string GetTempFilePath()
+    {
+        var tempFileName = Path.GetRandomFileName();
+        var tempFilePath = Path.Combine(_fileCacheOptions.Value.LocalCacheDirectory, tempFileName);
+        return tempFilePath;
     }
     
     private void Cleanup(string filePath)


### PR DESCRIPTION
This PR contains the following improvements for the File HTTP Response activity:

1. Control location of temp folder
2. Compute e-tag based on file hash instead of modified date to ensure uniqueness

### === auto-pr-body ===


Summary:
This pull request introduces a number of changes to improve the `WriteFileHttpResponse`, `HttpFeature` and `ZipManager` classes. The changes include using `MD5.Create()` to calculate etag header value in `WriteFileHttpResponse`, switching to `IOptions<HttpFileCacheOptions>` to configure the `IFileCacheStorageProvider` in `HttpFeature`, and adding a new `HttpFileCacheOptions` class for default `LocalCacheDirectory` configuration. The `ZipManager` has also been changed to use `GetTempFilePath` for zip blobs.

List of Changes: 
- Changed `WriteFileHttpResponse` to use `MD5.Create()` to compute the etag header value and `FluentStorage.Utils.Extensions` when sending a file stream. 
- Changed `HttpFeature` to use `IOptions<HttpFileCacheOptions>` to configure the `IFileCacheStorageProvider` instead of an unconfigured instance. 
- Added a new `HttpFileCacheOptions` class for default `LocalCacheDirectory` configuration. 
- Updated `ZipManager` to use `GetTempFilePath` when getting a temporary file path for a zip blob. 

Refactoring Target:
- Add comments to explain why `MD5.Create()` is used to calculate the etag header value in `WriteFileHttpResponse`. 
- Consider merging `GetTempFilePath()` into the logic that creates the iOS zip blob in `ZipManager`.