### PR TITLE
Add requester info into WorkflowExecutionContext

### DIFF
--- a/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/Execute/Endpoint.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/Execute/Endpoint.cs
@@ -71,7 +71,8 @@ internal class Execute : ElsaEndpoint<Request, Response>
             VersionOptions = versionOptions,
             TriggerActivityId = request.TriggerActivityId,
             InstanceId = instanceId,
-            CancellationTokens = cancellationToken
+            CancellationTokens = cancellationToken,
+            Requester = HttpContext.User?.Identity?.Name,
         };
 
         // Write the workflow instance ID to the response header. This allows clients to read the header even if the workflow writes a response body. 

--- a/src/modules/Elsa.Workflows.Core/Contexts/WorkflowExecutionContext.cs
+++ b/src/modules/Elsa.Workflows.Core/Contexts/WorkflowExecutionContext.cs
@@ -51,7 +51,8 @@ public class WorkflowExecutionContext : IExecutionContext
         string? triggerActivityId,
         IEnumerable<ActivityIncident> incidents,
         DateTimeOffset createdAt,
-        CancellationTokens cancellationTokens)
+        CancellationTokens cancellationTokens,
+        string? requester = default)
     {
         ServiceProvider = serviceProvider;
         SystemClock = serviceProvider.GetRequiredService<ISystemClock>();
@@ -69,6 +70,7 @@ public class WorkflowExecutionContext : IExecutionContext
         TriggerActivityId = triggerActivityId;
         CreatedAt = createdAt;
         CancellationTokens = cancellationTokens;
+        Requester = requester;
         Incidents = incidents.ToList();
     }
 
@@ -84,7 +86,8 @@ public class WorkflowExecutionContext : IExecutionContext
         IDictionary<string, object>? properties = default,
         ExecuteActivityDelegate? executeDelegate = default,
         string? triggerActivityId = default,
-        CancellationTokens cancellationTokens = default)
+        CancellationTokens cancellationTokens = default,
+        string? requester = default)
     {
         var systemClock = serviceProvider.GetRequiredService<ISystemClock>();
 
@@ -99,7 +102,8 @@ public class WorkflowExecutionContext : IExecutionContext
             properties,
             executeDelegate,
             triggerActivityId,
-            cancellationTokens
+            cancellationTokens,
+            requester
         );
     }
 
@@ -150,7 +154,8 @@ public class WorkflowExecutionContext : IExecutionContext
         IDictionary<string, object>? properties = default,
         ExecuteActivityDelegate? executeDelegate = default,
         string? triggerActivityId = default,
-        CancellationTokens cancellationTokens = default)
+        CancellationTokens cancellationTokens = default,
+        string? requester = default)
     {
         // Setup a workflow execution context.
         var workflowExecutionContext = new WorkflowExecutionContext(
@@ -163,7 +168,8 @@ public class WorkflowExecutionContext : IExecutionContext
             triggerActivityId,
             incidents,
             createdAt,
-            cancellationTokens)
+            cancellationTokens,
+            requester)
         {
             MemoryRegister = workflow.CreateRegister()
         };
@@ -346,6 +352,12 @@ public class WorkflowExecutionContext : IExecutionContext
     /// A set of cancellation tokens that can be used to cancel the workflow execution without cancelling system-level operations.
     /// </summary>
     public CancellationTokens CancellationTokens { get; }
+
+    /// <summary>
+    /// The user/service who triggered this workflow.
+    /// When the workflow is triggered from the Studio, this value will be the user Identity name (who logged in).
+    /// </summary>
+    public string? Requester { get; set; }
 
     /// <summary>
     /// A list of <see cref="ActivityCompletionCallbackEntry"/> callbacks that are invoked when the associated child activity completes.

--- a/src/modules/Elsa.Workflows.Core/Options/RunWorkflowOptions.cs
+++ b/src/modules/Elsa.Workflows.Core/Options/RunWorkflowOptions.cs
@@ -18,4 +18,9 @@ public class RunWorkflowOptions
     public IDictionary<string, object>? Properties { get; set; }
     public string? TriggerActivityId { get; set; }
     public CancellationTokens CancellationTokens { get; set; }
+    /// <summary>
+    /// The user/service who triggered this workflow.
+    /// When the workflow is triggered from the Studio, this value will be the user Identity name (who logged in).
+    /// </summary>
+    public string? Requester { get; set; }
 }

--- a/src/modules/Elsa.Workflows.Core/Services/WorkflowRunner.cs
+++ b/src/modules/Elsa.Workflows.Core/Services/WorkflowRunner.cs
@@ -103,7 +103,8 @@ public class WorkflowRunner : IWorkflowRunner
             properties,
             default,
             triggerActivityId,
-            options?.CancellationTokens ?? cancellationToken);
+            options?.CancellationTokens ?? cancellationToken,
+            options?.Requester);
 
         // Schedule the first activity.
         workflowExecutionContext.ScheduleWorkflow();

--- a/src/modules/Elsa.Workflows.Runtime/Options/StartWorkflowHostOptions.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Options/StartWorkflowHostOptions.cs
@@ -24,4 +24,10 @@ public class StartWorkflowHostOptions
 
     /// <summary>Cancellation tokens that can be used to cancel the workflow instance without cancelling system-level operations.</summary>
     public CancellationTokens CancellationTokens { get; set; }
+
+    /// <summary>
+    /// The user/service who triggered this workflow.
+    /// When the workflow is triggered from the Studio, this value will be the user Identity name (who logged in).
+    /// </summary>
+    public string? Requester { get; set; }
 }

--- a/src/modules/Elsa.Workflows.Runtime/Options/StartWorkflowRuntimeOptions.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Options/StartWorkflowRuntimeOptions.cs
@@ -21,4 +21,10 @@ public class StartWorkflowRuntimeOptions
     public string? InstanceId { get; set; }
 
     public CancellationTokens CancellationTokens { get; set; }
+
+    /// <summary>
+    /// The user/service who triggered this workflow.
+    /// When the workflow is triggered from the Studio, this value will be the user Identity name (who logged in).
+    /// </summary>
+    public string? Requester { get; set; }
 }

--- a/src/modules/Elsa.Workflows.Runtime/Services/DefaultWorkflowRuntime.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Services/DefaultWorkflowRuntime.cs
@@ -308,7 +308,8 @@ public class DefaultWorkflowRuntime : IWorkflowRuntime
                 Input = input,
                 Properties = options.Properties,
                 TriggerActivityId = options.TriggerActivityId,
-                CancellationTokens = cancellationTokens
+                CancellationTokens = cancellationTokens,
+                Requester = options.Requester
             };
             await workflowHost.StartWorkflowAsync(startWorkflowOptions, cancellationTokens.ApplicationCancellationToken);
             var workflowState = workflowHost.WorkflowState;

--- a/src/modules/Elsa.Workflows.Runtime/Services/WorkflowHost.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Services/WorkflowHost.cs
@@ -80,7 +80,8 @@ public class WorkflowHost : IWorkflowHost
             Input = input,
             Properties = properties,
             TriggerActivityId = options?.TriggerActivityId,
-            CancellationTokens = options?.CancellationTokens ?? cancellationToken
+            CancellationTokens = options?.CancellationTokens ?? cancellationToken,
+            Requester = options?.Requester
         };
 
         using var scope = _serviceScopeFactory.CreateScope();


### PR DESCRIPTION
Add Requester property to WorkflowExecutionContext, along with some other classes.

This new property can be used to save the requester information: who or which service triggered this workflow.

In particular, when a workflow is triggered from Studio, the user (who logged in) identity name will be set. This gives custom activities the ability to know which user has triggered the workflow (when from Studio), which helps:
- Audit purpose
- Permission control
- Custom logic based on the request user