### PR TITLE
Missing WorkflowPassCompleted enum element in WorkflowPersistenceBehavior.cs

### DIFF
--- a/src/core/Elsa.Abstractions/Models/WorkflowPersistenceBehavior.cs
+++ b/src/core/Elsa.Abstractions/Models/WorkflowPersistenceBehavior.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
 namespace Elsa.Models
@@ -15,7 +15,12 @@ namespace Elsa.Models
         /// Workflow instances are persisted after the workflow completed a burst of execution.
         /// </summary>
         WorkflowBurst,
-        
+
+        /// <summary>
+        /// Workflow instances are persisted after the workflow executed scheduled activities.
+        /// </summary>
+        WorkflowPassCompleted,
+
         /// <summary>
         /// Workflow instances are persisted after each activity that executed.
         /// </summary>

--- a/src/core/Elsa.Core/Handlers/PersistWorkflow.cs
+++ b/src/core/Elsa.Core/Handlers/PersistWorkflow.cs
@@ -27,7 +27,7 @@ namespace Elsa.Handlers
         {
             var behavior = notification.WorkflowExecutionContext.WorkflowBlueprint.PersistenceBehavior;
 
-            if (behavior == WorkflowPersistenceBehavior.ActivityExecuted || notification.ActivityExecutionContext.ActivityBlueprint.PersistWorkflow)
+            if (behavior == WorkflowPersistenceBehavior.ActivityExecuted || behavior == WorkflowPersistenceBehavior.WorkflowPassCompleted || notification.ActivityExecutionContext.ActivityBlueprint.PersistWorkflow)
                 await SaveWorkflowAsync(notification.WorkflowExecutionContext.WorkflowInstance, cancellationToken);
         }
 


### PR DESCRIPTION
In Elsa.Abstractions there is enum for serialization of existing workflows in blob storage. WorkflowPassCompleted is missing there.