### PR TITLE
Changed Service Lifetime of RunTaskDispatcher

### DIFF
--- a/src/modules/Elsa.Workflows.Runtime/Features/WorkflowRuntimeFeature.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Features/WorkflowRuntimeFeature.cs
@@ -157,7 +157,7 @@ public class WorkflowRuntimeFeature : FeatureBase
             .AddScoped(WorkflowExecutionLogStore)
             .AddScoped(ActivityExecutionLogStore)
             .AddScoped(WorkflowInboxStore)
-            .AddSingleton(RunTaskDispatcher)
+            .AddScoped(RunTaskDispatcher)
             .AddSingleton(BackgroundActivityScheduler)
             .AddScoped<IBookmarkManager, DefaultBookmarkManager>()
             .AddScoped<IActivityExecutionManager, DefaultActivityExecutionManager>()


### PR DESCRIPTION
Following the guide for External Application Integration from the documentation an exceptions happens from the RunTask activity.

Changing the lifetime of RunTaskDispatcher to scoped resolved this.