### PR TITLE
Use NET 8 SDK artifacts output

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+
+  <PropertyGroup>
+    <UseArtifactsOutput>true</UseArtifactsOutput>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
Use the new [NET 8 SDK artifacts output layout](https://learn.microsoft.com/en-us/dotnet/core/sdk/artifacts-output) feature which consolidates `bin` and `obj` folders under root level `artifacts` directory. Need to have `Directory.Build.props` to root level for proper configuration (you might want to consider such standard way over common.props too). For a solution with large amount of projects this can help both with I/O performance and cleanup (deleting `obj` and `bin` folders as they are in single place).

To remove old cruft, might be good idea to run locally in solution root directory:

```powershell
Get-ChildItem .\ -include bin,obj -Recurse | foreach ($_) { remove-item $_.fullname -Force -Recurse }
```