### PR TITLE
Feature HTTP Activity : Allow adding Authorization Header without validation

### DIFF
--- a/src/modules/Elsa.Http/Activities/SendHttpRequestBase.cs
+++ b/src/modules/Elsa.Http/Activities/SendHttpRequestBase.cs
@@ -57,19 +57,14 @@ public abstract class SendHttpRequestBase : Activity<HttpResponseMessage>
     /// The Authorization header value to send with the request.
     /// </summary>
     /// <example>Bearer {some-access-token}</example>
-    [Input(
-        Description = "The Authorization header value to send with the request. For example: Bearer {some-access-token}",
-        Category = "Security"
-    )]
+    [Input(Description = "The Authorization header value to send with the request. For example: Bearer {some-access-token}", Category = "Security")]
     public Input<string?> Authorization { get; set; } = default!;
 
     /// <summary>
-    /// A boolean that allow to add Authorization Header without validation.
+    /// A value that allows to add the Authorization header without validation.
     /// </summary>
-    [Input(
-        Description = "A boolean that allow to add Authorization Header without validation. This is usefull for header that are not in the Standard HTTP. ",
-        Category = "Security")]
-    public Input<bool> AddAuthorizatonHeaderWithoutValidation { get; set; } = default!;
+    [Input(Description = "A value that allows to add the Authorization header without validation.", Category = "Security")]
+    public Input<bool> DisableAuthorizationHeaderValidation { get; set; } = default!;
 
     /// <summary>
     /// The headers to send along with the request.
@@ -162,7 +157,7 @@ public abstract class SendHttpRequestBase : Activity<HttpResponseMessage>
         var request = new HttpRequestMessage(new HttpMethod(method), url);
         var headers = context.GetHeaders(RequestHeaders);
         var authorization = Authorization.GetOrDefault(context);
-        var addAuthorizationWithoutValidation = AddAuthorizatonHeaderWithoutValidation.GetOrDefault(context);
+        var addAuthorizationWithoutValidation = DisableAuthorizationHeaderValidation.GetOrDefault(context);
 
         if (!string.IsNullOrWhiteSpace(authorization))
             if(addAuthorizationWithoutValidation)

--- a/src/modules/Elsa.Http/Activities/SendHttpRequestBase.cs
+++ b/src/modules/Elsa.Http/Activities/SendHttpRequestBase.cs
@@ -64,6 +64,14 @@ public abstract class SendHttpRequestBase : Activity<HttpResponseMessage>
     public Input<string?> Authorization { get; set; } = default!;
 
     /// <summary>
+    /// A boolean that allow to add Authorization Header without validation.
+    /// </summary>
+    [Input(
+        Description = "A boolean that allow to add Authorization Header without validation. This is usefull for header that are not in the Standard HTTP. ",
+        Category = "Security")]
+    public Input<bool> AddAuthorizatonHeaderWithoutValidation { get; set; } = default!;
+
+    /// <summary>
     /// The headers to send along with the request.
     /// </summary>
     [Input(Description = "The headers to send along with the request.", Category = "Advanced")]
@@ -154,9 +162,13 @@ public abstract class SendHttpRequestBase : Activity<HttpResponseMessage>
         var request = new HttpRequestMessage(new HttpMethod(method), url);
         var headers = context.GetHeaders(RequestHeaders);
         var authorization = Authorization.GetOrDefault(context);
+        var addAuthorizationWithoutValidation = AddAuthorizatonHeaderWithoutValidation.GetOrDefault(context);
 
         if (!string.IsNullOrWhiteSpace(authorization))
-            request.Headers.Authorization = AuthenticationHeaderValue.Parse(authorization);
+            if(addAuthorizationWithoutValidation)
+                request.Headers.TryAddWithoutValidation("Authorization", authorization);
+            else
+                request.Headers.Authorization = AuthenticationHeaderValue.Parse(authorization);
 
         foreach (var header in headers)
             request.Headers.Add(header.Key, header.Value.AsEnumerable());


### PR DESCRIPTION
This PR allow the user to choose to validate or not the Authorization Header when adding to the request.

__Motivation__

User can be in situation where the Authorization Header is not strictly following the HTTP Standard.
For example, it seems that for example, the AWS Signature is not accepted by the C# implementation.

_sigv4-auth-using-authorization-header_ 
```
Authorization: AWS4-HMAC-SHA256 
Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request, 
SignedHeaders=host;range;x-amz-date,
Signature=fe5f80f77d5fa3beca038a248ff027d0445342fe2855ddc963176630326f1024
```

for example, the semicolon `;` in the SignedHeaders part seems to not be compatible. I don't know who is not respecting the RFC.

So instead of force the user to create a new HTTP activity, I propose to add this feature to allow the user to choose the behavior.

