### PR TITLE
Custom Db Schema for SqlServer, PostgreSql and Oracle

### DIFF
--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/CustomDbContextOptionsExtensionInfo.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/CustomDbContextOptionsExtensionInfo.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
+namespace Elsa.Persistence.EntityFramework.Core;
+
+/// <summary>
+/// Contains options for configuring Elsa's Entity Framework Core integration.
+/// </summary>
+public class CustomDbContextOptionsExtensionInfo : DbContextOptionsExtensionInfo
+{
+    /// <inheritdoc />
+    public CustomDbContextOptionsExtensionInfo(IDbContextOptionsExtension extension)
+        : base(extension)
+    {
+    }
+
+    /// <inheritdoc />
+    public override bool IsDatabaseProvider => false;
+
+    /// <inheritdoc />
+    public override string LogFragment => "";
+
+#if NET6_0_OR_GREATER
+        public override int GetServiceProviderHashCode()
+        /// <inheritdoc />
+    {
+        // Return a unique hash code for your custom extension
+        return 0;
+    }
+#else
+    public override long GetServiceProviderHashCode()
+        /// <inheritdoc />
+    {
+        // Return a unique hash code for your custom extension
+        return 0;
+    }
+#endif
+
+    /// <inheritdoc />
+    public override void PopulateDebugInfo(IDictionary<string, string> debugInfo)
+    {
+    }
+
+#if NET6_0_OR_GREATER
+
+    /// <inheritdoc />
+    public override bool ShouldUseSameServiceProvider(DbContextOptionsExtensionInfo other)
+    {
+        return true;
+    }
+#endif
+}

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/DbSchemaAwareMigrationAssembly.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/DbSchemaAwareMigrationAssembly.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Migrations.Internal;
+
+namespace Elsa.Persistence.EntityFramework.Core;
+
+public class DbSchemaAwareMigrationAssembly : MigrationsAssembly
+{
+    private readonly DbContext _context;
+
+    public DbSchemaAwareMigrationAssembly(ICurrentDbContext currentContext,
+        IDbContextOptions options, IMigrationsIdGenerator idGenerator,
+        IDiagnosticsLogger<DbLoggerCategory.Migrations> logger)
+        : base(currentContext, options, idGenerator, logger)
+    {
+        _context = currentContext.Context;
+    }
+
+    public override Migration CreateMigration(TypeInfo migrationClass,
+        string activeProvider)
+    {
+        if (activeProvider == null)
+            throw new ArgumentNullException(nameof(activeProvider));
+
+        var hasCtorWithSchema = migrationClass
+            .GetConstructor(new[] { typeof(IElsaDbContextSchema) }) != null;
+
+        if (hasCtorWithSchema && _context is IElsaDbContextSchema schema)
+        {
+            var instance = (Migration)Activator.CreateInstance(migrationClass.AsType(), schema);
+            instance.ActiveProvider = activeProvider;
+            return instance;
+        }
+
+        return base.CreateMigration(migrationClass, activeProvider);
+    }
+}

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/Elsa.Persistence.EntityFramework.Core.csproj
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/Elsa.Persistence.EntityFramework.Core.csproj
@@ -31,4 +31,8 @@
         <ProjectReference Include="..\..\..\core\Elsa.Core\Elsa.Core.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+      <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" />
+    </ItemGroup>
+
 </Project>

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/ElsaDbContextOptions.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/ElsaDbContextOptions.cs
@@ -1,0 +1,25 @@
+using JetBrains.Annotations;
+
+namespace Elsa.Persistence.EntityFramework.Core;
+
+/// <summary>
+/// Provides options for configuring Elsa's Entity Framework Core integration.
+/// </summary>
+[PublicAPI]
+public class ElsaDbContextOptions
+{
+    /// <summary>
+    /// The schema used by Elsa.
+    /// </summary>
+    public string? SchemaName { get; set; }
+    
+    /// <summary>
+    /// The table used to store the migrations history.
+    /// </summary>
+    public string? MigrationsHistoryTableName { get; set; }
+    
+    /// <summary>
+    /// The assembly name containing the migrations.
+    /// </summary>
+    public string? MigrationsAssemblyName { get; set; }
+}

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/ElsaDbContextOptionsExtension.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/ElsaDbContextOptionsExtension.cs
@@ -1,0 +1,38 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Elsa.Persistence.EntityFramework.Core;
+
+/// <summary>
+/// Provides options for configuring Elsa's Entity Framework Core integration.
+/// </summary>
+public class ElsaDbContextOptionsExtension : IDbContextOptionsExtension
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ElsaDbContextOptionsExtension"/> class.
+    /// </summary>
+    /// <param name="options">The options.</param>
+    public ElsaDbContextOptionsExtension(ElsaDbContextOptions? options)
+    {
+        Options = options;
+    }
+
+    /// <summary>
+    /// Gets the options.
+    /// </summary>
+    public ElsaDbContextOptions? Options { get; }
+
+    /// <inheritdoc />
+    public DbContextOptionsExtensionInfo Info => new CustomDbContextOptionsExtensionInfo(this);
+
+    /// <inheritdoc />
+    public void ApplyServices(IServiceCollection services)
+    {
+    }
+
+    /// <inheritdoc />
+    public void Validate(IDbContextOptions options)
+    {
+
+    }
+}

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/ElsaDbContextOptionsExtensions.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/ElsaDbContextOptionsExtensions.cs
@@ -1,0 +1,28 @@
+using System.Reflection;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Elsa.Persistence.EntityFramework.Core;
+
+/// <summary>
+/// Provides options for configuring Elsa's Entity Framework Core integration.
+/// </summary>
+public static class ElsaDbContextOptionsExtensions
+{
+    /// <summary>
+    /// Installs a custom extension for Elsa's Entity Framework Core integration.
+    /// </summary>
+    /// <param name="optionsBuilder">The options builder to install the extension on.</param>
+    /// <param name="options">The options to install.</param>
+    public static DbContextOptionsBuilder UseElsaDbContextOptions(this DbContextOptionsBuilder optionsBuilder, ElsaDbContextOptions? options)
+    {
+        ((IDbContextOptionsBuilderInfrastructure)optionsBuilder).AddOrUpdateExtension(new ElsaDbContextOptionsExtension(options));
+        optionsBuilder.ReplaceService<IMigrationsAssembly, DbSchemaAwareMigrationAssembly>();
+        return optionsBuilder;
+    }
+
+    public static string GetMigrationsAssemblyName(this ElsaDbContextOptions? options, Assembly migrationsAssembly) => options?.MigrationsAssemblyName ?? migrationsAssembly.GetName().Name!;
+    public static string GetMigrationsHistoryTableName(this ElsaDbContextOptions? options) => options?.MigrationsHistoryTableName ?? ElsaContext.MigrationsHistoryTable;
+    public static string GetSchemaName(this ElsaDbContextOptions? options) => options?.SchemaName ?? ElsaContext.ElsaSchema;
+}

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/IElsaDbContextSchema.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/IElsaDbContextSchema.cs
@@ -1,0 +1,12 @@
+namespace Elsa.Persistence.EntityFramework.Core;
+
+/// <summary>
+/// Interface to provide custom Elsa Db Context Schema in Migration
+/// </summary>
+public interface IElsaDbContextSchema
+{
+    /// <summary>
+    /// Name of the Schema
+    /// </summary>
+    public string Schema { get; }
+}

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.MySql/DbContextOptionsBuilderExtensions.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.MySql/DbContextOptionsBuilderExtensions.cs
@@ -9,10 +9,10 @@ namespace Elsa.Persistence.EntityFramework.MySql
         /// <summary>
         /// Configures the context to use MySql 
         /// </summary>
-        public static DbContextOptionsBuilder UseMySql(this DbContextOptionsBuilder builder, string connectionString) => 
+        public static DbContextOptionsBuilder UseMySql(this DbContextOptionsBuilder builder, string connectionString, ElsaDbContextOptions? options = default) => 
             builder.UseMySql(connectionString, ServerVersion.AutoDetect(connectionString), db => db
-                .MigrationsAssembly(typeof(MySqlElsaContextFactory).Assembly.GetName().Name)
-                .MigrationsHistoryTable(ElsaContext.MigrationsHistoryTable, ElsaContext.ElsaSchema)
+                .MigrationsAssembly(options.GetMigrationsAssemblyName(typeof(MySqlElsaContextFactory).Assembly))
+                .MigrationsHistoryTable(options.GetMigrationsHistoryTableName(), options.GetSchemaName())
                 .SchemaBehavior(MySqlSchemaBehavior.Ignore));
     }
 }

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Oracle/DbContextOptionsBuilderExtensions.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Oracle/DbContextOptionsBuilderExtensions.cs
@@ -8,9 +8,11 @@ namespace Elsa.Persistence.EntityFramework.Oracle
         /// <summary>
         /// Configures the context to use Oracle.
         /// </summary>
-        public static DbContextOptionsBuilder UseOracle(this DbContextOptionsBuilder builder, string connectionString) =>
-            builder.UseOracle(connectionString, db => db
-                .MigrationsAssembly(typeof(OracleElsaContextFactory).Assembly.GetName().Name)
-                .MigrationsHistoryTable(ElsaContext.MigrationsHistoryTable, ElsaContext.ElsaSchema));
+        public static DbContextOptionsBuilder UseOracle(this DbContextOptionsBuilder builder, string connectionString, ElsaDbContextOptions? options = default) =>
+            builder
+                .UseElsaDbContextOptions(options)
+                .UseOracle(connectionString, db => db
+                .MigrationsAssembly(options.GetMigrationsAssemblyName(typeof(OracleElsaContextFactory).Assembly))
+                .MigrationsHistoryTable(options.GetMigrationsHistoryTableName(), options.GetSchemaName()));
     }
 }

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Oracle/Migrations/20211215111405_Initial.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Oracle/Migrations/20211215111405_Initial.cs
@@ -1,18 +1,24 @@
 ﻿using System;
+using Elsa.Persistence.EntityFramework.Core;
 using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace Elsa.Persistence.EntityFramework.Oracle.Migrations
 {
     public partial class Initial : Migration
     {
+        private readonly IElsaDbContextSchema _schema;
+        public Initial(IElsaDbContextSchema schema)
+        {
+            _schema = schema ?? throw new ArgumentNullException(nameof(schema));
+        }
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.EnsureSchema(
-                name: "Elsa");
+                name: _schema.Schema);
 
             migrationBuilder.CreateTable(
                 name: "Bookmarks",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "NVARCHAR2(450)", nullable: false),
@@ -32,7 +38,7 @@ namespace Elsa.Persistence.EntityFramework.Oracle.Migrations
 
             migrationBuilder.CreateTable(
                 name: "WorkflowDefinitions",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "NVARCHAR2(450)", nullable: false),
@@ -57,7 +63,7 @@ namespace Elsa.Persistence.EntityFramework.Oracle.Migrations
 
             migrationBuilder.CreateTable(
                 name: "WorkflowExecutionLogRecords",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "NVARCHAR2(450)", nullable: false),
@@ -78,7 +84,7 @@ namespace Elsa.Persistence.EntityFramework.Oracle.Migrations
 
             migrationBuilder.CreateTable(
                 name: "WorkflowInstances",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "NVARCHAR2(450)", nullable: false),
@@ -106,200 +112,200 @@ namespace Elsa.Persistence.EntityFramework.Oracle.Migrations
 
             migrationBuilder.CreateIndex(
                 name: "IX_Bookmark_ActivityId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Bookmarks",
                 column: "ActivityId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_Bookmark_ActivityType",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Bookmarks",
                 column: "ActivityType");
 
             migrationBuilder.CreateIndex(
                 name: "IX_Bookmark_ActivityType_TenantId_Hash",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Bookmarks",
                 columns: new[] { "ActivityType", "TenantId", "Hash" });
 
             migrationBuilder.CreateIndex(
                 name: "IX_Bookmark_CorrelationId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Bookmarks",
                 column: "CorrelationId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_Bookmark_Hash",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Bookmarks",
                 column: "Hash");
 
             migrationBuilder.CreateIndex(
                 name: "IX_Bookmark_Hash_CorrelationId_TenantId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Bookmarks",
                 columns: new[] { "Hash", "CorrelationId", "TenantId" });
 
             migrationBuilder.CreateIndex(
                 name: "IX_Bookmark_TenantId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Bookmarks",
                 column: "TenantId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_Bookmark_WorkflowInstanceId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Bookmarks",
                 column: "WorkflowInstanceId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowDefinition_DefinitionId_VersionId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitions",
                 columns: new[] { "DefinitionId", "Version" },
                 unique: true);
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowDefinition_IsLatest",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitions",
                 column: "IsLatest");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowDefinition_IsPublished",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitions",
                 column: "IsPublished");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowDefinition_Name",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitions",
                 column: "Name");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowDefinition_Tag",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitions",
                 column: "Tag");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowDefinition_TenantId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitions",
                 column: "TenantId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowDefinition_Version",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitions",
                 column: "Version");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_ActivityId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "ActivityId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_ActivityType",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "ActivityType");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_TenantId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "TenantId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_Timestamp",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "Timestamp");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_WorkflowInstanceId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "WorkflowInstanceId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_ContextId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "ContextId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_ContextType",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "ContextType");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_CorrelationId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "CorrelationId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_CreatedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "CreatedAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_DefinitionId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "DefinitionId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_FaultedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "FaultedAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_FinishedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "FinishedAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_LastExecutedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "LastExecutedAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_Name",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "Name");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_TenantId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "TenantId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_WorkflowStatus",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "WorkflowStatus");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_WorkflowStatus_DefinitionId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 columns: new[] { "WorkflowStatus", "DefinitionId" });
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_WorkflowStatus_DefinitionId_Version",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 columns: new[] { "WorkflowStatus", "DefinitionId", "Version" });
         }
@@ -308,19 +314,19 @@ namespace Elsa.Persistence.EntityFramework.Oracle.Migrations
         {
             migrationBuilder.DropTable(
                 name: "Bookmarks",
-                schema: "Elsa");
+                schema: _schema.Schema);
 
             migrationBuilder.DropTable(
                 name: "WorkflowDefinitions",
-                schema: "Elsa");
+                schema: _schema.Schema);
 
             migrationBuilder.DropTable(
                 name: "WorkflowExecutionLogRecords",
-                schema: "Elsa");
+                schema: _schema.Schema);
 
             migrationBuilder.DropTable(
                 name: "WorkflowInstances",
-                schema: "Elsa");
+                schema: _schema.Schema);
         }
     }
 }

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Oracle/Migrations/20220120170132_Update241.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Oracle/Migrations/20220120170132_Update241.cs
@@ -1,14 +1,21 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+﻿using System;
+using Elsa.Persistence.EntityFramework.Core;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace Elsa.Persistence.EntityFramework.Oracle.Migrations
 {
     public partial class Update241 : Migration
     {
+        private readonly IElsaDbContextSchema _schema;
+        public Update241(IElsaDbContextSchema schema)
+        {
+            _schema = schema ?? throw new ArgumentNullException(nameof(schema));
+        }
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.AlterColumn<string>(
                 name: "DefinitionVersionId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 type: "NVARCHAR2(450)",
                 nullable: false,
@@ -17,7 +24,7 @@ namespace Elsa.Persistence.EntityFramework.Oracle.Migrations
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_DefinitionVersionId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "DefinitionVersionId");
         }
@@ -26,12 +33,12 @@ namespace Elsa.Persistence.EntityFramework.Oracle.Migrations
         {
             migrationBuilder.DropIndex(
                 name: "IX_WorkflowInstance_DefinitionVersionId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances");
 
             migrationBuilder.AlterColumn<string>(
                 name: "DefinitionVersionId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 type: "NVARCHAR2(2000)",
                 nullable: false,

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Oracle/Migrations/20220120204210_Update25.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Oracle/Migrations/20220120204210_Update25.cs
@@ -1,14 +1,21 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+﻿using System;
+using Elsa.Persistence.EntityFramework.Core;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace Elsa.Persistence.EntityFramework.Oracle.Migrations
 {
     public partial class Update25 : Migration
     {
+        private readonly IElsaDbContextSchema _schema;
+        public Update25(IElsaDbContextSchema schema)
+        {
+            _schema = schema ?? throw new ArgumentNullException(nameof(schema));
+        }
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.CreateTable(
                 name: "Triggers",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "NVARCHAR2(450)", nullable: false),
@@ -27,43 +34,43 @@ namespace Elsa.Persistence.EntityFramework.Oracle.Migrations
 
             migrationBuilder.CreateIndex(
                 name: "IX_Trigger_ActivityId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Triggers",
                 column: "ActivityId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_Trigger_ActivityType",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Triggers",
                 column: "ActivityType");
 
             migrationBuilder.CreateIndex(
                 name: "IX_Trigger_ActivityType_TenantId_Hash",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Triggers",
                 columns: new[] { "ActivityType", "TenantId", "Hash" });
 
             migrationBuilder.CreateIndex(
                 name: "IX_Trigger_Hash",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Triggers",
                 column: "Hash");
 
             migrationBuilder.CreateIndex(
                 name: "IX_Trigger_Hash_TenantId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Triggers",
                 columns: new[] { "Hash", "TenantId" });
 
             migrationBuilder.CreateIndex(
                 name: "IX_Trigger_TenantId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Triggers",
                 column: "TenantId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_Trigger_WorkflowDefinitionId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Triggers",
                 column: "WorkflowDefinitionId");
         }
@@ -72,7 +79,7 @@ namespace Elsa.Persistence.EntityFramework.Oracle.Migrations
         {
             migrationBuilder.DropTable(
                 name: "Triggers",
-                schema: "Elsa");
+                schema: _schema.Schema);
         }
     }
 }

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Oracle/Migrations/20220512203705_Update28.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Oracle/Migrations/20220512203705_Update28.cs
@@ -1,15 +1,21 @@
 ﻿using System;
+using Elsa.Persistence.EntityFramework.Core;
 using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace Elsa.Persistence.EntityFramework.Oracle.Migrations
 {
     public partial class Update28 : Migration
     {
+        private readonly IElsaDbContextSchema _schema;
+        public Update28(IElsaDbContextSchema schema)
+        {
+            _schema = schema ?? throw new ArgumentNullException(nameof(schema));
+        }
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.AddColumn<DateTimeOffset>(
                 name: "CreatedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitions",
                 type: "TIMESTAMP(7) WITH TIME ZONE",
                 nullable: false,
@@ -20,7 +26,7 @@ namespace Elsa.Persistence.EntityFramework.Oracle.Migrations
         {
             migrationBuilder.DropColumn(
                 name: "CreatedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitions");
         }
     }

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.PostgreSql/DbContextOptionsBuilderExtensions.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.PostgreSql/DbContextOptionsBuilderExtensions.cs
@@ -8,9 +8,11 @@ namespace Elsa.Persistence.EntityFramework.PostgreSql
         /// <summary>
         /// Configures the context to use PostgreSql.
         /// </summary>
-        public static DbContextOptionsBuilder UsePostgreSql(this DbContextOptionsBuilder builder, string connectionString) => 
-            builder.UseNpgsql(connectionString, db => db
-                .MigrationsAssembly(typeof(PostgreSqlElsaContextFactory).Assembly.GetName().Name)
-                .MigrationsHistoryTable(ElsaContext.MigrationsHistoryTable, ElsaContext.ElsaSchema));
+        public static DbContextOptionsBuilder UsePostgreSql(this DbContextOptionsBuilder builder, string connectionString, ElsaDbContextOptions? options = default) => 
+            builder
+                .UseElsaDbContextOptions(options)
+                .UseNpgsql(connectionString, db => db
+                .MigrationsAssembly(options.GetMigrationsAssemblyName(typeof(PostgreSqlElsaContextFactory).Assembly))
+                .MigrationsHistoryTable(options.GetMigrationsHistoryTableName(), options.GetSchemaName()));
     }
 }

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.PostgreSql/Migrations/20210523093439_Initial.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.PostgreSql/Migrations/20210523093439_Initial.cs
@@ -1,18 +1,24 @@
 ﻿using System;
+using Elsa.Persistence.EntityFramework.Core;
 using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace Elsa.Persistence.EntityFramework.PostgreSql.Migrations
 {
     public partial class Initial : Migration
     {
+        private readonly IElsaDbContextSchema _schema;
+        public Initial(IElsaDbContextSchema schema)
+        {
+            _schema = schema ?? throw new ArgumentNullException(nameof(schema));
+        }
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.EnsureSchema(
-                name: "Elsa");
+                name: _schema.Schema);
 
             migrationBuilder.CreateTable(
                 name: "Bookmarks",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "text", nullable: false),
@@ -32,7 +38,7 @@ namespace Elsa.Persistence.EntityFramework.PostgreSql.Migrations
 
             migrationBuilder.CreateTable(
                 name: "WorkflowDefinitions",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "text", nullable: false),
@@ -57,7 +63,7 @@ namespace Elsa.Persistence.EntityFramework.PostgreSql.Migrations
 
             migrationBuilder.CreateTable(
                 name: "WorkflowExecutionLogRecords",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "text", nullable: false),
@@ -78,7 +84,7 @@ namespace Elsa.Persistence.EntityFramework.PostgreSql.Migrations
 
             migrationBuilder.CreateTable(
                 name: "WorkflowInstances",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "text", nullable: false),
@@ -104,200 +110,200 @@ namespace Elsa.Persistence.EntityFramework.PostgreSql.Migrations
 
             migrationBuilder.CreateIndex(
                 name: "IX_Bookmark_ActivityId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Bookmarks",
                 column: "ActivityId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_Bookmark_ActivityType",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Bookmarks",
                 column: "ActivityType");
 
             migrationBuilder.CreateIndex(
                 name: "IX_Bookmark_ActivityType_TenantId_Hash",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Bookmarks",
                 columns: new[] { "ActivityType", "TenantId", "Hash" });
 
             migrationBuilder.CreateIndex(
                 name: "IX_Bookmark_CorrelationId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Bookmarks",
                 column: "CorrelationId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_Bookmark_Hash",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Bookmarks",
                 column: "Hash");
 
             migrationBuilder.CreateIndex(
                 name: "IX_Bookmark_Hash_CorrelationId_TenantId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Bookmarks",
                 columns: new[] { "Hash", "CorrelationId", "TenantId" });
 
             migrationBuilder.CreateIndex(
                 name: "IX_Bookmark_TenantId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Bookmarks",
                 column: "TenantId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_Bookmark_WorkflowInstanceId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Bookmarks",
                 column: "WorkflowInstanceId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowDefinition_DefinitionId_VersionId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitions",
                 columns: new[] { "DefinitionId", "Version" },
                 unique: true);
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowDefinition_IsLatest",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitions",
                 column: "IsLatest");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowDefinition_IsPublished",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitions",
                 column: "IsPublished");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowDefinition_Name",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitions",
                 column: "Name");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowDefinition_Tag",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitions",
                 column: "Tag");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowDefinition_TenantId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitions",
                 column: "TenantId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowDefinition_Version",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitions",
                 column: "Version");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_ActivityId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "ActivityId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_ActivityType",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "ActivityType");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_TenantId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "TenantId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_Timestamp",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "Timestamp");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_WorkflowInstanceId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "WorkflowInstanceId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_ContextId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "ContextId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_ContextType",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "ContextType");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_CorrelationId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "CorrelationId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_CreatedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "CreatedAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_DefinitionId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "DefinitionId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_FaultedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "FaultedAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_FinishedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "FinishedAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_LastExecutedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "LastExecutedAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_Name",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "Name");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_TenantId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "TenantId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_WorkflowStatus",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "WorkflowStatus");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_WorkflowStatus_DefinitionId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 columns: new[] { "WorkflowStatus", "DefinitionId" });
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_WorkflowStatus_DefinitionId_Version",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 columns: new[] { "WorkflowStatus", "DefinitionId", "Version" });
         }
@@ -306,19 +312,19 @@ namespace Elsa.Persistence.EntityFramework.PostgreSql.Migrations
         {
             migrationBuilder.DropTable(
                 name: "Bookmarks",
-                schema: "Elsa");
+                schema: _schema.Schema);
 
             migrationBuilder.DropTable(
                 name: "WorkflowDefinitions",
-                schema: "Elsa");
+                schema: _schema.Schema);
 
             migrationBuilder.DropTable(
                 name: "WorkflowExecutionLogRecords",
-                schema: "Elsa");
+                schema: _schema.Schema);
 
             migrationBuilder.DropTable(
                 name: "WorkflowInstances",
-                schema: "Elsa");
+                schema: _schema.Schema);
         }
     }
 }

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.PostgreSql/Migrations/20210611200035_Update21.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.PostgreSql/Migrations/20210611200035_Update21.cs
@@ -1,14 +1,21 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+﻿using System;
+using Elsa.Persistence.EntityFramework.Core;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace Elsa.Persistence.EntityFramework.PostgreSql.Migrations
 {
     public partial class Update21 : Migration
     {
+        private readonly IElsaDbContextSchema _schema;
+        public Update21(IElsaDbContextSchema schema)
+        {
+            _schema = schema ?? throw new ArgumentNullException(nameof(schema));
+        }
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.AlterColumn<string>(
                 name: "CorrelationId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 type: "text",
                 nullable: false,
@@ -19,14 +26,14 @@ namespace Elsa.Persistence.EntityFramework.PostgreSql.Migrations
 
             migrationBuilder.AddColumn<string>(
                 name: "LastExecutedActivityId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 type: "text",
                 nullable: true);
 
             migrationBuilder.AddColumn<string>(
                 name: "OutputStorageProviderName",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitions",
                 type: "text",
                 nullable: true);
@@ -36,17 +43,17 @@ namespace Elsa.Persistence.EntityFramework.PostgreSql.Migrations
         {
             migrationBuilder.DropColumn(
                 name: "LastExecutedActivityId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances");
 
             migrationBuilder.DropColumn(
                 name: "OutputStorageProviderName",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitions");
 
             migrationBuilder.AlterColumn<string>(
                 name: "CorrelationId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 type: "text",
                 nullable: true,

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.PostgreSql/Migrations/20210923112216_Update23.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.PostgreSql/Migrations/20210923112216_Update23.cs
@@ -1,14 +1,21 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+﻿using System;
+using Elsa.Persistence.EntityFramework.Core;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace Elsa.Persistence.EntityFramework.PostgreSql.Migrations
 {
     public partial class Update23 : Migration
     {
+        private readonly IElsaDbContextSchema _schema;
+        public Update23(IElsaDbContextSchema schema)
+        {
+            _schema = schema ?? throw new ArgumentNullException(nameof(schema));
+        }
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.DropColumn(
                 name: "OutputStorageProviderName",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitions");
         }
 
@@ -16,7 +23,7 @@ namespace Elsa.Persistence.EntityFramework.PostgreSql.Migrations
         {
             migrationBuilder.AddColumn<string>(
                 name: "OutputStorageProviderName",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitions",
                 type: "text",
                 nullable: true);

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.PostgreSql/Migrations/20211215100208_Update24.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.PostgreSql/Migrations/20211215100208_Update24.cs
@@ -1,14 +1,21 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+﻿using System;
+using Elsa.Persistence.EntityFramework.Core;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace Elsa.Persistence.EntityFramework.PostgreSql.Migrations
 {
     public partial class Update24 : Migration
     {
+        private readonly IElsaDbContextSchema _schema;
+        public Update24(IElsaDbContextSchema schema)
+        {
+            _schema = schema ?? throw new ArgumentNullException(nameof(schema));
+        }
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.AddColumn<string>(
                 name: "DefinitionVersionId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 type: "text",
                 nullable: false,
@@ -16,7 +23,7 @@ namespace Elsa.Persistence.EntityFramework.PostgreSql.Migrations
 
             migrationBuilder.AlterColumn<string>(
                 name: "CorrelationId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Bookmarks",
                 type: "text",
                 nullable: false,
@@ -30,12 +37,12 @@ namespace Elsa.Persistence.EntityFramework.PostgreSql.Migrations
         {
             migrationBuilder.DropColumn(
                 name: "DefinitionVersionId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances");
 
             migrationBuilder.AlterColumn<string>(
                 name: "CorrelationId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Bookmarks",
                 type: "text",
                 nullable: true,

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.PostgreSql/Migrations/20220120170155_Update241.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.PostgreSql/Migrations/20220120170155_Update241.cs
@@ -1,14 +1,21 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+﻿using System;
+using Elsa.Persistence.EntityFramework.Core;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace Elsa.Persistence.EntityFramework.PostgreSql.Migrations
 {
     public partial class Update241 : Migration
     {
+        private readonly IElsaDbContextSchema _schema;
+        public Update241(IElsaDbContextSchema schema)
+        {
+            _schema = schema ?? throw new ArgumentNullException(nameof(schema));
+        }
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_DefinitionVersionId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "DefinitionVersionId");
         }
@@ -17,7 +24,7 @@ namespace Elsa.Persistence.EntityFramework.PostgreSql.Migrations
         {
             migrationBuilder.DropIndex(
                 name: "IX_WorkflowInstance_DefinitionVersionId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances");
         }
     }

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.PostgreSql/Migrations/20220120204155_Update25.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.PostgreSql/Migrations/20220120204155_Update25.cs
@@ -1,14 +1,21 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+﻿using System;
+using Elsa.Persistence.EntityFramework.Core;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace Elsa.Persistence.EntityFramework.PostgreSql.Migrations
 {
     public partial class Update25 : Migration
     {
+        private readonly IElsaDbContextSchema _schema;
+        public Update25(IElsaDbContextSchema schema)
+        {
+            _schema = schema ?? throw new ArgumentNullException(nameof(schema));
+        }
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.CreateTable(
                 name: "Triggers",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "text", nullable: false),
@@ -27,43 +34,43 @@ namespace Elsa.Persistence.EntityFramework.PostgreSql.Migrations
 
             migrationBuilder.CreateIndex(
                 name: "IX_Trigger_ActivityId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Triggers",
                 column: "ActivityId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_Trigger_ActivityType",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Triggers",
                 column: "ActivityType");
 
             migrationBuilder.CreateIndex(
                 name: "IX_Trigger_ActivityType_TenantId_Hash",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Triggers",
                 columns: new[] { "ActivityType", "TenantId", "Hash" });
 
             migrationBuilder.CreateIndex(
                 name: "IX_Trigger_Hash",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Triggers",
                 column: "Hash");
 
             migrationBuilder.CreateIndex(
                 name: "IX_Trigger_Hash_TenantId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Triggers",
                 columns: new[] { "Hash", "TenantId" });
 
             migrationBuilder.CreateIndex(
                 name: "IX_Trigger_TenantId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Triggers",
                 column: "TenantId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_Trigger_WorkflowDefinitionId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Triggers",
                 column: "WorkflowDefinitionId");
         }
@@ -72,7 +79,7 @@ namespace Elsa.Persistence.EntityFramework.PostgreSql.Migrations
         {
             migrationBuilder.DropTable(
                 name: "Triggers",
-                schema: "Elsa");
+                schema: _schema.Schema);
         }
     }
 }

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.PostgreSql/Migrations/20220512203651_Update28.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.PostgreSql/Migrations/20220512203651_Update28.cs
@@ -1,15 +1,21 @@
 ﻿using System;
+using Elsa.Persistence.EntityFramework.Core;
 using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace Elsa.Persistence.EntityFramework.PostgreSql.Migrations
 {
     public partial class Update28 : Migration
     {
+        private readonly IElsaDbContextSchema _schema;
+        public Update28(IElsaDbContextSchema schema)
+        {
+            _schema = schema ?? throw new ArgumentNullException(nameof(schema));
+        }
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.AddColumn<DateTimeOffset>(
                 name: "CreatedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitions",
                 type: "timestamp with time zone",
                 nullable: false,
@@ -20,7 +26,7 @@ namespace Elsa.Persistence.EntityFramework.PostgreSql.Migrations
         {
             migrationBuilder.DropColumn(
                 name: "CreatedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitions");
         }
     }

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.SqlServer/DbContextOptionsBuilderExtensions.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.SqlServer/DbContextOptionsBuilderExtensions.cs
@@ -9,12 +9,14 @@ namespace Elsa.Persistence.EntityFramework.SqlServer
         /// <summary>
         /// Configures the context to use SqlServer.
         /// </summary>
-        public static DbContextOptionsBuilder UseSqlServer(this DbContextOptionsBuilder builder, string connectionString, Type? migrationsAssemblyMarker = default)
+        public static DbContextOptionsBuilder UseSqlServer(this DbContextOptionsBuilder builder, string connectionString, Type? migrationsAssemblyMarker = default, ElsaDbContextOptions? options = default)
         {
             migrationsAssemblyMarker ??= typeof(SqlServerElsaContextFactory);
-            return builder.UseSqlServer(connectionString, db => db
-                .MigrationsAssembly(migrationsAssemblyMarker.Assembly.GetName().Name)
-                .MigrationsHistoryTable(ElsaContext.MigrationsHistoryTable, ElsaContext.ElsaSchema));
+            return builder.
+                UseElsaDbContextOptions(options)
+                .UseSqlServer(connectionString, db => db
+                .MigrationsAssembly(options.GetMigrationsAssemblyName(migrationsAssemblyMarker.Assembly))
+                .MigrationsHistoryTable(options.GetMigrationsHistoryTableName(), options.GetSchemaName()));
         }
     }
 }

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.SqlServer/Migrations/20210523093504_Initial.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.SqlServer/Migrations/20210523093504_Initial.cs
@@ -1,18 +1,24 @@
 ﻿using System;
+using Elsa.Persistence.EntityFramework.Core;
 using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace Elsa.Persistence.EntityFramework.SqlServer.Migrations
 {
     public partial class Initial : Migration
     {
+        private readonly IElsaDbContextSchema _schema;
+        public Initial(IElsaDbContextSchema schema)
+        {
+            _schema = schema ?? throw new ArgumentNullException(nameof(schema));
+        }
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.EnsureSchema(
-                name: "Elsa");
+                name: _schema.Schema);
 
             migrationBuilder.CreateTable(
                 name: "Bookmarks",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "nvarchar(450)", nullable: false),
@@ -32,7 +38,7 @@ namespace Elsa.Persistence.EntityFramework.SqlServer.Migrations
 
             migrationBuilder.CreateTable(
                 name: "WorkflowDefinitions",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "nvarchar(450)", nullable: false),
@@ -57,7 +63,7 @@ namespace Elsa.Persistence.EntityFramework.SqlServer.Migrations
 
             migrationBuilder.CreateTable(
                 name: "WorkflowExecutionLogRecords",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "nvarchar(450)", nullable: false),
@@ -78,7 +84,7 @@ namespace Elsa.Persistence.EntityFramework.SqlServer.Migrations
 
             migrationBuilder.CreateTable(
                 name: "WorkflowInstances",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "nvarchar(450)", nullable: false),
@@ -104,200 +110,200 @@ namespace Elsa.Persistence.EntityFramework.SqlServer.Migrations
 
             migrationBuilder.CreateIndex(
                 name: "IX_Bookmark_ActivityId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Bookmarks",
                 column: "ActivityId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_Bookmark_ActivityType",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Bookmarks",
                 column: "ActivityType");
 
             migrationBuilder.CreateIndex(
                 name: "IX_Bookmark_ActivityType_TenantId_Hash",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Bookmarks",
                 columns: new[] { "ActivityType", "TenantId", "Hash" });
 
             migrationBuilder.CreateIndex(
                 name: "IX_Bookmark_CorrelationId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Bookmarks",
                 column: "CorrelationId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_Bookmark_Hash",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Bookmarks",
                 column: "Hash");
 
             migrationBuilder.CreateIndex(
                 name: "IX_Bookmark_Hash_CorrelationId_TenantId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Bookmarks",
                 columns: new[] { "Hash", "CorrelationId", "TenantId" });
 
             migrationBuilder.CreateIndex(
                 name: "IX_Bookmark_TenantId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Bookmarks",
                 column: "TenantId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_Bookmark_WorkflowInstanceId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Bookmarks",
                 column: "WorkflowInstanceId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowDefinition_DefinitionId_VersionId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitions",
                 columns: new[] { "DefinitionId", "Version" },
                 unique: true);
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowDefinition_IsLatest",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitions",
                 column: "IsLatest");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowDefinition_IsPublished",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitions",
                 column: "IsPublished");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowDefinition_Name",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitions",
                 column: "Name");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowDefinition_Tag",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitions",
                 column: "Tag");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowDefinition_TenantId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitions",
                 column: "TenantId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowDefinition_Version",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitions",
                 column: "Version");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_ActivityId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "ActivityId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_ActivityType",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "ActivityType");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_TenantId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "TenantId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_Timestamp",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "Timestamp");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowExecutionLogRecord_WorkflowInstanceId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowExecutionLogRecords",
                 column: "WorkflowInstanceId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_ContextId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "ContextId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_ContextType",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "ContextType");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_CorrelationId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "CorrelationId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_CreatedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "CreatedAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_DefinitionId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "DefinitionId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_FaultedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "FaultedAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_FinishedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "FinishedAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_LastExecutedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "LastExecutedAt");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_Name",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "Name");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_TenantId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "TenantId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_WorkflowStatus",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "WorkflowStatus");
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_WorkflowStatus_DefinitionId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 columns: new[] { "WorkflowStatus", "DefinitionId" });
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_WorkflowStatus_DefinitionId_Version",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 columns: new[] { "WorkflowStatus", "DefinitionId", "Version" });
         }
@@ -306,19 +312,19 @@ namespace Elsa.Persistence.EntityFramework.SqlServer.Migrations
         {
             migrationBuilder.DropTable(
                 name: "Bookmarks",
-                schema: "Elsa");
+                schema: _schema.Schema);
 
             migrationBuilder.DropTable(
                 name: "WorkflowDefinitions",
-                schema: "Elsa");
+                schema: _schema.Schema);
 
             migrationBuilder.DropTable(
                 name: "WorkflowExecutionLogRecords",
-                schema: "Elsa");
+                schema: _schema.Schema);
 
             migrationBuilder.DropTable(
                 name: "WorkflowInstances",
-                schema: "Elsa");
+                schema: _schema.Schema);
         }
     }
 }

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.SqlServer/Migrations/20210611200049_Update21.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.SqlServer/Migrations/20210611200049_Update21.cs
@@ -1,14 +1,26 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+﻿using System;
+using Elsa.Persistence.EntityFramework.Core;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace Elsa.Persistence.EntityFramework.SqlServer.Migrations
 {
     public partial class Update21 : Migration
     {
+        private readonly IElsaDbContextSchema _schema;
+        public Update21(IElsaDbContextSchema schema)
+        {
+            _schema = schema ?? throw new ArgumentNullException(nameof(schema));
+        }
         protected override void Up(MigrationBuilder migrationBuilder)
         {
+            migrationBuilder.DropIndex(
+                name: "IX_WorkflowInstance_CorrelationId",
+                schema: _schema.Schema,
+                table: "WorkflowInstances");
+
             migrationBuilder.AlterColumn<string>(
                 name: "CorrelationId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 type: "nvarchar(450)",
                 nullable: false,
@@ -16,17 +28,23 @@ namespace Elsa.Persistence.EntityFramework.SqlServer.Migrations
                 oldClrType: typeof(string),
                 oldType: "nvarchar(450)",
                 oldNullable: true);
-
+            
+            migrationBuilder.CreateIndex(
+                name: "IX_WorkflowInstance_CorrelationId",
+                schema: _schema.Schema,
+                table: "WorkflowInstances",
+                column: "CorrelationId");
+            
             migrationBuilder.AddColumn<string>(
                 name: "LastExecutedActivityId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 type: "nvarchar(max)",
                 nullable: true);
 
             migrationBuilder.AddColumn<string>(
                 name: "OutputStorageProviderName",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitions",
                 type: "nvarchar(max)",
                 nullable: true);
@@ -36,22 +54,33 @@ namespace Elsa.Persistence.EntityFramework.SqlServer.Migrations
         {
             migrationBuilder.DropColumn(
                 name: "LastExecutedActivityId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances");
 
             migrationBuilder.DropColumn(
                 name: "OutputStorageProviderName",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitions");
 
+            migrationBuilder.DropIndex(
+                name: "IX_WorkflowInstance_CorrelationId",
+                schema: _schema.Schema,
+                table: "WorkflowInstances");
+            
             migrationBuilder.AlterColumn<string>(
                 name: "CorrelationId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 type: "nvarchar(450)",
                 nullable: true,
                 oldClrType: typeof(string),
                 oldType: "nvarchar(450)");
+            
+            migrationBuilder.CreateIndex(
+                name: "IX_WorkflowInstance_CorrelationId",
+                schema: _schema.Schema,
+                table: "WorkflowInstances",
+                column: "CorrelationId");
         }
     }
 }

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.SqlServer/Migrations/20210923112224_Update23.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.SqlServer/Migrations/20210923112224_Update23.cs
@@ -1,14 +1,21 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+﻿using System;
+using Elsa.Persistence.EntityFramework.Core;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace Elsa.Persistence.EntityFramework.SqlServer.Migrations
 {
     public partial class Update23 : Migration
     {
+        private readonly IElsaDbContextSchema _schema;
+        public Update23(IElsaDbContextSchema schema)
+        {
+            _schema = schema ?? throw new ArgumentNullException(nameof(schema));
+        }
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.DropColumn(
                 name: "OutputStorageProviderName",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitions");
         }
 
@@ -16,7 +23,7 @@ namespace Elsa.Persistence.EntityFramework.SqlServer.Migrations
         {
             migrationBuilder.AddColumn<string>(
                 name: "OutputStorageProviderName",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitions",
                 type: "nvarchar(max)",
                 nullable: true);

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.SqlServer/Migrations/20211215100215_Update24.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.SqlServer/Migrations/20211215100215_Update24.cs
@@ -1,22 +1,39 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+﻿using System;
+using Elsa.Persistence.EntityFramework.Core;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace Elsa.Persistence.EntityFramework.SqlServer.Migrations
 {
     public partial class Update24 : Migration
     {
+        private readonly IElsaDbContextSchema _schema;
+        public Update24(IElsaDbContextSchema schema)
+        {
+            _schema = schema ?? throw new ArgumentNullException(nameof(schema));
+        }
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.AddColumn<string>(
                 name: "DefinitionVersionId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 type: "nvarchar(max)",
                 nullable: false,
                 defaultValue: "");
 
+            migrationBuilder.DropIndex(
+                name: "IX_Bookmark_CorrelationId",
+                schema: _schema.Schema,
+                table: "Bookmarks");            
+            
+            migrationBuilder.DropIndex(
+                name: "IX_Bookmark_Hash_CorrelationId_TenantId",
+                schema: _schema.Schema,
+                table: "Bookmarks");
+            
             migrationBuilder.AlterColumn<string>(
                 name: "CorrelationId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Bookmarks",
                 type: "nvarchar(450)",
                 nullable: false,
@@ -24,23 +41,58 @@ namespace Elsa.Persistence.EntityFramework.SqlServer.Migrations
                 oldClrType: typeof(string),
                 oldType: "nvarchar(450)",
                 oldNullable: true);
+            
+            migrationBuilder.CreateIndex(
+                name: "IX_Bookmark_CorrelationId",
+                schema: _schema.Schema,
+                table: "Bookmarks",
+                column: "CorrelationId");
+            
+            migrationBuilder.CreateIndex(
+                name: "IX_Bookmark_Hash_CorrelationId_TenantId",
+                schema: _schema.Schema,
+                table: "Bookmarks",
+                columns: new[] { "Hash", "CorrelationId", "TenantId" });
+
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.DropColumn(
                 name: "DefinitionVersionId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances");
 
+            migrationBuilder.DropIndex(
+                name: "IX_Bookmark_CorrelationId",
+                schema: _schema.Schema,
+                table: "Bookmarks");
+            
+            migrationBuilder.DropIndex(
+                name: "IX_Bookmark_Hash_CorrelationId_TenantId",
+                schema: _schema.Schema,
+                table: "Bookmarks");
+            
             migrationBuilder.AlterColumn<string>(
                 name: "CorrelationId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Bookmarks",
                 type: "nvarchar(450)",
                 nullable: true,
                 oldClrType: typeof(string),
                 oldType: "nvarchar(450)");
+            
+            migrationBuilder.CreateIndex(
+                name: "IX_Bookmark_CorrelationId",
+                schema: _schema.Schema,
+                table: "Bookmarks",
+                column: "CorrelationId");
+            
+            migrationBuilder.CreateIndex(
+                name: "IX_Bookmark_Hash_CorrelationId_TenantId",
+                schema: _schema.Schema,
+                table: "Bookmarks",
+                columns: new[] { "Hash", "CorrelationId", "TenantId" });
         }
     }
 }

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.SqlServer/Migrations/20220120170305_Update241.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.SqlServer/Migrations/20220120170305_Update241.cs
@@ -1,14 +1,21 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+﻿using System;
+using Elsa.Persistence.EntityFramework.Core;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace Elsa.Persistence.EntityFramework.SqlServer.Migrations
 {
     public partial class Update241 : Migration
     {
+        private readonly IElsaDbContextSchema _schema;
+        public Update241(IElsaDbContextSchema schema)
+        {
+            _schema = schema ?? throw new ArgumentNullException(nameof(schema));
+        }
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.AlterColumn<string>(
                 name: "DefinitionVersionId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 type: "nvarchar(450)",
                 nullable: false,
@@ -17,7 +24,7 @@ namespace Elsa.Persistence.EntityFramework.SqlServer.Migrations
 
             migrationBuilder.CreateIndex(
                 name: "IX_WorkflowInstance_DefinitionVersionId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 column: "DefinitionVersionId");
         }
@@ -26,12 +33,12 @@ namespace Elsa.Persistence.EntityFramework.SqlServer.Migrations
         {
             migrationBuilder.DropIndex(
                 name: "IX_WorkflowInstance_DefinitionVersionId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances");
 
             migrationBuilder.AlterColumn<string>(
                 name: "DefinitionVersionId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowInstances",
                 type: "nvarchar(max)",
                 nullable: false,

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.SqlServer/Migrations/20220120204205_Update25.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.SqlServer/Migrations/20220120204205_Update25.cs
@@ -1,14 +1,21 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+﻿using System;
+using Elsa.Persistence.EntityFramework.Core;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace Elsa.Persistence.EntityFramework.SqlServer.Migrations
 {
     public partial class Update25 : Migration
     {
+        private readonly IElsaDbContextSchema _schema;
+        public Update25(IElsaDbContextSchema schema)
+        {
+            _schema = schema ?? throw new ArgumentNullException(nameof(schema));
+        }
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.CreateTable(
                 name: "Triggers",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 columns: table => new
                 {
                     Id = table.Column<string>(type: "nvarchar(450)", nullable: false),
@@ -27,43 +34,43 @@ namespace Elsa.Persistence.EntityFramework.SqlServer.Migrations
 
             migrationBuilder.CreateIndex(
                 name: "IX_Trigger_ActivityId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Triggers",
                 column: "ActivityId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_Trigger_ActivityType",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Triggers",
                 column: "ActivityType");
 
             migrationBuilder.CreateIndex(
                 name: "IX_Trigger_ActivityType_TenantId_Hash",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Triggers",
                 columns: new[] { "ActivityType", "TenantId", "Hash" });
 
             migrationBuilder.CreateIndex(
                 name: "IX_Trigger_Hash",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Triggers",
                 column: "Hash");
 
             migrationBuilder.CreateIndex(
                 name: "IX_Trigger_Hash_TenantId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Triggers",
                 columns: new[] { "Hash", "TenantId" });
 
             migrationBuilder.CreateIndex(
                 name: "IX_Trigger_TenantId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Triggers",
                 column: "TenantId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_Trigger_WorkflowDefinitionId",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "Triggers",
                 column: "WorkflowDefinitionId");
         }
@@ -72,7 +79,7 @@ namespace Elsa.Persistence.EntityFramework.SqlServer.Migrations
         {
             migrationBuilder.DropTable(
                 name: "Triggers",
-                schema: "Elsa");
+                schema: _schema.Schema);
         }
     }
 }

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.SqlServer/Migrations/20220512203701_Update28.cs
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.SqlServer/Migrations/20220512203701_Update28.cs
@@ -1,15 +1,21 @@
 ﻿using System;
+using Elsa.Persistence.EntityFramework.Core;
 using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace Elsa.Persistence.EntityFramework.SqlServer.Migrations
 {
     public partial class Update28 : Migration
     {
+        private readonly IElsaDbContextSchema _schema;
+        public Update28(IElsaDbContextSchema schema)
+        {
+            _schema = schema ?? throw new ArgumentNullException(nameof(schema));
+        }
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.AddColumn<DateTimeOffset>(
                 name: "CreatedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitions",
                 type: "datetimeoffset",
                 nullable: false,
@@ -20,7 +26,7 @@ namespace Elsa.Persistence.EntityFramework.SqlServer.Migrations
         {
             migrationBuilder.DropColumn(
                 name: "CreatedAt",
-                schema: "Elsa",
+                schema: _schema.Schema,
                 table: "WorkflowDefinitions");
         }
     }


### PR DESCRIPTION
This PR allows you to define a custom DB Schema in V2. This basically merges this https://github.com/elsa-workflows/elsa-core/pull/4638 in V2.

Defining a custom Schema:

```
 elsa.UseWorkflowManagement(management => { management.UseEntityFrameworkCore(ef =>
        ef.UseSqlServer("Server=(localdb)\\MSSQLLocalDb;Initial Catalog=Elsav3CustomSchema;Integrated Security=True;",
        new ElsaDbContextOptions()
        {
            SchemaName = "CustomSchemaName",
        }));
    });
```
If no Custom-Schema is defined, `Elsa` will be used.

This change applies to
- SqlServer
- PostgreSql
- Oracle
- MySql
