### PR TITLE
Features : Allow Customization of DbContext  Schema

### DIFF
--- a/src/modules/Elsa.EntityFrameworkCore.Common/Contracts/IElsaDbContextSchema.cs
+++ b/src/modules/Elsa.EntityFrameworkCore.Common/Contracts/IElsaDbContextSchema.cs
@@ -1,0 +1,12 @@
+﻿namespace Elsa.EntityFrameworkCore.Common.Contracts;
+
+/// <summary>
+/// Interface to provide custom Elsa Db Context Schema in Migration
+/// </summary>
+public interface IElsaDbContextSchema
+{
+    /// <summary>
+    /// Name of the Schema
+    /// </summary>
+    public string Schema { get; }
+}

--- a/src/modules/Elsa.EntityFrameworkCore.Common/DbSchemaAwareMigrationAssembly.cs
+++ b/src/modules/Elsa.EntityFrameworkCore.Common/DbSchemaAwareMigrationAssembly.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations.Internal;
+using Microsoft.EntityFrameworkCore.Migrations;
+using System.Reflection;
+using Elsa.EntityFrameworkCore.Common.Contracts;
+
+namespace Elsa.EntityFrameworkCore.Common;
+
+/// <summary>
+/// Class That enable Schema change for Migration
+/// </summary>
+public class DbSchemaAwareMigrationAssembly : MigrationsAssembly
+{
+    private readonly DbContext _context;
+
+    public DbSchemaAwareMigrationAssembly(ICurrentDbContext currentContext,
+          IDbContextOptions options, IMigrationsIdGenerator idGenerator,
+          IDiagnosticsLogger<DbLoggerCategory.Migrations> logger)
+      : base(currentContext, options, idGenerator, logger)
+    {
+        _context = currentContext.Context;
+    }
+
+    public override Migration CreateMigration(TypeInfo migrationClass,
+          string activeProvider)
+    {
+        if (activeProvider == null)
+            throw new ArgumentNullException(nameof(activeProvider));
+
+        var hasCtorWithSchema = migrationClass
+                .GetConstructor(new[] { typeof(IElsaDbContextSchema) }) != null;
+
+        if (hasCtorWithSchema && _context is IElsaDbContextSchema schema)
+        {
+            var instance = (Migration)Activator.CreateInstance(migrationClass.AsType(), schema);
+            instance.ActiveProvider = activeProvider;
+            return instance;
+        }
+
+        return base.CreateMigration(migrationClass, activeProvider);
+    }
+}

--- a/src/modules/Elsa.EntityFrameworkCore.Common/ElsaDbContextBase.cs
+++ b/src/modules/Elsa.EntityFrameworkCore.Common/ElsaDbContextBase.cs
@@ -1,19 +1,21 @@
-﻿using Elsa.EntityFrameworkCore.Extensions;
+﻿using Elsa.EntityFrameworkCore.Common.Contracts;
+using Elsa.EntityFrameworkCore.Extensions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Elsa.EntityFrameworkCore.Common;
-
 /// <summary>
 /// An optional base class to implement with some opinions on certain converters to install for certain DB providers.
 /// </summary>
-public abstract class ElsaDbContextBase : DbContext
+public abstract class ElsaDbContextBase : DbContext, IElsaDbContextSchema
 {
     /// <summary>
-    /// The schema used by Elsa.
+    /// The default schema used by Elsa.
     /// </summary>
     public static string ElsaSchema { get; set;  } = "Elsa";
-
+    private string _schema;
+    /// <inheritdoc/>
+    public string Schema => _schema;
     /// <summary>
     /// The table used to store the migrations history.
     /// </summary>
@@ -25,15 +27,15 @@ public abstract class ElsaDbContextBase : DbContext
     protected ElsaDbContextBase(DbContextOptions options) : base(options)
     {
         var elsaDbContextOptions = options.FindExtension<ElsaDbContextOptionsExtension>()?.Options;
-        
+
         // ReSharper disable once VirtualMemberCallInConstructor
-        Schema = !string.IsNullOrWhiteSpace(elsaDbContextOptions?.SchemaName) ? elsaDbContextOptions.SchemaName : ElsaSchema;
+        _schema = !string.IsNullOrWhiteSpace(elsaDbContextOptions?.SchemaName) ? elsaDbContextOptions.SchemaName : ElsaSchema;
     }
 
     /// <summary>
     /// The schema used by Elsa.
     /// </summary>
-    protected virtual string Schema { get; set; }
+   // protected virtual string Schema { get; set; }
 
     /// <inheritdoc />
     protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/src/modules/Elsa.EntityFrameworkCore.Common/ElsaDbContextOptionsExtension.cs
+++ b/src/modules/Elsa.EntityFrameworkCore.Common/ElsaDbContextOptionsExtension.cs
@@ -33,9 +33,6 @@ public class ElsaDbContextOptionsExtension : IDbContextOptionsExtension
     /// <inheritdoc />
     public void Validate(IDbContextOptions options)
     {
-        if(!string.IsNullOrWhiteSpace(Options?.SchemaName) && string.IsNullOrWhiteSpace(Options.MigrationsAssemblyName))
-        {
-            throw new ArgumentException("MigrationsAssemblyName must be defined for manual migrations");
-        }
+
     }
 }

--- a/src/modules/Elsa.EntityFrameworkCore.Common/ElsaDbContextOptionsExtensions.cs
+++ b/src/modules/Elsa.EntityFrameworkCore.Common/ElsaDbContextOptionsExtensions.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace Elsa.EntityFrameworkCore.Common;
 
@@ -17,6 +18,7 @@ public static class ElsaDbContextOptionsExtensions
     public static DbContextOptionsBuilder UseElsaDbContextOptions(this DbContextOptionsBuilder optionsBuilder, ElsaDbContextOptions? options)
     {
         ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(new ElsaDbContextOptionsExtension(options));
+        optionsBuilder.ReplaceService<IMigrationsAssembly, DbSchemaAwareMigrationAssembly>();
         return optionsBuilder;
     }
 

--- a/src/modules/Elsa.EntityFrameworkCore.MySql/Migrations/Alterations/20231015122151_Initial.cs
+++ b/src/modules/Elsa.EntityFrameworkCore.MySql/Migrations/Alterations/20231015122151_Initial.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Elsa.EntityFrameworkCore.Common.Contracts;
 using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
@@ -8,18 +9,23 @@ namespace Elsa.EntityFrameworkCore.MySql.Migrations.Alterations
     /// <inheritdoc />
     public partial class Initial : Migration
     {
+        private readonly IElsaDbContextSchema _schema;
+        public Initial(IElsaDbContextSchema schema)
+        {
+            _schema = schema ?? throw new ArgumentNullException(nameof(schema));
+        }
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.EnsureSchema(
-                name: "Elsa");
+                name: _schema.Schema);
 
             migrationBuilder.AlterDatabase()
                 .Annotation("MySql:CharSet", "utf8mb4");
 
             migrationBuilder.CreateTable(
                 name: "AlterationJobs",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "varchar(255)", nullable: false)
@@ -43,7 +49,7 @@ namespace Elsa.EntityFrameworkCore.MySql.Migrations.Alterations
 
             migrationBuilder.CreateTable(
                 name: "AlterationPlans",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "varchar(255)", nullable: false)
@@ -65,61 +71,61 @@ namespace Elsa.EntityFrameworkCore.MySql.Migrations.Alterations
 
             migrationBuilder.CreateIndex(
                 name: "IX_AlterationJob_CompletedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "AlterationJobs",
                 column: "CompletedAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_AlterationJob_CreatedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "AlterationJobs",
                 column: "CreatedAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_AlterationJob_PlanId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "AlterationJobs",
                 column: "PlanId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_AlterationJob_StartedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "AlterationJobs",
                 column: "StartedAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_AlterationJob_Status",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "AlterationJobs",
                 column: "Status");
 
             migrationBuilder.CreateIndex(
                 name: "IX_AlterationJob_WorkflowInstanceId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "AlterationJobs",
                 column: "WorkflowInstanceId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_AlterationPlan_CompletedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "AlterationPlans",
                 column: "CompletedAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_AlterationPlan_CreatedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "AlterationPlans",
                 column: "CreatedAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_AlterationPlan_StartedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "AlterationPlans",
                 column: "StartedAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_AlterationPlan_Status",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "AlterationPlans",
                 column: "Status");
         }
@@ -129,11 +135,11 @@ namespace Elsa.EntityFrameworkCore.MySql.Migrations.Alterations
         {
             migrationBuilder.DropTable(
                 name: "AlterationJobs",
-                schema: "Elsa");
+                schema: _schema.Schema);
 
             migrationBuilder.DropTable(
                 name: "AlterationPlans",
-                schema: "Elsa");
+                schema: _schema.Schema);
         }
     }
 }

--- a/src/modules/Elsa.EntityFrameworkCore.MySql/Migrations/Identity/20231015122238_Initial.cs
+++ b/src/modules/Elsa.EntityFrameworkCore.MySql/Migrations/Identity/20231015122238_Initial.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+﻿using Elsa.EntityFrameworkCore.Common.Contracts;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 
@@ -7,18 +8,23 @@ namespace Elsa.EntityFrameworkCore.MySql.Migrations.Identity
     /// <inheritdoc />
     public partial class Initial : Migration
     {
+        private readonly IElsaDbContextSchema _schema;
+        public Initial(IElsaDbContextSchema schema)
+        {
+            _schema = schema ?? throw new ArgumentNullException(nameof(schema));
+        }
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.EnsureSchema(
-                name: "Elsa");
+                name: _schema.Schema);
 
             migrationBuilder.AlterDatabase()
                 .Annotation("MySql:CharSet", "utf8mb4");
 
             migrationBuilder.CreateTable(
                 name: "Applications",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "varchar(255)", nullable: false)
@@ -46,7 +52,7 @@ namespace Elsa.EntityFrameworkCore.MySql.Migrations.Identity
 
             migrationBuilder.CreateTable(
                 name: "Roles",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "varchar(255)", nullable: false)
@@ -64,7 +70,7 @@ namespace Elsa.EntityFrameworkCore.MySql.Migrations.Identity
 
             migrationBuilder.CreateTable(
                 name: "Users",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "varchar(255)", nullable: false)
@@ -86,28 +92,28 @@ namespace Elsa.EntityFrameworkCore.MySql.Migrations.Identity
 
             migrationBuilder.CreateIndex(
                 name: "IX_Application_ClientId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Applications",
                 column: "ClientId",
                 unique: true);
 
             migrationBuilder.CreateIndex(
                 name: "IX_Application_Name",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Applications",
                 column: "Name",
                 unique: true);
 
             migrationBuilder.CreateIndex(
                 name: "IX_Role_Name",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Roles",
                 column: "Name",
                 unique: true);
 
             migrationBuilder.CreateIndex(
                 name: "IX_User_Name",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Users",
                 column: "Name",
                 unique: true);
@@ -118,15 +124,15 @@ namespace Elsa.EntityFrameworkCore.MySql.Migrations.Identity
         {
             migrationBuilder.DropTable(
                 name: "Applications",
-                schema: "Elsa");
+                schema: _schema.Schema);
 
             migrationBuilder.DropTable(
                 name: "Roles",
-                schema: "Elsa");
+                schema: _schema.Schema);
 
             migrationBuilder.DropTable(
                 name: "Users",
-                schema: "Elsa");
+                schema: _schema.Schema);
         }
     }
 }

--- a/src/modules/Elsa.EntityFrameworkCore.MySql/Migrations/Labels/20231015122253_Initial.cs
+++ b/src/modules/Elsa.EntityFrameworkCore.MySql/Migrations/Labels/20231015122253_Initial.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+﻿using Elsa.EntityFrameworkCore.Common.Contracts;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 
@@ -7,18 +8,23 @@ namespace Elsa.EntityFrameworkCore.MySql.Migrations.Labels
     /// <inheritdoc />
     public partial class Initial : Migration
     {
+        private readonly IElsaDbContextSchema _schema;
+        public Initial(IElsaDbContextSchema schema)
+        {
+            _schema = schema ?? throw new ArgumentNullException(nameof(schema));
+        }
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.EnsureSchema(
-                name: "Elsa");
+                name: _schema.Schema);
 
             migrationBuilder.AlterDatabase()
                 .Annotation("MySql:CharSet", "utf8mb4");
 
             migrationBuilder.CreateTable(
                 name: "Labels",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "varchar(255)", nullable: false)
@@ -40,7 +46,7 @@ namespace Elsa.EntityFrameworkCore.MySql.Migrations.Labels
 
             migrationBuilder.CreateTable(
                 name: "WorkflowDefinitionLabels",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "varchar(255)", nullable: false)
@@ -60,19 +66,19 @@ namespace Elsa.EntityFrameworkCore.MySql.Migrations.Labels
 
             migrationBuilder.CreateIndex(
                 name: "WorkflowDefinitionLabel_LabelId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitionLabels",
                 column: "LabelId");
 
             migrationBuilder.CreateIndex(
                 name: "WorkflowDefinitionLabel_WorkflowDefinitionId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitionLabels",
                 column: "WorkflowDefinitionId");
 
             migrationBuilder.CreateIndex(
                 name: "WorkflowDefinitionLabel_WorkflowDefinitionVersionId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitionLabels",
                 column: "WorkflowDefinitionVersionId");
         }
@@ -82,11 +88,11 @@ namespace Elsa.EntityFrameworkCore.MySql.Migrations.Labels
         {
             migrationBuilder.DropTable(
                 name: "Labels",
-                schema: "Elsa");
+                schema: _schema.Schema);
 
             migrationBuilder.DropTable(
                 name: "WorkflowDefinitionLabels",
-                schema: "Elsa");
+                schema: _schema.Schema);
         }
     }
 }

--- a/src/modules/Elsa.EntityFrameworkCore.MySql/Migrations/Management/20231015122223_Initial.cs
+++ b/src/modules/Elsa.EntityFrameworkCore.MySql/Migrations/Management/20231015122223_Initial.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Elsa.EntityFrameworkCore.Common.Contracts;
 using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
@@ -8,18 +9,23 @@ namespace Elsa.EntityFrameworkCore.MySql.Migrations.Management
     /// <inheritdoc />
     public partial class Initial : Migration
     {
+        private readonly IElsaDbContextSchema _schema;
+        public Initial(IElsaDbContextSchema schema)
+        {
+            _schema = schema ?? throw new ArgumentNullException(nameof(schema));
+        }
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.EnsureSchema(
-                name: "Elsa");
+                name: _schema.Schema);
 
             migrationBuilder.AlterDatabase()
                 .Annotation("MySql:CharSet", "utf8mb4");
 
             migrationBuilder.CreateTable(
                 name: "WorkflowDefinitions",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "varchar(255)", nullable: false)
@@ -58,7 +64,7 @@ namespace Elsa.EntityFrameworkCore.MySql.Migrations.Management
 
             migrationBuilder.CreateTable(
                 name: "WorkflowInstances",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "varchar(255)", nullable: false)
@@ -91,110 +97,110 @@ namespace Elsa.EntityFrameworkCore.MySql.Migrations.Management
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowDefinition_DefinitionId_Version",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitions",
                 columns: new[] { "DefinitionId", "Version" },
                 unique: true);
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowDefinition_IsLatest",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitions",
                 column: "IsLatest");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowDefinition_IsPublished",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitions",
                 column: "IsPublished");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowDefinition_Name",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitions",
                 column: "Name");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowDefinition_UsableAsActivity",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitions",
                 column: "UsableAsActivity");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowDefinition_Version",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitions",
                 column: "Version");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_CorrelationId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "CorrelationId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_CreatedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "CreatedAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_DefinitionId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "DefinitionId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_FinishedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "FinishedAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_Name",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "Name");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_Status",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "Status");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_Status_DefinitionId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 columns: new[] { "Status", "DefinitionId" });
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_Status_SubStatus",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 columns: new[] { "Status", "SubStatus" });
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_Status_SubStatus_DefinitionId_Version",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 columns: new[] { "Status", "SubStatus", "DefinitionId", "Version" });
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_SubStatus",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "SubStatus");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_SubStatus_DefinitionId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 columns: new[] { "SubStatus", "DefinitionId" });
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_UpdatedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "UpdatedAt");
         }
@@ -204,11 +210,11 @@ namespace Elsa.EntityFrameworkCore.MySql.Migrations.Management
         {
             migrationBuilder.DropTable(
                 name: "WorkflowDefinitions",
-                schema: "Elsa");
+                schema: _schema.Schema);
 
             migrationBuilder.DropTable(
                 name: "WorkflowInstances",
-                schema: "Elsa");
+                schema: _schema.Schema);
         }
     }
 }

--- a/src/modules/Elsa.EntityFrameworkCore.MySql/Migrations/Runtime/20231024160940_Initial.cs
+++ b/src/modules/Elsa.EntityFrameworkCore.MySql/Migrations/Runtime/20231024160940_Initial.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Elsa.EntityFrameworkCore.Common.Contracts;
 using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
@@ -8,18 +9,23 @@ namespace Elsa.EntityFrameworkCore.MySql.Migrations.Runtime
     /// <inheritdoc />
     public partial class Initial : Migration
     {
+        private readonly IElsaDbContextSchema _schema;
+        public Initial(IElsaDbContextSchema schema)
+        {
+            _schema = schema ?? throw new ArgumentNullException(nameof(schema));
+        }
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.EnsureSchema(
-                name: "Elsa");
+                name: _schema.Schema);
 
             migrationBuilder.AlterDatabase()
                 .Annotation("MySql:CharSet", "utf8mb4");
 
             migrationBuilder.CreateTable(
                 name: "ActivityExecutionRecords",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "varchar(255)", nullable: false)
@@ -57,7 +63,7 @@ namespace Elsa.EntityFrameworkCore.MySql.Migrations.Runtime
 
             migrationBuilder.CreateTable(
                 name: "Bookmarks",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     BookmarkId = table.Column<string>(type: "varchar(255)", nullable: false)
@@ -86,7 +92,7 @@ namespace Elsa.EntityFrameworkCore.MySql.Migrations.Runtime
 
             migrationBuilder.CreateTable(
                 name: "Triggers",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "varchar(255)", nullable: false)
@@ -112,7 +118,7 @@ namespace Elsa.EntityFrameworkCore.MySql.Migrations.Runtime
 
             migrationBuilder.CreateTable(
                 name: "WorkflowExecutionLogRecords",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "varchar(255)", nullable: false)
@@ -158,7 +164,7 @@ namespace Elsa.EntityFrameworkCore.MySql.Migrations.Runtime
 
             migrationBuilder.CreateTable(
                 name: "WorkflowInboxMessages",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "varchar(255)", nullable: false)
@@ -188,271 +194,271 @@ namespace Elsa.EntityFrameworkCore.MySql.Migrations.Runtime
 
             migrationBuilder.CreateIndex(
                 name: "IX_ActivityExecutionRecord_ActivityId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "ActivityExecutionRecords",
                 column: "ActivityId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_ActivityExecutionRecord_ActivityName",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "ActivityExecutionRecords",
                 column: "ActivityName");
 
             migrationBuilder.CreateIndex(
                 name: "IX_ActivityExecutionRecord_ActivityNodeId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "ActivityExecutionRecords",
                 column: "ActivityNodeId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_ActivityExecutionRecord_ActivityType",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "ActivityExecutionRecords",
                 column: "ActivityType");
 
             migrationBuilder.CreateIndex(
                 name: "IX_ActivityExecutionRecord_ActivityType_ActivityTypeVersion",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "ActivityExecutionRecords",
                 columns: new[] { "ActivityType", "ActivityTypeVersion" });
 
             migrationBuilder.CreateIndex(
                 name: "IX_ActivityExecutionRecord_ActivityTypeVersion",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "ActivityExecutionRecords",
                 column: "ActivityTypeVersion");
 
             migrationBuilder.CreateIndex(
                 name: "IX_ActivityExecutionRecord_CompletedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "ActivityExecutionRecords",
                 column: "CompletedAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_ActivityExecutionRecord_HasBookmarks",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "ActivityExecutionRecords",
                 column: "HasBookmarks");
 
             migrationBuilder.CreateIndex(
                 name: "IX_ActivityExecutionRecord_StartedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "ActivityExecutionRecords",
                 column: "StartedAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_ActivityExecutionRecord_Status",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "ActivityExecutionRecords",
                 column: "Status");
 
             migrationBuilder.CreateIndex(
                 name: "IX_ActivityExecutionRecord_WorkflowInstanceId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "ActivityExecutionRecords",
                 column: "WorkflowInstanceId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_StoredBookmark_ActivityInstanceId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Bookmarks",
                 column: "ActivityInstanceId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_StoredBookmark_ActivityTypeName",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Bookmarks",
                 column: "ActivityTypeName");
 
             migrationBuilder.CreateIndex(
                 name: "IX_StoredBookmark_ActivityTypeName_Hash",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Bookmarks",
                 columns: new[] { "ActivityTypeName", "Hash" });
 
             migrationBuilder.CreateIndex(
                 name: "IX_StoredBookmark_ActivityTypeName_Hash_WorkflowInstanceId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Bookmarks",
                 columns: new[] { "ActivityTypeName", "Hash", "WorkflowInstanceId" });
 
             migrationBuilder.CreateIndex(
                 name: "IX_StoredBookmark_CreatedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Bookmarks",
                 column: "CreatedAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_StoredBookmark_Hash",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Bookmarks",
                 column: "Hash");
 
             migrationBuilder.CreateIndex(
                 name: "IX_StoredBookmark_WorkflowInstanceId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Bookmarks",
                 column: "WorkflowInstanceId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_StoredTrigger_Hash",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Triggers",
                 column: "Hash");
 
             migrationBuilder.CreateIndex(
                 name: "IX_StoredTrigger_Name",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Triggers",
                 column: "Name");
 
             migrationBuilder.CreateIndex(
                 name: "IX_StoredTrigger_WorkflowDefinitionId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Triggers",
                 column: "WorkflowDefinitionId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_StoredTrigger_WorkflowDefinitionVersionId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Triggers",
                 column: "WorkflowDefinitionVersionId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_ActivityId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "ActivityId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_ActivityInstanceId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "ActivityInstanceId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_ActivityName",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "ActivityName");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_ActivityNodeId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "ActivityNodeId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_ActivityType",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "ActivityType");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_ActivityType_ActivityTypeVersion",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 columns: new[] { "ActivityType", "ActivityTypeVersion" });
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_ActivityTypeVersion",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "ActivityTypeVersion");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_EventName",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "EventName");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_ParentActivityInstanceId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "ParentActivityInstanceId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_Sequence",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "Sequence");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_Timestamp",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "Timestamp");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_Timestamp_Sequence",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 columns: new[] { "Timestamp", "Sequence" });
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_WorkflowDefinitionId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "WorkflowDefinitionId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_WorkflowDefinitionVersionId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "WorkflowDefinitionVersionId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_WorkflowInstanceId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "WorkflowInstanceId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_WorkflowVersion",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "WorkflowVersion");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInboxMessage_ActivityInstanceId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInboxMessages",
                 column: "ActivityInstanceId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInboxMessage_ActivityTypeName",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInboxMessages",
                 column: "ActivityTypeName");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInboxMessage_CorrelationId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInboxMessages",
                 column: "CorrelationId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInboxMessage_CreatedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInboxMessages",
                 column: "CreatedAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInboxMessage_ExpiresAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInboxMessages",
                 column: "ExpiresAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInboxMessage_Hash",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInboxMessages",
                 column: "Hash");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInboxMessage_WorkflowInstanceId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInboxMessages",
                 column: "WorkflowInstanceId");
         }
@@ -462,23 +468,23 @@ namespace Elsa.EntityFrameworkCore.MySql.Migrations.Runtime
         {
             migrationBuilder.DropTable(
                 name: "ActivityExecutionRecords",
-                schema: "Elsa");
+                schema: _schema.Schema);
 
             migrationBuilder.DropTable(
                 name: "Bookmarks",
-                schema: "Elsa");
+                schema: _schema.Schema);
 
             migrationBuilder.DropTable(
                 name: "Triggers",
-                schema: "Elsa");
+                schema: _schema.Schema);
 
             migrationBuilder.DropTable(
                 name: "WorkflowExecutionLogRecords",
-                schema: "Elsa");
+                schema: _schema.Schema);
 
             migrationBuilder.DropTable(
                 name: "WorkflowInboxMessages",
-                schema: "Elsa");
+                schema: _schema.Schema);
         }
     }
 }

--- a/src/modules/Elsa.EntityFrameworkCore.PostgreSql/Migrations/Alterations/20231015122203_Initial.cs
+++ b/src/modules/Elsa.EntityFrameworkCore.PostgreSql/Migrations/Alterations/20231015122203_Initial.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Elsa.EntityFrameworkCore.Common.Contracts;
 using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
@@ -8,15 +9,20 @@ namespace Elsa.EntityFrameworkCore.PostgreSql.Migrations.Alterations
     /// <inheritdoc />
     public partial class Initial : Migration
     {
+        private readonly IElsaDbContextSchema _schema;
+        public Initial(IElsaDbContextSchema schema)
+        {
+            _schema = schema ?? throw new ArgumentNullException(nameof(schema));
+        }
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.EnsureSchema(
-                name: "Elsa");
+                name: _schema.Schema);
 
             migrationBuilder.CreateTable(
                 name: "AlterationJobs",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "text", nullable: false),
@@ -35,7 +41,7 @@ namespace Elsa.EntityFrameworkCore.PostgreSql.Migrations.Alterations
 
             migrationBuilder.CreateTable(
                 name: "AlterationPlans",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "text", nullable: false),
@@ -53,61 +59,61 @@ namespace Elsa.EntityFrameworkCore.PostgreSql.Migrations.Alterations
 
             migrationBuilder.CreateIndex(
                 name: "IX_AlterationJob_CompletedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "AlterationJobs",
                 column: "CompletedAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_AlterationJob_CreatedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "AlterationJobs",
                 column: "CreatedAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_AlterationJob_PlanId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "AlterationJobs",
                 column: "PlanId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_AlterationJob_StartedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "AlterationJobs",
                 column: "StartedAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_AlterationJob_Status",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "AlterationJobs",
                 column: "Status");
 
             migrationBuilder.CreateIndex(
                 name: "IX_AlterationJob_WorkflowInstanceId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "AlterationJobs",
                 column: "WorkflowInstanceId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_AlterationPlan_CompletedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "AlterationPlans",
                 column: "CompletedAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_AlterationPlan_CreatedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "AlterationPlans",
                 column: "CreatedAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_AlterationPlan_StartedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "AlterationPlans",
                 column: "StartedAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_AlterationPlan_Status",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "AlterationPlans",
                 column: "Status");
         }
@@ -117,11 +123,11 @@ namespace Elsa.EntityFrameworkCore.PostgreSql.Migrations.Alterations
         {
             migrationBuilder.DropTable(
                 name: "AlterationJobs",
-                schema: "Elsa");
+                schema: _schema.Schema);
 
             migrationBuilder.DropTable(
                 name: "AlterationPlans",
-                schema: "Elsa");
+                schema: _schema.Schema);
         }
     }
 }

--- a/src/modules/Elsa.EntityFrameworkCore.PostgreSql/Migrations/Identity/20231015122250_Initial.cs
+++ b/src/modules/Elsa.EntityFrameworkCore.PostgreSql/Migrations/Identity/20231015122250_Initial.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+﻿using Elsa.EntityFrameworkCore.Common.Contracts;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 
@@ -7,15 +8,20 @@ namespace Elsa.EntityFrameworkCore.PostgreSql.Migrations.Identity
     /// <inheritdoc />
     public partial class Initial : Migration
     {
+        private readonly IElsaDbContextSchema _schema;
+        public Initial(IElsaDbContextSchema schema)
+        {
+            _schema = schema ?? throw new ArgumentNullException(nameof(schema));
+        }
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.EnsureSchema(
-                name: "Elsa");
+                name: _schema.Schema);
 
             migrationBuilder.CreateTable(
                 name: "Applications",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "text", nullable: false),
@@ -34,7 +40,7 @@ namespace Elsa.EntityFrameworkCore.PostgreSql.Migrations.Identity
 
             migrationBuilder.CreateTable(
                 name: "Roles",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "text", nullable: false),
@@ -48,7 +54,7 @@ namespace Elsa.EntityFrameworkCore.PostgreSql.Migrations.Identity
 
             migrationBuilder.CreateTable(
                 name: "Users",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "text", nullable: false),
@@ -64,28 +70,28 @@ namespace Elsa.EntityFrameworkCore.PostgreSql.Migrations.Identity
 
             migrationBuilder.CreateIndex(
                 name: "IX_Application_ClientId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Applications",
                 column: "ClientId",
                 unique: true);
 
             migrationBuilder.CreateIndex(
                 name: "IX_Application_Name",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Applications",
                 column: "Name",
                 unique: true);
 
             migrationBuilder.CreateIndex(
                 name: "IX_Role_Name",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Roles",
                 column: "Name",
                 unique: true);
 
             migrationBuilder.CreateIndex(
                 name: "IX_User_Name",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Users",
                 column: "Name",
                 unique: true);
@@ -96,15 +102,15 @@ namespace Elsa.EntityFrameworkCore.PostgreSql.Migrations.Identity
         {
             migrationBuilder.DropTable(
                 name: "Applications",
-                schema: "Elsa");
+                schema: _schema.Schema);
 
             migrationBuilder.DropTable(
                 name: "Roles",
-                schema: "Elsa");
+                schema: _schema.Schema);
 
             migrationBuilder.DropTable(
                 name: "Users",
-                schema: "Elsa");
+                schema: _schema.Schema);
         }
     }
 }

--- a/src/modules/Elsa.EntityFrameworkCore.PostgreSql/Migrations/Labels/20231015122304_Initial.cs
+++ b/src/modules/Elsa.EntityFrameworkCore.PostgreSql/Migrations/Labels/20231015122304_Initial.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+﻿using Elsa.EntityFrameworkCore.Common.Contracts;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 
@@ -7,15 +8,20 @@ namespace Elsa.EntityFrameworkCore.PostgreSql.Migrations.Labels
     /// <inheritdoc />
     public partial class Initial : Migration
     {
+        private readonly IElsaDbContextSchema _schema;
+        public Initial(IElsaDbContextSchema schema)
+        {
+            _schema = schema ?? throw new ArgumentNullException(nameof(schema));
+        }
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.EnsureSchema(
-                name: "Elsa");
+                name: _schema.Schema);
 
             migrationBuilder.CreateTable(
                 name: "Labels",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "text", nullable: false),
@@ -31,7 +37,7 @@ namespace Elsa.EntityFrameworkCore.PostgreSql.Migrations.Labels
 
             migrationBuilder.CreateTable(
                 name: "WorkflowDefinitionLabels",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "text", nullable: false),
@@ -46,19 +52,19 @@ namespace Elsa.EntityFrameworkCore.PostgreSql.Migrations.Labels
 
             migrationBuilder.CreateIndex(
                 name: "WorkflowDefinitionLabel_LabelId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitionLabels",
                 column: "LabelId");
 
             migrationBuilder.CreateIndex(
                 name: "WorkflowDefinitionLabel_WorkflowDefinitionId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitionLabels",
                 column: "WorkflowDefinitionId");
 
             migrationBuilder.CreateIndex(
                 name: "WorkflowDefinitionLabel_WorkflowDefinitionVersionId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitionLabels",
                 column: "WorkflowDefinitionVersionId");
         }
@@ -68,11 +74,11 @@ namespace Elsa.EntityFrameworkCore.PostgreSql.Migrations.Labels
         {
             migrationBuilder.DropTable(
                 name: "Labels",
-                schema: "Elsa");
+                schema: _schema.Schema);
 
             migrationBuilder.DropTable(
                 name: "WorkflowDefinitionLabels",
-                schema: "Elsa");
+                schema: _schema.Schema);
         }
     }
 }

--- a/src/modules/Elsa.EntityFrameworkCore.PostgreSql/Migrations/Management/20231015122234_Initial.cs
+++ b/src/modules/Elsa.EntityFrameworkCore.PostgreSql/Migrations/Management/20231015122234_Initial.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Elsa.EntityFrameworkCore.Common.Contracts;
 using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
@@ -8,15 +9,20 @@ namespace Elsa.EntityFrameworkCore.PostgreSql.Migrations.Management
     /// <inheritdoc />
     public partial class Initial : Migration
     {
+        private readonly IElsaDbContextSchema _schema;
+        public Initial(IElsaDbContextSchema schema)
+        {
+            _schema = schema ?? throw new ArgumentNullException(nameof(schema));
+        }
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.EnsureSchema(
-                name: "Elsa");
+                name: _schema.Schema);
 
             migrationBuilder.CreateTable(
                 name: "WorkflowDefinitions",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "text", nullable: false),
@@ -44,7 +50,7 @@ namespace Elsa.EntityFrameworkCore.PostgreSql.Migrations.Management
 
             migrationBuilder.CreateTable(
                 name: "WorkflowInstances",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "text", nullable: false),
@@ -68,110 +74,110 @@ namespace Elsa.EntityFrameworkCore.PostgreSql.Migrations.Management
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowDefinition_DefinitionId_Version",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitions",
                 columns: new[] { "DefinitionId", "Version" },
                 unique: true);
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowDefinition_IsLatest",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitions",
                 column: "IsLatest");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowDefinition_IsPublished",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitions",
                 column: "IsPublished");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowDefinition_Name",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitions",
                 column: "Name");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowDefinition_UsableAsActivity",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitions",
                 column: "UsableAsActivity");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowDefinition_Version",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitions",
                 column: "Version");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_CorrelationId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "CorrelationId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_CreatedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "CreatedAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_DefinitionId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "DefinitionId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_FinishedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "FinishedAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_Name",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "Name");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_Status",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "Status");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_Status_DefinitionId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 columns: new[] { "Status", "DefinitionId" });
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_Status_SubStatus",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 columns: new[] { "Status", "SubStatus" });
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_Status_SubStatus_DefinitionId_Version",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 columns: new[] { "Status", "SubStatus", "DefinitionId", "Version" });
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_SubStatus",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "SubStatus");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_SubStatus_DefinitionId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 columns: new[] { "SubStatus", "DefinitionId" });
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_UpdatedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "UpdatedAt");
         }
@@ -181,11 +187,11 @@ namespace Elsa.EntityFrameworkCore.PostgreSql.Migrations.Management
         {
             migrationBuilder.DropTable(
                 name: "WorkflowDefinitions",
-                schema: "Elsa");
+                schema: _schema.Schema);
 
             migrationBuilder.DropTable(
                 name: "WorkflowInstances",
-                schema: "Elsa");
+                schema: _schema.Schema);
         }
     }
 }

--- a/src/modules/Elsa.EntityFrameworkCore.PostgreSql/Migrations/Runtime/20231024160952_Initial.cs
+++ b/src/modules/Elsa.EntityFrameworkCore.PostgreSql/Migrations/Runtime/20231024160952_Initial.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Elsa.EntityFrameworkCore.Common.Contracts;
 using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
@@ -8,15 +9,20 @@ namespace Elsa.EntityFrameworkCore.PostgreSql.Migrations.Runtime
     /// <inheritdoc />
     public partial class Initial : Migration
     {
+        private readonly IElsaDbContextSchema _schema;
+        public Initial(IElsaDbContextSchema schema)
+        {
+            _schema = schema ?? throw new ArgumentNullException(nameof(schema));
+        }
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.EnsureSchema(
-                name: "Elsa");
+                name: _schema.Schema);
 
             migrationBuilder.CreateTable(
                 name: "ActivityExecutionRecords",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "text", nullable: false),
@@ -42,7 +48,7 @@ namespace Elsa.EntityFrameworkCore.PostgreSql.Migrations.Runtime
 
             migrationBuilder.CreateTable(
                 name: "Bookmarks",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     BookmarkId = table.Column<string>(type: "text", nullable: false),
@@ -62,7 +68,7 @@ namespace Elsa.EntityFrameworkCore.PostgreSql.Migrations.Runtime
 
             migrationBuilder.CreateTable(
                 name: "Triggers",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "text", nullable: false),
@@ -80,7 +86,7 @@ namespace Elsa.EntityFrameworkCore.PostgreSql.Migrations.Runtime
 
             migrationBuilder.CreateTable(
                 name: "WorkflowExecutionLogRecords",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "text", nullable: false),
@@ -110,7 +116,7 @@ namespace Elsa.EntityFrameworkCore.PostgreSql.Migrations.Runtime
 
             migrationBuilder.CreateTable(
                 name: "WorkflowInboxMessages",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "text", nullable: false),
@@ -131,271 +137,271 @@ namespace Elsa.EntityFrameworkCore.PostgreSql.Migrations.Runtime
 
             migrationBuilder.CreateIndex(
                 name: "IX_ActivityExecutionRecord_ActivityId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "ActivityExecutionRecords",
                 column: "ActivityId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_ActivityExecutionRecord_ActivityName",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "ActivityExecutionRecords",
                 column: "ActivityName");
 
             migrationBuilder.CreateIndex(
                 name: "IX_ActivityExecutionRecord_ActivityNodeId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "ActivityExecutionRecords",
                 column: "ActivityNodeId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_ActivityExecutionRecord_ActivityType",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "ActivityExecutionRecords",
                 column: "ActivityType");
 
             migrationBuilder.CreateIndex(
                 name: "IX_ActivityExecutionRecord_ActivityType_ActivityTypeVersion",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "ActivityExecutionRecords",
                 columns: new[] { "ActivityType", "ActivityTypeVersion" });
 
             migrationBuilder.CreateIndex(
                 name: "IX_ActivityExecutionRecord_ActivityTypeVersion",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "ActivityExecutionRecords",
                 column: "ActivityTypeVersion");
 
             migrationBuilder.CreateIndex(
                 name: "IX_ActivityExecutionRecord_CompletedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "ActivityExecutionRecords",
                 column: "CompletedAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_ActivityExecutionRecord_HasBookmarks",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "ActivityExecutionRecords",
                 column: "HasBookmarks");
 
             migrationBuilder.CreateIndex(
                 name: "IX_ActivityExecutionRecord_StartedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "ActivityExecutionRecords",
                 column: "StartedAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_ActivityExecutionRecord_Status",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "ActivityExecutionRecords",
                 column: "Status");
 
             migrationBuilder.CreateIndex(
                 name: "IX_ActivityExecutionRecord_WorkflowInstanceId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "ActivityExecutionRecords",
                 column: "WorkflowInstanceId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_StoredBookmark_ActivityInstanceId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Bookmarks",
                 column: "ActivityInstanceId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_StoredBookmark_ActivityTypeName",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Bookmarks",
                 column: "ActivityTypeName");
 
             migrationBuilder.CreateIndex(
                 name: "IX_StoredBookmark_ActivityTypeName_Hash",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Bookmarks",
                 columns: new[] { "ActivityTypeName", "Hash" });
 
             migrationBuilder.CreateIndex(
                 name: "IX_StoredBookmark_ActivityTypeName_Hash_WorkflowInstanceId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Bookmarks",
                 columns: new[] { "ActivityTypeName", "Hash", "WorkflowInstanceId" });
 
             migrationBuilder.CreateIndex(
                 name: "IX_StoredBookmark_CreatedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Bookmarks",
                 column: "CreatedAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_StoredBookmark_Hash",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Bookmarks",
                 column: "Hash");
 
             migrationBuilder.CreateIndex(
                 name: "IX_StoredBookmark_WorkflowInstanceId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Bookmarks",
                 column: "WorkflowInstanceId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_StoredTrigger_Hash",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Triggers",
                 column: "Hash");
 
             migrationBuilder.CreateIndex(
                 name: "IX_StoredTrigger_Name",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Triggers",
                 column: "Name");
 
             migrationBuilder.CreateIndex(
                 name: "IX_StoredTrigger_WorkflowDefinitionId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Triggers",
                 column: "WorkflowDefinitionId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_StoredTrigger_WorkflowDefinitionVersionId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Triggers",
                 column: "WorkflowDefinitionVersionId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_ActivityId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "ActivityId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_ActivityInstanceId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "ActivityInstanceId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_ActivityName",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "ActivityName");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_ActivityNodeId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "ActivityNodeId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_ActivityType",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "ActivityType");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_ActivityType_ActivityTypeVersion",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 columns: new[] { "ActivityType", "ActivityTypeVersion" });
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_ActivityTypeVersion",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "ActivityTypeVersion");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_EventName",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "EventName");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_ParentActivityInstanceId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "ParentActivityInstanceId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_Sequence",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "Sequence");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_Timestamp",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "Timestamp");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_Timestamp_Sequence",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 columns: new[] { "Timestamp", "Sequence" });
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_WorkflowDefinitionId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "WorkflowDefinitionId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_WorkflowDefinitionVersionId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "WorkflowDefinitionVersionId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_WorkflowInstanceId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "WorkflowInstanceId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_WorkflowVersion",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "WorkflowVersion");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInboxMessage_ActivityInstanceId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInboxMessages",
                 column: "ActivityInstanceId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInboxMessage_ActivityTypeName",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInboxMessages",
                 column: "ActivityTypeName");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInboxMessage_CorrelationId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInboxMessages",
                 column: "CorrelationId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInboxMessage_CreatedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInboxMessages",
                 column: "CreatedAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInboxMessage_ExpiresAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInboxMessages",
                 column: "ExpiresAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInboxMessage_Hash",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInboxMessages",
                 column: "Hash");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInboxMessage_WorkflowInstanceId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInboxMessages",
                 column: "WorkflowInstanceId");
         }
@@ -405,23 +411,23 @@ namespace Elsa.EntityFrameworkCore.PostgreSql.Migrations.Runtime
         {
             migrationBuilder.DropTable(
                 name: "ActivityExecutionRecords",
-                schema: "Elsa");
+                schema: _schema.Schema);
 
             migrationBuilder.DropTable(
                 name: "Bookmarks",
-                schema: "Elsa");
+                schema: _schema.Schema);
 
             migrationBuilder.DropTable(
                 name: "Triggers",
-                schema: "Elsa");
+                schema: _schema.Schema);
 
             migrationBuilder.DropTable(
                 name: "WorkflowExecutionLogRecords",
-                schema: "Elsa");
+                schema: _schema.Schema);
 
             migrationBuilder.DropTable(
                 name: "WorkflowInboxMessages",
-                schema: "Elsa");
+                schema: _schema.Schema);
         }
     }
 }

--- a/src/modules/Elsa.EntityFrameworkCore.SqlServer/Migrations/Alterations/20231015122155_Initial.cs
+++ b/src/modules/Elsa.EntityFrameworkCore.SqlServer/Migrations/Alterations/20231015122155_Initial.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Elsa.EntityFrameworkCore.Common.Contracts;
 using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
@@ -8,15 +9,20 @@ namespace Elsa.EntityFrameworkCore.SqlServer.Migrations.Alterations
     /// <inheritdoc />
     public partial class Initial : Migration
     {
+        private readonly IElsaDbContextSchema _schema;
+        public Initial(IElsaDbContextSchema schema)
+        {
+            _schema = schema ?? throw new ArgumentNullException(nameof(schema));
+        }
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.EnsureSchema(
-                name: "Elsa");
+                name: _schema.Schema);
 
             migrationBuilder.CreateTable(
                 name: "AlterationJobs",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "nvarchar(450)", nullable: false),
@@ -35,7 +41,7 @@ namespace Elsa.EntityFrameworkCore.SqlServer.Migrations.Alterations
 
             migrationBuilder.CreateTable(
                 name: "AlterationPlans",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "nvarchar(450)", nullable: false),
@@ -53,61 +59,61 @@ namespace Elsa.EntityFrameworkCore.SqlServer.Migrations.Alterations
 
             migrationBuilder.CreateIndex(
                 name: "IX_AlterationJob_CompletedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "AlterationJobs",
                 column: "CompletedAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_AlterationJob_CreatedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "AlterationJobs",
                 column: "CreatedAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_AlterationJob_PlanId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "AlterationJobs",
                 column: "PlanId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_AlterationJob_StartedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "AlterationJobs",
                 column: "StartedAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_AlterationJob_Status",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "AlterationJobs",
                 column: "Status");
 
             migrationBuilder.CreateIndex(
                 name: "IX_AlterationJob_WorkflowInstanceId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "AlterationJobs",
                 column: "WorkflowInstanceId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_AlterationPlan_CompletedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "AlterationPlans",
                 column: "CompletedAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_AlterationPlan_CreatedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "AlterationPlans",
                 column: "CreatedAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_AlterationPlan_StartedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "AlterationPlans",
                 column: "StartedAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_AlterationPlan_Status",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "AlterationPlans",
                 column: "Status");
         }
@@ -117,11 +123,11 @@ namespace Elsa.EntityFrameworkCore.SqlServer.Migrations.Alterations
         {
             migrationBuilder.DropTable(
                 name: "AlterationJobs",
-                schema: "Elsa");
+                schema: _schema.Schema);
 
             migrationBuilder.DropTable(
                 name: "AlterationPlans",
-                schema: "Elsa");
+                schema: _schema.Schema);
         }
     }
 }

--- a/src/modules/Elsa.EntityFrameworkCore.SqlServer/Migrations/Identity/20231015122242_Initial.cs
+++ b/src/modules/Elsa.EntityFrameworkCore.SqlServer/Migrations/Identity/20231015122242_Initial.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+﻿using Elsa.EntityFrameworkCore.Common.Contracts;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 
@@ -7,15 +8,20 @@ namespace Elsa.EntityFrameworkCore.SqlServer.Migrations.Identity
     /// <inheritdoc />
     public partial class Initial : Migration
     {
+        private readonly IElsaDbContextSchema _schema;
+        public Initial(IElsaDbContextSchema schema)
+        {
+            _schema = schema ?? throw new ArgumentNullException(nameof(schema));
+        }
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.EnsureSchema(
-                name: "Elsa");
+                name: _schema.Schema);
 
             migrationBuilder.CreateTable(
                 name: "Applications",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "nvarchar(450)", nullable: false),
@@ -34,7 +40,7 @@ namespace Elsa.EntityFrameworkCore.SqlServer.Migrations.Identity
 
             migrationBuilder.CreateTable(
                 name: "Roles",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "nvarchar(450)", nullable: false),
@@ -48,7 +54,7 @@ namespace Elsa.EntityFrameworkCore.SqlServer.Migrations.Identity
 
             migrationBuilder.CreateTable(
                 name: "Users",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "nvarchar(450)", nullable: false),
@@ -64,28 +70,28 @@ namespace Elsa.EntityFrameworkCore.SqlServer.Migrations.Identity
 
             migrationBuilder.CreateIndex(
                 name: "IX_Application_ClientId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Applications",
                 column: "ClientId",
                 unique: true);
 
             migrationBuilder.CreateIndex(
                 name: "IX_Application_Name",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Applications",
                 column: "Name",
                 unique: true);
 
             migrationBuilder.CreateIndex(
                 name: "IX_Role_Name",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Roles",
                 column: "Name",
                 unique: true);
 
             migrationBuilder.CreateIndex(
                 name: "IX_User_Name",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Users",
                 column: "Name",
                 unique: true);
@@ -96,15 +102,15 @@ namespace Elsa.EntityFrameworkCore.SqlServer.Migrations.Identity
         {
             migrationBuilder.DropTable(
                 name: "Applications",
-                schema: "Elsa");
+                schema: _schema.Schema);
 
             migrationBuilder.DropTable(
                 name: "Roles",
-                schema: "Elsa");
+                schema: _schema.Schema);
 
             migrationBuilder.DropTable(
                 name: "Users",
-                schema: "Elsa");
+                schema: _schema.Schema);
         }
     }
 }

--- a/src/modules/Elsa.EntityFrameworkCore.SqlServer/Migrations/Labels/20231015122257_Initial.cs
+++ b/src/modules/Elsa.EntityFrameworkCore.SqlServer/Migrations/Labels/20231015122257_Initial.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+﻿using Elsa.EntityFrameworkCore.Common.Contracts;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 
@@ -7,15 +8,20 @@ namespace Elsa.EntityFrameworkCore.SqlServer.Migrations.Labels
     /// <inheritdoc />
     public partial class Initial : Migration
     {
+        private readonly IElsaDbContextSchema _schema;
+        public Initial(IElsaDbContextSchema schema)
+        {
+            _schema = schema ?? throw new ArgumentNullException(nameof(schema));
+        }
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.EnsureSchema(
-                name: "Elsa");
+                name: _schema.Schema);
 
             migrationBuilder.CreateTable(
                 name: "Labels",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "nvarchar(450)", nullable: false),
@@ -31,7 +37,7 @@ namespace Elsa.EntityFrameworkCore.SqlServer.Migrations.Labels
 
             migrationBuilder.CreateTable(
                 name: "WorkflowDefinitionLabels",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "nvarchar(450)", nullable: false),
@@ -46,19 +52,19 @@ namespace Elsa.EntityFrameworkCore.SqlServer.Migrations.Labels
 
             migrationBuilder.CreateIndex(
                 name: "WorkflowDefinitionLabel_LabelId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitionLabels",
                 column: "LabelId");
 
             migrationBuilder.CreateIndex(
                 name: "WorkflowDefinitionLabel_WorkflowDefinitionId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitionLabels",
                 column: "WorkflowDefinitionId");
 
             migrationBuilder.CreateIndex(
                 name: "WorkflowDefinitionLabel_WorkflowDefinitionVersionId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitionLabels",
                 column: "WorkflowDefinitionVersionId");
         }
@@ -68,11 +74,11 @@ namespace Elsa.EntityFrameworkCore.SqlServer.Migrations.Labels
         {
             migrationBuilder.DropTable(
                 name: "Labels",
-                schema: "Elsa");
+                schema: _schema.Schema);
 
             migrationBuilder.DropTable(
                 name: "WorkflowDefinitionLabels",
-                schema: "Elsa");
+                schema: _schema.Schema);
         }
     }
 }

--- a/src/modules/Elsa.EntityFrameworkCore.SqlServer/Migrations/Management/20231015122227_Initial.cs
+++ b/src/modules/Elsa.EntityFrameworkCore.SqlServer/Migrations/Management/20231015122227_Initial.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Elsa.EntityFrameworkCore.Common.Contracts;
 using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
@@ -8,15 +9,20 @@ namespace Elsa.EntityFrameworkCore.SqlServer.Migrations.Management
     /// <inheritdoc />
     public partial class Initial : Migration
     {
+        private readonly IElsaDbContextSchema _schema;
+        public Initial(IElsaDbContextSchema schema)
+        {
+            _schema = schema ?? throw new ArgumentNullException(nameof(schema));
+        }
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.EnsureSchema(
-                name: "Elsa");
+                name: _schema.Schema);
 
             migrationBuilder.CreateTable(
                 name: "WorkflowDefinitions",
-                schema: "Elsa",
+                schema: _schema.Schema  ,
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "nvarchar(450)", nullable: false),
@@ -44,7 +50,7 @@ namespace Elsa.EntityFrameworkCore.SqlServer.Migrations.Management
 
             migrationBuilder.CreateTable(
                 name: "WorkflowInstances",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "nvarchar(450)", nullable: false),
@@ -68,110 +74,110 @@ namespace Elsa.EntityFrameworkCore.SqlServer.Migrations.Management
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowDefinition_DefinitionId_Version",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitions",
                 columns: new[] { "DefinitionId", "Version" },
                 unique: true);
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowDefinition_IsLatest",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitions",
                 column: "IsLatest");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowDefinition_IsPublished",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitions",
                 column: "IsPublished");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowDefinition_Name",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitions",
                 column: "Name");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowDefinition_UsableAsActivity",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitions",
                 column: "UsableAsActivity");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowDefinition_Version",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitions",
                 column: "Version");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_CorrelationId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "CorrelationId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_CreatedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "CreatedAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_DefinitionId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "DefinitionId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_FinishedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "FinishedAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_Name",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "Name");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_Status",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "Status");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_Status_DefinitionId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 columns: new[] { "Status", "DefinitionId" });
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_Status_SubStatus",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 columns: new[] { "Status", "SubStatus" });
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_Status_SubStatus_DefinitionId_Version",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 columns: new[] { "Status", "SubStatus", "DefinitionId", "Version" });
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_SubStatus",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "SubStatus");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_SubStatus_DefinitionId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 columns: new[] { "SubStatus", "DefinitionId" });
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_UpdatedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "UpdatedAt");
         }
@@ -181,11 +187,11 @@ namespace Elsa.EntityFrameworkCore.SqlServer.Migrations.Management
         {
             migrationBuilder.DropTable(
                 name: "WorkflowDefinitions",
-                schema: "Elsa");
+                schema: _schema.Schema);
 
             migrationBuilder.DropTable(
                 name: "WorkflowInstances",
-                schema: "Elsa");
+                schema: _schema.Schema);
         }
     }
 }

--- a/src/modules/Elsa.EntityFrameworkCore.SqlServer/Migrations/Runtime/20231024160944_Initial.cs
+++ b/src/modules/Elsa.EntityFrameworkCore.SqlServer/Migrations/Runtime/20231024160944_Initial.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Elsa.EntityFrameworkCore.Common.Contracts;
 using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
@@ -8,15 +9,20 @@ namespace Elsa.EntityFrameworkCore.SqlServer.Migrations.Runtime
     /// <inheritdoc />
     public partial class Initial : Migration
     {
+        private readonly IElsaDbContextSchema _schema;
+        public Initial(IElsaDbContextSchema schema)
+        {
+            _schema = schema ?? throw new ArgumentNullException(nameof(schema));
+        }
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.EnsureSchema(
-                name: "Elsa");
+                name: _schema.Schema);
 
             migrationBuilder.CreateTable(
                 name: "ActivityExecutionRecords",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "nvarchar(450)", nullable: false),
@@ -42,7 +48,7 @@ namespace Elsa.EntityFrameworkCore.SqlServer.Migrations.Runtime
 
             migrationBuilder.CreateTable(
                 name: "Bookmarks",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     BookmarkId = table.Column<string>(type: "nvarchar(450)", nullable: false),
@@ -62,7 +68,7 @@ namespace Elsa.EntityFrameworkCore.SqlServer.Migrations.Runtime
 
             migrationBuilder.CreateTable(
                 name: "Triggers",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "nvarchar(450)", nullable: false),
@@ -80,7 +86,7 @@ namespace Elsa.EntityFrameworkCore.SqlServer.Migrations.Runtime
 
             migrationBuilder.CreateTable(
                 name: "WorkflowExecutionLogRecords",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "nvarchar(450)", nullable: false),
@@ -110,7 +116,7 @@ namespace Elsa.EntityFrameworkCore.SqlServer.Migrations.Runtime
 
             migrationBuilder.CreateTable(
                 name: "WorkflowInboxMessages",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "nvarchar(450)", nullable: false),
@@ -131,271 +137,271 @@ namespace Elsa.EntityFrameworkCore.SqlServer.Migrations.Runtime
 
             migrationBuilder.CreateIndex(
                 name: "IX_ActivityExecutionRecord_ActivityId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "ActivityExecutionRecords",
                 column: "ActivityId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_ActivityExecutionRecord_ActivityName",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "ActivityExecutionRecords",
                 column: "ActivityName");
 
             migrationBuilder.CreateIndex(
                 name: "IX_ActivityExecutionRecord_ActivityNodeId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "ActivityExecutionRecords",
                 column: "ActivityNodeId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_ActivityExecutionRecord_ActivityType",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "ActivityExecutionRecords",
                 column: "ActivityType");
 
             migrationBuilder.CreateIndex(
                 name: "IX_ActivityExecutionRecord_ActivityType_ActivityTypeVersion",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "ActivityExecutionRecords",
                 columns: new[] { "ActivityType", "ActivityTypeVersion" });
 
             migrationBuilder.CreateIndex(
                 name: "IX_ActivityExecutionRecord_ActivityTypeVersion",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "ActivityExecutionRecords",
                 column: "ActivityTypeVersion");
 
             migrationBuilder.CreateIndex(
                 name: "IX_ActivityExecutionRecord_CompletedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "ActivityExecutionRecords",
                 column: "CompletedAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_ActivityExecutionRecord_HasBookmarks",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "ActivityExecutionRecords",
                 column: "HasBookmarks");
 
             migrationBuilder.CreateIndex(
                 name: "IX_ActivityExecutionRecord_StartedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "ActivityExecutionRecords",
                 column: "StartedAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_ActivityExecutionRecord_Status",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "ActivityExecutionRecords",
                 column: "Status");
 
             migrationBuilder.CreateIndex(
                 name: "IX_ActivityExecutionRecord_WorkflowInstanceId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "ActivityExecutionRecords",
                 column: "WorkflowInstanceId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_StoredBookmark_ActivityInstanceId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Bookmarks",
                 column: "ActivityInstanceId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_StoredBookmark_ActivityTypeName",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Bookmarks",
                 column: "ActivityTypeName");
 
             migrationBuilder.CreateIndex(
                 name: "IX_StoredBookmark_ActivityTypeName_Hash",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Bookmarks",
                 columns: new[] { "ActivityTypeName", "Hash" });
 
             migrationBuilder.CreateIndex(
                 name: "IX_StoredBookmark_ActivityTypeName_Hash_WorkflowInstanceId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Bookmarks",
                 columns: new[] { "ActivityTypeName", "Hash", "WorkflowInstanceId" });
 
             migrationBuilder.CreateIndex(
                 name: "IX_StoredBookmark_CreatedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Bookmarks",
                 column: "CreatedAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_StoredBookmark_Hash",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Bookmarks",
                 column: "Hash");
 
             migrationBuilder.CreateIndex(
                 name: "IX_StoredBookmark_WorkflowInstanceId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Bookmarks",
                 column: "WorkflowInstanceId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_StoredTrigger_Hash",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Triggers",
                 column: "Hash");
 
             migrationBuilder.CreateIndex(
                 name: "IX_StoredTrigger_Name",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Triggers",
                 column: "Name");
 
             migrationBuilder.CreateIndex(
                 name: "IX_StoredTrigger_WorkflowDefinitionId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Triggers",
                 column: "WorkflowDefinitionId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_StoredTrigger_WorkflowDefinitionVersionId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Triggers",
                 column: "WorkflowDefinitionVersionId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_ActivityId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "ActivityId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_ActivityInstanceId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "ActivityInstanceId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_ActivityName",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "ActivityName");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_ActivityNodeId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "ActivityNodeId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_ActivityType",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "ActivityType");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_ActivityType_ActivityTypeVersion",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 columns: new[] { "ActivityType", "ActivityTypeVersion" });
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_ActivityTypeVersion",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "ActivityTypeVersion");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_EventName",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "EventName");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_ParentActivityInstanceId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "ParentActivityInstanceId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_Sequence",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "Sequence");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_Timestamp",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "Timestamp");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_Timestamp_Sequence",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 columns: new[] { "Timestamp", "Sequence" });
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_WorkflowDefinitionId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "WorkflowDefinitionId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_WorkflowDefinitionVersionId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "WorkflowDefinitionVersionId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_WorkflowInstanceId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "WorkflowInstanceId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_WorkflowVersion",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "WorkflowVersion");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInboxMessage_ActivityInstanceId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInboxMessages",
                 column: "ActivityInstanceId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInboxMessage_ActivityTypeName",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInboxMessages",
                 column: "ActivityTypeName");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInboxMessage_CorrelationId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInboxMessages",
                 column: "CorrelationId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInboxMessage_CreatedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInboxMessages",
                 column: "CreatedAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInboxMessage_ExpiresAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInboxMessages",
                 column: "ExpiresAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInboxMessage_Hash",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInboxMessages",
                 column: "Hash");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInboxMessage_WorkflowInstanceId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInboxMessages",
                 column: "WorkflowInstanceId");
         }
@@ -405,23 +411,23 @@ namespace Elsa.EntityFrameworkCore.SqlServer.Migrations.Runtime
         {
             migrationBuilder.DropTable(
                 name: "ActivityExecutionRecords",
-                schema: "Elsa");
+                schema: _schema.Schema);
 
             migrationBuilder.DropTable(
                 name: "Bookmarks",
-                schema: "Elsa");
+                schema: _schema.Schema);
 
             migrationBuilder.DropTable(
                 name: "Triggers",
-                schema: "Elsa");
+                schema: _schema.Schema);
 
             migrationBuilder.DropTable(
                 name: "WorkflowExecutionLogRecords",
-                schema: "Elsa");
+                schema: _schema.Schema);
 
             migrationBuilder.DropTable(
                 name: "WorkflowInboxMessages",
-                schema: "Elsa");
+                schema: _schema.Schema);
         }
     }
 }


### PR DESCRIPTION
This PR allow you to define a custom Schema Name for the `DbContext` **And** take this information into account in Migration.

for example : 
```csharp
    elsa.UseWorkflowManagement(management => { management.UseEntityFrameworkCore(ef =>
        ef.UseSqlServer("Server=(localdb)\\MSSQLLocalDb;Initial Catalog=Elsav3CustomSchema;Integrated Security=True;",
        new ElsaDbContextOptions()
        {
            SchemaName = "CustomSchemaName",
        }));
    });
```

If not defined, the default Schema Name will be `Elsa`
This change is available for the following provider : 
- SqlServer
- Mysql
- PostgreSql

Sqlite does'nt seems to take into account any schema name.

### === auto-pr-body ===


Summary:
This pull request changes the hardcoded schema "Elsa" to "_schema.Schema" in CreateIndex(), CreateTable() and DropTable() methods, as well as adding a constructor to the Initial.cs file and changing the schema in 11 associated indexes. 

List of changes: 
- Replaced "Elsa" schema with _schema.Schema in the migration constructors 
- Replaced hardcoded string "Elsa" with _schema.Schema for 11 indexes
- Added a constructor to Initial.cs to accept the _schema.Schema variable 

Refactoring Suggestions: 
- Use constants to refer to the schema name to reduce repetition and make the code more readable and maintainable 
- Utilize a loop to traverse the array of indexes which were changed instead of manually updating each one 
- Consolidate code blocks to reduce complexity and improve readability of the code