### PR TITLE
Enhancement/dynamic options provider

### DIFF
--- a/src/clients/Elsa.Api.Client/Resources/ActivityDescriptors/Models/InputDescriptor.cs
+++ b/src/clients/Elsa.Api.Client/Resources/ActivityDescriptors/Models/InputDescriptor.cs
@@ -54,4 +54,20 @@ public class InputDescriptor : PropertyDescriptor
     /// If no driver is specified, the referenced memory block will remain in memory for as long as the expression execution context exists.
     /// </summary>
     public string? StorageDriverType { get; set; }
+
+    /// <summary>
+    /// True if the data provided is dynamic
+    /// </summary>
+    public bool IsRefreashable { get; set; }
+
+    /// <summary>
+    /// The property Name on which this input depends. 
+    /// </summary>
+    public string[]? DependsOn { get; set; }
+
+    /// <summary>
+    /// The property Name which can change the activatation of this property
+    /// </summary>
+    public string[]? ActivatedBy { get; set; }
+
 }

--- a/src/modules/Elsa.CSharp/Activities/RunCSharp/RunCSharpOptionsProvider.cs
+++ b/src/modules/Elsa.CSharp/Activities/RunCSharp/RunCSharpOptionsProvider.cs
@@ -7,6 +7,8 @@ namespace Elsa.CSharp.Activities;
 
 internal class RunCSharpOptionsProvider : IActivityPropertyOptionsProvider
 {
+    public bool isRefreashable => false;
+
     public ValueTask<IDictionary<string, object>> GetOptionsAsync(PropertyInfo property,object? context, CancellationToken cancellationToken = default)
     {
         var options = new Dictionary<string, object>

--- a/src/modules/Elsa.Http/ActivityOptionProviders/HttpContentTypeOptionsProvider.cs
+++ b/src/modules/Elsa.Http/ActivityOptionProviders/HttpContentTypeOptionsProvider.cs
@@ -23,6 +23,8 @@ public class HttpContentTypeOptionsProvider : IActivityPropertyOptionsProvider
         _httpContentFactories = httpContentFactories;
     }
 
+    public bool isRefreashable => false;
+
     /// <inheritdoc />
     public ValueTask<IDictionary<string, object>> GetOptionsAsync(PropertyInfo property,object? context, CancellationToken cancellationToken = default)
     {

--- a/src/modules/Elsa.JavaScript/Activities/RunJavaScript/RunJavaScriptOptionsProvider.cs
+++ b/src/modules/Elsa.JavaScript/Activities/RunJavaScript/RunJavaScriptOptionsProvider.cs
@@ -7,6 +7,8 @@ namespace Elsa.JavaScript.Activities;
 
 internal class RunJavaScriptOptionsProvider : IActivityPropertyOptionsProvider
 {
+    public bool isRefreashable => false;
+
     public ValueTask<IDictionary<string, object>> GetOptionsAsync(PropertyInfo property, object? context, CancellationToken cancellationToken = default)
     {
         var options = new Dictionary<string, object>

--- a/src/modules/Elsa.Workflows.Api/Endpoints/ActivityDescriptorOptions/Get/Endpoint.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/ActivityDescriptorOptions/Get/Endpoint.cs
@@ -44,6 +44,6 @@ internal class Get : ElsaEndpoint<Request, Response>
 
         var inputOptions = await optionsResolver.GetOptionsAsync(propertyDescriptor!.PropertyInfo, request.Context, cancellationToken);
 
-        await SendOkAsync(new Response(inputOptions), cancellationToken);
+        await SendOkAsync(new Response(inputOptions.OptionsItems), cancellationToken);
     }
 }

--- a/src/modules/Elsa.Workflows.Core/Attributes/InputAttribute.cs
+++ b/src/modules/Elsa.Workflows.Core/Attributes/InputAttribute.cs
@@ -94,4 +94,14 @@ public class InputAttribute : Attribute
     /// A value indicating whether this input can be serialized as part of the workflow instance,
     /// </summary>
     public bool IsSerializable { get; set; } = true;
+
+    /// <summary>
+    /// The property Name on which this input depends. 
+    /// </summary>
+    public string[]? DependsOn { get; set; }
+
+    /// <summary>
+    /// The property Name which can change the activatation of this property
+    /// </summary>
+    public string[]? ActivatedBy { get; set; }
 }

--- a/src/modules/Elsa.Workflows.Core/Contracts/IActivityPropertyOptionsProvider.cs
+++ b/src/modules/Elsa.Workflows.Core/Contracts/IActivityPropertyOptionsProvider.cs
@@ -8,6 +8,10 @@ namespace Elsa.Workflows.Core.Contracts;
 public interface IActivityPropertyOptionsProvider
 {
     /// <summary>
+    /// return True if you provide dynamic data
+    /// </summary>
+    public bool isRefreashable { get;}
+    /// <summary>
     /// Returns options for the specified property.
     /// </summary>
     ValueTask<IDictionary<string, object>> GetOptionsAsync(PropertyInfo property,object? context = default,  CancellationToken cancellationToken = default);

--- a/src/modules/Elsa.Workflows.Core/Contracts/IPropertyOptionsResolver.cs
+++ b/src/modules/Elsa.Workflows.Core/Contracts/IPropertyOptionsResolver.cs
@@ -1,3 +1,4 @@
+using Elsa.Workflows.Core.Models;
 using System.Reflection;
 
 namespace Elsa.Workflows.Core.Contracts;
@@ -13,7 +14,7 @@ public interface IPropertyOptionsResolver
     /// <param name="propertyInfo">The property to return options for.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>Options for the specified property</returns>
-    ValueTask<IDictionary<string, object>?> GetOptionsAsync(PropertyInfo propertyInfo, CancellationToken cancellationToken = default);
+    ValueTask<OptionsProviderResult?> GetOptionsAsync(PropertyInfo propertyInfo, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Returns options for the specified property
@@ -22,5 +23,5 @@ public interface IPropertyOptionsResolver
     /// <param name="context">An content object that can be used by the provider</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns></returns>
-    ValueTask<IDictionary<string, object>?> GetOptionsAsync(PropertyInfo propertyInfo,object context, CancellationToken cancellationToken = default);
+    ValueTask<OptionsProviderResult?> GetOptionsAsync(PropertyInfo propertyInfo,object context, CancellationToken cancellationToken = default);
 }

--- a/src/modules/Elsa.Workflows.Core/Models/InputDescriptor.cs
+++ b/src/modules/Elsa.Workflows.Core/Models/InputDescriptor.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using Elsa.Features.Attributes;
 using Elsa.Workflows.Core.Contracts;
 
 namespace Elsa.Workflows.Core.Models;
@@ -33,7 +34,10 @@ public class InputDescriptor : PropertyDescriptor
         bool isSerializable = true,
         bool isSynthetic = false,
         Type? storageDriverType = default,
-        PropertyInfo? propertyInfo = default)
+        PropertyInfo? propertyInfo = default,
+        bool isRefreashable = false,
+        string[]? dependsOn = default,
+        string[]? activatedBy = default)
     {
         Name = name;
         Type = type;
@@ -50,6 +54,9 @@ public class InputDescriptor : PropertyDescriptor
         DefaultSyntax = defaultSyntax;
         IsReadOnly = isReadOnly;
         StorageDriverType = storageDriverType;
+        IsRefreashable = isRefreashable;
+        DependsOn = dependsOn;
+        ActivatedBy = activatedBy;
         IsSynthetic = isSynthetic;
         IsBrowsable = isBrowsable;
         IsSerializable = isSerializable;
@@ -96,4 +103,19 @@ public class InputDescriptor : PropertyDescriptor
     /// If no driver is specified, the referenced memory block will remain in memory for as long as the expression execution context exists.
     /// </summary>
     public Type? StorageDriverType { get; set; }
+
+    /// <summary>
+    /// True if UI can call the Options Provider to refresh the option values
+    /// </summary>
+    public bool? IsRefreashable { get; }
+
+    /// <summary>
+    /// List of Property Name on which the property depends
+    /// </summary>
+    public string[]? DependsOn { get; }
+
+    /// <summary>
+    /// List of Property Name that activate this property
+    /// </summary>
+    public string[]? ActivatedBy { get; }
 }

--- a/src/modules/Elsa.Workflows.Core/Models/OptionsProviderResult.cs
+++ b/src/modules/Elsa.Workflows.Core/Models/OptionsProviderResult.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Elsa.Workflows.Core.Models
+{
+    public  class OptionsProviderResult
+    {
+        public IDictionary<string, object> ProviderMetadata { get; set; } = new Dictionary<string, object>();
+
+        public IDictionary<string, object> OptionsItems { get; set; }
+    }
+}

--- a/src/modules/Elsa.Workflows.Core/Services/ActivityDescriber.cs
+++ b/src/modules/Elsa.Workflows.Core/Services/ActivityDescriber.cs
@@ -166,7 +166,7 @@ public class ActivityDescriber : IActivityDescriber
             GetUIHint(wrappedPropertyType, inputAttribute),
             inputAttribute?.DisplayName ?? propertyInfo.Name.Humanize(LetterCasing.Title),
             descriptionAttribute?.Description ?? inputAttribute?.Description,
-            inputOptions,
+            inputOptions.OptionsItems,
             inputAttribute?.Category,
             inputAttribute?.Order ?? 0,
             _defaultValueResolver.GetDefaultValue(propertyInfo),
@@ -176,7 +176,10 @@ public class ActivityDescriber : IActivityDescriber
             inputAttribute?.IsSerializable ?? true,
             false,
             default,
-            propertyInfo
+            propertyInfo,
+            bool.Parse(inputOptions.ProviderMetadata["isRefreshable"].ToString()),
+            inputAttribute?.DependsOn,
+            inputAttribute?.ActivatedBy
         );
     }
 


### PR DESCRIPTION
This PR modifies the Options Provider and add some Attributes to Input Properties. 
Theses Attributes will help UI to know if a provider provides Dynamic or Static Data and take decision to call the API when rendering the UI.
Attributes define if an input property is Refreshable, Depends On other Properties or is activable by other properties.

Some work will then be implemented on UI side with this PR.

### === auto-pr-body ===

 
Summary:
- Added a property named "isRefreshable" to `InputDescriptor` class.
- Added a read-only property "isRefreshable" to all implementing instances of `IActivityPropertyOptionsProvider`.
- Added properties "DependsOn" and "ActivatedBy" to `InputAttribute` class.
- Modified the `GetOptionsAsync` method of `Endpoint` class to return an `OptionsItems` model as the result.
- Added properties "DependsOn" and "ActivatedBy" to `InputDescriptor` class.
- Changed the return type of `GetOptionsAsync` from `IDictionary<string, object>?` to `OptionsProviderResult?` in the `IPropertyOptionsResolver` interface.
Refactoring Target:
- Create a separate base class to contain the shared logic between all implementing instances of `IActivityPropertyOptionsProvider`.
- Refactor `InputDescriptor` and `InputAttribute` classes to share logic when appropriate.
- Replace the `string[]?` properties in both `InputDescriptor` and `InputAttribute` classes with a list to eliminate the need for null checks.
- Refactor the `GetOptionsAsync` method to have an input for the `OptionsItems` model to eliminate the extra logic.
- Split `OptionsProviderResult` class into two classes `OptionsProviderMetadataResult` and `OptionsProviderItemsResult` for better scalability.
- Use a data type other than `string` to store the `IsRefreshable` property in `InputDescriptor` class.