### PR TITLE
Upgraded samples and dashboard to .NET 8

### DIFF
--- a/src/dashboards/ElsaDashboard/ElsaDashboard.Web.csproj
+++ b/src/dashboards/ElsaDashboard/ElsaDashboard.Web.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFrameworks>net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/samples/aspnet/Elsa.Samples.Auth0Http/Elsa.Samples.Auth0Http.csproj
+++ b/src/samples/aspnet/Elsa.Samples.Auth0Http/Elsa.Samples.Auth0Http.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>

--- a/src/samples/aspnet/Elsa.Samples.ContextualWorkflowHttp/Elsa.Samples.ContextualWorkflowHttp.csproj
+++ b/src/samples/aspnet/Elsa.Samples.ContextualWorkflowHttp/Elsa.Samples.ContextualWorkflowHttp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/samples/aspnet/Elsa.Samples.CorrelationHttp/Elsa.Samples.CorrelationHttp.csproj
+++ b/src/samples/aspnet/Elsa.Samples.CorrelationHttp/Elsa.Samples.CorrelationHttp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/samples/aspnet/Elsa.Samples.CustomActivities/Elsa.Samples.CustomActivities.csproj
+++ b/src/samples/aspnet/Elsa.Samples.CustomActivities/Elsa.Samples.CustomActivities.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/src/samples/aspnet/Elsa.Samples.CustomTenantIdSource/Elsa.Samples.CustomTenantIdSource.csproj
+++ b/src/samples/aspnet/Elsa.Samples.CustomTenantIdSource/Elsa.Samples.CustomTenantIdSource.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/samples/aspnet/Elsa.Samples.DocumentApproval/Elsa.Samples.DocumentApproval.csproj
+++ b/src/samples/aspnet/Elsa.Samples.DocumentApproval/Elsa.Samples.DocumentApproval.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/samples/aspnet/Elsa.Samples.ExtendHttpEndpoint/Elsa.Samples.ExtendHttpEndpoint.csproj
+++ b/src/samples/aspnet/Elsa.Samples.ExtendHttpEndpoint/Elsa.Samples.ExtendHttpEndpoint.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 

--- a/src/samples/aspnet/Elsa.Samples.FaultyWorkflows/Elsa.Samples.FaultyWorkflows.csproj
+++ b/src/samples/aspnet/Elsa.Samples.FaultyWorkflows/Elsa.Samples.FaultyWorkflows.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/samples/aspnet/Elsa.Samples.ForkJoinTimerAndSignalHttp/Elsa.Samples.ForkJoinTimerAndSignalHttp.csproj
+++ b/src/samples/aspnet/Elsa.Samples.ForkJoinTimerAndSignalHttp/Elsa.Samples.ForkJoinTimerAndSignalHttp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
     

--- a/src/samples/aspnet/Elsa.Samples.HelloWorldHttp/Elsa.Samples.HelloWorldHttp.csproj
+++ b/src/samples/aspnet/Elsa.Samples.HelloWorldHttp/Elsa.Samples.HelloWorldHttp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/samples/aspnet/Elsa.Samples.HttpEndpointSecurity/Elsa.Samples.HttpEndpointSecurity.csproj
+++ b/src/samples/aspnet/Elsa.Samples.HttpEndpointSecurity/Elsa.Samples.HttpEndpointSecurity.csproj
@@ -1,19 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
-
-    <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0'">
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.10" />
-    </ItemGroup>
-
-    <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0'">
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.8" />
-    </ItemGroup>
     
     <ItemGroup>
         <PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/aspnet/Elsa.Samples.InProcessBackgroundMediator/Elsa.Samples.InProcessBackgroundMediator.csproj
+++ b/src/samples/aspnet/Elsa.Samples.InProcessBackgroundMediator/Elsa.Samples.InProcessBackgroundMediator.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>

--- a/src/samples/aspnet/Elsa.Samples.InfiniteLoopDetection/Elsa.Samples.InfiniteLoopDetection.csproj
+++ b/src/samples/aspnet/Elsa.Samples.InfiniteLoopDetection/Elsa.Samples.InfiniteLoopDetection.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/samples/aspnet/Elsa.Samples.Interrupts/Elsa.Samples.Interrupts.csproj
+++ b/src/samples/aspnet/Elsa.Samples.Interrupts/Elsa.Samples.Interrupts.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <LangVersion>latest</LangVersion>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/samples/aspnet/Elsa.Samples.InvokeWorkflowFromController/Elsa.Samples.InvokeWorkflowFromController.csproj
+++ b/src/samples/aspnet/Elsa.Samples.InvokeWorkflowFromController/Elsa.Samples.InvokeWorkflowFromController.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/samples/aspnet/Elsa.Samples.MaskPii/Elsa.Samples.MaskPii.csproj
+++ b/src/samples/aspnet/Elsa.Samples.MaskPii/Elsa.Samples.MaskPii.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>

--- a/src/samples/aspnet/Elsa.Samples.MassTransitRabbitMq/Elsa.Samples.MassTransitRabbitMq.csproj
+++ b/src/samples/aspnet/Elsa.Samples.MassTransitRabbitMq/Elsa.Samples.MassTransitRabbitMq.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/samples/aspnet/Elsa.Samples.NestedForks/Elsa.Samples.NestedForks.csproj
+++ b/src/samples/aspnet/Elsa.Samples.NestedForks/Elsa.Samples.NestedForks.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/samples/aspnet/Elsa.Samples.ReadModelHttp/Elsa.Samples.ReadModelHttp.csproj
+++ b/src/samples/aspnet/Elsa.Samples.ReadModelHttp/Elsa.Samples.ReadModelHttp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/samples/aspnet/Elsa.Samples.SendHttp/Elsa.Samples.SendHttp.csproj
+++ b/src/samples/aspnet/Elsa.Samples.SendHttp/Elsa.Samples.SendHttp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/samples/aspnet/Elsa.Samples.SignalApi/Elsa.Samples.SignalApi.csproj
+++ b/src/samples/aspnet/Elsa.Samples.SignalApi/Elsa.Samples.SignalApi.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/samples/aspnet/Elsa.Samples.UniqueCorrelatedWorkflows/Elsa.Samples.UniqueCorrelatedWorkflows.csproj
+++ b/src/samples/aspnet/Elsa.Samples.UniqueCorrelatedWorkflows/Elsa.Samples.UniqueCorrelatedWorkflows.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/samples/console/Elsa.Samples.BuildAndDispatchConsole/Elsa.Samples.BuildAndDispatchConsole.csproj
+++ b/src/samples/console/Elsa.Samples.BuildAndDispatchConsole/Elsa.Samples.BuildAndDispatchConsole.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/samples/console/Elsa.Samples.CompensationConsole/Elsa.Samples.CompensationConsole.csproj
+++ b/src/samples/console/Elsa.Samples.CompensationConsole/Elsa.Samples.CompensationConsole.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>

--- a/src/samples/console/Elsa.Samples.CustomActivityOutcomes/Elsa.Samples.CustomActivityOutcomes.csproj
+++ b/src/samples/console/Elsa.Samples.CustomActivityOutcomes/Elsa.Samples.CustomActivityOutcomes.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/samples/console/Elsa.Samples.CustomOutcomeActivityConsole/Elsa.Samples.CustomOutcomeActivityConsole.csproj
+++ b/src/samples/console/Elsa.Samples.CustomOutcomeActivityConsole/Elsa.Samples.CustomOutcomeActivityConsole.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/samples/console/Elsa.Samples.DeclarativeCompositeActivitiesConsole/Elsa.Samples.DeclarativeCompositeActivitiesConsole.csproj
+++ b/src/samples/console/Elsa.Samples.DeclarativeCompositeActivitiesConsole/Elsa.Samples.DeclarativeCompositeActivitiesConsole.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/samples/console/Elsa.Samples.Elasticsearch/Elsa.Samples.Elasticsearch.csproj
+++ b/src/samples/console/Elsa.Samples.Elasticsearch/Elsa.Samples.Elasticsearch.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/samples/console/Elsa.Samples.EntityChanged/Elsa.Samples.EntityChanged.csproj
+++ b/src/samples/console/Elsa.Samples.EntityChanged/Elsa.Samples.EntityChanged.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/src/samples/console/Elsa.Samples.FileBasedWorkflow/Elsa.Samples.FileBasedWorkflow.csproj
+++ b/src/samples/console/Elsa.Samples.FileBasedWorkflow/Elsa.Samples.FileBasedWorkflow.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/samples/console/Elsa.Samples.ForEachLoopConsole/Elsa.Samples.ForEachLoopConsole.csproj
+++ b/src/samples/console/Elsa.Samples.ForEachLoopConsole/Elsa.Samples.ForEachLoopConsole.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/samples/console/Elsa.Samples.ForLoopConsole/Elsa.Samples.ForLoopConsole.csproj
+++ b/src/samples/console/Elsa.Samples.ForLoopConsole/Elsa.Samples.ForLoopConsole.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/samples/console/Elsa.Samples.Forks/Elsa.Samples.Forks.csproj
+++ b/src/samples/console/Elsa.Samples.Forks/Elsa.Samples.Forks.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/samples/console/Elsa.Samples.HappinessConsole/Elsa.Samples.HappinessConsole.csproj
+++ b/src/samples/console/Elsa.Samples.HappinessConsole/Elsa.Samples.HappinessConsole.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/samples/console/Elsa.Samples.HelloWorldConsole/Elsa.Samples.HelloWorldConsole.csproj
+++ b/src/samples/console/Elsa.Samples.HelloWorldConsole/Elsa.Samples.HelloWorldConsole.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/samples/console/Elsa.Samples.IfThenElse/Elsa.Samples.IfThenElse.csproj
+++ b/src/samples/console/Elsa.Samples.IfThenElse/Elsa.Samples.IfThenElse.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/samples/console/Elsa.Samples.LoadAndRunFromDatabaseConsole/Elsa.Samples.LoadAndRunFromDatabaseConsole.csproj
+++ b/src/samples/console/Elsa.Samples.LoadAndRunFromDatabaseConsole/Elsa.Samples.LoadAndRunFromDatabaseConsole.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>

--- a/src/samples/console/Elsa.Samples.ProgrammaticCompositeActivitiesConsole/Elsa.Samples.ProgrammaticCompositeActivitiesConsole.csproj
+++ b/src/samples/console/Elsa.Samples.ProgrammaticCompositeActivitiesConsole/Elsa.Samples.ProgrammaticCompositeActivitiesConsole.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/samples/console/Elsa.Samples.ReadLineEchoConsole/Elsa.Samples.ReadLineEchoConsole.csproj
+++ b/src/samples/console/Elsa.Samples.ReadLineEchoConsole/Elsa.Samples.ReadLineEchoConsole.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/samples/console/Elsa.Samples.ReadLineToFile/Elsa.Samples.ReadLineToFile.csproj
+++ b/src/samples/console/Elsa.Samples.ReadLineToFile/Elsa.Samples.ReadLineToFile.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <TargetFramework>net5.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/samples/console/Elsa.Samples.RpaWebConsole/Elsa.Samples.RpaWebConsole.csproj
+++ b/src/samples/console/Elsa.Samples.RpaWebConsole/Elsa.Samples.RpaWebConsole.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/samples/console/Elsa.Samples.Serialization/Elsa.Samples.Serialization.csproj
+++ b/src/samples/console/Elsa.Samples.Serialization/Elsa.Samples.Serialization.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/samples/console/Elsa.Samples.SignalingConsole/Elsa.Samples.SignalingConsole.csproj
+++ b/src/samples/console/Elsa.Samples.SignalingConsole/Elsa.Samples.SignalingConsole.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/samples/console/Elsa.Samples.SwitchConsole/Elsa.Samples.SwitchConsole.csproj
+++ b/src/samples/console/Elsa.Samples.SwitchConsole/Elsa.Samples.SwitchConsole.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/samples/console/Elsa.Samples.UserTaskConsole/Elsa.Samples.UserTaskConsole.csproj
+++ b/src/samples/console/Elsa.Samples.UserTaskConsole/Elsa.Samples.UserTaskConsole.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/samples/console/Elsa.Samples.WhileLoopConsole/Elsa.Samples.WhileLoopConsole.csproj
+++ b/src/samples/console/Elsa.Samples.WhileLoopConsole/Elsa.Samples.WhileLoopConsole.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/samples/dashboard/aspnetcore/ElsaDashboard.Samples.AspNetCore.SubPath/ElsaDashboard.Samples.AspNetCore.SubPath.csproj
+++ b/src/samples/dashboard/aspnetcore/ElsaDashboard.Samples.AspNetCore.SubPath/ElsaDashboard.Samples.AspNetCore.SubPath.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/samples/dashboard/blazor/ElsaDashboard.Samples.BlazorServer/ElsaDashboard.Samples.BlazorServer.csproj
+++ b/src/samples/dashboard/blazor/ElsaDashboard.Samples.BlazorServer/ElsaDashboard.Samples.BlazorServer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/samples/dashboard/blazor/ElsaDashboard.Samples.BlazorWasm/ElsaDashboard.Samples.BlazorWasm.csproj
+++ b/src/samples/dashboard/blazor/ElsaDashboard.Samples.BlazorWasm/ElsaDashboard.Samples.BlazorWasm.csproj
@@ -1,21 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
-
-    <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0'">
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="5.0.10" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="5.0.10" PrivateAssets="all" />
-    </ItemGroup>
-
-    <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0'">
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.1" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="6.0.1" PrivateAssets="all" />
-    </ItemGroup>
     
     <ItemGroup>
       <ProjectReference Include="..\..\..\..\designer\bindings\aspnet\Elsa.Designer.Components.Web\Elsa.Designer.Components.Web.csproj" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.1" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.1" PrivateAssets="all" />
     </ItemGroup>
-
 </Project>

--- a/src/samples/persistence/Elsa.Samples.Persistence.EntityFramework/Elsa.Samples.Persistence.EntityFramework.csproj
+++ b/src/samples/persistence/Elsa.Samples.Persistence.EntityFramework/Elsa.Samples.Persistence.EntityFramework.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/samples/persistence/Elsa.Samples.Persistence.YesSql/Elsa.Samples.Persistence.YesSql.csproj
+++ b/src/samples/persistence/Elsa.Samples.Persistence.YesSql/Elsa.Samples.Persistence.YesSql.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/samples/worker/Elsa.Samples.AzureServiceBusWorker/Elsa.Samples.AzureServiceBusWorker.csproj
+++ b/src/samples/worker/Elsa.Samples.AzureServiceBusWorker/Elsa.Samples.AzureServiceBusWorker.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/samples/worker/Elsa.Samples.BreakLoop/Elsa.Samples.BreakLoop.csproj
+++ b/src/samples/worker/Elsa.Samples.BreakLoop/Elsa.Samples.BreakLoop.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
     

--- a/src/samples/worker/Elsa.Samples.CustomAttributesChildWorker/Elsa.Samples.CustomAttributesChildWorker.csproj
+++ b/src/samples/worker/Elsa.Samples.CustomAttributesChildWorker/Elsa.Samples.CustomAttributesChildWorker.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/samples/worker/Elsa.Samples.DistributedLock/Elsa.Samples.DistributedLock.csproj
+++ b/src/samples/worker/Elsa.Samples.DistributedLock/Elsa.Samples.DistributedLock.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
     

--- a/src/samples/worker/Elsa.Samples.Faulting/Elsa.Samples.Faulting.csproj
+++ b/src/samples/worker/Elsa.Samples.Faulting/Elsa.Samples.Faulting.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/samples/worker/Elsa.Samples.MqttWorker/Elsa.Samples.MqttWorker.csproj
+++ b/src/samples/worker/Elsa.Samples.MqttWorker/Elsa.Samples.MqttWorker.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>
         <IsPackable>false</IsPackable>

--- a/src/samples/worker/Elsa.Samples.MultiTenantChildWorker/Elsa.Samples.MultiTenantChildWorker.csproj
+++ b/src/samples/worker/Elsa.Samples.MultiTenantChildWorker/Elsa.Samples.MultiTenantChildWorker.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/samples/worker/Elsa.Samples.RabbitMqWorker/Elsa.Samples.RabbitMqWorker.csproj
+++ b/src/samples/worker/Elsa.Samples.RabbitMqWorker/Elsa.Samples.RabbitMqWorker.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/samples/worker/Elsa.Samples.RebusErrorWorker/Elsa.Samples.RebusErrorWorker.csproj
+++ b/src/samples/worker/Elsa.Samples.RebusErrorWorker/Elsa.Samples.RebusErrorWorker.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/samples/worker/Elsa.Samples.RebusWorker/Elsa.Samples.RebusWorker.csproj
+++ b/src/samples/worker/Elsa.Samples.RebusWorker/Elsa.Samples.RebusWorker.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/samples/worker/Elsa.Samples.RunChildWorkflowWorker/Elsa.Samples.RunChildWorkflowWorker.csproj
+++ b/src/samples/worker/Elsa.Samples.RunChildWorkflowWorker/Elsa.Samples.RunChildWorkflowWorker.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/samples/worker/Elsa.Samples.Timers.Hangfire/Elsa.Samples.Timers.Hangfire.csproj
+++ b/src/samples/worker/Elsa.Samples.Timers.Hangfire/Elsa.Samples.Timers.Hangfire.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
         <RootNamespace>Elsa.Samples.Timers</RootNamespace>
     </PropertyGroup>

--- a/src/samples/worker/Elsa.Samples.Timers.Quartz/Elsa.Samples.Timers.Quartz.csproj
+++ b/src/samples/worker/Elsa.Samples.Timers.Quartz/Elsa.Samples.Timers.Quartz.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
         <RootNamespace>Elsa.Samples.Timers</RootNamespace>
     </PropertyGroup>

--- a/src/samples/worker/Elsa.Samples.WatchDirectoryWorker/Elsa.Samples.WatchDirectoryWorker.csproj
+++ b/src/samples/worker/Elsa.Samples.WatchDirectoryWorker/Elsa.Samples.WatchDirectoryWorker.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <TargetFramework>net5.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/samples/worker/Elsa.Samples.WhileLoopWorker/Elsa.Samples.WhileLoopWorker.csproj
+++ b/src/samples/worker/Elsa.Samples.WhileLoopWorker/Elsa.Samples.WhileLoopWorker.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
     


### PR DESCRIPTION
Elsa-Dashboard build is failing because of multiple target frameworks in the dashboard project that lead to multiple concurrent builds when building the docker image.

See: https://github.com/elsa-workflows/elsa-core/actions/runs/7618024455/job/20748326979

With this PR I changed the dashboard project to only build .NET 8 to (hopefully) prevent that concurrency issue.
Additionally I upgraded all sample projects to .NET 8.

@sfmskywalker I hope this finally fixes the github build 😶