### PR TITLE
Allow creation of variables dynamically via `setVariable`

### DIFF
--- a/src/bundles/Elsa.Server.Web/Program.cs
+++ b/src/bundles/Elsa.Server.Web/Program.cs
@@ -28,7 +28,7 @@ const bool useHangfire = false;
 const bool useQuartz = true;
 const bool useMassTransit = true;
 const bool useMassTransitAzureServiceBus = false;
-const bool useMassTransitRabbitMq = true;
+const bool useMassTransitRabbitMq = false;
 
 var builder = WebApplication.CreateBuilder(args);
 var services = builder.Services;

--- a/src/modules/Elsa.Workflows.Core/Extensions/ExpressionExecutionContextExtensions.cs
+++ b/src/modules/Elsa.Workflows.Core/Extensions/ExpressionExecutionContextExtensions.cs
@@ -296,7 +296,6 @@ public static class ExpressionExecutionContextExtensions
         if(variable != null)
             variable.Set(context, value);
         
-        // Create the variable if it doesn't exist.
         if (variable == null)
             CreateVariable(context, variableName, value);
     }

--- a/src/modules/Elsa.Workflows.Core/Extensions/ExpressionExecutionContextExtensions.cs
+++ b/src/modules/Elsa.Workflows.Core/Extensions/ExpressionExecutionContextExtensions.cs
@@ -292,7 +292,13 @@ public static class ExpressionExecutionContextExtensions
             select v;
 
         var variable = q.FirstOrDefault();
-        variable?.Set(context, value);
+        
+        if(variable != null)
+            variable.Set(context, value);
+        
+        // Create the variable if it doesn't exist.
+        if (variable == null)
+            CreateVariable(context, variableName, value);
     }
 
     /// <summary>


### PR DESCRIPTION
This PR addresses #4789 by allowing the JS function `setVariable` to dynamically create a new variable if the specified variable doesn't already exist in the current scope.

This change however, does not create a workflow variable definition, which means it will currently not be visible from the Variables panel when looking at the workflow instance viewer. This might be part of an improvement in a later iteration.