### PR TITLE
Elsa2 dotnet8 migration

### DIFF
--- a/src/activities/Elsa.Activities.Http.OpenApi/Elsa.Activities.Http.OpenApi.csproj
+++ b/src/activities/Elsa.Activities.Http.OpenApi/Elsa.Activities.Http.OpenApi.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\configureawait.props" />
 
     <PropertyGroup>
-        <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
         <Description>
             Elsa is a set of workflow libraries and tools that enable lean and mean workflowing capabilities in any .NET Core application.
             This package provides Swashbuckle filters that include HTTP Endpoint activities.

--- a/src/activities/Elsa.Activities.Http/Elsa.Activities.Http.csproj
+++ b/src/activities/Elsa.Activities.Http/Elsa.Activities.Http.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\configureawait.props" />
 
     <PropertyGroup>
-        <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
         <Description>
             Elsa is a set of workflow libraries and tools that enable lean and mean workflowing capabilities in any .NET Core application.
             This package provides the following Console activities:
@@ -19,6 +19,10 @@
         <ProjectReference Include="..\..\core\Elsa.Core\Elsa.Core.csproj" />
         <ProjectReference Include="..\..\scripting\Elsa.Scripting.JavaScript\Elsa.Scripting.JavaScript.csproj" />
         <ProjectReference Include="..\..\scripting\Elsa.Scripting.Liquid\Elsa.Scripting.Liquid.csproj" />
+    </ItemGroup>
+    
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0'">
+        <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="8.0.0" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0'">

--- a/src/activities/Elsa.Activities.Kafka/Elsa.Activities.Kafka.csproj
+++ b/src/activities/Elsa.Activities.Kafka/Elsa.Activities.Kafka.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\configureawait.props" />
     
     <PropertyGroup>
-        <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
         <Description>
             Elsa is a set of workflow libraries and tools that enable lean and mean workflowing capabilities in any .NET Core application.
             This package provides activities to send and receive messages using Kafka.</Description>        

--- a/src/activities/Elsa.Activities.RabbitMq/Elsa.Activities.RabbitMq.csproj
+++ b/src/activities/Elsa.Activities.RabbitMq/Elsa.Activities.RabbitMq.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\configureawait.props" />
     
     <PropertyGroup>
-        <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
         <Description>
             Elsa is a set of workflow libraries and tools that enable lean and mean workflowing capabilities in any .NET Core application.
             This package provides activities to send and receive messages using Rabbit MQ.</Description>        

--- a/src/activities/Elsa.Activities.Sql/Elsa.Activities.Sql.csproj
+++ b/src/activities/Elsa.Activities.Sql/Elsa.Activities.Sql.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\configureawait.props" />
     
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
       <Description>
           Elsa is a set of workflow libraries and tools that enable lean and mean workflowing capabilities in any .NET Core application.
           This package provides activities to run SQL queries on given database using an connection string.

--- a/src/activities/Elsa.Activities.Telnyx/Elsa.Activities.Telnyx.csproj
+++ b/src/activities/Elsa.Activities.Telnyx/Elsa.Activities.Telnyx.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\configureawait.props" />
 
     <PropertyGroup>
-        <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
         <Description>
             Elsa is a set of workflow libraries and tools that enable lean and mean workflowing capabilities in any .NET Core application.
             This package provides activities to integrate with Telnyx.

--- a/src/activities/webhooks/Elsa.Activities.Webhooks/Elsa.Activities.Webhooks.csproj
+++ b/src/activities/webhooks/Elsa.Activities.Webhooks/Elsa.Activities.Webhooks.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\..\configureawait.props" />
 
     <PropertyGroup>
-        <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
         <Description>
             Elsa is a set of workflow libraries and tools that enable lean and mean workflowing capabilities in any .NET Core application.
             This package provides Webhook activities.

--- a/src/activities/webhooks/Elsa.Webhooks.Api/Elsa.Webhooks.Api.csproj
+++ b/src/activities/webhooks/Elsa.Webhooks.Api/Elsa.Webhooks.Api.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\..\configureawait.props"/>
 
     <PropertyGroup>
-        <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
         <Description>
             Elsa is a set of workflow libraries and tools that enable lean and mean workflowing capabilities in any .NET Core application.
             This package provides Webhook API endpoints for managing webhook definitions.

--- a/src/activities/webhooks/Elsa.Webhooks.Persistence.EntityFramework.Core/Elsa.Webhooks.Persistence.EntityFramework.Core.csproj
+++ b/src/activities/webhooks/Elsa.Webhooks.Persistence.EntityFramework.Core/Elsa.Webhooks.Persistence.EntityFramework.Core.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\..\configureawait.props" />
 
     <PropertyGroup>
-        <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
         <Description>
             Elsa is a set of workflow libraries and tools that enable lean and mean workflowing capabilities in any .NET Core application.
             This package provides Webhook EF Core persistence.

--- a/src/activities/webhooks/Elsa.Webhooks.Persistence.EntityFramework.MySql/Elsa.Webhooks.Persistence.EntityFramework.MySql.csproj
+++ b/src/activities/webhooks/Elsa.Webhooks.Persistence.EntityFramework.MySql/Elsa.Webhooks.Persistence.EntityFramework.MySql.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\..\configureawait.props" />
 
     <PropertyGroup>
-        <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
         <Description>
             Elsa is a set of workflow libraries and tools that enable lean and mean workflowing capabilities in any .NET Core application.
             This package provides the MySql EF Core provider for Webhook persistence.
@@ -34,6 +34,14 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="7.0.0" />
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0'">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.0-beta.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/activities/webhooks/Elsa.Webhooks.Persistence.EntityFramework.PostgreSql/Elsa.Webhooks.Persistence.EntityFramework.PostgreSql.csproj
+++ b/src/activities/webhooks/Elsa.Webhooks.Persistence.EntityFramework.PostgreSql/Elsa.Webhooks.Persistence.EntityFramework.PostgreSql.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\..\configureawait.props" />
 
     <PropertyGroup>
-        <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
         <Description>
             Elsa is a set of workflow libraries and tools that enable lean and mean workflowing capabilities in any .NET Core application.
             This package provides the PostgreSQL EF Core provider for Webhook persistence.
@@ -34,6 +34,15 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.0" />
+    </ItemGroup>
+
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0'">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/activities/webhooks/Elsa.Webhooks.Persistence.EntityFramework.SqlServer/Elsa.Webhooks.Persistence.EntityFramework.SqlServer.csproj
+++ b/src/activities/webhooks/Elsa.Webhooks.Persistence.EntityFramework.SqlServer/Elsa.Webhooks.Persistence.EntityFramework.SqlServer.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\..\configureawait.props" />
 
     <PropertyGroup>
-        <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
         <Description>
             Elsa is a set of workflow libraries and tools that enable lean and mean workflowing capabilities in any .NET Core application.
             This package provides the SqlServer EF Core provider for Webhook persistence.
@@ -34,6 +34,14 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.0" />
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0'">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
     </ItemGroup>
     
 

--- a/src/activities/webhooks/Elsa.Webhooks.Persistence.EntityFramework.Sqlite/Elsa.Webhooks.Persistence.EntityFramework.Sqlite.csproj
+++ b/src/activities/webhooks/Elsa.Webhooks.Persistence.EntityFramework.Sqlite/Elsa.Webhooks.Persistence.EntityFramework.Sqlite.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\..\configureawait.props" />
 
     <PropertyGroup>
-        <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
         <Description>
             Elsa is a set of workflow libraries and tools that enable lean and mean workflowing capabilities in any .NET Core application.
             This package provides the Sqlite EF Core provider for Webhook persistence.
@@ -34,6 +34,14 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.0" />
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0'">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/activities/webhooks/Elsa.Webhooks.Persistence.MongoDb/Elsa.Webhooks.Persistence.MongoDb.csproj
+++ b/src/activities/webhooks/Elsa.Webhooks.Persistence.MongoDb/Elsa.Webhooks.Persistence.MongoDb.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\..\configureawait.props" />
 
     <PropertyGroup>
-        <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
         <Description>
             Elsa is a set of workflow libraries and tools that enable lean and mean workflowing capabilities in any .NET Core application.
             This package provides the MongoDB provider for Webhook persistence.

--- a/src/activities/webhooks/Elsa.Webhooks.Persistence.YesSql/Elsa.Webhooks.Persistence.YesSql.csproj
+++ b/src/activities/webhooks/Elsa.Webhooks.Persistence.YesSql/Elsa.Webhooks.Persistence.YesSql.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\..\configureawait.props" />
 
     <PropertyGroup>
-        <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
         <Description>
             Elsa is a set of workflow libraries and tools that enable lean and mean workflowing capabilities in any .NET Core application.
             This package provides the YesSQL provider for Webhook persistence.

--- a/src/dashboards/ElsaDashboard/ElsaDashboard.Web.csproj
+++ b/src/dashboards/ElsaDashboard/ElsaDashboard.Web.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/designer/bindings/aspnet/Elsa.Designer.Components.Web/Elsa.Designer.Components.Web.csproj
+++ b/src/designer/bindings/aspnet/Elsa.Designer.Components.Web/Elsa.Designer.Components.Web.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\..\..\configureawait.props" />
     
     <PropertyGroup>
-        <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
         <Description>
             Elsa is a set of workflow libraries and tools that enable lean and mean workflowing capabilities in any .NET Core application.
             This package provides ASP.NET Core component bindings for the Elsa Designer web component.
@@ -28,4 +28,7 @@
       <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="7.0.0" />
     </ItemGroup>
 
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0'">
+        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.0" />
+    </ItemGroup>
 </Project>

--- a/src/modules/secrets/Elsa.Secrets.Api/Elsa.Secrets.Api.csproj
+++ b/src/modules/secrets/Elsa.Secrets.Api/Elsa.Secrets.Api.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\..\configureawait.props" />
 
     <PropertyGroup>
-        <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
         <Description>
             Elsa Secrets API is an optional part of Elsa Workflows.
         </Description>

--- a/src/modules/secrets/Elsa.Secrets.Http/Elsa.Secrets.Http.csproj
+++ b/src/modules/secrets/Elsa.Secrets.Http/Elsa.Secrets.Http.csproj
@@ -4,7 +4,7 @@
   <Import Project="..\..\..\..\configureawait.props" />
 
   <PropertyGroup>
-      <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+      <TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
       <Description>
           Elsa Secrets is an optional part of Elsa Workflows.
       </Description>

--- a/src/modules/secrets/Elsa.Secrets.Http/Elsa.Secrets.Http.csproj
+++ b/src/modules/secrets/Elsa.Secrets.Http/Elsa.Secrets.Http.csproj
@@ -11,8 +11,11 @@
       <PackageTags>elsa, secrets</PackageTags>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0'">
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0'">
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/modules/secrets/Elsa.Secrets.Persistence.EntityFramework.Core/Elsa.Secrets.Persistence.EntityFramework.Core.csproj
+++ b/src/modules/secrets/Elsa.Secrets.Persistence.EntityFramework.Core/Elsa.Secrets.Persistence.EntityFramework.Core.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\..\configureawait.props"/>
 
     <PropertyGroup>
-        <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
         <Description>
             Elsa Secrets Entity Framework Core is an optional part of Elsa Workflows.
         </Description>

--- a/src/modules/secrets/Elsa.Secrets.Persistence.EntityFramework.MySql/Elsa.Secrets.Persistence.EntityFramework.MySql.csproj
+++ b/src/modules/secrets/Elsa.Secrets.Persistence.EntityFramework.MySql/Elsa.Secrets.Persistence.EntityFramework.MySql.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\..\configureawait.props" />
     
   <PropertyGroup>
-      <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+      <TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
       <Description>
           Elsa Secrets Entity Framework MySql is an optional part of Elsa Workflows.
       </Description>

--- a/src/modules/secrets/Elsa.Secrets.Persistence.EntityFramework.SqlServer/Elsa.Secrets.Persistence.EntityFramework.SqlServer.csproj
+++ b/src/modules/secrets/Elsa.Secrets.Persistence.EntityFramework.SqlServer/Elsa.Secrets.Persistence.EntityFramework.SqlServer.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\..\configureawait.props" />
     
   <PropertyGroup>
-      <TargetFrameworks>net7.0;net5.0;net6.0;</TargetFrameworks>
+      <TargetFrameworks>net7.0;net5.0;net6.0;net8.0</TargetFrameworks>
       <Description>
           Elsa Secrets Entity Framework SqlServer is an optional part of Elsa Workflows.
       </Description>
@@ -26,6 +26,10 @@
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0'">
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.0" />
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0'">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/modules/secrets/Elsa.Secrets.Persistence.EntityFramework.Sqlite/Elsa.Secrets.Persistence.EntityFramework.Sqlite.csproj
+++ b/src/modules/secrets/Elsa.Secrets.Persistence.EntityFramework.Sqlite/Elsa.Secrets.Persistence.EntityFramework.Sqlite.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\..\configureawait.props" />
     
   <PropertyGroup>
-      <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+      <TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
       <Description>
           Elsa Secrets Entity Framework SQLite is an optional part of Elsa Workflows.
       </Description>

--- a/src/modules/secrets/Elsa.Secrets.Persistence.MongoDb/Elsa.Secrets.Persistence.MongoDb.csproj
+++ b/src/modules/secrets/Elsa.Secrets.Persistence.MongoDb/Elsa.Secrets.Persistence.MongoDb.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\..\configureawait.props"/>
 
     <PropertyGroup>
-        <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <Description>

--- a/src/modules/secrets/Elsa.Secrets.Sql/Elsa.Secrets.Sql.csproj
+++ b/src/modules/secrets/Elsa.Secrets.Sql/Elsa.Secrets.Sql.csproj
@@ -11,10 +11,12 @@
       <PackageTags>elsa, secrets</PackageTags>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0'">
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
   </ItemGroup>
-
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0'">
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\activities\Elsa.Activities.Sql\Elsa.Activities.Sql.csproj" />
     <ProjectReference Include="..\..\..\core\Elsa.Abstractions\Elsa.Abstractions.csproj" />

--- a/src/modules/secrets/Elsa.Secrets.Sql/Elsa.Secrets.Sql.csproj
+++ b/src/modules/secrets/Elsa.Secrets.Sql/Elsa.Secrets.Sql.csproj
@@ -4,7 +4,7 @@
   <Import Project="..\..\..\..\configureawait.props" />
 
   <PropertyGroup>
-      <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+      <TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
       <Description>
           Elsa Secrets is an optional part of Elsa Workflows.
       </Description>

--- a/src/modules/secrets/Elsa.Secrets/Elsa.Secrets.csproj
+++ b/src/modules/secrets/Elsa.Secrets/Elsa.Secrets.csproj
@@ -4,7 +4,7 @@
   <Import Project="..\..\..\..\configureawait.props" />
 
   <PropertyGroup>
-      <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+      <TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
       <Description>
           Elsa Secrets is an optional part of Elsa Workflows.
       </Description>

--- a/src/modules/secrets/Elsa.Secrets/Elsa.Secrets.csproj
+++ b/src/modules/secrets/Elsa.Secrets/Elsa.Secrets.csproj
@@ -11,8 +11,11 @@
       <PackageTags>elsa, secrets</PackageTags>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0'">
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0'">
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/modules/workflowsettings/Elsa.WorkflowSettings.Api/Elsa.WorkflowSettings.Api.csproj
+++ b/src/modules/workflowsettings/Elsa.WorkflowSettings.Api/Elsa.WorkflowSettings.Api.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\..\configureawait.props" />
     
     <PropertyGroup>
-        <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/src/modules/workflowsettings/Elsa.WorkflowSettings.Persistence.EntityFramework.Core/Elsa.WorkflowSettings.Persistence.EntityFramework.Core.csproj
+++ b/src/modules/workflowsettings/Elsa.WorkflowSettings.Persistence.EntityFramework.Core/Elsa.WorkflowSettings.Persistence.EntityFramework.Core.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\..\configureawait.props" />
 
     <PropertyGroup>
-        <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
         <Description>
             Elsa Workflow Settings is an optional part of Elsa Workflows.
             This package provides Entity Framework Core entities used by the Workflow Settings persistence EF Core providers.

--- a/src/modules/workflowsettings/Elsa.WorkflowSettings.Persistence.EntityFramework.MySql/Elsa.WorkflowSettings.Persistence.EntityFramework.MySql.csproj
+++ b/src/modules/workflowsettings/Elsa.WorkflowSettings.Persistence.EntityFramework.MySql/Elsa.WorkflowSettings.Persistence.EntityFramework.MySql.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\..\configureawait.props" />
 
     <PropertyGroup>
-        <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
         <Description>
             Elsa Workflow Settings is an optional part of Elsa Workflows.
             This package provides Entity Framework Core migrations for the MySql database provider.

--- a/src/modules/workflowsettings/Elsa.WorkflowSettings.Persistence.EntityFramework.PostgreSql/Elsa.WorkflowSettings.Persistence.EntityFramework.PostgreSql.csproj
+++ b/src/modules/workflowsettings/Elsa.WorkflowSettings.Persistence.EntityFramework.PostgreSql/Elsa.WorkflowSettings.Persistence.EntityFramework.PostgreSql.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\..\configureawait.props" />
 
     <PropertyGroup>
-        <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
         <Description>
             Elsa Workflow Settings is an optional part of Elsa Workflows.
             This package provides Entity Framework Core migrations for the PostgreSql database provider.
@@ -34,6 +34,14 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.0" />
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0'">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
     </ItemGroup>
 
   <ItemGroup>

--- a/src/modules/workflowsettings/Elsa.WorkflowSettings.Persistence.EntityFramework.SqlServer/Elsa.WorkflowSettings.Persistence.EntityFramework.SqlServer.csproj
+++ b/src/modules/workflowsettings/Elsa.WorkflowSettings.Persistence.EntityFramework.SqlServer/Elsa.WorkflowSettings.Persistence.EntityFramework.SqlServer.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\..\configureawait.props" />
 
     <PropertyGroup>
-        <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
         <Description>
             Elsa Workflow Settings is an optional part of Elsa Workflows.
             This package provides Entity Framework Core migrations for the SQL Server database provider.
@@ -34,6 +34,14 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.0" />
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0'">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/modules/workflowsettings/Elsa.WorkflowSettings.Persistence.EntityFramework.Sqlite/Elsa.WorkflowSettings.Persistence.EntityFramework.Sqlite.csproj
+++ b/src/modules/workflowsettings/Elsa.WorkflowSettings.Persistence.EntityFramework.Sqlite/Elsa.WorkflowSettings.Persistence.EntityFramework.Sqlite.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\..\configureawait.props" />
 
     <PropertyGroup>
-        <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
         <Description>
             Elsa Workflow Settings is an optional part of Elsa Workflows.
             This package provides Entity Framework Core migrations for the Sqlite database provider.
@@ -34,6 +34,14 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.0" />
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0'">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/modules/workflowsettings/Elsa.WorkflowSettings.Persistence.MongoDb/Elsa.WorkflowSettings.Persistence.MongoDb.csproj
+++ b/src/modules/workflowsettings/Elsa.WorkflowSettings.Persistence.MongoDb/Elsa.WorkflowSettings.Persistence.MongoDb.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\..\configureawait.props" />
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.1;net5.0;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
         <Description>
             Elsa Workflow Settings is an optional part of Elsa Workflows.
             This package provides a MongoDb persistence provider.

--- a/src/modules/workflowsettings/Elsa.WorkflowSettings.Persistence.YesSql/Elsa.WorkflowSettings.Persistence.YesSql.csproj
+++ b/src/modules/workflowsettings/Elsa.WorkflowSettings.Persistence.YesSql/Elsa.WorkflowSettings.Persistence.YesSql.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\..\configureawait.props" />
 
     <PropertyGroup>
-        <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
         <Description>
             Elsa Workflow Settings is an optional part of Elsa Workflows.
             This package provides a YesSql persistence provider.

--- a/src/modules/workflowtesting/Elsa.WorkflowTesting.Api/Elsa.WorkflowTesting.Api.csproj
+++ b/src/modules/workflowtesting/Elsa.WorkflowTesting.Api/Elsa.WorkflowTesting.Api.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\..\configureawait.props" />
     
     <PropertyGroup>
-        <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/modules/workflowtesting/Elsa.WorkflowTesting/Elsa.WorkflowTesting.csproj
+++ b/src/modules/workflowtesting/Elsa.WorkflowTesting/Elsa.WorkflowTesting.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\..\configureawait.props" />
     
     <PropertyGroup>
-        <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
     </PropertyGroup>
     
     <ItemGroup>

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/Elsa.Persistence.EntityFramework.Core.csproj
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/Elsa.Persistence.EntityFramework.Core.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\..\configureawait.props" />
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.1;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
         <Description>
             Elsa is a set of workflow libraries and tools that enable lean and mean workflowing capabilities in any .NET Core application.
             This package provides Entity Framework Core entities used by the various Elsa persistence EF Core providers.
@@ -25,6 +25,11 @@
     <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0'">
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.0" />
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0'">
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.MySql/Elsa.Persistence.EntityFramework.MySql.csproj
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.MySql/Elsa.Persistence.EntityFramework.MySql.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\..\configureawait.props" />
 
     <PropertyGroup>
-        <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
         <Description>
             Elsa is a set of workflow libraries and tools that enable lean and mean workflowing capabilities in any .NET Core application.
             This package provides Entity Framework Core migrations for the MySql database provider.
@@ -39,6 +39,15 @@
         </PackageReference>
         <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="7.0.0" />
     </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0'">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.0-beta.2" />
+    </ItemGroup>
+
 
     <ItemGroup>
       <Folder Include="Migrations" />

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Oracle/Elsa.Persistence.EntityFramework.Oracle.csproj
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Oracle/Elsa.Persistence.EntityFramework.Oracle.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\..\configureawait.props" />
 
     <PropertyGroup>
-        <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
         <Description>
             Elsa is a set of workflow libraries and tools that enable lean and mean workflowing capabilities in any .NET Core application.
             This package provides Entity Framework Core migrations for the Oracle database provider.
@@ -38,6 +38,13 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Oracle.EntityFrameworkCore" Version="7.21.8" />
+    </ItemGroup>
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0'">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Oracle.EntityFrameworkCore" Version="8.21.121" />
     </ItemGroup>
 
 </Project>

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.PostgreSql/Elsa.Persistence.EntityFramework.PostgreSql.csproj
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.PostgreSql/Elsa.Persistence.EntityFramework.PostgreSql.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\..\configureawait.props" />
 
     <PropertyGroup>
-        <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
         <Description>
             Elsa is a set of workflow libraries and tools that enable lean and mean workflowing capabilities in any .NET Core application.
             This package provides Entity Framework Core migrations for the PostgreSql database provider.
@@ -38,6 +38,14 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.0" />
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0'">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
     </ItemGroup>
 
 </Project>

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.SqlServer/Elsa.Persistence.EntityFramework.SqlServer.csproj
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.SqlServer/Elsa.Persistence.EntityFramework.SqlServer.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\..\configureawait.props" />
 
     <PropertyGroup>
-        <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
         <Description>
             Elsa is a set of workflow libraries and tools that enable lean and mean workflowing capabilities in any .NET Core application.
             This package provides Entity Framework Core migrations for the SQL Server database provider.
@@ -35,7 +35,15 @@
         </PackageReference>
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.0" />
     </ItemGroup>
-    
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0'">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    </ItemGroup>
+
     <ItemGroup>
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.Design" Version="1.1.6" />
     </ItemGroup>

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Sqlite/Elsa.Persistence.EntityFramework.Sqlite.csproj
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Sqlite/Elsa.Persistence.EntityFramework.Sqlite.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\..\configureawait.props" />
 
     <PropertyGroup>
-        <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
         <Description>
             Elsa is a set of workflow libraries and tools that enable lean and mean workflowing capabilities in any .NET Core application.
             This package provides Entity Framework Core migrations for the Sqlite database provider.
@@ -40,4 +40,11 @@
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.0" />
     </ItemGroup>
 
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0'">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0" />
+    </ItemGroup>
 </Project>

--- a/src/persistence/Elsa.Persistence.MongoDb/Elsa.Persistence.MongoDb.csproj
+++ b/src/persistence/Elsa.Persistence.MongoDb/Elsa.Persistence.MongoDb.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\configureawait.props"/>
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.1;net5.0;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
         <Description>
             Elsa is a set of workflow libraries and tools that enable super-fast workflowing capabilities in any .NET Core application.
             This package provides a MongoDb persistence provider.

--- a/src/samples/persistence/Elsa.Samples.Persistence.EntityFramework/Elsa.Samples.Persistence.EntityFramework.csproj
+++ b/src/samples/persistence/Elsa.Samples.Persistence.EntityFramework/Elsa.Samples.Persistence.EntityFramework.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
@@ -23,4 +23,7 @@
       <PackageReference Include="System.Text.Encodings.Web" Version="7.0.0" />
     </ItemGroup>
 
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0'">
+        <PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" />
+    </ItemGroup>
 </Project>

--- a/src/server/Elsa.Server.Api/Elsa.Server.Api.csproj
+++ b/src/server/Elsa.Server.Api/Elsa.Server.Api.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\configureawait.props" />
 
     <PropertyGroup>
-        <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
         <Description>
             Elsa is a set of workflow libraries and tools that enable lean and mean workflowing capabilities in any .NET Core application.
             This package provides API endpoints to interact with the workflow host.
@@ -23,6 +23,10 @@
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0'">
         <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.0" />
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0'">
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Added .NET 8 Support by adding target framework in *.csproj files and added corresponding references.
- open issue: as of today there is only a Beta Version 8 of Pomelo.EntityFrameworkCore.MySql available. Will have to wait before merge