### PR TITLE
3537 Switch to DefaultContractResolver

### DIFF
--- a/src/core/Elsa.Core/Serialization/DefaultContentSerializer.cs
+++ b/src/core/Elsa.Core/Serialization/DefaultContentSerializer.cs
@@ -31,7 +31,7 @@ namespace Elsa.Serialization
             settings.PreserveReferencesHandling = PreserveReferencesHandling.Objects;
             settings.TypeNameAssemblyFormatHandling = TypeNameAssemblyFormatHandling.Simple;
             settings.TypeNameHandling = TypeNameHandling.Auto;
-            settings.ContractResolver = new CamelCasePropertyNamesContractResolver
+            settings.ContractResolver = new DefaultContractResolver
             {
                 NamingStrategy = new CamelCaseNamingStrategy
                 {


### PR DESCRIPTION
Switch from `CamelCasePropertyNamesContractResolver` to `DefaultContractResolver`. `CamelCasePropertyNamesContractResolver` has a shared cache for contracts between instances. If any Dictionary<string, string> is previously serialized with settings to process dictionary keys, `ActivityDefinitionProperty.Expressions` will also be serialized with dictionary key processing. It's better to use DefaultContractResolver, which has a cache for each instance.