### PR TITLE
Allow to change encryption algorithm for secret properties

### DIFF
--- a/src/modules/secrets/Elsa.Secrets/Encryption/AesSecretEncryptor.cs
+++ b/src/modules/secrets/Elsa.Secrets/Encryption/AesSecretEncryptor.cs
@@ -1,0 +1,66 @@
+﻿namespace Elsa.Secrets.Encryption
+{
+    using System;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Elsa.Secrets.Models;
+    using Elsa.Secrets.Options;
+    using Microsoft.Extensions.Options;
+
+    public class AesSecretEncryptor : ISecretEncryptor
+    {
+        private readonly SecretsConfigOptions _secretsConfig;
+
+        public AesSecretEncryptor(IOptions<SecretsConfigOptions> options)
+        {
+            _secretsConfig = options.Value;
+        }
+
+        public Task EncryptProperties(Secret secret, CancellationToken cancellationToken = default)
+        {
+            if (_secretsConfig.EncryptionEnabled == true)
+            {
+                foreach (var property in secret.Properties)
+                {
+                    if (property.IsEncrypted || (_secretsConfig.EncryptedProperties?.Contains(property.Name, StringComparer.OrdinalIgnoreCase) ?? false))
+                    {
+                        continue;
+                    }
+
+                    foreach (var (key, value) in property.Expressions)
+                    {
+                        property.Expressions[key] = AesEncryption.Encrypt(_secretsConfig.EncryptionKey, value);
+                    }
+
+                    property.IsEncrypted = true;
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task DecryptPropertiesAsync(Secret secret, CancellationToken cancellationToken = default)
+        {
+            if (_secretsConfig.EncryptionEnabled == true)
+            {
+                foreach (var property in secret.Properties)
+                {
+                    if (!property.IsEncrypted)
+                    {
+                        continue;
+                    }
+
+                    foreach (var (key, value) in property.Expressions)
+                    {
+                        property.Expressions[key] = AesEncryption.Decrypt(_secretsConfig.EncryptionKey, value);
+                    }
+
+                    property.IsEncrypted = false;
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/modules/secrets/Elsa.Secrets/Encryption/ISecretEncryptor.cs
+++ b/src/modules/secrets/Elsa.Secrets/Encryption/ISecretEncryptor.cs
@@ -1,0 +1,12 @@
+﻿namespace Elsa.Secrets.Encryption
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Elsa.Secrets.Models;
+
+    public interface ISecretEncryptor
+    {
+        Task EncryptProperties(Secret secret, CancellationToken cancellationToken = default);
+        Task DecryptPropertiesAsync(Secret secret, CancellationToken cancellationToken = default);
+    }
+}

--- a/src/modules/secrets/Elsa.Secrets/Extensions/SecretsOptionsBuilderExtensions.cs
+++ b/src/modules/secrets/Elsa.Secrets/Extensions/SecretsOptionsBuilderExtensions.cs
@@ -12,6 +12,8 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Elsa.Secrets.Extensions
 {
+    using Elsa.Secrets.Encryption;
+
     public static class SecretsOptionsBuilderExtensions
     {
         public static ElsaOptionsBuilder AddSecrets(this ElsaOptionsBuilder elsaOptions, IConfiguration configuration)
@@ -23,7 +25,8 @@ namespace Elsa.Secrets.Extensions
                 .AddScoped<ISecretsManager, SecretsManager>()
                 .AddScoped<ISecretsProvider, SecretsProvider>()
                 .Decorate<ISecretsStore, EventPublishingSecretsStore>()
-                .AddNotificationHandlersFrom<DescribingActivityTypeHandler>();
+                .AddNotificationHandlersFrom<DescribingActivityTypeHandler>()
+                .AddSingleton<ISecretEncryptor, AesSecretEncryptor>();
 
             elsaOptions.Services
                 .TryAddProvider<IExpressionHandler, SecretsExpressionHandler>(ServiceLifetime.Scoped);

--- a/src/modules/secrets/Elsa.Secrets/Providers/SecretsProvider.cs
+++ b/src/modules/secrets/Elsa.Secrets/Providers/SecretsProvider.cs
@@ -81,7 +81,6 @@ namespace Elsa.Secrets.Providers
         public async Task<bool> IsSecretValueSensitiveData(string type, string name)
         {
             var secrets = await _secretsManager.GetSecrets(type, false);
-            var formatter = _valueFormatters.FirstOrDefault(x => x.Type == type);
             var secret = secrets.Where(x => x.Name?.Equals(name, StringComparison.InvariantCultureIgnoreCase) == true && x.Type?.Equals(type, StringComparison.InvariantCultureIgnoreCase) == true)
                 ?.FirstOrDefault();
             if (secret == null)
@@ -89,6 +88,7 @@ namespace Elsa.Secrets.Providers
                 return false;
             }
 
+            var formatter = _valueFormatters.FirstOrDefault(x => x.Type == type);
             return formatter?.IsSecretValueSensitiveData(secret) ?? false;
         }
         


### PR DESCRIPTION
I added new interface for encryptor so it is easy to change encryption method in server configuration. However I have few questions about `SecretsConfigOptions` that was added recently. It has 2 properties: `Enabled` and `EncryptionEnabled`. Before my changes for encryption `Enabled` property was used and `EncryptionEnabled` was unused at all. 

Should I return using of `Enabled` property and remove `EncryptionEnabled`?

Also options have `ConnectionStringIdentifier` and `ConnectionString` that are not used from options class at all. Should we keep it in options class?