### PR TITLE
Update FastEndpoints* nuget packages to 5.21.2 version

### DIFF
--- a/src/common/Elsa.Api.Common/Elsa.Api.Common.csproj
+++ b/src/common/Elsa.Api.Common/Elsa.Api.Common.csproj
@@ -19,9 +19,9 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-        <PackageReference Include="FastEndpoints" Version="5.20.1.7-beta"/>
-        <PackageReference Include="FastEndpoints.Security" Version="5.20.1.7-beta"/>
-        <PackageReference Include="FastEndpoints.Swagger" Version="5.20.1.7-beta"/> 
+        <PackageReference Include="FastEndpoints" Version="5.21.2"/>
+        <PackageReference Include="FastEndpoints.Security" Version="5.21.2"/>
+        <PackageReference Include="FastEndpoints.Swagger" Version="5.21.2"/>
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Use the latest release version, instead of the beta version.