### PR TITLE
Change endpoint to Post

### DIFF
--- a/src/clients/Elsa.Api.Client/Resources/ActivityDescriptorOptions/Contracts/IActivityDescriptorOptionsApi.cs
+++ b/src/clients/Elsa.Api.Client/Resources/ActivityDescriptorOptions/Contracts/IActivityDescriptorOptionsApi.cs
@@ -17,6 +17,6 @@ public interface IActivityDescriptorOptionsApi
     /// <param name="request">The context request.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The response containing the activity descriptors.</returns>
-    [Get("/descriptors/activities/{activityTypeName}/options/{propertyName}")]
+    [Post("/descriptors/activities/{activityTypeName}/options/{propertyName}")]
     Task<GetActivityDescriptorOptionsResponse> GetAsync(string activityTypeName, string propertyName, [Body]GetActivityDescriptorOptionsRequest request, CancellationToken cancellationToken = default);
 }

--- a/src/modules/Elsa.Workflows.Api/Endpoints/ActivityDescriptorOptions/Get/Endpoint.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/ActivityDescriptorOptions/Get/Endpoint.cs
@@ -24,7 +24,7 @@ internal class Get : ElsaEndpoint<Request, Response>
     /// <inheritdoc />
     public override void Configure()
     {
-        Get("/descriptors/activities/{activityTypeName}/options/{propertyName}");
+        Post("/descriptors/activities/{activityTypeName}/options/{propertyName}");
         ConfigurePermissions("read:*", "read:activity-descriptors-options");
     }
 


### PR DESCRIPTION
### === auto-pr-body ===



Summary: Changes to '/descriptors/activities/{activityTypeName}/options/{propertyName}' Endpoint

List of Changes: 
- Changed HTTP verb from GET to POST
- Added permission configure

Refactoring Target:
- Create a separate permission configure method to avoid code duplication
- Consider using a more specific permission configure to this endpoint instead of generic permissions