### PR TITLE
New options to control retry logic for transient failures

### DIFF
--- a/src/clients/Elsa.Api.Client/Extensions/DependencyInjectionExtensions.cs
+++ b/src/clients/Elsa.Api.Client/Extensions/DependencyInjectionExtensions.cs
@@ -92,9 +92,10 @@ public static class DependencyInjectionExtensions
         httpClientBuilderOptions?.ConfigureHttpClientBuilder?.Invoke(builder);
 
         var retryCount = httpClientBuilderOptions?.TransientHttpErrorRetryCount ?? 0;
+        var sleepDurationProvider = httpClientBuilderOptions?.SleepDurationProvider ?? (retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)));
         if (retryCount > 0)
         {
-            builder.AddTransientHttpErrorPolicy(p => p.WaitAndRetryAsync(retryCount, retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt))));
+            builder.AddTransientHttpErrorPolicy(p => p.WaitAndRetryAsync(retryCount, sleepDurationProvider));
         }
     }
 

--- a/src/clients/Elsa.Api.Client/Extensions/DependencyInjectionExtensions.cs
+++ b/src/clients/Elsa.Api.Client/Extensions/DependencyInjectionExtensions.cs
@@ -90,7 +90,12 @@ public static class DependencyInjectionExtensions
     {
         var builder = services.AddRefitClient<T>(CreateRefitSettings, typeof(T).Name).ConfigureHttpClient(ConfigureElsaApiHttpClient);
         httpClientBuilderOptions?.ConfigureHttpClientBuilder?.Invoke(builder);
-        builder.AddTransientHttpErrorPolicy(p => p.WaitAndRetryAsync(3, retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt))));
+
+        var retryCount = httpClientBuilderOptions?.TransientHttpErrorRetryCount ?? 0;
+        if (retryCount > 0)
+        {
+            builder.AddTransientHttpErrorPolicy(p => p.WaitAndRetryAsync(retryCount, retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt))));
+        }
     }
 
     /// <summary>

--- a/src/clients/Elsa.Api.Client/Options/ElsaClientBuilderOptions.cs
+++ b/src/clients/Elsa.Api.Client/Options/ElsaClientBuilderOptions.cs
@@ -41,7 +41,15 @@ public class ElsaClientBuilderOptions
     /// <item><description>HTTP 5XX status codes(server errors)</description></item>
     /// <item><description>HTTP 408 status code(request timeout)</description></item>
     /// </list>
+    /// Default value is 3.
     /// Set the value to 0 to disable automatic retry.
     /// </summary>
     public int TransientHttpErrorRetryCount { get; set; } = 3;
+
+    /// <summary>
+    /// The function that provides the duration to wait for for each transient failure retry attempt.
+    /// This option is useless if TransientHttpErrorRetryCount is set to 0.
+    /// Default strategy is exponential backoff: TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)).
+    /// </summary>
+    public Func<int, TimeSpan> SleepDurationProvider = retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt));
 }

--- a/src/clients/Elsa.Api.Client/Options/ElsaClientBuilderOptions.cs
+++ b/src/clients/Elsa.Api.Client/Options/ElsaClientBuilderOptions.cs
@@ -33,4 +33,15 @@ public class ElsaClientBuilderOptions
     /// Gets or sets a delegate that can be used to configure the HTTP client builder.
     /// </summary>
     public Action<IHttpClientBuilder> ConfigureHttpClientBuilder { get; set; } = _ => { };
+
+    /// <summary>
+    /// Number of automatic retries for transient failures, including following categories:
+    /// <list type = "bullet" >
+    /// <item><description> Network failures(as <see cref = "HttpRequestException" />)</description></item>
+    /// <item><description>HTTP 5XX status codes(server errors)</description></item>
+    /// <item><description>HTTP 408 status code(request timeout)</description></item>
+    /// </list>
+    /// Set the value to 0 to disable automatic retry.
+    /// </summary>
+    public int TransientHttpErrorRetryCount { get; set; } = 3;
 }


### PR DESCRIPTION
Add a new option to control the number of automatic retries for transient failures.

Currently when a workflow is triggered from Elsa Studio, it will retry for 3 times automatically if failed, and each time it will start from the the beginning. This means some activities may be run for up to 4 times (for example, when the workflow has two activities, and the first one activity always gets success and the second one is always failed, the first one will be run for 4 times successfully).

Fixes elsa-workflows/elsa-studio#108

