### PR TITLE
Make the timeout configurable for acquiring the DistributedLock in ContinueRunningWorkflows

### DIFF
--- a/src/core/Elsa.Core/Options/ElsaOptions.cs
+++ b/src/core/Elsa.Core/Options/ElsaOptions.cs
@@ -60,6 +60,11 @@ namespace Elsa.Options
         /// The amount of time to wait before giving up on trying to acquire a lock.
         /// </summary>
         public Duration DistributedLockTimeout { get; set; } = Duration.FromHours(1);
+        
+        /// <summary>
+        /// The amount of time to wait to acquire the DistributedLock before skipping resuming a running or idle Workflows at startup
+        /// </summary>
+        public Duration ContinueWorkflowsOnStartupTimeout { get; set; } = Duration.FromHours(1);
 
         public Type DefaultWorkflowStorageProviderType { get; set; }
         public WorkflowChannelOptions WorkflowChannelOptions { get; set; } = new();

--- a/src/core/Elsa.Core/StartupTasks/ContinueRunningWorkflows.cs
+++ b/src/core/Elsa.Core/StartupTasks/ContinueRunningWorkflows.cs
@@ -67,7 +67,7 @@ namespace Elsa.StartupTasks
 
             foreach (var instance in instances)
             {
-                await using var correlationLockHandle = await _distributedLockProvider.AcquireLockAsync(instance.CorrelationId, _elsaOptions.DistributedLockTimeout, cancellationToken);
+                await using var correlationLockHandle = await _distributedLockProvider.AcquireLockAsync(instance.CorrelationId, _elsaOptions.ContinueWorkflowsOnStartupTimeout, cancellationToken);
 
                 if (correlationLockHandle == null)
                 {
@@ -106,7 +106,7 @@ namespace Elsa.StartupTasks
 
             foreach (var instance in instances)
             {
-                await using var correlationLockHandle = await _distributedLockProvider.AcquireLockAsync(instance.CorrelationId, _elsaOptions.DistributedLockTimeout, cancellationToken);
+                await using var correlationLockHandle = await _distributedLockProvider.AcquireLockAsync(instance.CorrelationId, _elsaOptions.ContinueWorkflowsOnStartupTimeout, cancellationToken);
 
                 if (correlationLockHandle == null)
                 {


### PR DESCRIPTION
Currently in a multi node environment, a running Workflow on one node can block the ResumeWorkflow Startup on another node.

This PR adds an additional configuration setting to be able to have a custom timeout for acquiring the DistributedLock  in the ContinueRunningWorkflows Startup, which resumes all `running` or `idling`  Workflows.

With this setting i can define a short Timeout like 5-10s before i stop acquiring the lock.

If i can not acquire the lock in a short timespan, i assume that the other node is running this workflow, and i can skip resuming this workflow. 
This design would potentially leave 2 edgecases unhandled:
- the lock acquisistion is very slow for different reasons (network problems, unresponsive DB or similar)
- Potentially: another instance hasn't correctly disposed its DB Lock 

I choose the default timeout of 1h like before on the DistributedLockTimeout, to not break stuff,  but maybe a default timeout of 5-10 seconds would be good.
 
see also: https://github.com/elsa-workflows/elsa-core/discussions/4654