### PR TITLE
feat(scoped): move dependancies to scoped instead of singleton

### DIFF
--- a/src/common/Elsa.DropIns/Extensions/ServiceCollectionExtensions.cs
+++ b/src/common/Elsa.DropIns/Extensions/ServiceCollectionExtensions.cs
@@ -19,7 +19,7 @@ internal static class ServiceCollectionExtensions
     public static IServiceCollection AddDropInInstaller(this IServiceCollection services, Action<DropInOptions>? configureOptions = default)
     {
         services.AddDropInCore(configureOptions);
-        services.AddScoped<IDropInInstaller, DropInInstaller>();
+        services.AddSingleton<IDropInInstaller, DropInInstaller>();
         
         return services;
     }

--- a/src/common/Elsa.DropIns/Extensions/ServiceCollectionExtensions.cs
+++ b/src/common/Elsa.DropIns/Extensions/ServiceCollectionExtensions.cs
@@ -19,7 +19,7 @@ internal static class ServiceCollectionExtensions
     public static IServiceCollection AddDropInInstaller(this IServiceCollection services, Action<DropInOptions>? configureOptions = default)
     {
         services.AddDropInCore(configureOptions);
-        services.AddSingleton<IDropInInstaller, DropInInstaller>();
+        services.AddScoped<IDropInInstaller, DropInInstaller>();
         
         return services;
     }

--- a/src/common/Elsa.Features/Implementations/Module.cs
+++ b/src/common/Elsa.Features/Implementations/Module.cs
@@ -1,5 +1,3 @@
-using System.ComponentModel;
-using System.Reflection;
 using Elsa.Extensions;
 using Elsa.Features.Attributes;
 using Elsa.Features.Contracts;
@@ -8,6 +6,8 @@ using Elsa.Features.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
+using System.ComponentModel;
+using System.Reflection;
 
 namespace Elsa.Features.Implementations;
 

--- a/src/common/Elsa.Mediator/Extensions/DependencyInjectionExtensions.cs
+++ b/src/common/Elsa.Mediator/Extensions/DependencyInjectionExtensions.cs
@@ -1,5 +1,6 @@
-using System.Reflection;
-using System.Threading.Channels;
+using Elsa.Mediator.Channels;
+using Elsa.Mediator.Contracts;
+using Elsa.Mediator.HostedServices;
 using Elsa.Mediator.Middleware.Command;
 using Elsa.Mediator.Middleware.Command.Contracts;
 using Elsa.Mediator.Middleware.Notification;
@@ -7,14 +8,13 @@ using Elsa.Mediator.Middleware.Notification.Contracts;
 using Elsa.Mediator.Middleware.Request;
 using Elsa.Mediator.Middleware.Request.Contracts;
 using Elsa.Mediator.Models;
-using Elsa.Mediator.Channels;
-using Elsa.Mediator.Contracts;
-using Elsa.Mediator.HostedServices;
 using Elsa.Mediator.Options;
 using Elsa.Mediator.Services;
 using JetBrains.Annotations;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using System.Reflection;
+using System.Threading.Channels;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection;
@@ -90,14 +90,14 @@ public static class DependencyInjectionExtensions
     /// </summary>
     public static IServiceCollection AddMessageConsumer<T, TConsumer>(this IServiceCollection services) where TConsumer : class, IConsumer<T> where T : notnull
     {
-        return services.AddSingleton<IConsumer<T>, TConsumer>();
+        return services.AddScoped<IConsumer<T>, TConsumer>();
     }
 
     /// <summary>
     /// Registers a <see cref="ICommandHandler{T}"/> with the service container.
     /// </summary>
     public static IServiceCollection AddCommandHandler<THandler>(this IServiceCollection services) where THandler : class, ICommandHandler =>
-        services.AddSingleton<ICommandHandler, THandler>();
+        services.AddScoped<ICommandHandler, THandler>();
 
     /// <summary>
     /// Registers a <see cref="ICommandHandler{T}"/> with the service container.
@@ -113,7 +113,7 @@ public static class DependencyInjectionExtensions
         where THandler : class, ICommandHandler<TCommand, TResult>
         where TCommand : ICommand<TResult>
     {
-        return services.AddSingleton<ICommandHandler, THandler>();
+        return services.AddScoped<ICommandHandler, THandler>();
     }
 
     /// <summary>
@@ -122,7 +122,7 @@ public static class DependencyInjectionExtensions
     public static IServiceCollection AddNotificationHandler<THandler>(this IServiceCollection services)
         where THandler : class, INotificationHandler
     {
-        return services.AddSingleton<INotificationHandler, THandler>();
+        return services.AddScoped<INotificationHandler, THandler>();
     }
 
     /// <summary>
@@ -131,7 +131,7 @@ public static class DependencyInjectionExtensions
     public static IServiceCollection AddNotificationHandler<THandler, TNotification>(this IServiceCollection services)
         where THandler : class, INotificationHandler<TNotification>
         where TNotification : INotification =>
-        services.AddSingleton<INotificationHandler, THandler>();
+        services.AddScoped<INotificationHandler, THandler>();
 
     /// <summary>
     /// Registers a <see cref="INotificationHandler{T}"/> with the service container.
@@ -139,7 +139,7 @@ public static class DependencyInjectionExtensions
     public static IServiceCollection AddNotificationHandler<THandler, TNotification>(this IServiceCollection services, Func<IServiceProvider, THandler> factory)
         where THandler : class, INotificationHandler<TNotification>
         where TNotification : INotification =>
-        services.AddSingleton<INotificationHandler, THandler>(factory);
+        services.AddScoped<INotificationHandler, THandler>(factory);
 
     /// <summary>
     /// Registers a <see cref="IRequestHandler{TRequest,TResponse}"/> with the service container.
@@ -148,7 +148,7 @@ public static class DependencyInjectionExtensions
         where THandler : class, IRequestHandler<TRequest, TResponse>
         where TRequest : IRequest<TResponse>?
     {
-        return services.AddSingleton<IRequestHandler, THandler>();
+        return services.AddScoped<IRequestHandler, THandler>();
     }
 
     /// <summary>
@@ -226,7 +226,7 @@ public static class DependencyInjectionExtensions
         var types = assembly.DefinedTypes.Where(x => serviceType.IsAssignableFrom(x));
 
         foreach (var type in types)
-            services.AddSingleton(serviceType, type);
+            services.AddScoped(serviceType, type);
 
         return services;
     }

--- a/src/common/Elsa.Mediator/HostedServices/BackgroundCommandSenderHostedService.cs
+++ b/src/common/Elsa.Mediator/HostedServices/BackgroundCommandSenderHostedService.cs
@@ -1,5 +1,6 @@
 using System.Threading.Channels;
 using Elsa.Mediator.Contracts;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
@@ -12,16 +13,16 @@ public class BackgroundCommandSenderHostedService : BackgroundService
 {
     private readonly int _workerCount;
     private readonly ICommandsChannel _commandsChannel;
-    private readonly ICommandSender _commandSender;
+    private readonly IServiceScopeFactory _scopeFactory;
     private readonly IList<Channel<ICommand>> _outputs;
     private readonly ILogger _logger;
 
     /// <inheritdoc />
-    public BackgroundCommandSenderHostedService(int workerCount, ICommandsChannel commandsChannel, ICommandSender commandSender, ILogger<BackgroundCommandSenderHostedService> logger)
+    public BackgroundCommandSenderHostedService(int workerCount, ICommandsChannel commandsChannel, IServiceScopeFactory scopeFactory, ILogger<BackgroundCommandSenderHostedService> logger)
     {
         _workerCount = workerCount;
         _commandsChannel = commandsChannel;
-        _commandSender = commandSender;
+        _scopeFactory = scopeFactory;
         _logger = logger;
         _outputs = new List<Channel<ICommand>>(workerCount);
     }
@@ -57,7 +58,10 @@ public class BackgroundCommandSenderHostedService : BackgroundService
         {
             try
             {
-                await _commandSender.SendAsync(command, CommandStrategy.Default, cancellationToken);
+                using var scope = _scopeFactory.CreateScope();
+                var commandSender = scope.ServiceProvider.GetRequiredService<ICommandSender>();
+
+                await commandSender.SendAsync(command, CommandStrategy.Default, cancellationToken);
             }
             catch (Exception e)
             {

--- a/src/common/Elsa.Mediator/Middleware/Notification/Components/NotificationHandlerInvokerMiddleware.cs
+++ b/src/common/Elsa.Mediator/Middleware/Notification/Components/NotificationHandlerInvokerMiddleware.cs
@@ -1,6 +1,7 @@
 using Elsa.Mediator.Contexts;
 using Elsa.Mediator.Contracts;
 using Elsa.Mediator.Middleware.Notification.Contracts;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Elsa.Mediator.Middleware.Notification.Components;
@@ -9,17 +10,21 @@ namespace Elsa.Mediator.Middleware.Notification.Components;
 public class NotificationHandlerInvokerMiddleware : INotificationMiddleware
 {
     private readonly NotificationMiddlewareDelegate _next;
-    private readonly IEnumerable<INotificationHandler> _notificationHandlers;
+    private readonly IServiceScopeFactory _scopeFactory;
     private readonly ILogger<NotificationHandlerInvokerMiddleware> _logger;
     private readonly IServiceProvider _serviceProvider;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="NotificationHandlerInvokerMiddleware"/> class.
     /// </summary>
-    public NotificationHandlerInvokerMiddleware(NotificationMiddlewareDelegate next, IEnumerable<INotificationHandler> notificationHandlers, ILogger<NotificationHandlerInvokerMiddleware> logger, IServiceProvider serviceProvider)
+    public NotificationHandlerInvokerMiddleware(
+        NotificationMiddlewareDelegate next,
+        IServiceScopeFactory scopeFactory,
+        ILogger<NotificationHandlerInvokerMiddleware> logger,
+        IServiceProvider serviceProvider)
     {
         _next = next;
-        _notificationHandlers = notificationHandlers;
+        _scopeFactory = scopeFactory;
         _logger = logger;
         _serviceProvider = serviceProvider;
     }
@@ -27,11 +32,14 @@ public class NotificationHandlerInvokerMiddleware : INotificationMiddleware
     /// <inheritdoc />
     public async ValueTask InvokeAsync(NotificationContext context)
     {
+        using var scope = _scopeFactory.CreateScope();
+        var notificationHandlers = scope.ServiceProvider.GetServices<INotificationHandler>();
+
         // Find all handlers for the specified notification.
         var notification = context.Notification;
         var notificationType = notification.GetType();
         var handlerType = typeof(INotificationHandler<>).MakeGenericType(notificationType);
-        var handlers = _notificationHandlers.Where(x => handlerType.IsInstanceOfType(x)).DistinctBy(x => x.GetType()).ToArray();
+        var handlers = notificationHandlers.Where(x => handlerType.IsInstanceOfType(x)).DistinctBy(x => x.GetType()).ToArray();
         var strategyContext = new NotificationStrategyContext(notification, handlers, _logger, _serviceProvider, context.CancellationToken);
 
         await context.NotificationStrategy.PublishAsync(strategyContext);

--- a/src/common/Elsa.Mediator/Middleware/Request/Components/RequestHandlerInvokerMiddleware.cs
+++ b/src/common/Elsa.Mediator/Middleware/Request/Components/RequestHandlerInvokerMiddleware.cs
@@ -1,5 +1,6 @@
 using Elsa.Mediator.Contracts;
 using Elsa.Mediator.Middleware.Request.Contracts;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Elsa.Mediator.Middleware.Request.Components;
 
@@ -9,29 +10,32 @@ namespace Elsa.Mediator.Middleware.Request.Components;
 public class RequestHandlerInvokerMiddleware : IRequestMiddleware
 {
     private readonly RequestMiddlewareDelegate _next;
-    private readonly IEnumerable<IRequestHandler> _requestHandlers;
+    private readonly IServiceScopeFactory _scopeFactory;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RequestHandlerInvokerMiddleware"/> class.
     /// </summary>
     /// <param name="next">The next middleware in the pipeline.</param>
-    /// <param name="requestHandlers">The request handlers to invoke.</param>
-    public RequestHandlerInvokerMiddleware(RequestMiddlewareDelegate next, IEnumerable<IRequestHandler> requestHandlers)
+    /// <param name="scopeFactory">Scope factory to create the scope and get dependancies.</param>
+    public RequestHandlerInvokerMiddleware(RequestMiddlewareDelegate next, IServiceScopeFactory scopeFactory)
     {
         _next = next;
-        _requestHandlers = requestHandlers;
+        _scopeFactory = scopeFactory;
     }
 
     /// <inheritdoc />
     public async ValueTask InvokeAsync(RequestContext context)
     {
+        using var scope = _scopeFactory.CreateScope();
+        var requestHandlers = scope.ServiceProvider.GetServices<IRequestHandler>();
+
         // Find all handlers for the specified request.
         var request = context.Request;
         var requestType = request.GetType();
         var responseType = context.ResponseType;
         var handlerType = typeof(IRequestHandler<,>).MakeGenericType(requestType, responseType);
-        var handlers = _requestHandlers.Where(x => handlerType.IsInstanceOfType(x)).ToArray();
-        
+        var handlers = requestHandlers.Where(x => handlerType.IsInstanceOfType(x)).ToArray();
+
         foreach (var handler in handlers)
         {
             var handleMethod = handlerType.GetMethod("HandleAsync")!;
@@ -44,7 +48,7 @@ public class RequestHandlerInvokerMiddleware : IRequestMiddleware
             var resultProperty = taskWithReturnType.GetProperty(nameof(Task<object>.Result))!;
             context.Responses.Add(resultProperty.GetValue(task)!);
         }
-        
+
         // Invoke next middleware.
         await _next(context);
     }

--- a/src/common/Elsa.Testing.Shared/TestApplicationBuilder.cs
+++ b/src/common/Elsa.Testing.Shared/TestApplicationBuilder.cs
@@ -31,7 +31,7 @@ public class TestApplicationBuilder
 
         _services
             .AddSingleton(testOutputHelper)
-            .AddScoped<IConfiguration, ConfigurationManager>()
+            .AddSingleton<IConfiguration, ConfigurationManager>()
             .AddLogging(logging => logging.AddProvider(new XunitLoggerProvider(testOutputHelper)).SetMinimumLevel(LogLevel.Debug));
 
         _configureElsa += elsa => elsa

--- a/src/common/Elsa.Testing.Shared/TestApplicationBuilder.cs
+++ b/src/common/Elsa.Testing.Shared/TestApplicationBuilder.cs
@@ -31,7 +31,7 @@ public class TestApplicationBuilder
 
         _services
             .AddSingleton(testOutputHelper)
-            .AddSingleton<IConfiguration, ConfigurationManager>()
+            .AddScoped<IConfiguration, ConfigurationManager>()
             .AddLogging(logging => logging.AddProvider(new XunitLoggerProvider(testOutputHelper)).SetMinimumLevel(LogLevel.Debug));
 
         _configureElsa += elsa => elsa

--- a/src/modules/Elsa.Alterations.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/modules/Elsa.Alterations.Core/Extensions/ServiceCollectionExtensions.cs
@@ -18,12 +18,12 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddAlterationsCore(this IServiceCollection services)
     {
         services.Configure<AlterationOptions>(_ => { }); // Ensure that the options are configured even if the application doesn't do so.
-        services.AddSingleton<IAlterationPlanScheduler, DefaultAlterationPlanScheduler>();
-        services.AddSingleton<IAlterationJobRunner, DefaultAlterationJobRunner>();
-        services.AddSingleton<IAlterationRunner, DefaultAlterationRunner>();
-        services.AddSingleton<IAlteredWorkflowDispatcher, DefaultAlteredWorkflowDispatcher>();
-        services.AddSingleton<IAlterationSerializer, AlterationSerializer>();
-        services.AddSingleton<ISerializationOptionsConfigurator, AlterationSerializationOptionConfigurator>();
+        services.AddScoped<IAlterationPlanScheduler, DefaultAlterationPlanScheduler>();
+        services.AddScoped<IAlterationJobRunner, DefaultAlterationJobRunner>();
+        services.AddScoped<IAlterationRunner, DefaultAlterationRunner>();
+        services.AddScoped<IAlteredWorkflowDispatcher, DefaultAlteredWorkflowDispatcher>();
+        services.AddScoped<IAlterationSerializer, AlterationSerializer>();
+        services.AddScoped<ISerializationOptionsConfigurator, AlterationSerializationOptionConfigurator>();
         return services;
     }
 
@@ -33,7 +33,7 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddAlteration<T, THandler>(this IServiceCollection services) where T : IAlteration where THandler : class, IAlterationHandler
     {
         services.Configure<AlterationOptions>(options => options.AlterationTypes.Add(typeof(T)));
-        services.AddSingleton<IAlterationHandler, THandler>();
+        services.AddScoped<IAlterationHandler, THandler>();
         return services;
     }
 }

--- a/src/modules/Elsa.Alterations.MassTransit/Features/AlterationsMassTransitFeature.cs
+++ b/src/modules/Elsa.Alterations.MassTransit/Features/AlterationsMassTransitFeature.cs
@@ -37,6 +37,6 @@ public class MassTransitAlterationsFeature : FeatureBase
         var queueName = KebabCaseEndpointNameFormatter.Instance.Consumer<RunAlterationJobConsumer>();
         var queueAddress = new Uri($"queue:elsa-{queueName}");
         EndpointConvention.Map<RunAlterationJob>(queueAddress);
-        Services.AddSingleton<MassTransitAlterationJobDispatcher>();
+        Services.AddScoped<MassTransitAlterationJobDispatcher>();
     }
 }

--- a/src/modules/Elsa.Alterations/Features/AlterationsFeature.cs
+++ b/src/modules/Elsa.Alterations/Features/AlterationsFeature.cs
@@ -26,12 +26,12 @@ public class AlterationsFeature : FeatureBase
     /// Gets or sets the factory for the alteration plan store.
     /// </summary>
     public Func<IServiceProvider, IAlterationPlanStore> AlterationPlanStoreFactory { get; set; } = sp => sp.GetRequiredService<MemoryAlterationPlanStore>();
-    
+
     /// <summary>
     /// Gets or sets the factory for the alteration job store.
     /// </summary>
     public Func<IServiceProvider, IAlterationJobStore> AlterationJobStoreFactory { get; set; } = sp => sp.GetRequiredService<MemoryAlterationJobStore>();
-    
+
     /// <summary>
     /// Gets or sets the factory for the alteration job dispatcher.
     /// </summary>
@@ -47,7 +47,7 @@ public class AlterationsFeature : FeatureBase
         Services.AddAlteration<T, THandler>();
         return this;
     }
-    
+
     /// <inheritdoc />
     public override void Configure()
     {
@@ -59,13 +59,13 @@ public class AlterationsFeature : FeatureBase
     {
         Services.AddAlterations();
         Services.AddAlterationsCore();
-        Services.AddSingleton<BackgroundAlterationJobDispatcher>();
-        Services.AddSingleton<MemoryAlterationPlanStore>();
-        Services.AddSingleton<MemoryAlterationJobStore>();
-        Services.AddSingleton(new MemoryStore<AlterationPlan>());
-        Services.AddSingleton(new MemoryStore<AlterationJob>());
-        Services.AddSingleton(AlterationPlanStoreFactory);
-        Services.AddSingleton(AlterationJobStoreFactory);
-        Services.AddSingleton(AlterationJobDispatcherFactory);
+        Services.AddScoped<BackgroundAlterationJobDispatcher>();
+
+        Services.AddMemoryStore<AlterationPlan, MemoryAlterationPlanStore>();
+        Services.AddMemoryStore<AlterationJob, MemoryAlterationJobStore>();
+
+        Services.AddScoped(AlterationPlanStoreFactory);
+        Services.AddScoped(AlterationJobStoreFactory);
+        Services.AddScoped(AlterationJobDispatcherFactory);
     }
 }

--- a/src/modules/Elsa.AzureServiceBus/Features/AzureServiceBusFeature.cs
+++ b/src/modules/Elsa.AzureServiceBus/Features/AzureServiceBusFeature.cs
@@ -67,17 +67,17 @@ public class AzureServiceBusFeature : FeatureBase
         Services.Configure(AzureServiceBusOptions);
 
         Services
-            .AddSingleton(ServiceBusAdministrationClientFactory)
-            .AddSingleton(ServiceBusClientFactory)
-            .AddSingleton<ConfigurationQueueTopicAndSubscriptionProvider>()
-            .AddSingleton<IWorkerManager, WorkerManager>()
+            .AddScoped(ServiceBusAdministrationClientFactory)
+            .AddScoped(ServiceBusClientFactory)
+            .AddScoped<ConfigurationQueueTopicAndSubscriptionProvider>()
+            .AddScoped<IWorkerManager, WorkerManager>()
             .AddTransient<IServiceBusInitializer, ServiceBusInitializer>();
 
         // Definition providers.
         Services
-            .AddSingleton<IQueueProvider>(sp => sp.GetRequiredService<ConfigurationQueueTopicAndSubscriptionProvider>())
-            .AddSingleton<ITopicProvider>(sp => sp.GetRequiredService<ConfigurationQueueTopicAndSubscriptionProvider>())
-            .AddSingleton<ISubscriptionProvider>(sp => sp.GetRequiredService<ConfigurationQueueTopicAndSubscriptionProvider>());
+            .AddScoped<IQueueProvider>(sp => sp.GetRequiredService<ConfigurationQueueTopicAndSubscriptionProvider>())
+            .AddScoped<ITopicProvider>(sp => sp.GetRequiredService<ConfigurationQueueTopicAndSubscriptionProvider>())
+            .AddScoped<ISubscriptionProvider>(sp => sp.GetRequiredService<ConfigurationQueueTopicAndSubscriptionProvider>());
 
         // Handlers.
         Services.AddHandlersFrom<UpdateWorkers>();

--- a/src/modules/Elsa.AzureServiceBus/Features/AzureServiceBusFeature.cs
+++ b/src/modules/Elsa.AzureServiceBus/Features/AzureServiceBusFeature.cs
@@ -67,10 +67,10 @@ public class AzureServiceBusFeature : FeatureBase
         Services.Configure(AzureServiceBusOptions);
 
         Services
-            .AddScoped(ServiceBusAdministrationClientFactory)
-            .AddScoped(ServiceBusClientFactory)
-            .AddScoped<ConfigurationQueueTopicAndSubscriptionProvider>()
-            .AddScoped<IWorkerManager, WorkerManager>()
+            .AddSingleton(ServiceBusAdministrationClientFactory)
+            .AddSingleton(ServiceBusClientFactory)
+            .AddSingleton<ConfigurationQueueTopicAndSubscriptionProvider>()
+            .AddSingleton<IWorkerManager, WorkerManager>()
             .AddTransient<IServiceBusInitializer, ServiceBusInitializer>();
 
         // Definition providers.

--- a/src/modules/Elsa.Common/Extensions/DependencyInjectionExtensions.cs
+++ b/src/modules/Elsa.Common/Extensions/DependencyInjectionExtensions.cs
@@ -16,7 +16,7 @@ public static class DependencyInjectionExtensions
     public static IServiceCollection AddMemoryStore<TEntity, TStore>(this IServiceCollection services) where TStore : class
     {
          services.TryAddSingleton<MemoryStore<TEntity>>();
-         services.TryAddSingleton<TStore>();
+         services.TryAddScoped<TStore>();
          return services;
     }
 }

--- a/src/modules/Elsa.Common/Features/SystemClockFeature.cs
+++ b/src/modules/Elsa.Common/Features/SystemClockFeature.cs
@@ -19,6 +19,6 @@ public class SystemClockFeature : FeatureBase
     /// <inheritdoc />
     public override void Apply()
     {
-        Services.AddSingleton<ISystemClock, SystemClock>();
+        Services.AddScoped<ISystemClock, SystemClock>();
     }
 }

--- a/src/modules/Elsa.Dapper/Features/DapperFeature.cs
+++ b/src/modules/Elsa.Dapper/Features/DapperFeature.cs
@@ -30,6 +30,6 @@ public class DapperFeature : FeatureBase
     /// <inheritdoc />
     public override void Apply()
     {
-        Services.AddSingleton(DbConnectionProvider);
+        Services.AddScoped(DbConnectionProvider);
     }
 }

--- a/src/modules/Elsa.Dapper/Modules/Identity/Features/Feature.cs
+++ b/src/modules/Elsa.Dapper/Modules/Identity/Features/Feature.cs
@@ -38,8 +38,8 @@ public class DapperIdentityPersistenceFeature : FeatureBase
     {
         base.Apply();
 
-        Services.AddSingleton<DapperUserStore>();
-        Services.AddSingleton<DapperApplicationStore>();
-        Services.AddSingleton<DapperRoleStore>();
+        Services.AddScoped<DapperUserStore>();
+        Services.AddScoped<DapperApplicationStore>();
+        Services.AddScoped<DapperRoleStore>();
     }
 }

--- a/src/modules/Elsa.Dapper/Modules/Management/Features/DapperWorkflowDefinitionPersistenceFeature.cs
+++ b/src/modules/Elsa.Dapper/Modules/Management/Features/DapperWorkflowDefinitionPersistenceFeature.cs
@@ -34,6 +34,6 @@ public class DapperWorkflowDefinitionPersistenceFeature : FeatureBase
     {
         base.Apply();
         
-        Services.AddSingleton<DapperWorkflowDefinitionStore>();
+        Services.AddScoped<DapperWorkflowDefinitionStore>();
     }
 }

--- a/src/modules/Elsa.Dapper/Modules/Management/Features/DapperWorkflowInstancePersistenceFeature.cs
+++ b/src/modules/Elsa.Dapper/Modules/Management/Features/DapperWorkflowInstancePersistenceFeature.cs
@@ -31,6 +31,6 @@ public class DapperWorkflowInstancePersistenceFeature : FeatureBase
     {
         base.Apply();
         
-        Services.AddSingleton<DapperWorkflowInstanceStore>();
+        Services.AddScoped<DapperWorkflowInstanceStore>();
     }
 }

--- a/src/modules/Elsa.Dapper/Modules/Management/Features/DapperWorkflowManagementPersistenceFeature.cs
+++ b/src/modules/Elsa.Dapper/Modules/Management/Features/DapperWorkflowManagementPersistenceFeature.cs
@@ -36,7 +36,7 @@ public class DapperWorkflowManagementPersistenceFeature : FeatureBase
     {
         base.Apply();
         
-        Services.AddSingleton<DapperWorkflowInstanceStore>();
-        Services.AddSingleton<DapperWorkflowDefinitionStore>();
+        Services.AddScoped<DapperWorkflowInstanceStore>();
+        Services.AddScoped<DapperWorkflowDefinitionStore>();
     }
 }

--- a/src/modules/Elsa.Dapper/Modules/Runtime/Features/DapperWorkflowRuntimePersistenceFeature.cs
+++ b/src/modules/Elsa.Dapper/Modules/Runtime/Features/DapperWorkflowRuntimePersistenceFeature.cs
@@ -39,10 +39,10 @@ public class DapperWorkflowRuntimePersistenceFeature : FeatureBase
     {
         base.Apply();
 
-        Services.AddSingleton<DapperTriggerStore>();
-        Services.AddSingleton<DapperBookmarkStore>();
-        Services.AddSingleton<DapperWorkflowInboxMessageStore>();
-        Services.AddSingleton<DapperWorkflowExecutionLogStore>();
-        Services.AddSingleton<DapperActivityExecutionRecordStore>();
+        Services.AddScoped<DapperTriggerStore>();
+        Services.AddScoped<DapperBookmarkStore>();
+        Services.AddScoped<DapperWorkflowInboxMessageStore>();
+        Services.AddScoped<DapperWorkflowExecutionLogStore>();
+        Services.AddScoped<DapperActivityExecutionRecordStore>();
     }
 }

--- a/src/modules/Elsa.Dsl/Features/DslFeature.cs
+++ b/src/modules/Elsa.Dsl/Features/DslFeature.cs
@@ -18,8 +18,8 @@ public class DslFeature : FeatureBase
     public override void Configure()
     {
         Services
-            .AddSingleton<IDslEngine, DslEngine>()
-            .AddSingleton<ITypeSystem, TypeSystem>()
+            .AddScoped<IDslEngine, DslEngine>()
+            .AddScoped<ITypeSystem, TypeSystem>()
             .AddSingleton<IFunctionActivityRegistry, FunctionActivityRegistry>();
     }
 }

--- a/src/modules/Elsa.Dsl/Features/DslFeature.cs
+++ b/src/modules/Elsa.Dsl/Features/DslFeature.cs
@@ -18,8 +18,8 @@ public class DslFeature : FeatureBase
     public override void Configure()
     {
         Services
-            .AddScoped<IDslEngine, DslEngine>()
-            .AddScoped<ITypeSystem, TypeSystem>()
+            .AddSingleton<IDslEngine, DslEngine>()
+            .AddSingleton<ITypeSystem, TypeSystem>()
             .AddSingleton<IFunctionActivityRegistry, FunctionActivityRegistry>();
     }
 }

--- a/src/modules/Elsa.Elasticsearch/Common/PersistenceFeatureBase.cs
+++ b/src/modules/Elsa.Elasticsearch/Common/PersistenceFeatureBase.cs
@@ -23,12 +23,12 @@ public abstract class ElasticPersistenceFeatureBase : FeatureBase
     protected void AddStore<TModel, TStore>() where TModel : class where TStore : class
     {
         Services
-            .AddSingleton<ElasticStore<TModel>>()
-            .AddSingleton<TStore>();
+            .AddScoped<ElasticStore<TModel>>()
+            .AddScoped<TStore>();
     }
 
     /// <summary>
     /// Registers an <see cref="IIndexConfiguration"/>.
     /// </summary>
-    protected void AddIndexConfiguration<TDocument>(Func<IServiceProvider, IIndexConfiguration<TDocument>> configuration) => Services.AddSingleton<IIndexConfiguration>(configuration);
+    protected void AddIndexConfiguration<TDocument>(Func<IServiceProvider, IIndexConfiguration<TDocument>> configuration) => Services.AddScoped<IIndexConfiguration>(configuration);
 }

--- a/src/modules/Elsa.Elasticsearch/Features/ElasticsearchFeature.cs
+++ b/src/modules/Elsa.Elasticsearch/Features/ElasticsearchFeature.cs
@@ -29,7 +29,7 @@ public class ElasticsearchFeature : FeatureBase
     public override void Apply()
     {
         Services.Configure(Options);
-        Services.AddSingleton(sp => new ElasticsearchClient(GetSettings(sp)));
+        Services.AddScoped(sp => new ElasticsearchClient(GetSettings(sp)));
     }
 
     private static ElasticsearchClientSettings GetSettings(IServiceProvider serviceProvider)

--- a/src/modules/Elsa.Email/Features/EmailFeature.cs
+++ b/src/modules/Elsa.Email/Features/EmailFeature.cs
@@ -44,8 +44,8 @@ public class EmailFeature : FeatureBase
     {
         Services
             .Configure(ConfigureOptions)
-            .AddSingleton<MailKitSmtpService>()
-            .AddSingleton(SmtpService)
+            .AddScoped<MailKitSmtpService>()
+            .AddScoped(SmtpService)
             .AddHttpClient<IDownloader, DefaultDownloader>(ConfigureDownloaderHttpClient);
     }
 }

--- a/src/modules/Elsa.EntityFrameworkCore.Common/PersistenceFeatureBase.cs
+++ b/src/modules/Elsa.EntityFrameworkCore.Common/PersistenceFeatureBase.cs
@@ -21,16 +21,16 @@ public abstract class PersistenceFeatureBase<TDbContext> : FeatureBase where TDb
     /// Gets or sets a value indicating whether to use context pooling.
     /// </summary>
     public bool UseContextPooling { get; set; }
-    
+
     /// <summary>
     /// Gets or sets a value indicating whether to run migrations.
     /// </summary>
     public bool RunMigrations { get; set; } = true;
-    
+
     /// <summary>
     /// Gets or sets the lifetime of the <see cref="IDbContextFactory{TContext}"/>. Defaults to <see cref="ServiceLifetime.Singleton"/>.
     /// </summary>
-    public ServiceLifetime DbContextFactoryLifetime { get; set; } = ServiceLifetime.Singleton;
+    public ServiceLifetime DbContextFactoryLifetime { get; set; } = ServiceLifetime.Scoped;
 
     /// <summary>
     /// Gets or sets the callback used to configure the <see cref="DbContextOptionsBuilder"/>.
@@ -64,8 +64,8 @@ public abstract class PersistenceFeatureBase<TDbContext> : FeatureBase where TDb
     protected void AddStore<TEntity, TStore>() where TEntity : class where TStore : class
     {
         Services
-            .AddSingleton<Store<TDbContext, TEntity>>()
-            .AddSingleton<TStore>()
+            .AddScoped<Store<TDbContext, TEntity>>()
+            .AddScoped<TStore>()
             ;
     }
 
@@ -77,8 +77,8 @@ public abstract class PersistenceFeatureBase<TDbContext> : FeatureBase where TDb
     protected void AddEntityStore<TEntity, TStore>() where TEntity : Entity where TStore : class
     {
         Services
-            .AddSingleton<EntityStore<TDbContext, TEntity>>()
-            .AddSingleton<TStore>()
+            .AddScoped<EntityStore<TDbContext, TEntity>>()
+            .AddScoped<TStore>()
             ;
     }
 }

--- a/src/modules/Elsa.EntityFrameworkCore.Common/RunMigrationsHostedService.cs
+++ b/src/modules/Elsa.EntityFrameworkCore.Common/RunMigrationsHostedService.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 namespace Elsa.EntityFrameworkCore.Common;
@@ -8,17 +9,22 @@ namespace Elsa.EntityFrameworkCore.Common;
 /// </summary>
 public class RunMigrationsHostedService<TDbContext> : IHostedService where TDbContext : DbContext
 {
-    private readonly IDbContextFactory<TDbContext> _dbContextFactory;
-    
+    private readonly IServiceScopeFactory _scopeFactory;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="RunMigrationsHostedService{TDbContext}"/> class.
     /// </summary>
-    public RunMigrationsHostedService(IDbContextFactory<TDbContext> dbContextFactoryFactory) => _dbContextFactory = dbContextFactoryFactory;
+    public RunMigrationsHostedService(IServiceScopeFactory scopeFactory)
+    {
+        _scopeFactory = scopeFactory;
+    }
 
     /// <inheritdoc />
     public async Task StartAsync(CancellationToken cancellationToken)
     {
-        await using var dbContext = await _dbContextFactory.CreateDbContextAsync(cancellationToken);
+        using var scope = _scopeFactory.CreateScope();
+        var dbContextFactory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<TDbContext>>();
+        await using var dbContext = await dbContextFactory.CreateDbContextAsync(cancellationToken);
         await dbContext.Database.MigrateAsync(cancellationToken);
         await dbContext.DisposeAsync();
     }

--- a/src/modules/Elsa.Environments/Features/EnvironmentsFeature.cs
+++ b/src/modules/Elsa.Environments/Features/EnvironmentsFeature.cs
@@ -37,7 +37,7 @@ public class EnvironmentsFeature : FeatureBase
     {
         Services.Configure(EnvironmentsOptions);
 
-        Services.AddScoped<IEnvironmentsProvider, ConfigurationEnvironmentsProvider>();
-        Services.AddScoped<IEnvironmentsManager, DefaultEnvironmentsManager>();
+        Services.AddSingleton<IEnvironmentsProvider, ConfigurationEnvironmentsProvider>();
+        Services.AddSingleton<IEnvironmentsManager, DefaultEnvironmentsManager>();
     }
 }

--- a/src/modules/Elsa.Environments/Features/EnvironmentsFeature.cs
+++ b/src/modules/Elsa.Environments/Features/EnvironmentsFeature.cs
@@ -37,7 +37,7 @@ public class EnvironmentsFeature : FeatureBase
     {
         Services.Configure(EnvironmentsOptions);
 
-        Services.AddSingleton<IEnvironmentsProvider, ConfigurationEnvironmentsProvider>();
-        Services.AddSingleton<IEnvironmentsManager, DefaultEnvironmentsManager>();
+        Services.AddScoped<IEnvironmentsProvider, ConfigurationEnvironmentsProvider>();
+        Services.AddScoped<IEnvironmentsManager, DefaultEnvironmentsManager>();
     }
 }

--- a/src/modules/Elsa.Expressions/Extensions/ModuleExtensions.cs
+++ b/src/modules/Elsa.Expressions/Extensions/ModuleExtensions.cs
@@ -31,7 +31,7 @@ public static class ModuleExtensions
     /// <param name="services">The services.</param>
     public static IServiceCollection AddExpressionDescriptorProvider<T>(this IServiceCollection services) where T: class, IExpressionDescriptorProvider
     {
-        return services.AddSingleton<IExpressionDescriptorProvider, T>();
+        return services.AddScoped<IExpressionDescriptorProvider, T>();
     }
     
     /// <summary>

--- a/src/modules/Elsa.Expressions/Features/ExpressionsFeature.cs
+++ b/src/modules/Elsa.Expressions/Features/ExpressionsFeature.cs
@@ -20,7 +20,7 @@ public class ExpressionsFeature : FeatureBase
     public override void Configure()
     {
         Services
-            .AddSingleton<IExpressionEvaluator, ExpressionEvaluator>()
+            .AddScoped<IExpressionEvaluator, ExpressionEvaluator>()
             .AddSingleton<IWellKnownTypeRegistry, WellKnownTypeRegistry>();
     }
 }

--- a/src/modules/Elsa.FileStorage/Features/BlobStorageFeature.cs
+++ b/src/modules/Elsa.FileStorage/Features/BlobStorageFeature.cs
@@ -32,7 +32,7 @@ public class FileStorageFeature : FeatureBase
     /// <inheritdoc />
     public override void Apply()
     {
-        Services.AddSingleton<IBlobStorageProvider>(sp => new BlobStorageProvider(BlobStorage(sp)));
+        Services.AddScoped<IBlobStorageProvider>(sp => new BlobStorageProvider(BlobStorage(sp)));
     }
 
     /// <summary>

--- a/src/modules/Elsa.Hangfire/Features/HangfireBackgroundActivityInvokerFeature.cs
+++ b/src/modules/Elsa.Hangfire/Features/HangfireBackgroundActivityInvokerFeature.cs
@@ -31,6 +31,6 @@ public class HangfireBackgroundActivitySchedulerFeature : FeatureBase
     /// <inheritdoc />
     public override void Apply()
     {
-        Services.AddScoped<HangfireBackgroundActivityScheduler>();
+        Services.AddSingleton<HangfireBackgroundActivityScheduler>();
     }
 }

--- a/src/modules/Elsa.Hangfire/Features/HangfireBackgroundActivityInvokerFeature.cs
+++ b/src/modules/Elsa.Hangfire/Features/HangfireBackgroundActivityInvokerFeature.cs
@@ -31,6 +31,6 @@ public class HangfireBackgroundActivitySchedulerFeature : FeatureBase
     /// <inheritdoc />
     public override void Apply()
     {
-        Services.AddSingleton<HangfireBackgroundActivityScheduler>();
+        Services.AddScoped<HangfireBackgroundActivityScheduler>();
     }
 }

--- a/src/modules/Elsa.Hangfire/Features/HangfireSchedulerFeature.cs
+++ b/src/modules/Elsa.Hangfire/Features/HangfireSchedulerFeature.cs
@@ -33,7 +33,7 @@ public class HangfireSchedulerFeature : FeatureBase
     /// <inheritdoc />
     public override void Apply()
     {
-        Services.AddSingleton<HangfireWorkflowScheduler>();
-        Services.AddSingleton<IActivityDescriptorModifier, CronActivityDescriptorModifier>();
+        Services.AddScoped<HangfireWorkflowScheduler>();
+        Services.AddScoped<IActivityDescriptorModifier, CronActivityDescriptorModifier>();
     }
 }

--- a/src/modules/Elsa.Hangfire/Features/HangfireSchedulerFeature.cs
+++ b/src/modules/Elsa.Hangfire/Features/HangfireSchedulerFeature.cs
@@ -33,7 +33,7 @@ public class HangfireSchedulerFeature : FeatureBase
     /// <inheritdoc />
     public override void Apply()
     {
-        Services.AddScoped<HangfireWorkflowScheduler>();
-        Services.AddScoped<IActivityDescriptorModifier, CronActivityDescriptorModifier>();
+        Services.AddSingleton<HangfireWorkflowScheduler>();
+        Services.AddSingleton<IActivityDescriptorModifier, CronActivityDescriptorModifier>();
     }
 }

--- a/src/modules/Elsa.Http/Extensions/ServiceCollectionExtensions.cs
+++ b/src/modules/Elsa.Http/Extensions/ServiceCollectionExtensions.cs
@@ -17,7 +17,7 @@ public static class ServiceCollectionExtensions
     /// </summary>
     public static IServiceCollection AddHttpCorrelationIdSelector<T>(this IServiceCollection services) where T : class, IHttpCorrelationIdSelector
     {
-        services.AddSingleton<IHttpCorrelationIdSelector, T>();
+        services.AddScoped<IHttpCorrelationIdSelector, T>();
         return services;
     }
     
@@ -26,7 +26,7 @@ public static class ServiceCollectionExtensions
     /// </summary>
     public static IServiceCollection AddHttpCorrelationIdSelector(this IServiceCollection services, Func<IServiceProvider, IHttpCorrelationIdSelector> factory)
     {
-        services.AddSingleton(factory);
+        services.AddScoped(factory);
         return services;
     }
 }

--- a/src/modules/Elsa.Http/Features/HttpFeature.cs
+++ b/src/modules/Elsa.Http/Features/HttpFeature.cs
@@ -147,12 +147,12 @@ public class HttpFeature : FeatureBase
         HttpClientBuilder(httpClientBuilder);
 
         Services
-            .AddSingleton<IRouteMatcher, RouteMatcher>()
-            .AddSingleton<IRouteTable, RouteTable>()
-            .AddSingleton<IAbsoluteUrlProvider, DefaultAbsoluteUrlProvider>()
-            .AddSingleton<IHttpBookmarkProcessor, HttpBookmarkProcessor>()
-            .AddSingleton<IRouteTableUpdater, DefaultRouteTableUpdater>()
-            .AddSingleton(ContentTypeProvider)
+            .AddScoped<IRouteMatcher, RouteMatcher>()
+            .AddScoped<IRouteTable, RouteTable>()
+            .AddScoped<IAbsoluteUrlProvider, DefaultAbsoluteUrlProvider>()
+            .AddScoped<IHttpBookmarkProcessor, HttpBookmarkProcessor>()
+            .AddScoped<IRouteTableUpdater, DefaultRouteTableUpdater>()
+            .AddScoped(ContentTypeProvider)
             .AddHttpContextAccessor()
             
             // Handlers.
@@ -160,41 +160,41 @@ public class HttpFeature : FeatureBase
             .AddNotificationHandler<UpdateRouteTable>()
 
             // Content parsers.
-            .AddSingleton<IHttpContentParser, StringHttpContentParser>()
-            .AddSingleton<IHttpContentParser, JsonHttpContentParser>()
-            .AddSingleton<IHttpContentParser, XmlHttpContentParser>()
+            .AddScoped<IHttpContentParser, StringHttpContentParser>()
+            .AddScoped<IHttpContentParser, JsonHttpContentParser>()
+            .AddScoped<IHttpContentParser, XmlHttpContentParser>()
 
             // HTTP content factories.
-            .AddSingleton<IHttpContentFactory, TextContentFactory>()
-            .AddSingleton<IHttpContentFactory, JsonContentFactory>()
-            .AddSingleton<IHttpContentFactory, XmlContentFactory>()
-            .AddSingleton<IHttpContentFactory, FormUrlEncodedHttpContentFactory>()
+            .AddScoped<IHttpContentFactory, TextContentFactory>()
+            .AddScoped<IHttpContentFactory, JsonContentFactory>()
+            .AddScoped<IHttpContentFactory, XmlContentFactory>()
+            .AddScoped<IHttpContentFactory, FormUrlEncodedHttpContentFactory>()
 
             // Activity property options providers.
-            .AddSingleton<IActivityPropertyOptionsProvider, HttpContentTypeOptionsProvider>()
+            .AddScoped<IActivityPropertyOptionsProvider, HttpContentTypeOptionsProvider>()
 
             // Port resolvers.
-            .AddSingleton<IActivityResolver, SendHttpRequestActivityResolver>()
+            .AddScoped<IActivityResolver, SendHttpRequestActivityResolver>()
 
             // HTTP endpoint handlers.
-            .AddSingleton<AuthenticationBasedHttpEndpointAuthorizationHandler>()
-            .AddSingleton<AllowAnonymousHttpEndpointAuthorizationHandler>()
-            .AddSingleton<DefaultHttpEndpointFaultHandler>()
-            .AddSingleton(HttpEndpointWorkflowFaultHandler)
-            .AddSingleton(HttpEndpointAuthorizationHandler)
+            .AddScoped<AuthenticationBasedHttpEndpointAuthorizationHandler>()
+            .AddScoped<AllowAnonymousHttpEndpointAuthorizationHandler>()
+            .AddScoped<DefaultHttpEndpointFaultHandler>()
+            .AddScoped(HttpEndpointWorkflowFaultHandler)
+            .AddScoped(HttpEndpointAuthorizationHandler)
 
             // Downloadable content handlers.
-            .AddSingleton<IDownloadableManager, DefaultDownloadableManager>()
-            .AddSingleton<IDownloadableContentHandler, MultiDownloadableContentHandler>()
-            .AddSingleton<IDownloadableContentHandler, BinaryDownloadableContentHandler>()
-            .AddSingleton<IDownloadableContentHandler, StreamDownloadableContentHandler>()
-            .AddSingleton<IDownloadableContentHandler, FormFileDownloadableContentHandler>()
-            .AddSingleton<IDownloadableContentHandler, DownloadableDownloadableContentHandler>()
-            .AddSingleton<IDownloadableContentHandler, UrlDownloadableContentHandler>()
+            .AddScoped<IDownloadableManager, DefaultDownloadableManager>()
+            .AddScoped<IDownloadableContentHandler, MultiDownloadableContentHandler>()
+            .AddScoped<IDownloadableContentHandler, BinaryDownloadableContentHandler>()
+            .AddScoped<IDownloadableContentHandler, StreamDownloadableContentHandler>()
+            .AddScoped<IDownloadableContentHandler, FormFileDownloadableContentHandler>()
+            .AddScoped<IDownloadableContentHandler, DownloadableDownloadableContentHandler>()
+            .AddScoped<IDownloadableContentHandler, UrlDownloadableContentHandler>()
 
             // File caches.
-            .AddSingleton(FileCache)
-            .AddSingleton<ZipManager>()
+            .AddScoped(FileCache)
+            .AddScoped<ZipManager>()
 
             // AuthenticationBasedHttpEndpointAuthorizationHandler requires Authorization services.
             // We could consider creating a separate module for installing authorization services.
@@ -205,10 +205,10 @@ public class HttpFeature : FeatureBase
 
         // Add selectors.
         foreach (var httpCorrelationIdSelectorType in HttpCorrelationIdSelectorTypes)
-            Services.AddSingleton(typeof(IHttpCorrelationIdSelector), httpCorrelationIdSelectorType);
+            Services.AddScoped(typeof(IHttpCorrelationIdSelector), httpCorrelationIdSelectorType);
 
         foreach (var httpWorkflowInstanceIdSelectorType in HttpWorkflowInstanceIdSelectorTypes)
-            Services.AddSingleton(typeof(IHttpWorkflowInstanceIdSelector), httpWorkflowInstanceIdSelectorType);
+            Services.AddScoped(typeof(IHttpWorkflowInstanceIdSelector), httpWorkflowInstanceIdSelectorType);
 
         Services.Configure<ExpressionOptions>(options =>
         {

--- a/src/modules/Elsa.Http/HostedServices/UpdateRouteTableHostedService.cs
+++ b/src/modules/Elsa.Http/HostedServices/UpdateRouteTableHostedService.cs
@@ -1,6 +1,5 @@
-﻿using System.Threading;
-using System.Threading.Tasks;
-using Elsa.Http.Contracts;
+﻿using Elsa.Http.Contracts;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 namespace Elsa.Http.HostedServices;
@@ -10,19 +9,21 @@ namespace Elsa.Http.HostedServices;
 /// </summary>
 public class UpdateRouteTableHostedService : BackgroundService
 {
-    private readonly IRouteTableUpdater _routeTableUpdater;
+    private readonly IServiceScopeFactory _scopeFactory;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="UpdateRouteTableHostedService"/> class.
     /// </summary>
-    public UpdateRouteTableHostedService(IRouteTableUpdater routeTableUpdater)
+    public UpdateRouteTableHostedService(IServiceScopeFactory scopeFactory)
     {
-        _routeTableUpdater = routeTableUpdater;
+        _scopeFactory = scopeFactory;
     }
 
     /// <inheritdoc />
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        await _routeTableUpdater.UpdateAsync(stoppingToken);
+        using var scope = _scopeFactory.CreateScope();
+        var routeTableUpdater = scope.ServiceProvider.GetRequiredService<IRouteTableUpdater>();
+        await routeTableUpdater.UpdateAsync(stoppingToken);
     }
 }

--- a/src/modules/Elsa.Http/Middleware/WorkflowsMiddleware.cs
+++ b/src/modules/Elsa.Http/Middleware/WorkflowsMiddleware.cs
@@ -1,29 +1,25 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
+using Elsa.Extensions;
+using Elsa.Http.Bookmarks;
 using Elsa.Http.Contracts;
 using Elsa.Http.Models;
 using Elsa.Http.Options;
+using Elsa.Workflows.Core;
 using Elsa.Workflows.Core.Contracts;
 using Elsa.Workflows.Core.Helpers;
-using Elsa.Workflows.Runtime.Contracts;
-using JetBrains.Annotations;
-using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Options;
-using System.Net;
-using System.Net.Mime;
-using System.Text.Json;
-using System.Threading;
-using System.Threading.Tasks;
-using Elsa.Extensions;
-using Elsa.Http.Bookmarks;
-using Elsa.Workflows.Core;
 using Elsa.Workflows.Core.Models;
 using Elsa.Workflows.Core.State;
+using Elsa.Workflows.Runtime.Contracts;
 using Elsa.Workflows.Runtime.Filters;
 using Elsa.Workflows.Runtime.Matches;
 using Elsa.Workflows.Runtime.Options;
 using Elsa.Workflows.Runtime.Results;
+using JetBrains.Annotations;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using System.Net;
+using System.Net.Mime;
+using System.Text.Json;
 
 namespace Elsa.Http.Middleware;
 
@@ -34,18 +30,7 @@ namespace Elsa.Http.Middleware;
 public class WorkflowsMiddleware
 {
     private readonly RequestDelegate _next;
-    private readonly IWorkflowRuntime _workflowRuntime;
-    private readonly IRouteMatcher _routeMatcher;
-    private readonly IRouteTable _routeTable;
-    private readonly IEnumerable<IHttpCorrelationIdSelector> _correlationIdSelectors;
-    private readonly IEnumerable<IHttpWorkflowInstanceIdSelector> _workflowInstanceIdSelectors;
-    private readonly IHttpBookmarkProcessor _httpBookmarkProcessor;
-    private readonly IHttpEndpointFaultHandler _httpEndpointFaultHandler;
-    private readonly IHttpEndpointAuthorizationHandler _httpEndpointAuthorizationHandler;
-    private readonly IBookmarkStore _bookmarkStore;
-    private readonly ITriggerStore _triggerStore;
-    private readonly IBookmarkHasher _hasher;
-    private readonly IBookmarkPayloadSerializer _serializer;
+    private readonly IServiceScopeFactory _scopeFactory;
     private readonly HttpActivityOptions _options;
     private readonly string _activityTypeName = ActivityTypeNameHelper.GenerateTypeName<HttpEndpoint>();
 
@@ -54,34 +39,12 @@ public class WorkflowsMiddleware
     /// </summary>
     public WorkflowsMiddleware(
         RequestDelegate next,
-        IWorkflowRuntime workflowRuntime,
-        IOptions<HttpActivityOptions> options,
-        IHttpBookmarkProcessor httpBookmarkProcessor,
-        IHttpEndpointFaultHandler httpEndpointFaultHandler,
-        IHttpEndpointAuthorizationHandler httpEndpointAuthorizationHandler,
-        IBookmarkStore bookmarkStore,
-        ITriggerStore triggerStore,
-        IBookmarkHasher hasher,
-        IBookmarkPayloadSerializer serializer,
-        IRouteMatcher routeMatcher,
-        IRouteTable routeTable,
-        IEnumerable<IHttpCorrelationIdSelector> correlationIdSelectors,
-        IEnumerable<IHttpWorkflowInstanceIdSelector> workflowInstanceIdSelectors)
+        IServiceScopeFactory scopeFactory,
+        IOptions<HttpActivityOptions> options)
     {
         _next = next;
-        _workflowRuntime = workflowRuntime;
+        _scopeFactory = scopeFactory;
         _options = options.Value;
-        _httpBookmarkProcessor = httpBookmarkProcessor;
-        _httpEndpointFaultHandler = httpEndpointFaultHandler;
-        _httpEndpointAuthorizationHandler = httpEndpointAuthorizationHandler;
-        _bookmarkStore = bookmarkStore;
-        _triggerStore = triggerStore;
-        _hasher = hasher;
-        _serializer = serializer;
-        _routeMatcher = routeMatcher;
-        _routeTable = routeTable;
-        _correlationIdSelectors = correlationIdSelectors;
-        _workflowInstanceIdSelectors = workflowInstanceIdSelectors;
     }
 
     /// <summary>
@@ -89,6 +52,9 @@ public class WorkflowsMiddleware
     /// </summary>
     public async Task InvokeAsync(HttpContext httpContext)
     {
+        using var scope = _scopeFactory.CreateScope();
+        var workflowRuntime = scope.ServiceProvider.GetRequiredService<IWorkflowRuntime>();
+
         var path = GetPath(httpContext);
         var basePath = _options.BasePath?.ToString().NormalizeRoute();
 
@@ -105,7 +71,7 @@ public class WorkflowsMiddleware
             path = path[basePath.Length..];
         }
 
-        var matchingPath = GetMatchingRoute(path);
+        var matchingPath = GetMatchingRoute(scope, path);
 
         var input = new Dictionary<string, object>
         {
@@ -116,12 +82,12 @@ public class WorkflowsMiddleware
         var cancellationToken = httpContext.RequestAborted;
         var request = httpContext.Request;
         var method = request.Method.ToLowerInvariant();
-        var correlationId = await GetCorrelationIdAsync(httpContext, httpContext.RequestAborted);
-        var workflowInstanceId = await GetWorkflowInstanceIdAsync(httpContext, httpContext.RequestAborted);
+        var correlationId = await GetCorrelationIdAsync(scope, httpContext, httpContext.RequestAborted);
+        var workflowInstanceId = await GetWorkflowInstanceIdAsync(scope, httpContext, httpContext.RequestAborted);
         var bookmarkPayload = new HttpEndpointBookmarkPayload(matchingPath, method);
         var triggerOptions = new TriggerWorkflowsOptions(correlationId, workflowInstanceId, default, input);
         var workflowsFilter = new WorkflowsFilter(_activityTypeName, bookmarkPayload, triggerOptions);
-        var workflowMatches = (await _workflowRuntime.FindWorkflowsAsync(workflowsFilter, cancellationToken)).ToList();
+        var workflowMatches = (await workflowRuntime.FindWorkflowsAsync(workflowsFilter, cancellationToken)).ToList();
 
         if (await HandleNoWorkflowsFoundAsync(httpContext, workflowMatches, basePath))
             return;
@@ -131,27 +97,34 @@ public class WorkflowsMiddleware
 
         var matchedWorkflow = workflowMatches.Single();
 
-        if (await AuthorizeAsync(httpContext, matchedWorkflow, bookmarkPayload, cancellationToken))
+        if (await AuthorizeAsync(scope, httpContext, matchedWorkflow, bookmarkPayload, cancellationToken))
             return;
 
         // Get settings from the bookmark payload.
         var foundBookmarkPayload = matchedWorkflow.Payload as HttpEndpointBookmarkPayload;
-        
+
         // Get the configured request timeout, if any.
         var requestTimeout = foundBookmarkPayload?.RequestTimeout;
 
         if (requestTimeout == null)
         {
             // If no request timeout was configured, execute the workflow without a timeout.
-            await ExecuteWorkflowAsync(matchedWorkflow, correlationId, input, requestTimeout, httpContext, cancellationToken);
+            await ExecuteWorkflowAsync(scope, workflowRuntime, matchedWorkflow, correlationId, input, requestTimeout, httpContext, cancellationToken);
             return;
         }
 
         // If a request timeout was configured, execute the workflow within the specified timeout.
-        await ExecuteWorkflowWithinTimeoutAsync(matchedWorkflow, correlationId, input, requestTimeout.Value, httpContext);
+        await ExecuteWorkflowWithinTimeoutAsync(scope, workflowRuntime, matchedWorkflow, correlationId, input, requestTimeout.Value, httpContext);
     }
 
-    private async Task ExecuteWorkflowWithinTimeoutAsync(WorkflowMatch matchedWorkflow, string? correlationId, IDictionary<string, object> input, TimeSpan requestTimeout, HttpContext httpContext)
+    private async Task ExecuteWorkflowWithinTimeoutAsync(
+        IServiceScope scope,
+        IWorkflowRuntime workflowRuntime,
+        WorkflowMatch matchedWorkflow,
+        string? correlationId,
+        IDictionary<string, object> input,
+        TimeSpan requestTimeout,
+        HttpContext httpContext)
     {
         using var cts = new CancellationTokenSource(requestTimeout);
         var originalCancellationToken = httpContext.RequestAborted;
@@ -160,10 +133,12 @@ public class WorkflowsMiddleware
         var applicationCancellationToken = cts.Token;
         var cancellationTokens = new CancellationTokens(applicationCancellationToken, systemCancellationToken);
 
-        await ExecuteWorkflowAsync(matchedWorkflow, correlationId, input, requestTimeout, httpContext, cancellationTokens);
+        await ExecuteWorkflowAsync(scope, workflowRuntime, matchedWorkflow, correlationId, input, requestTimeout, httpContext, cancellationTokens);
     }
 
     private async Task ExecuteWorkflowAsync(
+        IServiceScope scope,
+        IWorkflowRuntime workflowRuntime,
         WorkflowMatch matchedWorkflow,
         string? correlationId,
         IDictionary<string, object> input,
@@ -171,14 +146,15 @@ public class WorkflowsMiddleware
         HttpContext httpContext,
         CancellationTokens cancellationTokens)
     {
+        var httpBookmarkProcessor = scope.ServiceProvider.GetRequiredService<IHttpBookmarkProcessor>();
         var systemCancellationToken = cancellationTokens.SystemCancellationToken;
-        var executionResult = await _workflowRuntime.ExecuteWorkflowAsync(matchedWorkflow, input, cancellationTokens);
+        var executionResult = await workflowRuntime.ExecuteWorkflowAsync(matchedWorkflow, input, cancellationTokens);
 
-        if (await HandleWorkflowFaultAsync(httpContext, executionResult, systemCancellationToken))
+        if (await HandleWorkflowFaultAsync(scope, workflowRuntime, httpContext, executionResult, systemCancellationToken))
             return;
 
         // Process the trigger result by resuming each HTTP bookmark, if any.
-        var affectedWorkflowStates = await _httpBookmarkProcessor.ProcessBookmarks(
+        var affectedWorkflowStates = await httpBookmarkProcessor.ProcessBookmarks(
             new List<WorkflowExecutionResult> { executionResult },
             correlationId,
             input,
@@ -188,14 +164,17 @@ public class WorkflowsMiddleware
         var faultedWorkflowState = affectedWorkflowStates.FirstOrDefault(x => x.SubStatus == WorkflowSubStatus.Faulted);
 
         if (faultedWorkflowState != null)
-            await HandleWorkflowFaultAsync(httpContext, faultedWorkflowState, systemCancellationToken);
+            await HandleWorkflowFaultAsync(scope, httpContext, faultedWorkflowState, systemCancellationToken);
     }
 
-    private string GetMatchingRoute(string path)
+    private string GetMatchingRoute(IServiceScope scope, string path)
     {
+        var routeMatcher = scope.ServiceProvider.GetRequiredService<IRouteMatcher>();
+        var routeTable = scope.ServiceProvider.GetRequiredService<IRouteTable>();
+
         var matchingRouteQuery =
-            from route in _routeTable
-            let routeValues = _routeMatcher.Match(route, path)
+            from route in routeTable
+            let routeValues = routeMatcher.Match(route, path)
             where routeValues != null
             select new { route, routeValues };
 
@@ -205,11 +184,13 @@ public class WorkflowsMiddleware
         return routeTemplate;
     }
 
-    private async Task<string?> GetCorrelationIdAsync(HttpContext httpContext, CancellationToken cancellationToken)
+    private async Task<string?> GetCorrelationIdAsync(IServiceScope scope, HttpContext httpContext, CancellationToken cancellationToken)
     {
+        var correlationIdSelectors = scope.ServiceProvider.GetServices<IHttpCorrelationIdSelector>();
+
         var correlationId = default(string);
 
-        foreach (var selector in _correlationIdSelectors.OrderByDescending(x => x.Priority))
+        foreach (var selector in correlationIdSelectors.OrderByDescending(x => x.Priority))
         {
             correlationId = await selector.GetCorrelationIdAsync(httpContext, cancellationToken);
 
@@ -220,11 +201,13 @@ public class WorkflowsMiddleware
         return correlationId;
     }
 
-    private async Task<string?> GetWorkflowInstanceIdAsync(HttpContext httpContext, CancellationToken cancellationToken)
+    private async Task<string?> GetWorkflowInstanceIdAsync(IServiceScope scope, HttpContext httpContext, CancellationToken cancellationToken)
     {
+        var workflowInstanceIdSelectors = scope.ServiceProvider.GetServices<IHttpWorkflowInstanceIdSelector>();
+
         var workflowInstanceId = default(string);
 
-        foreach (var selector in _workflowInstanceIdSelectors.OrderByDescending(x => x.Priority))
+        foreach (var selector in workflowInstanceIdSelectors.OrderByDescending(x => x.Priority))
         {
             workflowInstanceId = await selector.GetWorkflowInstanceIdAsync(httpContext, cancellationToken);
 
@@ -293,35 +276,38 @@ public class WorkflowsMiddleware
         return true;
     }
 
-    private async Task<bool> HandleWorkflowFaultAsync(HttpContext httpContext, WorkflowExecutionResult workflowExecutionResult, CancellationToken cancellationToken)
+    private async Task<bool> HandleWorkflowFaultAsync(IServiceScope scope, IWorkflowRuntime workflowRuntime, HttpContext httpContext, WorkflowExecutionResult workflowExecutionResult, CancellationToken cancellationToken)
     {
         var subStatus = workflowExecutionResult.SubStatus;
 
         if (subStatus != WorkflowSubStatus.Faulted || httpContext.Response.HasStarted)
             return false;
 
-        var workflowState = (await _workflowRuntime.ExportWorkflowStateAsync(workflowExecutionResult.WorkflowInstanceId, cancellationToken))!;
-        return await HandleWorkflowFaultAsync(httpContext, workflowState, cancellationToken);
+        var workflowState = (await workflowRuntime.ExportWorkflowStateAsync(workflowExecutionResult.WorkflowInstanceId, cancellationToken))!;
+        return await HandleWorkflowFaultAsync(scope, httpContext, workflowState, cancellationToken);
     }
 
-    private async Task<bool> HandleWorkflowFaultAsync(HttpContext httpContext, WorkflowState workflowState, CancellationToken cancellationToken)
+    private async Task<bool> HandleWorkflowFaultAsync(IServiceScope scope, HttpContext httpContext, WorkflowState workflowState, CancellationToken cancellationToken)
     {
-        await _httpEndpointFaultHandler.HandleAsync(new HttpEndpointFaultContext(httpContext, workflowState, cancellationToken));
+        var httpEndpointFaultHandler = scope.ServiceProvider.GetRequiredService<IHttpEndpointFaultHandler>();
+        await httpEndpointFaultHandler.HandleAsync(new HttpEndpointFaultContext(httpContext, workflowState, cancellationToken));
         return true;
     }
 
     private async Task<bool> AuthorizeAsync(
+        IServiceScope scope,
         HttpContext httpContext,
         WorkflowMatch pendingWorkflowMatch,
         HttpEndpointBookmarkPayload bookmarkPayload,
         CancellationToken cancellationToken)
     {
-        var payload = await GetBookmarkPayloadAsync(pendingWorkflowMatch, bookmarkPayload, cancellationToken);
+        var httpEndpointAuthorizationHandler = scope.ServiceProvider.GetRequiredService<IHttpEndpointAuthorizationHandler>();
+        var payload = await GetBookmarkPayloadAsync(scope, pendingWorkflowMatch, bookmarkPayload, cancellationToken);
 
         if (!(payload.Authorize ?? false))
             return false;
 
-        var authorized = await _httpEndpointAuthorizationHandler.AuthorizeAsync(new AuthorizeHttpEndpointContext(httpContext, pendingWorkflowMatch.WorkflowInstanceId, payload.Policy));
+        var authorized = await httpEndpointAuthorizationHandler.AuthorizeAsync(new AuthorizeHttpEndpointContext(httpContext, pendingWorkflowMatch.WorkflowInstanceId, payload.Policy));
 
         if (!authorized)
             httpContext.Response.StatusCode = (int)HttpStatusCode.Unauthorized;
@@ -329,19 +315,23 @@ public class WorkflowsMiddleware
         return !authorized;
     }
 
-    private async Task<HttpEndpointBookmarkPayload> GetBookmarkPayloadAsync(WorkflowMatch workflowMatch, HttpEndpointBookmarkPayload bookmarkPayload, CancellationToken cancellationToken)
+    private async Task<HttpEndpointBookmarkPayload> GetBookmarkPayloadAsync(IServiceScope scope, WorkflowMatch workflowMatch, HttpEndpointBookmarkPayload bookmarkPayload, CancellationToken cancellationToken)
     {
-        var hash = _hasher.Hash(_activityTypeName, bookmarkPayload);
+        var bookmarkStore = scope.ServiceProvider.GetRequiredService<IBookmarkStore>();
+        var triggerStore = scope.ServiceProvider.GetRequiredService<ITriggerStore>();
+        var hasher = scope.ServiceProvider.GetRequiredService<IBookmarkHasher>();
+
+        var hash = hasher.Hash(_activityTypeName, bookmarkPayload);
 
         if (workflowMatch is StartableWorkflowMatch)
         {
             var triggerFilter = new TriggerFilter { Hash = hash };
-            var trigger = (await _triggerStore.FindManyAsync(triggerFilter, cancellationToken)).First();
+            var trigger = (await triggerStore.FindManyAsync(triggerFilter, cancellationToken)).First();
             return trigger.GetPayload<HttpEndpointBookmarkPayload>();
         }
 
         var bookmarkFilter = new BookmarkFilter { Hash = hash };
-        var bookmark = (await _bookmarkStore.FindManyAsync(bookmarkFilter, cancellationToken)).First();
+        var bookmark = (await bookmarkStore.FindManyAsync(bookmarkFilter, cancellationToken)).First();
         return bookmark.GetPayload<HttpEndpointBookmarkPayload>();
     }
 }

--- a/src/modules/Elsa.Identity/Features/DefaultAuthenticationFeature.cs
+++ b/src/modules/Elsa.Identity/Features/DefaultAuthenticationFeature.cs
@@ -69,10 +69,10 @@ public class DefaultAuthenticationFeature : FeatureBase
 
         _configureApiKeyAuthorization(authBuilder);
 
-        Services.AddSingleton<IAuthorizationHandler, LocalHostRequirementHandler>();
-        Services.AddSingleton<IAuthorizationHandler, LocalHostPermissionRequirementHandler>();
-        Services.AddSingleton(ApiKeyProviderType);
-        Services.AddSingleton<IApiKeyProvider>(sp => (IApiKeyProvider)sp.GetRequiredService(ApiKeyProviderType));
+        Services.AddScoped<IAuthorizationHandler, LocalHostRequirementHandler>();
+        Services.AddScoped<IAuthorizationHandler, LocalHostPermissionRequirementHandler>();
+        Services.AddScoped(ApiKeyProviderType);
+        Services.AddScoped<IApiKeyProvider>(sp => (IApiKeyProvider)sp.GetRequiredService(ApiKeyProviderType));
         Services.AddAuthorization(options => options.AddPolicy(IdentityPolicyNames.SecurityRoot, policy => policy.AddRequirements(new LocalHostPermissionRequirement())));
     }
 }

--- a/src/modules/Elsa.Identity/Features/IdentityFeature.cs
+++ b/src/modules/Elsa.Identity/Features/IdentityFeature.cs
@@ -165,39 +165,39 @@ public class IdentityFeature : FeatureBase
 
         // User providers.
         Services
-            .AddSingleton<AdminUserProvider>()
-            .AddSingleton<StoreBasedUserProvider>()
-            .AddSingleton<ConfigurationBasedUserProvider>();
+            .AddScoped<AdminUserProvider>()
+            .AddScoped<StoreBasedUserProvider>()
+            .AddScoped<ConfigurationBasedUserProvider>();
         
         // Application providers.
         Services
-            .AddSingleton<StoreBasedApplicationProvider>()
-            .AddSingleton<ConfigurationBasedApplicationProvider>();
+            .AddScoped<StoreBasedApplicationProvider>()
+            .AddScoped<ConfigurationBasedApplicationProvider>();
         
         // Role providers.
         Services
-            .AddSingleton<AdminRoleProvider>()
-            .AddSingleton<StoreBasedRoleProvider>()
-            .AddSingleton<ConfigurationBasedRoleProvider>();
+            .AddScoped<AdminRoleProvider>()
+            .AddScoped<StoreBasedRoleProvider>()
+            .AddScoped<ConfigurationBasedRoleProvider>();
 
         // Services.
         Services
-            .AddSingleton(UserStore)
-            .AddSingleton(ApplicationStore)
-            .AddSingleton(RoleStore)
-            .AddSingleton(UserProvider)
-            .AddSingleton(ApplicationProvider)
-            .AddSingleton(RoleProvider)
-            .AddSingleton<ISecretHasher, DefaultSecretHasher>()
-            .AddSingleton<IAccessTokenIssuer, DefaultAccessTokenIssuer>()
-            .AddSingleton<IUserCredentialsValidator, DefaultUserCredentialsValidator>()
-            .AddSingleton<IApplicationCredentialsValidator, DefaultApplicationCredentialsValidator>()
-            .AddSingleton<IApiKeyGenerator>(sp => sp.GetRequiredService<DefaultApiKeyGeneratorAndParser>())
-            .AddSingleton<IApiKeyParser>(sp => sp.GetRequiredService<DefaultApiKeyGeneratorAndParser>())
-            .AddSingleton<IClientIdGenerator, DefaultClientIdGenerator>()
-            .AddSingleton<ISecretGenerator, DefaultSecretGenerator>()
-            .AddSingleton<IRandomStringGenerator, DefaultRandomStringGenerator>()
-            .AddSingleton<DefaultApiKeyGeneratorAndParser>()
+            .AddScoped(UserStore)
+            .AddScoped(ApplicationStore)
+            .AddScoped(RoleStore)
+            .AddScoped(UserProvider)
+            .AddScoped(ApplicationProvider)
+            .AddScoped(RoleProvider)
+            .AddScoped<ISecretHasher, DefaultSecretHasher>()
+            .AddScoped<IAccessTokenIssuer, DefaultAccessTokenIssuer>()
+            .AddScoped<IUserCredentialsValidator, DefaultUserCredentialsValidator>()
+            .AddScoped<IApplicationCredentialsValidator, DefaultApplicationCredentialsValidator>()
+            .AddScoped<IApiKeyGenerator>(sp => sp.GetRequiredService<DefaultApiKeyGeneratorAndParser>())
+            .AddScoped<IApiKeyParser>(sp => sp.GetRequiredService<DefaultApiKeyGeneratorAndParser>())
+            .AddScoped<IClientIdGenerator, DefaultClientIdGenerator>()
+            .AddScoped<ISecretGenerator, DefaultSecretGenerator>()
+            .AddScoped<IRandomStringGenerator, DefaultRandomStringGenerator>()
+            .AddScoped<DefaultApiKeyGeneratorAndParser>()
             ;
     }
 }

--- a/src/modules/Elsa.JavaScript/Extensions/DependencyInjectionExtensions.cs
+++ b/src/modules/Elsa.JavaScript/Extensions/DependencyInjectionExtensions.cs
@@ -14,7 +14,7 @@ public static class DependencyInjectionExtensions
     /// <param name="services">The service collection.</param>
     /// <typeparam name="T">The type of the function definition provider.</typeparam>
     /// <returns>The service collection.</returns>
-    public static IServiceCollection AddFunctionDefinitionProvider<T>(this IServiceCollection services) where T: class, IFunctionDefinitionProvider => services.AddSingleton<IFunctionDefinitionProvider, T>();
+    public static IServiceCollection AddFunctionDefinitionProvider<T>(this IServiceCollection services) where T: class, IFunctionDefinitionProvider => services.AddScoped<IFunctionDefinitionProvider, T>();
 
     /// <summary>
     /// Adds a <see cref="IFunctionDefinitionProvider"/> to the service collection.
@@ -24,7 +24,7 @@ public static class DependencyInjectionExtensions
     /// <typeparam name="T">The type of the function definition provider.</typeparam>
     /// <returns>The service collection.</returns>
     public static IServiceCollection AddFunctionDefinitionProvider<T>(this IServiceCollection services, Func<IServiceProvider, T> factory) where T: class, IFunctionDefinitionProvider => 
-        services.AddSingleton<IFunctionDefinitionProvider, T>(factory);
+        services.AddScoped<IFunctionDefinitionProvider, T>(factory);
     
     /// <summary>
     /// Adds a <see cref="ITypeDefinitionProvider"/> to the service collection.
@@ -32,7 +32,7 @@ public static class DependencyInjectionExtensions
     /// <param name="services">The service collection.</param>
     /// <typeparam name="T">The type of the type definition provider.</typeparam>
     /// <returns>The service collection.</returns>
-    public static IServiceCollection AddTypeDefinitionProvider<T>(this IServiceCollection services) where T: class, ITypeDefinitionProvider => services.AddSingleton<ITypeDefinitionProvider, T>();
+    public static IServiceCollection AddTypeDefinitionProvider<T>(this IServiceCollection services) where T: class, ITypeDefinitionProvider => services.AddScoped<ITypeDefinitionProvider, T>();
 
     /// <summary>
     /// Adds a <see cref="ITypeDefinitionProvider"/> to the service collection.
@@ -42,5 +42,5 @@ public static class DependencyInjectionExtensions
     /// <typeparam name="T">The type of the type definition provider.</typeparam>
     /// <returns>The service collection.</returns>
     public static IServiceCollection AddTypeDefinitionProvider<T>(this IServiceCollection services, Func<IServiceProvider, T> factory) where T: class, ITypeDefinitionProvider => 
-        services.AddSingleton<ITypeDefinitionProvider, T>();
+        services.AddScoped<ITypeDefinitionProvider, T>();
 }

--- a/src/modules/Elsa.JavaScript/Features/JavaScriptFeature.cs
+++ b/src/modules/Elsa.JavaScript/Features/JavaScriptFeature.cs
@@ -1,5 +1,4 @@
 using Elsa.Common.Features;
-using Elsa.Expressions.Contracts;
 using Elsa.Expressions.Features;
 using Elsa.Extensions;
 using Elsa.Features.Abstractions;
@@ -7,7 +6,6 @@ using Elsa.Features.Attributes;
 using Elsa.Features.Services;
 using Elsa.JavaScript.Activities;
 using Elsa.JavaScript.Contracts;
-using Elsa.JavaScript.Expressions;
 using Elsa.JavaScript.Extensions;
 using Elsa.JavaScript.HostedServices;
 using Elsa.JavaScript.Options;
@@ -32,7 +30,7 @@ public class JavaScriptFeature : FeatureBase
     public JavaScriptFeature(IModule module) : base(module)
     {
     }
-    
+
     /// <summary>
     /// Configures the Jint options.
     /// </summary>
@@ -54,33 +52,33 @@ public class JavaScriptFeature : FeatureBase
     public override void Apply()
     {
         Services.Configure(JintOptions);
-        
+
         // JavaScript services.
         Services
-            .AddSingleton<IJavaScriptEvaluator, JintJavaScriptEvaluator>()
-            .AddSingleton<ITypeDefinitionService, TypeDefinitionService>()
+            .AddScoped<IJavaScriptEvaluator, JintJavaScriptEvaluator>()
+            .AddScoped<ITypeDefinitionService, TypeDefinitionService>()
             .AddExpressionDescriptorProvider<JavaScriptExpressionDescriptorProvider>()
             ;
 
         // Type definition services.
         Services
-            .AddSingleton<ITypeDefinitionService, TypeDefinitionService>()
-            .AddSingleton<ITypeDescriber, TypeDescriber>()
-            .AddSingleton<ITypeDefinitionDocumentRenderer, TypeDefinitionDocumentRenderer>()
+            .AddScoped<ITypeDefinitionService, TypeDefinitionService>()
+            .AddScoped<ITypeDescriber, TypeDescriber>()
+            .AddScoped<ITypeDefinitionDocumentRenderer, TypeDefinitionDocumentRenderer>()
             .AddSingleton<ITypeAliasRegistry, TypeAliasRegistry>()
             .AddFunctionDefinitionProvider<CommonFunctionsDefinitionProvider>()
             .AddFunctionDefinitionProvider<ActivityOutputFunctionsDefinitionProvider>()
             .AddTypeDefinitionProvider<CommonTypeDefinitionProvider>()
             .AddTypeDefinitionProvider<VariableTypeDefinitionProvider>()
             ;
-        
+
         // Handlers.
         Services.AddNotificationHandlersFrom<JavaScriptFeature>();
-        
+
         // Activities.
         Module.UseWorkflowManagement(management => management.AddActivity<RunJavaScript>());
-        
-            Services.AddSingleton<IActivityPropertyOptionsProvider, RunJavaScriptOptionsProvider>()
-            .AddFunctionDefinitionProvider<InputFunctionsDefinitionProvider>();
+
+        Services.AddSingleton<IActivityPropertyOptionsProvider, RunJavaScriptOptionsProvider>()
+        .AddFunctionDefinitionProvider<InputFunctionsDefinitionProvider>();
     }
 }

--- a/src/modules/Elsa.Labels/Features/LabelsFeature.cs
+++ b/src/modules/Elsa.Labels/Features/LabelsFeature.cs
@@ -43,8 +43,8 @@ public class LabelsFeature : FeatureBase
         Services
             .AddMemoryStore<Label, InMemoryLabelStore>()
             .AddMemoryStore<WorkflowDefinitionLabel, InMemoryWorkflowDefinitionLabelStore>()
-            .AddSingleton(LabelStore)
-            .AddSingleton(WorkflowDefinitionLabelStore)
+            .AddScoped(LabelStore)
+            .AddScoped(WorkflowDefinitionLabelStore)
             ;
 
         Services.AddNotificationHandlersFrom(GetType());

--- a/src/modules/Elsa.Liquid/Features/LiquidFeature.cs
+++ b/src/modules/Elsa.Liquid/Features/LiquidFeature.cs
@@ -41,8 +41,8 @@ public class LiquidFeature : FeatureBase
         
         Services
             .AddHandlersFrom<ConfigureLiquidEngine>()
-            .AddSingleton<ILiquidTemplateManager, LiquidTemplateManager>()
-            .AddSingleton<LiquidParser>()
+            .AddScoped<ILiquidTemplateManager, LiquidTemplateManager>()
+            .AddScoped<LiquidParser>()
             .AddExpressionDescriptorProvider<LiquidExpressionDescriptorProvider>()
             .AddLiquidFilter<JsonFilter>("json")
             .AddLiquidFilter<Base64Filter>("base64")

--- a/src/modules/Elsa.MassTransit/Features/MassTransitWorkflowDispatcherFeature.cs
+++ b/src/modules/Elsa.MassTransit/Features/MassTransitWorkflowDispatcherFeature.cs
@@ -41,6 +41,6 @@ public class MassTransitWorkflowDispatcherFeature : FeatureBase
         EndpointConvention.Map<DispatchTriggerWorkflows>(queueAddress);
         EndpointConvention.Map<DispatchResumeWorkflows>(queueAddress);
         
-        Services.AddSingleton<MassTransitWorkflowDispatcher>();
+        Services.AddScoped<MassTransitWorkflowDispatcher>();
     }
 }

--- a/src/modules/Elsa.MongoDb/Common/PersistenceFeatureBase.cs
+++ b/src/modules/Elsa.MongoDb/Common/PersistenceFeatureBase.cs
@@ -23,8 +23,8 @@ public abstract class PersistenceFeatureBase : FeatureBase
     protected void AddStore<TDocument, TStore>() where TDocument : class where TStore : class
     {
         Services
-            .AddSingleton<MongoDbStore<TDocument>>()
-            .AddSingleton<TStore>()
+            .AddScoped<MongoDbStore<TDocument>>()
+            .AddScoped<TStore>()
             ;
     }
 
@@ -35,7 +35,7 @@ public abstract class PersistenceFeatureBase : FeatureBase
     /// <typeparam name="TDocument">The document type of the collection.</typeparam>
     protected void AddCollection<TDocument>(string collectionName) where TDocument : class
     {
-        Services.AddSingleton(
+        Services.AddScoped(
             sp => sp.GetRequiredService<IMongoDatabase>()
                 .GetCollection<TDocument>(collectionName));
     }

--- a/src/modules/Elsa.MongoDb/Features/MongoDbFeature.cs
+++ b/src/modules/Elsa.MongoDb/Features/MongoDbFeature.cs
@@ -40,7 +40,7 @@ public class MongoDbFeature : FeatureBase
     {
         Services.Configure(Options);
 
-        Services.AddSingleton(sp => CreateDatabase(sp, ConnectionString));
+        Services.AddScoped(sp => CreateDatabase(sp, ConnectionString));
 
         RegisterSerializers();
         RegisterClassMaps();

--- a/src/modules/Elsa.ProtoActor.Cluster.AzureContainerApps/Extensions/ServiceCollectionExtensions.cs
+++ b/src/modules/Elsa.ProtoActor.Cluster.AzureContainerApps/Extensions/ServiceCollectionExtensions.cs
@@ -32,9 +32,9 @@ public static class ServiceCollectionExtensions
         var configureOptions = configure ?? (_ => { });
         services.Configure(configureOptions);
         services.ConfigureOptions<AzureContainerAppsProviderOptionsValidator>();
-        services.AddSingleton<AzureContainerAppsProvider>();
-        services.AddSingleton<ISystemClock, DefaultSystemClock>();
-        services.AddSingleton<IContainerAppMetadataAccessor, EnvironmentContainerAppMetadataAccessor>();
+        services.AddScoped<AzureContainerAppsProvider>();
+        services.AddScoped<ISystemClock, DefaultSystemClock>();
+        services.AddScoped<IContainerAppMetadataAccessor, EnvironmentContainerAppMetadataAccessor>();
         services.AddTransient<AzureContainerAppsClusterMonitor>();
 
         if (armClientProvider != null)

--- a/src/modules/Elsa.ProtoActor.Cluster.AzureContainerApps/Readme.md
+++ b/src/modules/Elsa.ProtoActor.Cluster.AzureContainerApps/Readme.md
@@ -55,5 +55,5 @@ public class RedisClusterMemberStorage : IClusterMemberStore
 You can then register the implementation with the service collection:
 
 ```csharp
-services.AddSingleton<IClusterMemberStore, RedisClusterMemberStore>();
+services.AddScoped<IClusterMemberStore, RedisClusterMemberStore>();
 ```

--- a/src/modules/Elsa.ProtoActor.Cluster.AzureContainerApps/Stores/ResourceTags/ServiceCollectionExtensions.cs
+++ b/src/modules/Elsa.ProtoActor.Cluster.AzureContainerApps/Stores/ResourceTags/ServiceCollectionExtensions.cs
@@ -24,7 +24,7 @@ public static class ServiceCollectionExtensions
         services.Configure(configureOptions);
         services.ConfigureOptions<ResourceTagsMemberStoreOptionsValidator>();
 
-        services.AddSingleton<IClusterMemberStore, ResourceTagsClusterMemberStore>(sp =>
+        services.AddScoped<IClusterMemberStore, ResourceTagsClusterMemberStore>(sp =>
         {
             var clientProvider = sp.GetRequiredService<IArmClientProvider>();
             var logger = sp.GetRequiredService<ILogger<ResourceTagsClusterMemberStore>>();

--- a/src/modules/Elsa.ProtoActor/Features/ProtoActorFeature.cs
+++ b/src/modules/Elsa.ProtoActor/Features/ProtoActorFeature.cs
@@ -83,7 +83,7 @@ public class ProtoActorFeature : FeatureBase
         var services = Services;
 
         // Register ActorSystem.
-        services.AddSingleton(sp =>
+        services.AddScoped(sp =>
         {
             var systemConfig = Proto.ActorSystemConfig
                 .Setup()
@@ -118,22 +118,22 @@ public class ProtoActorFeature : FeatureBase
         Log.SetLoggerFactory(LoggerFactory.Create(l => l.AddConsole().SetMinimumLevel(LogLevel.Warning)));
 
         // Persistence.
-        services.AddSingleton(PersistenceProvider);
+        services.AddScoped(PersistenceProvider);
 
         // Mappers.
         services
-            .AddSingleton<BookmarkMapper>()
-            .AddSingleton<ExceptionMapper>()
-            .AddSingleton<WorkflowExecutionResultMapper>()
-            .AddSingleton<ActivityIncidentStateMapper>()
-            .AddSingleton<WorkflowStatusMapper>()
-            .AddSingleton<WorkflowSubStatusMapper>();
+            .AddScoped<BookmarkMapper>()
+            .AddScoped<ExceptionMapper>()
+            .AddScoped<WorkflowExecutionResultMapper>()
+            .AddScoped<ActivityIncidentStateMapper>()
+            .AddScoped<WorkflowStatusMapper>()
+            .AddScoped<WorkflowSubStatusMapper>();
 
         // Mediator handlers.
         services.AddHandlersFrom<ProtoActorFeature>();
 
         // Cluster.
-        services.AddSingleton(sp => sp.GetRequiredService<ActorSystem>().Cluster());
+        services.AddScoped(sp => sp.GetRequiredService<ActorSystem>().Cluster());
 
         // Actors.
         services

--- a/src/modules/Elsa.Quartz/Features/QuartzSchedulerFeature.cs
+++ b/src/modules/Elsa.Quartz/Features/QuartzSchedulerFeature.cs
@@ -39,9 +39,9 @@ public class QuartzSchedulerFeature : FeatureBase
     /// <inheritdoc />
     public override void Apply()
     {
-        Services.AddSingleton<IActivityDescriptorModifier, CronActivityDescriptorModifier>();
-        Services.AddSingleton<QuartzWorkflowScheduler>();
-        Services.AddSingleton<QuartzCronParser>();
+        Services.AddScoped<IActivityDescriptorModifier, CronActivityDescriptorModifier>();
+        Services.AddScoped<QuartzWorkflowScheduler>();
+        Services.AddScoped<QuartzCronParser>();
         Services.AddQuartz(quartz => quartz
             .AddJob<RunWorkflowJob>(job => job.WithIdentity(RunWorkflowJob.JobKey).StoreDurably())
             .AddJob<ResumeWorkflowJob>(job => job.WithIdentity(ResumeWorkflowJob.JobKey).StoreDurably()));

--- a/src/modules/Elsa.SasTokens/Extensions/ServiceCollectionExtensions.cs
+++ b/src/modules/Elsa.SasTokens/Extensions/ServiceCollectionExtensions.cs
@@ -14,7 +14,7 @@ public static class ServiceCollectionExtensions
     /// </summary>
     public static IServiceCollection AddSasTokens(this IServiceCollection services, Func<IServiceProvider, IDataProtectionProvider> dataProtectionProvider)
     {
-        services.AddSingleton<ITokenService>(sp =>
+        services.AddScoped<ITokenService>(sp =>
         {
             var protectionProvider = dataProtectionProvider(sp);
             return new DataProtectorTokenService(protectionProvider);

--- a/src/modules/Elsa.Scheduling/Features/SchedulingFeature.cs
+++ b/src/modules/Elsa.Scheduling/Features/SchedulingFeature.cs
@@ -42,13 +42,13 @@ public class SchedulingFeature : FeatureBase
     public override void Apply()
     {
         Services
-            .AddSingleton<ITriggerScheduler, DefaultTriggerScheduler>()
-            .AddSingleton<IBookmarkScheduler, DefaultBookmarkScheduler>()
-            .AddSingleton<IScheduler, LocalScheduler>()
-            .AddSingleton<DefaultWorkflowScheduler>()
-            .AddSingleton<CronosCronParser>()
-            .AddSingleton(CronParser)
-            .AddSingleton(WorkflowScheduler)
+            .AddScoped<ITriggerScheduler, DefaultTriggerScheduler>()
+            .AddScoped<IBookmarkScheduler, DefaultBookmarkScheduler>()
+            .AddScoped<IScheduler, LocalScheduler>()
+            .AddScoped<DefaultWorkflowScheduler>()
+            .AddScoped<CronosCronParser>()
+            .AddScoped(CronParser)
+            .AddScoped(WorkflowScheduler)
             .AddHandlersFrom<ScheduleWorkflows>();
 
         Module.Configure<WorkflowManagementFeature>(management => management.AddActivitiesFrom<SchedulingFeature>());

--- a/src/modules/Elsa.Scheduling/HostedServices/CreateSchedulesHostedService.cs
+++ b/src/modules/Elsa.Scheduling/HostedServices/CreateSchedulesHostedService.cs
@@ -3,6 +3,7 @@ using Elsa.Scheduling.Contracts;
 using Elsa.Workflows.Core.Helpers;
 using Elsa.Workflows.Runtime.Contracts;
 using Elsa.Workflows.Runtime.Filters;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Timer = Elsa.Scheduling.Activities.Timer;
 
@@ -13,37 +14,34 @@ namespace Elsa.Scheduling.HostedServices;
 /// </summary>
 public class CreateSchedulesHostedService : BackgroundService
 {
-    private readonly ITriggerStore _triggerStore;
-    private readonly IBookmarkStore _bookmarkStore;
-    private readonly ITriggerScheduler _triggerScheduler;
-    private readonly IBookmarkScheduler _bookmarkScheduler;
+    private readonly IServiceScopeFactory _scopeFactory;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CreateSchedulesHostedService"/> class.
     /// </summary>
-    public CreateSchedulesHostedService(
-        ITriggerStore triggerStore,
-        IBookmarkStore bookmarkStore,
-        ITriggerScheduler triggerScheduler,
-        IBookmarkScheduler bookmarkScheduler)
+    public CreateSchedulesHostedService(IServiceScopeFactory scopeFactory
+)
     {
-        _triggerStore = triggerStore;
-        _bookmarkStore = bookmarkStore;
-        _triggerScheduler = triggerScheduler;
-        _bookmarkScheduler = bookmarkScheduler;
+        _scopeFactory = scopeFactory;
     }
 
     /// <inheritdoc />
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
+        using var scope = _scopeFactory.CreateScope();
+        var triggerStore = scope.ServiceProvider.GetRequiredService<ITriggerStore>();
+        var bookmarkStore = scope.ServiceProvider.GetRequiredService<IBookmarkStore>();
+        var triggerScheduler = scope.ServiceProvider.GetRequiredService<ITriggerScheduler>();
+        var bookmarkScheduler = scope.ServiceProvider.GetRequiredService<IBookmarkScheduler>();
+
         var activityTypes = new[] { typeof(Cron), typeof(Timer), typeof(StartAt), typeof(Delay) };
         var activityTypeNames = activityTypes.Select(ActivityTypeNameHelper.GenerateTypeName).ToList();
         var triggerFilter = new TriggerFilter { Names = activityTypeNames };
         var bookmarkFilter = new BookmarkFilter { ActivityTypeNames = activityTypeNames };
-        var triggers = (await _triggerStore.FindManyAsync(triggerFilter, stoppingToken)).ToList();
-        var bookmarks = (await _bookmarkStore.FindManyAsync(bookmarkFilter, stoppingToken)).ToList();
+        var triggers = (await triggerStore.FindManyAsync(triggerFilter, stoppingToken)).ToList();
+        var bookmarks = (await bookmarkStore.FindManyAsync(bookmarkFilter, stoppingToken)).ToList();
 
-        await _triggerScheduler.ScheduleAsync(triggers, stoppingToken);
-        await _bookmarkScheduler.ScheduleAsync(bookmarks, stoppingToken);
+        await triggerScheduler.ScheduleAsync(triggers, stoppingToken);
+        await bookmarkScheduler.ScheduleAsync(bookmarks, stoppingToken);
     }
 }

--- a/src/modules/Elsa.Scheduling/ScheduledTasks/ScheduledRecurringTask.cs
+++ b/src/modules/Elsa.Scheduling/ScheduledTasks/ScheduledRecurringTask.cs
@@ -2,6 +2,7 @@ using Elsa.Common.Contracts;
 using Elsa.Mediator.Contracts;
 using Elsa.Scheduling.Commands;
 using Elsa.Scheduling.Contracts;
+using Microsoft.Extensions.DependencyInjection;
 using Timer = System.Timers.Timer;
 
 namespace Elsa.Scheduling.ScheduledTasks;
@@ -13,8 +14,8 @@ public class ScheduledRecurringTask : IScheduledTask
 {
     private readonly ITask _task;
     private readonly ISystemClock _systemClock;
+    private readonly IServiceScopeFactory _scopeFactory;
     private readonly TimeSpan _interval;
-    private readonly ICommandSender _commandSender;
     private readonly CancellationTokenSource _cancellationTokenSource;
     private DateTimeOffset _startAt;
     private Timer? _timer;
@@ -25,15 +26,15 @@ public class ScheduledRecurringTask : IScheduledTask
     /// <param name="task">The task to execute.</param>
     /// <param name="startAt">The instant at which to start executing the task.</param>
     /// <param name="interval">The interval at which to execute the task.</param>
-    /// <param name="commandSender">The command sender.</param>
     /// <param name="systemClock">The system clock.</param>
-    public ScheduledRecurringTask(ITask task, DateTimeOffset startAt, TimeSpan interval, ICommandSender commandSender, ISystemClock systemClock)
+    /// <param name="scopeFactory">Scope factory to create the scope and get dependancies.</param>
+    public ScheduledRecurringTask(ITask task, DateTimeOffset startAt, TimeSpan interval, ISystemClock systemClock, IServiceScopeFactory scopeFactory)
     {
         _task = task;
         _systemClock = systemClock;
+        _scopeFactory = scopeFactory;
         _startAt = startAt;
         _interval = interval;
-        _commandSender = commandSender;
         _cancellationTokenSource = new CancellationTokenSource();
 
         Schedule();
@@ -69,8 +70,8 @@ public class ScheduledRecurringTask : IScheduledTask
 
     private void SetupTimer(TimeSpan delay)
     {
-        if(delay < TimeSpan.Zero) delay = TimeSpan.FromSeconds(1);
-        
+        if (delay < TimeSpan.Zero) delay = TimeSpan.FromSeconds(1);
+
         _timer = new Timer(delay.TotalMilliseconds) { Enabled = true };
 
         _timer.Elapsed += async (_, _) =>
@@ -79,8 +80,11 @@ public class ScheduledRecurringTask : IScheduledTask
             _timer = null;
             _startAt = _systemClock.UtcNow + _interval;
 
+            using var scope = _scopeFactory.CreateScope();
+            var commandSender = scope.ServiceProvider.GetRequiredService<ICommandSender>();
+
             var cancellationToken = _cancellationTokenSource.Token;
-            if (!cancellationToken.IsCancellationRequested) await _commandSender.SendAsync(new RunScheduledTask(_task), cancellationToken);
+            if (!cancellationToken.IsCancellationRequested) await commandSender.SendAsync(new RunScheduledTask(_task), cancellationToken);
             if (!cancellationToken.IsCancellationRequested) Schedule();
         };
     }

--- a/src/modules/Elsa.Scheduling/ScheduledTasks/ScheduledSpecificInstantTask.cs
+++ b/src/modules/Elsa.Scheduling/ScheduledTasks/ScheduledSpecificInstantTask.cs
@@ -2,6 +2,7 @@ using Elsa.Common.Contracts;
 using Elsa.Mediator.Contracts;
 using Elsa.Scheduling.Commands;
 using Elsa.Scheduling.Contracts;
+using Microsoft.Extensions.DependencyInjection;
 using Timer = System.Timers.Timer;
 
 namespace Elsa.Scheduling.ScheduledTasks;
@@ -13,20 +14,20 @@ public class ScheduledSpecificInstantTask : IScheduledTask
 {
     private readonly ITask _task;
     private readonly ISystemClock _systemClock;
+    private readonly IServiceScopeFactory _scopeFactory;
     private readonly DateTimeOffset _startAt;
-    private readonly ICommandSender _commandSender;
     private readonly CancellationTokenSource _cancellationTokenSource;
     private Timer? _timer;
 
     /// <summary>
     /// Initializes a new instance of <see cref="ScheduledSpecificInstantTask"/>.
     /// </summary>
-    public ScheduledSpecificInstantTask(ITask task, DateTimeOffset startAt, ICommandSender commandSender, ISystemClock systemClock)
+    public ScheduledSpecificInstantTask(ITask task, DateTimeOffset startAt, ISystemClock systemClock, IServiceScopeFactory scopeFactory)
     {
         _task = task;
         _systemClock = systemClock;
+        _scopeFactory = scopeFactory;
         _startAt = startAt;
-        _commandSender = commandSender;
         _cancellationTokenSource = new CancellationTokenSource();
 
         Schedule();
@@ -50,9 +51,12 @@ public class ScheduledSpecificInstantTask : IScheduledTask
             _timer?.Dispose();
             _timer = null;
 
+            using var scope = _scopeFactory.CreateScope();
+            var commandSender = scope.ServiceProvider.GetRequiredService<ICommandSender>();
+
             var cancellationToken = _cancellationTokenSource.Token;
             if (!cancellationToken.IsCancellationRequested)
-                await _commandSender.SendAsync(new RunScheduledTask(_task), cancellationToken);
+                await commandSender.SendAsync(new RunScheduledTask(_task), cancellationToken);
         };
     }
 }

--- a/src/modules/Elsa.Webhooks/Features/WebhooksFeature.cs
+++ b/src/modules/Elsa.Webhooks/Features/WebhooksFeature.cs
@@ -67,7 +67,7 @@ public class WebhooksFeature : FeatureBase
             .AddScoped<BackgroundWebhookDispatcher>()
             .AddScoped(WebhookDispatcher)
             .AddScoped<IWebhookRegistrationService, DefaultWebhookRegistrationService>()
-            .AddScoped<IWebhookRegistrationProvider, OptionsWebhookRegistrationProvider>();
+            .AddSingleton<IWebhookRegistrationProvider, OptionsWebhookRegistrationProvider>();
 
         Services.Configure(WebhookOptions);
 

--- a/src/modules/Elsa.Webhooks/Features/WebhooksFeature.cs
+++ b/src/modules/Elsa.Webhooks/Features/WebhooksFeature.cs
@@ -64,10 +64,10 @@ public class WebhooksFeature : FeatureBase
     {
         Services
             .AddHandlersFrom<WebhooksFeature>()
-            .AddSingleton<BackgroundWebhookDispatcher>()
-            .AddSingleton(WebhookDispatcher)
-            .AddSingleton<IWebhookRegistrationService, DefaultWebhookRegistrationService>()
-            .AddSingleton<IWebhookRegistrationProvider, OptionsWebhookRegistrationProvider>();
+            .AddScoped<BackgroundWebhookDispatcher>()
+            .AddScoped(WebhookDispatcher)
+            .AddScoped<IWebhookRegistrationService, DefaultWebhookRegistrationService>()
+            .AddScoped<IWebhookRegistrationProvider, OptionsWebhookRegistrationProvider>();
 
         Services.Configure(WebhookOptions);
 

--- a/src/modules/Elsa.WorkflowContexts/Extensions/DependencyInjectionExtensions.cs
+++ b/src/modules/Elsa.WorkflowContexts/Extensions/DependencyInjectionExtensions.cs
@@ -17,6 +17,6 @@ public static class DependencyInjectionExtensions
     /// <returns>The service collection.</returns>
     public static IServiceCollection AddWorkflowContextProvider<T>(this IServiceCollection services) where T : class, IWorkflowContextProvider
     {
-        return services.AddSingleton<IWorkflowContextProvider, T>();
+        return services.AddScoped<IWorkflowContextProvider, T>();
     }
 }

--- a/src/modules/Elsa.WorkflowProviders.BlobStorage/Features/BlobStorageFeature.cs
+++ b/src/modules/Elsa.WorkflowProviders.BlobStorage/Features/BlobStorageFeature.cs
@@ -31,7 +31,7 @@ public class BlobStorageFeature : FeatureBase
     /// <inheritdoc />
     public override void Apply()
     {
-        Services.AddSingleton<IBlobStorageProvider>(sp => new BlobStorageProvider(BlobStorage(sp)));
+        Services.AddScoped<IBlobStorageProvider>(sp => new BlobStorageProvider(BlobStorage(sp)));
         Services.AddWorkflowDefinitionProvider<BlobStorageWorkflowProvider>();
     }
 

--- a/src/modules/Elsa.Workflows.Api/Features/WorkflowsApiFeature.cs
+++ b/src/modules/Elsa.Workflows.Api/Features/WorkflowsApiFeature.cs
@@ -35,7 +35,7 @@ public class WorkflowsApiFeature : FeatureBase
     /// <inheritdoc />
     public override void Apply()
     {
-        Services.AddSingleton<ISerializationOptionsConfigurator, SerializationConfigurator>();
+        Services.AddScoped<ISerializationOptionsConfigurator, SerializationConfigurator>();
         Module.AddFastEndpointsFromModule();
     }
 }

--- a/src/modules/Elsa.Workflows.Core/Extensions/ModuleExtensions.cs
+++ b/src/modules/Elsa.Workflows.Core/Extensions/ModuleExtensions.cs
@@ -16,6 +16,6 @@ public static class ModuleExtensions
 
     public static IServiceCollection AddStorageDriver<T>(this IServiceCollection services) where T : class, IStorageDriver
     {
-        return services.AddSingleton<IStorageDriver, T>();
+        return services.AddScoped<IStorageDriver, T>();
     }
 }

--- a/src/modules/Elsa.Workflows.Core/Features/FlowchartFeature.cs
+++ b/src/modules/Elsa.Workflows.Core/Features/FlowchartFeature.cs
@@ -19,6 +19,6 @@ public class FlowchartFeature : FeatureBase
     /// <inheritdoc />
     public override void Apply()
     {
-        Services.AddSingleton<ISerializationOptionsConfigurator, FlowchartSerializationOptionConfigurator>();
+        Services.AddScoped<ISerializationOptionsConfigurator, FlowchartSerializationOptionConfigurator>();
     }
 }

--- a/src/modules/Elsa.Workflows.Core/Features/WorkflowsFeature.cs
+++ b/src/modules/Elsa.Workflows.Core/Features/WorkflowsFeature.cs
@@ -119,62 +119,62 @@ public class WorkflowsFeature : FeatureBase
         services
 
             // Core.
-            .AddSingleton<IActivityInvoker, ActivityInvoker>()
-            .AddSingleton<IWorkflowRunner, WorkflowRunner>()
-            .AddSingleton<IActivityVisitor, ActivityVisitor>()
-            .AddSingleton<IIdentityGraphService, IdentityGraphService>()
-            .AddSingleton<IWorkflowStateExtractor, WorkflowStateExtractor>()
-            .AddSingleton<IActivitySchedulerFactory, ActivitySchedulerFactory>()
-            .AddSingleton<IHasher, Hasher>()
-            .AddSingleton<IBookmarkHasher, BookmarkHasher>()
-            .AddSingleton(IdentityGenerator)
-            .AddSingleton<IBookmarkPayloadSerializer>(sp => ActivatorUtilities.CreateInstance<BookmarkPayloadSerializer>(sp))
+            .AddScoped<IActivityInvoker, ActivityInvoker>()
+            .AddScoped<IWorkflowRunner, WorkflowRunner>()
+            .AddScoped<IActivityVisitor, ActivityVisitor>()
+            .AddScoped<IIdentityGraphService, IdentityGraphService>()
+            .AddScoped<IWorkflowStateExtractor, WorkflowStateExtractor>()
+            .AddScoped<IActivitySchedulerFactory, ActivitySchedulerFactory>()
+            .AddScoped<IHasher, Hasher>()
+            .AddScoped<IBookmarkHasher, BookmarkHasher>()
+            .AddScoped(IdentityGenerator)
+            .AddScoped<IBookmarkPayloadSerializer>(sp => ActivatorUtilities.CreateInstance<BookmarkPayloadSerializer>(sp))
             .AddSingleton<IActivityDescriber, ActivityDescriber>()
             .AddSingleton<IActivityRegistry, ActivityRegistry>()
             .AddSingleton<IPropertyDefaultValueResolver, PropertyDefaultValueResolver>()
             .AddSingleton<IPropertyOptionsResolver, PropertyOptionsResolver>()
             .AddSingleton<IActivityFactory, ActivityFactory>()
             .AddTransient<WorkflowBuilder>()
-            .AddSingleton(typeof(Func<IWorkflowBuilder>), sp => () => sp.GetRequiredService<WorkflowBuilder>())
-            .AddSingleton<IWorkflowBuilderFactory, WorkflowBuilderFactory>()
-            .AddSingleton<IVariablePersistenceManager, VariablePersistenceManager>()
-            .AddSingleton<IIncidentStrategyResolver, DefaultIncidentStrategyResolver>()
+            .AddScoped(typeof(Func<IWorkflowBuilder>), sp => () => sp.GetRequiredService<WorkflowBuilder>())
+            .AddScoped<IWorkflowBuilderFactory, WorkflowBuilderFactory>()
+            .AddScoped<IVariablePersistenceManager, VariablePersistenceManager>()
+            .AddScoped<IIncidentStrategyResolver, DefaultIncidentStrategyResolver>()
 
             // Incident Strategies.
             .AddTransient<IIncidentStrategy, FaultStrategy>()
             .AddTransient<IIncidentStrategy, ContinueWithIncidentsStrategy>()
 
             // Pipelines.
-            .AddSingleton<IActivityExecutionPipeline>(sp => new ActivityExecutionPipeline(sp, ActivityExecutionPipeline))
-            .AddSingleton<IWorkflowExecutionPipeline>(sp => new WorkflowExecutionPipeline(sp, WorkflowExecutionPipeline))
+            .AddScoped<IActivityExecutionPipeline>(sp => new ActivityExecutionPipeline(sp, ActivityExecutionPipeline))
+            .AddScoped<IWorkflowExecutionPipeline>(sp => new WorkflowExecutionPipeline(sp, WorkflowExecutionPipeline))
 
             // Built-in activity services.
-            .AddSingleton<IActivityResolver, PropertyBasedActivityResolver>()
-            .AddSingleton<IActivityResolver, SwitchActivityResolver>()
-            .AddSingleton<ISerializationOptionsConfigurator, AdditionalConvertersConfigurator>()
-            .AddSingleton<ISerializationOptionsConfigurator, CustomConstructorConfigurator>()
+            .AddScoped<IActivityResolver, PropertyBasedActivityResolver>()
+            .AddScoped<IActivityResolver, SwitchActivityResolver>()
+            .AddScoped<ISerializationOptionsConfigurator, AdditionalConvertersConfigurator>()
+            .AddScoped<ISerializationOptionsConfigurator, CustomConstructorConfigurator>()
 
             // Domain event handlers.
             .AddHandlersFrom<WorkflowsFeature>()
 
             // Stream providers.
-            .AddSingleton(StandardInStreamProvider)
-            .AddSingleton(StandardOutStreamProvider)
+            .AddScoped(StandardInStreamProvider)
+            .AddScoped(StandardOutStreamProvider)
 
             // Storage drivers.
-            .AddSingleton<IStorageDriverManager, StorageDriverManager>()
+            .AddScoped<IStorageDriverManager, StorageDriverManager>()
             .AddStorageDriver<WorkflowStorageDriver>()
             .AddStorageDriver<MemoryStorageDriver>()
 
             // Serialization.
-            .AddSingleton<IWorkflowStateSerializer, JsonWorkflowStateSerializer>()
-            .AddSingleton<IPayloadSerializer, JsonPayloadSerializer>()
-            .AddSingleton<IActivitySerializer, JsonActivitySerializer>()
-            .AddSingleton<IApiSerializer, ApiSerializer>()
-            .AddSingleton<ISafeSerializer, SafeSerializer>()
+            .AddScoped<IWorkflowStateSerializer, JsonWorkflowStateSerializer>()
+            .AddScoped<IPayloadSerializer, JsonPayloadSerializer>()
+            .AddScoped<IActivitySerializer, JsonActivitySerializer>()
+            .AddScoped<IApiSerializer, ApiSerializer>()
+            .AddScoped<ISafeSerializer, SafeSerializer>()
 
             // Instantiation strategies.
-            .AddSingleton<IWorkflowActivationStrategy, AllowAlwaysStrategy>()
+            .AddScoped<IWorkflowActivationStrategy, AllowAlwaysStrategy>()
 
             // Logging
             .AddLogging();

--- a/src/modules/Elsa.Workflows.Management/Extensions/ServiceCollectionExtensions.cs
+++ b/src/modules/Elsa.Workflows.Management/Extensions/ServiceCollectionExtensions.cs
@@ -11,5 +11,5 @@ public static class ServiceCollectionExtensions
     /// <summary>
     /// Registers a <see cref="IActivityProvider"/>.
     /// </summary>
-    public static IServiceCollection AddActivityProvider<T>(this IServiceCollection services) where T : class, IActivityProvider => services.AddSingleton<IActivityProvider, T>();
+    public static IServiceCollection AddActivityProvider<T>(this IServiceCollection services) where T : class, IActivityProvider => services.AddScoped<IActivityProvider, T>();
 }

--- a/src/modules/Elsa.Workflows.Management/Features/WorkflowDefinitionsFeature.cs
+++ b/src/modules/Elsa.Workflows.Management/Features/WorkflowDefinitionsFeature.cs
@@ -24,6 +24,6 @@ public class WorkflowDefinitionsFeature : FeatureBase
     /// <inheritdoc />
     public override void Apply()
     {
-        Services.AddSingleton(WorkflowDefinitionStore);
+        Services.AddScoped(WorkflowDefinitionStore);
     }
 }

--- a/src/modules/Elsa.Workflows.Management/Features/WorkflowInstancesFeature.cs
+++ b/src/modules/Elsa.Workflows.Management/Features/WorkflowInstancesFeature.cs
@@ -24,6 +24,6 @@ public class WorkflowInstancesFeature : FeatureBase
     /// <inheritdoc />
     public override void Apply()
     {
-        Services.AddSingleton(WorkflowInstanceStore);
+        Services.AddScoped(WorkflowInstanceStore);
     }
 }

--- a/src/modules/Elsa.Workflows.Management/Features/WorkflowManagementFeature.cs
+++ b/src/modules/Elsa.Workflows.Management/Features/WorkflowManagementFeature.cs
@@ -1,6 +1,3 @@
-using System.ComponentModel;
-using System.Dynamic;
-using System.Reflection;
 using Elsa.Common.Contracts;
 using Elsa.Common.Features;
 using Elsa.Expressions.Contracts;
@@ -22,6 +19,9 @@ using Elsa.Workflows.Management.Serialization;
 using Elsa.Workflows.Management.Services;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
+using System.ComponentModel;
+using System.Dynamic;
+using System.Reflection;
 
 namespace Elsa.Workflows.Management.Features;
 
@@ -156,25 +156,25 @@ public class WorkflowManagementFeature : FeatureBase
             .AddMemoryStore<WorkflowDefinition, MemoryWorkflowDefinitionStore>()
             .AddMemoryStore<WorkflowInstance, MemoryWorkflowInstanceStore>()
             .AddActivityProvider<TypedActivityProvider>()
-            .AddSingleton<IWorkflowDefinitionService, WorkflowDefinitionService>()
-            .AddSingleton<IWorkflowSerializer, WorkflowSerializer>()
-            .AddSingleton<IWorkflowValidator, WorkflowValidator>()
-            .AddSingleton<IWorkflowDefinitionPublisher, WorkflowDefinitionPublisher>()
-            .AddSingleton<IWorkflowDefinitionImporter, WorkflowDefinitionImporter>()
-            .AddSingleton<IWorkflowDefinitionManager, WorkflowDefinitionManager>()
-            .AddSingleton<IWorkflowInstanceManager, WorkflowInstanceManager>()
-            .AddSingleton<IActivityRegistryPopulator, ActivityRegistryPopulator>()
+            .AddScoped<IWorkflowDefinitionService, WorkflowDefinitionService>()
+            .AddScoped<IWorkflowSerializer, WorkflowSerializer>()
+            .AddScoped<IWorkflowValidator, WorkflowValidator>()
+            .AddScoped<IWorkflowDefinitionPublisher, WorkflowDefinitionPublisher>()
+            .AddScoped<IWorkflowDefinitionImporter, WorkflowDefinitionImporter>()
+            .AddScoped<IWorkflowDefinitionManager, WorkflowDefinitionManager>()
+            .AddScoped<IWorkflowInstanceManager, WorkflowInstanceManager>()
+            .AddScoped<IActivityRegistryPopulator, ActivityRegistryPopulator>()
             .AddSingleton<IExpressionDescriptorRegistry, ExpressionDescriptorRegistry>()
-            .AddSingleton<IExpressionDescriptorProvider, DefaultExpressionDescriptorProvider>()
-            .AddSingleton<IExpressionDescriptorRegistryPopulator, ExpressionDescriptorRegistryPopulator>()
-            .AddSingleton<ISerializationOptionsConfigurator, SerializationOptionsConfigurator>()
-            .AddSingleton<IWorkflowMaterializer, ClrWorkflowMaterializer>()
-            .AddSingleton<IWorkflowMaterializer, JsonWorkflowMaterializer>()
-            .AddSingleton<IActivityResolver, WorkflowDefinitionActivityResolver>()
+            .AddScoped<IExpressionDescriptorProvider, DefaultExpressionDescriptorProvider>()
+            .AddScoped<IExpressionDescriptorRegistryPopulator, ExpressionDescriptorRegistryPopulator>()
+            .AddScoped<ISerializationOptionsConfigurator, SerializationOptionsConfigurator>()
+            .AddScoped<IWorkflowMaterializer, ClrWorkflowMaterializer>()
+            .AddScoped<IWorkflowMaterializer, JsonWorkflowMaterializer>()
+            .AddScoped<IActivityResolver, WorkflowDefinitionActivityResolver>()
             .AddActivityProvider<WorkflowDefinitionActivityProvider>()
-            .AddSingleton<WorkflowDefinitionMapper>()
-            .AddSingleton<VariableDefinitionMapper>()
-            .AddSingleton<WorkflowStateMapper>()
+            .AddScoped<WorkflowDefinitionMapper>()
+            .AddScoped<VariableDefinitionMapper>()
+            .AddScoped<WorkflowStateMapper>()
             ;
 
         Services.AddNotificationHandlersFrom(GetType());

--- a/src/modules/Elsa.Workflows.Runtime/Extensions/DependencyInjectionExtensions.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Extensions/DependencyInjectionExtensions.cs
@@ -15,5 +15,5 @@ public static class DependencyInjectionExtensions
     /// <param name="services">The service collection.</param>
     /// <typeparam name="T">The type of the workflow definition provider.</typeparam>
     /// <returns>The service collection.</returns>
-    public static IServiceCollection AddWorkflowDefinitionProvider<T>(this IServiceCollection services) where T : class, IWorkflowProvider => services.AddSingleton<IWorkflowProvider, T>();
+    public static IServiceCollection AddWorkflowDefinitionProvider<T>(this IServiceCollection services) where T : class, IWorkflowProvider => services.AddScoped<IWorkflowProvider, T>();
 }

--- a/src/modules/Elsa.Workflows.Runtime/Features/WorkflowRuntimeFeature.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Features/WorkflowRuntimeFeature.cs
@@ -146,38 +146,38 @@ public class WorkflowRuntimeFeature : FeatureBase
 
         Services
             // Core.
-            .AddSingleton<ITriggerIndexer, TriggerIndexer>()
-            .AddSingleton<IWorkflowInstanceFactory, WorkflowInstanceFactory>()
-            .AddSingleton<IWorkflowHostFactory, WorkflowHostFactory>()
-            .AddSingleton<IBackgroundActivityInvoker, DefaultBackgroundActivityInvoker>()
-            .AddSingleton(WorkflowRuntime)
-            .AddSingleton(WorkflowDispatcher)
-            .AddSingleton(BookmarkStore)
-            .AddSingleton(TriggerStore)
-            .AddSingleton(WorkflowExecutionLogStore)
-            .AddSingleton(ActivityExecutionLogStore)
-            .AddSingleton(WorkflowInboxStore)
-            .AddSingleton(RunTaskDispatcher)
-            .AddSingleton(BackgroundActivityInvoker)
-            .AddSingleton<IBookmarkManager, DefaultBookmarkManager>()
-            .AddSingleton<IActivityExecutionManager, DefaultActivityExecutionManager>()
-            .AddSingleton<IActivityExecutionStatsService, ActivityExecutionStatsService>()
-            .AddSingleton<IActivityExecutionMapper, DefaultActivityExecutionMapper>()
-            .AddSingleton<IWorkflowDefinitionStorePopulator, DefaultWorkflowDefinitionStorePopulator>()
-            .AddSingleton<IRegistriesPopulator, DefaultRegistriesPopulator>()
-            .AddSingleton<ITaskReporter, TaskReporter>()
-            .AddSingleton<SynchronousTaskDispatcher>()
-            .AddSingleton<BackgroundTaskDispatcher>()
-            .AddSingleton<IEventPublisher, EventPublisher>()
-            .AddSingleton<IWorkflowInbox, DefaultWorkflowInbox>()
+            .AddScoped<ITriggerIndexer, TriggerIndexer>()
+            .AddScoped<IWorkflowInstanceFactory, WorkflowInstanceFactory>()
+            .AddScoped<IWorkflowHostFactory, WorkflowHostFactory>()
+            .AddScoped<IBackgroundActivityInvoker, DefaultBackgroundActivityInvoker>()
+            .AddScoped(WorkflowRuntime)
+            .AddScoped(WorkflowDispatcher)
+            .AddScoped(BookmarkStore)
+            .AddScoped(TriggerStore)
+            .AddScoped(WorkflowExecutionLogStore)
+            .AddScoped(ActivityExecutionLogStore)
+            .AddScoped(WorkflowInboxStore)
+            .AddScoped(RunTaskDispatcher)
+            .AddScoped(BackgroundActivityInvoker)
+            .AddScoped<IBookmarkManager, DefaultBookmarkManager>()
+            .AddScoped<IActivityExecutionManager, DefaultActivityExecutionManager>()
+            .AddScoped<IActivityExecutionStatsService, ActivityExecutionStatsService>()
+            .AddScoped<IActivityExecutionMapper, DefaultActivityExecutionMapper>()
+            .AddScoped<IWorkflowDefinitionStorePopulator, DefaultWorkflowDefinitionStorePopulator>()
+            .AddScoped<IRegistriesPopulator, DefaultRegistriesPopulator>()
+            .AddScoped<ITaskReporter, TaskReporter>()
+            .AddScoped<SynchronousTaskDispatcher>()
+            .AddScoped<BackgroundTaskDispatcher>()
+            .AddScoped<IEventPublisher, EventPublisher>()
+            .AddScoped<IWorkflowInbox, DefaultWorkflowInbox>()
             
             // Lazy services.
-            .AddSingleton<Func<IEnumerable<IWorkflowProvider>>>(sp => sp.GetServices<IWorkflowProvider>)
-            .AddSingleton<Func<IEnumerable<IWorkflowMaterializer>>>(sp => sp.GetServices<IWorkflowMaterializer>)
+            .AddScoped<Func<IEnumerable<IWorkflowProvider>>>(sp => sp.GetServices<IWorkflowProvider>)
+            .AddScoped<Func<IEnumerable<IWorkflowMaterializer>>>(sp => sp.GetServices<IWorkflowMaterializer>)
 
             // Noop stores.
-            .AddSingleton<MemoryWorkflowExecutionLogStore>()
-            .AddSingleton<MemoryActivityExecutionStore>()
+            .AddScoped<MemoryWorkflowExecutionLogStore>()
+            .AddScoped<MemoryActivityExecutionStore>()
             
             // Memory stores.
             .AddMemoryStore<StoredBookmark, MemoryBookmarkStore>()
@@ -187,7 +187,7 @@ public class WorkflowRuntimeFeature : FeatureBase
             .AddMemoryStore<WorkflowInboxMessage, MemoryWorkflowInboxMessageStore>()
 
             // Distributed locking.
-            .AddSingleton(DistributedLockProvider)
+            .AddScoped(DistributedLockProvider)
 
             // Workflow definition providers.
             .AddWorkflowDefinitionProvider<ClrWorkflowProvider>()
@@ -207,9 +207,9 @@ public class WorkflowRuntimeFeature : FeatureBase
             .AddNotificationHandler<DeleteWorkflowExecutionLogRecords>()
 
             // Workflow activation strategies.
-            .AddSingleton<IWorkflowActivationStrategy, SingletonStrategy>()
-            .AddSingleton<IWorkflowActivationStrategy, CorrelatedSingletonStrategy>()
-            .AddSingleton<IWorkflowActivationStrategy, CorrelationStrategy>()
+            .AddScoped<IWorkflowActivationStrategy, SingletonStrategy>()
+            .AddScoped<IWorkflowActivationStrategy, CorrelatedSingletonStrategy>()
+            .AddScoped<IWorkflowActivationStrategy, CorrelationStrategy>()
             ;
     }
 }

--- a/src/modules/Elsa.Workflows.Runtime/HostedServices/PopulateRegistriesHostedService.cs
+++ b/src/modules/Elsa.Workflows.Runtime/HostedServices/PopulateRegistriesHostedService.cs
@@ -1,5 +1,6 @@
 using Elsa.Workflows.Core.Contracts;
 using Elsa.Workflows.Runtime.Contracts;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 namespace Elsa.Workflows.Runtime.HostedServices;
@@ -9,18 +10,23 @@ namespace Elsa.Workflows.Runtime.HostedServices;
 /// </summary>
 public class PopulateRegistriesHostedService : IHostedService
 {
-    private readonly IRegistriesPopulator _registriesPopulator;
+    private readonly IServiceScopeFactory _scopeFactory;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PopulateRegistriesHostedService"/> class.
     /// </summary>
-    public PopulateRegistriesHostedService(IRegistriesPopulator registriesPopulator)
+    public PopulateRegistriesHostedService(IServiceScopeFactory scopeFactory)
     {
-        _registriesPopulator = registriesPopulator;
+        _scopeFactory = scopeFactory;
     }
 
     /// <inheritdoc />
-    public async Task StartAsync(CancellationToken cancellationToken) => await _registriesPopulator.PopulateAsync(cancellationToken);
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var registriesPopulator = scope.ServiceProvider.GetRequiredService<IRegistriesPopulator>();
+        await registriesPopulator.PopulateAsync(cancellationToken);
+    }
 
     /// <inheritdoc />
     public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;

--- a/src/modules/Elsa.Workflows.Runtime/Services/ActivityExecutionService.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Services/ActivityExecutionService.cs
@@ -26,7 +26,7 @@ public class ActivityExecutionStatsService : IActivityExecutionStatsService
         var filter = new ActivityExecutionRecordFilter
         {
             WorkflowInstanceId = workflowInstanceId,
-            ActivityNodeIds = activityNodeIds.ToList()
+            ActivityNodeIds = activityNodeIds?.ToList()
         };
         var order = new ActivityExecutionRecordOrder<DateTimeOffset>(x => x.StartedAt, OrderDirection.Ascending);
         var records = (await _store.FindManyAsync(filter, order, cancellationToken)).ToList();

--- a/src/samples/aspnet/Elsa.Samples.AspNet.TelnyxIntegration/Program.cs
+++ b/src/samples/aspnet/Elsa.Samples.AspNet.TelnyxIntegration/Program.cs
@@ -74,7 +74,7 @@ services
     .AddJwtBearer(JwtBearerDefaults.AuthenticationScheme, identityTokenOptions.ConfigureJwtBearerOptions);
 
 services.AddHttpContextAccessor();
-services.AddSingleton<IAuthorizationHandler, LocalHostRequirementHandler>();
+services.AddScoped<IAuthorizationHandler, LocalHostRequirementHandler>();
 
 // Grant localhost requests security root privileges.
 services.AddAuthorization(options => options.AddPolicy(IdentityPolicyNames.SecurityRoot, policy => policy.AddRequirements(new LocalHostRequirement())));

--- a/src/samples/aspnet/Elsa.Samples.AspNet.WorkflowContexts/Program.cs
+++ b/src/samples/aspnet/Elsa.Samples.AspNet.WorkflowContexts/Program.cs
@@ -81,7 +81,7 @@ services.AddHealthChecks();
 services.AddCors(cors => cors.AddDefaultPolicy(policy => policy.AllowAnyHeader().AllowAnyMethod().AllowAnyOrigin()));
 
 // Add domain services.
-services.AddSingleton<ICustomerStore, MemoryCustomerStore>();
+services.AddScoped<ICustomerStore, MemoryCustomerStore>();
 
 // Add workflow context providers.
 services.AddWorkflowContextProvider<CustomerWorkflowContextProvider>();

--- a/test/integration/Elsa.IntegrationTests/Scenarios/ActivityNotificationsMiddleware/Tests.cs
+++ b/test/integration/Elsa.IntegrationTests/Scenarios/ActivityNotificationsMiddleware/Tests.cs
@@ -1,7 +1,9 @@
 using System.Threading.Tasks;
 using Elsa.Testing.Shared;
+using Elsa.Workflows.Core;
 using Elsa.Workflows.Core.Contracts;
 using Elsa.Workflows.Core.Notifications;
+using Elsa.Workflows.Core.State;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 using Xunit.Abstractions;

--- a/test/integration/Elsa.ServiceBus.IntegrationTests/Scenarios/ServiceBus/ServiceBusTests.cs
+++ b/test/integration/Elsa.ServiceBus.IntegrationTests/Scenarios/ServiceBus/ServiceBusTests.cs
@@ -41,16 +41,16 @@ public class ServiceBusTest : IDisposable
             {
                 services
                     .AddSingleton(_serviceBusClient)
-                    .AddScoped<IServiceBusProcessorManager, ServiceBusProcessorManager>()
-                    .AddScoped<IWorkerManager, WorkerManager>()
+                    .AddSingleton<IServiceBusProcessorManager, ServiceBusProcessorManager>()
+                    .AddSingleton<IWorkerManager, WorkerManager>()
                     .AddSingleton(_resetEventManager)
 
-                    .AddScoped(sp =>
+                    .AddSingleton(sp =>
                     {
                         var options = sp.GetRequiredService<IOptions<MediatorOptions>>().Value;
                         return ActivatorUtilities.CreateInstance<BackgroundCommandSenderHostedService>(sp, options.CommandWorkerCount);
                     })
-                    .AddScoped(sp =>
+                    .AddSingleton(sp =>
                     {
                         var options = sp.GetRequiredService<IOptions<MediatorOptions>>().Value;
                         return ActivatorUtilities.CreateInstance<BackgroundEventPublisherHostedService>(sp, options.NotificationWorkerCount);

--- a/test/integration/Elsa.ServiceBus.IntegrationTests/Scenarios/ServiceBus/ServiceBusTests.cs
+++ b/test/integration/Elsa.ServiceBus.IntegrationTests/Scenarios/ServiceBus/ServiceBusTests.cs
@@ -1,19 +1,19 @@
 using Azure.Messaging.ServiceBus;
 using Elsa.AzureServiceBus.Contracts;
 using Elsa.AzureServiceBus.Services;
-using Elsa.Testing.Shared;
-using Elsa.Workflows.Core;
-using Microsoft.Extensions.DependencyInjection;
-using Xunit.Abstractions;
 using Elsa.Mediator.HostedServices;
 using Elsa.Mediator.Options;
 using Elsa.ServiceBus.IntegrationTests.Contracts;
 using Elsa.ServiceBus.IntegrationTests.Helpers;
 using Elsa.ServiceBus.IntegrationTests.Scenarios.Workflows;
-using Microsoft.Extensions.Options;
-using Elsa.Workflows.Runtime.Options;
+using Elsa.Testing.Shared;
+using Elsa.Workflows.Core;
 using Elsa.Workflows.Runtime.Contracts;
+using Elsa.Workflows.Runtime.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using NSubstitute;
+using Xunit.Abstractions;
 
 namespace Elsa.ServiceBus.IntegrationTests.Scenarios.ServiceBus;
 
@@ -41,16 +41,16 @@ public class ServiceBusTest : IDisposable
             {
                 services
                     .AddSingleton(_serviceBusClient)
-                    .AddSingleton<IServiceBusProcessorManager, ServiceBusProcessorManager>()
-                    .AddSingleton<IWorkerManager, WorkerManager>()
+                    .AddScoped<IServiceBusProcessorManager, ServiceBusProcessorManager>()
+                    .AddScoped<IWorkerManager, WorkerManager>()
                     .AddSingleton(_resetEventManager)
 
-                    .AddSingleton(sp =>
+                    .AddScoped(sp =>
                     {
                         var options = sp.GetRequiredService<IOptions<MediatorOptions>>().Value;
                         return ActivatorUtilities.CreateInstance<BackgroundCommandSenderHostedService>(sp, options.CommandWorkerCount);
                     })
-                    .AddSingleton(sp =>
+                    .AddScoped(sp =>
                     {
                         var options = sp.GetRequiredService<IOptions<MediatorOptions>>().Value;
                         return ActivatorUtilities.CreateInstance<BackgroundEventPublisherHostedService>(sp, options.NotificationWorkerCount);
@@ -254,7 +254,7 @@ public class ServiceBusTest : IDisposable
     {
         var correlationId = "EEE3D9CC-2279-4CE5-8F4F-FC6C65BF8814";
         _sbProcessorManager.Init("topicName", "subscriptionName");
-            
+
         //Init waitEvent :
         _resetEventManager.Init("receive1");
 
@@ -319,7 +319,7 @@ public class ServiceBusTest : IDisposable
     public async Task Receive_1_Message_Should_Not_Trigger()
     {
         _sbProcessorManager.Init("topicName1", "subscriptionName1");
-            
+
         // Init waitEvent:
         _resetEventManager.Init("receive1");
         _resetEventManager.Init("receive2");


### PR DESCRIPTION
Change the lifetime of dependancies to use scoped one to prepare the multitenant pull request (to avoid sharing most dependancies like store, dbContext, etc. I kept some in singleton like memory store, registries to avoid loose datas that are added once in hosted services.