### PR TITLE
2.x .NET 8 Build fix

### DIFF
--- a/src/modules/secrets/Elsa.Secrets.Persistence.EntityFramework.SqlServer/Elsa.Secrets.Persistence.EntityFramework.SqlServer.csproj
+++ b/src/modules/secrets/Elsa.Secrets.Persistence.EntityFramework.SqlServer/Elsa.Secrets.Persistence.EntityFramework.SqlServer.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\..\configureawait.props" />
     
   <PropertyGroup>
-      <TargetFrameworks>net7.0;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
+      <TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
       <Description>
           Elsa Secrets Entity Framework SqlServer is an optional part of Elsa Workflows.
       </Description>

--- a/src/persistence/Elsa.Persistence.MongoDb/Elsa.Persistence.MongoDb.csproj
+++ b/src/persistence/Elsa.Persistence.MongoDb/Elsa.Persistence.MongoDb.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\configureawait.props"/>
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.1;net5.0;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
         <Description>
             Elsa is a set of workflow libraries and tools that enable super-fast workflowing capabilities in any .NET Core application.
             This package provides a MongoDb persistence provider.

--- a/src/samples/dashboard/aspnetcore/ElsaDashboard.Samples.AspNetCore.Monolith/ElsaDashboard.Samples.AspNetCore.Monolith.csproj
+++ b/src/samples/dashboard/aspnetcore/ElsaDashboard.Samples.AspNetCore.Monolith/ElsaDashboard.Samples.AspNetCore.Monolith.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <UserSecretsId>a3259a33-fe85-4d27-b041-b92a506390f5</UserSecretsId>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Identity.Client" Version="4.54.1" />
+        <PackageReference Include="Microsoft.Identity.Client" Version="4.59.0" />
         <PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" />
     </ItemGroup>
 

--- a/src/samples/server/Elsa.Samples.Server.Host/Elsa.Samples.Server.Host.csproj
+++ b/src/samples/server/Elsa.Samples.Server.Host/Elsa.Samples.Server.Host.csproj
@@ -2,7 +2,7 @@
     <Import Project="..\..\..\..\configureawait.props" />
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <LangVersion>latest</LangVersion>
         <IsPackable>false</IsPackable>
         <Nullable>enable</Nullable>


### PR DESCRIPTION
Missed to upgrade the dependency of the ElsaDashboard.Samples.AspNetCore.Monolith project which lead to following build error:
`/home/runner/work/elsa-core/elsa-core/src/samples/dashboard/aspnetcore/ElsaDashboard.Samples.AspNetCore.Monolith/ElsaDashboard.Samples.AspNetCore.Monolith.csproj : error NU1605: Warning As Error: Detected package downgrade: Microsoft.Identity.Client from 4.56.0 to 4.54.1. Reference the package directly from the project to select a different version.  [/home/runner/work/elsa-core/elsa-core/Elsa.sln]
/home/runner/work/elsa-core/elsa-core/src/samples/dashboard/aspnetcore/ElsaDashboard.Samples.AspNetCore.Monolith/ElsaDashboard.Samples.AspNetCore.Monolith.csproj : error NU1605:  ElsaDashboard.Samples.AspNetCore.Monolith -> Elsa.Rebus.AzureServiceBus -> Rebus.AzureServiceBus 10.0.0 -> Azure.Identity 1.10.4 -> Microsoft.Identity.Client (>= 4.56.0)  [/home/runner/work/elsa-core/elsa-core/Elsa.sln]
/home/runner/work/elsa-core/elsa-core/src/samples/dashboard/aspnetcore/ElsaDashboard.Samples.AspNetCore.Monolith/ElsaDashboard.Samples.AspNetCore.Monolith.csproj : error NU1605:  ElsaDashboard.Samples.AspNetCore.Monolith -> Microsoft.Identity.Client (>= 4.54.1) [/home/runner/work/elsa-core/elsa-core/Elsa.sln]`

[sfmskywalker](https://github.com/sfmskywalker) sorry for that 😇