### PR TITLE
V3 - Fix ParallelForEach Behaviour when empty items

### DIFF
--- a/src/modules/Elsa.Workflows.Core/Activities/ParallelForEachT.cs
+++ b/src/modules/Elsa.Workflows.Core/Activities/ParallelForEachT.cs
@@ -43,6 +43,12 @@ public class ParallelForEach<T> : Activity
         var tags = new List<Guid>();
         var currentIndex = 0;
 
+        if (items.Count == 0)
+        {
+            await context.CompleteActivityAsync();
+            return;
+        }
+
         foreach (var item in items)
         {
             // For each item, declare a new variable for the work to be scheduled.


### PR DESCRIPTION
This PR fix the ParallelForEach when the Items list of ParallelForEach activity is empty.

Actually the activity keeps suspended.

Fix #4608 