### PR TITLE
Adds Swagger documentation generation and UI.

### DIFF
--- a/src/bundles/Elsa.WorkflowServer.Web/Program.cs
+++ b/src/bundles/Elsa.WorkflowServer.Web/Program.cs
@@ -160,6 +160,8 @@ services
 
         // Initialize drop-ins.
         elsa.InstallDropIns(options => options.DropInRootDirectory = Path.Combine(Directory.GetCurrentDirectory(), "App_Data", "DropIns"));
+
+        elsa.AddSwagger();
     });
 
 services.AddHealthChecks();
@@ -195,6 +197,10 @@ app.UseJsonSerializationErrorHandler();
 
 // Elsa HTTP Endpoint activities
 app.UseWorkflows();
+
+// Swagger API documentation
+if (app.Environment.IsDevelopment())
+    app.UseSwaggerUI();
 
 // SignalR.
 app.UseWorkflowsSignalRHubs();

--- a/src/common/Elsa.Api.Common/Extensions/SwaggerExtensions.cs
+++ b/src/common/Elsa.Api.Common/Extensions/SwaggerExtensions.cs
@@ -1,0 +1,57 @@
+﻿using Elsa.Features.Services;
+using FastEndpoints.Swagger;
+using Microsoft.AspNetCore.Builder;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Elsa.Extensions
+{
+    /// <summary>
+    /// Extensions to enable the generation of Swagger API Documentation and associated Swagger UI.
+    /// </summary>
+    public static class SwaggerExtensions
+    {
+        /// <summary>
+        /// Registers Swagger document generator.
+        /// </summary>
+        public static IModule AddSwagger(this IModule module)
+        {
+            Version ver = new(3, 0);
+
+            // Swagger API documentation
+            module.Services.SwaggerDocument(o =>
+            {
+                o.EnableJWTBearerAuth = false;
+                o.DocumentSettings = s =>
+                {
+                    s.DocumentName = $"v{ver.Major}";
+                    s.Title = "Elsa API";
+                    s.Version = $"v{ver.Major}.{ver.Minor}";
+                    s.AddAuth("ApiKey", new()
+                    {
+                        Name = "Authorization",
+                        In = NSwag.OpenApiSecurityApiKeyLocation.Header,
+                        Type = NSwag.OpenApiSecuritySchemeType.ApiKey,
+                        Description = "Enter: ApiKey [your API key]"
+                    });
+                };
+            });
+
+            return module;
+        }
+
+        /// <summary>
+        /// Adds middleware to enable the Swagger UI at '/swagger'
+        /// </summary>
+        public static IApplicationBuilder UseSwaggerUI(this IApplicationBuilder app)
+        {
+            return app.UseSwaggerGen();
+        }
+
+    }
+}


### PR DESCRIPTION
This adds the Swagger documentation generation and Swagger UI middleware as a pair of extension methods (Issue #4299)

Once these are added to the application, you can view the API documentation by visiting: /swagger

At the moment I've hard-coded the version number at "3.0" - is there a better means of getting the version number of the API? The Elsa.Api.Common project's version number doesn't appear to be set.

Just submitting this PR at this stage to make sure this is heading in the right direction... I'll be adding some actual documentation to the API endpoints and updating this PR for further feedback / review.

Thanks! 

