### PR TITLE
Add WorkflowContext client API

### DIFF
--- a/src/bundles/Elsa.WorkflowServer.Web/Program.cs
+++ b/src/bundles/Elsa.WorkflowServer.Web/Program.cs
@@ -16,6 +16,7 @@ using Elsa.MongoDb.Extensions;
 using Elsa.MongoDb.Modules.Identity;
 using Elsa.MongoDb.Modules.Management;
 using Elsa.MongoDb.Modules.Runtime;
+using Elsa.WorkflowServer.Web.WorkflowContexts;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Options;
 using Proto.Persistence.Sqlite;
@@ -159,7 +160,8 @@ services
                 });
 
                 alterations.UseMassTransitDispatcher();
-            });
+            })
+            .UseWorkflowContexts();
 
         // Initialize drop-ins.
         elsa.InstallDropIns(options => options.DropInRootDirectory = Path.Combine(Directory.GetCurrentDirectory(), "App_Data", "DropIns"));
@@ -167,6 +169,8 @@ services
         elsa.AddSwagger();
     });
 
+services.AddWorkflowContextProvider<CustomerWorkflowContextProvider>();
+services.AddWorkflowContextProvider<OrderWorkflowContextProvider>();
 services.AddHealthChecks();
 services.AddControllers();
 services.AddCors(cors => cors.AddDefaultPolicy(policy => policy.AllowAnyHeader().AllowAnyMethod().AllowAnyOrigin().WithExposedHeaders("*")));

--- a/src/bundles/Elsa.WorkflowServer.Web/WorkflowContexts/CustomerContext.cs
+++ b/src/bundles/Elsa.WorkflowServer.Web/WorkflowContexts/CustomerContext.cs
@@ -1,0 +1,17 @@
+using Elsa.WorkflowContexts.Contracts;
+using Elsa.Workflows.Core;
+
+namespace Elsa.WorkflowServer.Web.WorkflowContexts;
+
+public class CustomerWorkflowContextProvider : IWorkflowContextProvider
+{
+    public async ValueTask<object?> LoadAsync(WorkflowExecutionContext workflowExecutionContext)
+    {
+        throw new NotImplementedException();
+    }
+
+    public async ValueTask SaveAsync(WorkflowExecutionContext workflowExecutionContext, object? context)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/bundles/Elsa.WorkflowServer.Web/WorkflowContexts/OrderWorkflowContextProvider.cs
+++ b/src/bundles/Elsa.WorkflowServer.Web/WorkflowContexts/OrderWorkflowContextProvider.cs
@@ -1,0 +1,17 @@
+using Elsa.WorkflowContexts.Contracts;
+using Elsa.Workflows.Core;
+
+namespace Elsa.WorkflowServer.Web.WorkflowContexts;
+
+public class OrderWorkflowContextProvider : IWorkflowContextProvider
+{
+    public async ValueTask<object?> LoadAsync(WorkflowExecutionContext workflowExecutionContext)
+    {
+        throw new NotImplementedException();
+    }
+
+    public async ValueTask SaveAsync(WorkflowExecutionContext workflowExecutionContext, object? context)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/clients/Elsa.Api.Client/Extensions/DependencyInjectionExtensions.cs
+++ b/src/clients/Elsa.Api.Client/Extensions/DependencyInjectionExtensions.cs
@@ -14,6 +14,7 @@ using Elsa.Api.Client.Resources.StorageDrivers.Contracts;
 using Elsa.Api.Client.Resources.VariableTypes.Contracts;
 using Elsa.Api.Client.Resources.WorkflowActivationStrategies.Contracts;
 using Elsa.Api.Client.Resources.WorkflowDefinitions.Contracts;
+using Elsa.Api.Client.Resources.WorkflowExecutionContexts.Contracts;
 using Elsa.Api.Client.Resources.WorkflowInstances.Contracts;
 using Elsa.Api.Client.Services;
 using JetBrains.Annotations;
@@ -52,6 +53,7 @@ public static class DependencyInjectionExtensions
         services.AddApi<ILoginApi>(builderOptions);
         services.AddApi<IFeaturesApi>(builderOptions);
         services.AddApi<IJavaScriptApi>(builderOptions);
+        services.AddApi<IWorkflowContextProviderDescriptorsApi>(builderOptions);
         return services;
     }
 

--- a/src/clients/Elsa.Api.Client/Extensions/DictionaryExtensions.cs
+++ b/src/clients/Elsa.Api.Client/Extensions/DictionaryExtensions.cs
@@ -10,7 +10,7 @@ public static class DictionaryExtensions
     /// <summary>
     /// Returns the value of the specified property if it exists, otherwise the default value.
     /// </summary>
-    public static T? TryGetValue<T>(this IDictionary<string, object> dictionary, string key, Func<T>? defaultValue = default, JsonSerializerOptions? serializerOptions = default)
+    public static T TryGetValue<T>(this IDictionary<string, object> dictionary, string key, Func<T>? defaultValue = default, JsonSerializerOptions? serializerOptions = default)
     {
         var caseInsensitiveDictionary = ToCaseInsensitiveDictionary(dictionary);
 
@@ -23,7 +23,7 @@ public static class DictionaryExtensions
         }
 
         if (defaultValue == null)
-            return default;
+            return default!;
 
         var defaultVal = defaultValue()!;
         dictionary[key] = defaultVal;

--- a/src/clients/Elsa.Api.Client/Resources/Features/Contracts/IFeaturesApi.cs
+++ b/src/clients/Elsa.Api.Client/Resources/Features/Contracts/IFeaturesApi.cs
@@ -1,4 +1,5 @@
 using Elsa.Api.Client.Resources.Features.Models;
+using Elsa.Api.Client.Shared.Models;
 using Refit;
 
 namespace Elsa.Api.Client.Resources.Features.Contracts;
@@ -11,9 +12,12 @@ public interface IFeaturesApi
     /// <summary>
     /// Gets the specified feature.
     /// </summary>
-    /// <param name="fullName">The fully qualified name of the feature.</param>
-    /// <param name="cancellationToken">An optional cancellation token.</param>
-    /// <returns>Information about the feature.</returns>
     [Get("/features/installed/{fullName}")]
     Task<FeatureDescriptor> GetAsync(string fullName, CancellationToken cancellationToken = default);
+    
+    /// <summary>
+    /// Gets the specified feature.
+    /// </summary>
+    [Get("/features/installed")]
+    Task<ListResponse<FeatureDescriptor>> ListAsync(CancellationToken cancellationToken = default);
 }

--- a/src/clients/Elsa.Api.Client/Resources/WorkflowExecutionContexts/Contracts/IWorkflowContextProviderDescriptorsApi.cs
+++ b/src/clients/Elsa.Api.Client/Resources/WorkflowExecutionContexts/Contracts/IWorkflowContextProviderDescriptorsApi.cs
@@ -1,0 +1,19 @@
+using Elsa.Api.Client.Resources.WorkflowExecutionContexts.Models;
+using Elsa.Api.Client.Shared.Models;
+using JetBrains.Annotations;
+using Refit;
+
+namespace Elsa.Api.Client.Resources.WorkflowExecutionContexts.Contracts;
+
+/// <summary>
+/// Provides workflow context provider descriptors.
+/// </summary>
+[PublicAPI]
+public interface IWorkflowContextProviderDescriptorsApi
+{
+    /// <summary>
+    /// Returns a list of workflow context provider descriptors.
+    /// </summary>
+    [Get("/workflow-contexts/provider-descriptors")]
+    Task<ListResponse<WorkflowContextProviderDescriptor>> ListAsync(CancellationToken cancellationToken = default);
+}

--- a/src/clients/Elsa.Api.Client/Resources/WorkflowExecutionContexts/Models/WorkflowContextProviderDescriptor.cs
+++ b/src/clients/Elsa.Api.Client/Resources/WorkflowExecutionContexts/Models/WorkflowContextProviderDescriptor.cs
@@ -1,0 +1,8 @@
+namespace Elsa.Api.Client.Resources.WorkflowExecutionContexts.Models;
+
+/// <summary>
+/// Represents a workflow context provider descriptor.
+/// </summary>
+/// <param name="Name">The name of the workflow context provider.</param>
+/// <param name="Type">The type of the workflow context provider.</param>
+public record WorkflowContextProviderDescriptor(string Name, string Type);

--- a/src/modules/Elsa.WorkflowContexts/Endpoints/ProviderTypes/List/Endpoint.cs
+++ b/src/modules/Elsa.WorkflowContexts/Endpoints/ProviderTypes/List/Endpoint.cs
@@ -1,11 +1,12 @@
 using Elsa.Abstractions;
+using Elsa.Models;
 using Elsa.WorkflowContexts.Contracts;
 using JetBrains.Annotations;
 
 namespace Elsa.WorkflowContexts.Endpoints.ProviderTypes.List;
 
-[PublicAPI]
-internal class List : ElsaEndpointWithoutRequest<Response>
+[UsedImplicitly]
+internal class List : ElsaEndpointWithoutRequest<ListResponse<WorkflowContextProviderDescriptor>>
 {
     private readonly ICollection<WorkflowContextProviderDescriptor> _providerDescriptors;
 
@@ -23,14 +24,14 @@ internal class List : ElsaEndpointWithoutRequest<Response>
         ConfigurePermissions("read:workflow-context-provider-descriptors");
     }
 
-    public override Task<Response> ExecuteAsync(CancellationToken cancellationToken)
+    public override Task<ListResponse<WorkflowContextProviderDescriptor>> ExecuteAsync(CancellationToken cancellationToken)
     {
-        return Task.FromResult(new Response(_providerDescriptors, _providerDescriptors.Count));
+        return Task.FromResult(new ListResponse<WorkflowContextProviderDescriptor>(_providerDescriptors));
     }
 }
 
-[PublicAPI]
+[UsedImplicitly]
 internal record Response(ICollection<WorkflowContextProviderDescriptor> Descriptors, int Count);
 
-[PublicAPI]
+[UsedImplicitly]
 internal record WorkflowContextProviderDescriptor(string Name, Type Type);

--- a/src/modules/Elsa.WorkflowContexts/Extensions/ModuleExtensions.cs
+++ b/src/modules/Elsa.WorkflowContexts/Extensions/ModuleExtensions.cs
@@ -16,7 +16,6 @@ public static class ModuleExtensions
     /// </summary>
     /// <param name="module">The module.</param>
     /// <param name="configure">The configuration delegate.</param>
-    /// <returns>The module.</returns>
     public static IModule UseWorkflowContexts(this IModule module, Action<WorkflowContextsFeature>? configure = default)
     {
         module.Use(configure);

--- a/src/modules/Elsa.Workflows.Api/Endpoints/Features/List/Endpoint.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/Features/List/Endpoint.cs
@@ -1,6 +1,7 @@
 using Elsa.Abstractions;
 using Elsa.Features.Contracts;
 using Elsa.Features.Models;
+using Elsa.Models;
 using JetBrains.Annotations;
 
 namespace Elsa.Workflows.Api.Endpoints.Features.List;
@@ -9,7 +10,7 @@ namespace Elsa.Workflows.Api.Endpoints.Features.List;
 /// Returns a list of installed features.
 /// </summary>
 [PublicAPI]
-internal class List : ElsaEndpointWithoutRequest<Response>
+internal class List : ElsaEndpointWithoutRequest<ListResponse<FeatureDescriptor>>
 {
     private readonly IInstalledFeatureRegistry _installedFeatureRegistry;
 
@@ -27,14 +28,11 @@ internal class List : ElsaEndpointWithoutRequest<Response>
     }
 
     /// <inheritdoc />
-    public override Task<Response> ExecuteAsync(CancellationToken cancellationToken)
+    public override Task<ListResponse<FeatureDescriptor>> ExecuteAsync(CancellationToken cancellationToken)
     {
         var descriptors = _installedFeatureRegistry.List().ToList();
-        var response = new Response(descriptors);
+        var response = new ListResponse<FeatureDescriptor>(descriptors);
 
         return Task.FromResult(response);
     }
 }
-
-[PublicAPI]
-internal record Response(ICollection<FeatureDescriptor> InstalledFeatures);


### PR DESCRIPTION
This PR adds a client API for accessing workflow contexts from the server, which is used by the new [WorkflowContext module for Elsa Studio](https://github.com/elsa-workflows/elsa-studio/issues/41).

