### PR TITLE
Add input application to workflow state extractor

### DIFF
--- a/src/modules/Elsa.Workflows.Core/Services/WorkflowStateExtractor.cs
+++ b/src/modules/Elsa.Workflows.Core/Services/WorkflowStateExtractor.cs
@@ -35,6 +35,13 @@ public class WorkflowStateExtractor : IWorkflowStateExtractor
 
         return state;
     }
+    
+    private void ApplyInput(WorkflowState state, WorkflowExecutionContext workflowExecutionContext)
+    {
+        // Only add input from state if the input doesn't already exist on the workflow execution context.
+        foreach (var inputItem in state.Input)
+            if (!workflowExecutionContext.Input.ContainsKey(inputItem.Key)) workflowExecutionContext.Input.Add(inputItem.Key, inputItem.Value);
+    }
 
     private IDictionary<string, object> GetPersistableInput(WorkflowExecutionContext workflowExecutionContext)
     {
@@ -55,7 +62,6 @@ public class WorkflowStateExtractor : IWorkflowStateExtractor
     /// <inheritdoc />
     public WorkflowExecutionContext Apply(WorkflowExecutionContext workflowExecutionContext, WorkflowState state)
     {
-        // Do not map input. We don't want to overwrite the input that was passed to the workflow.
         workflowExecutionContext.Id = state.Id;
         workflowExecutionContext.CorrelationId = state.CorrelationId;
         workflowExecutionContext.SubStatus = state.SubStatus;
@@ -63,6 +69,7 @@ public class WorkflowStateExtractor : IWorkflowStateExtractor
         workflowExecutionContext.Output = state.Output;
         workflowExecutionContext.ExecutionLogSequence = state.ExecutionLogSequence;
         workflowExecutionContext.CreatedAt = state.CreatedAt;
+        ApplyInput(state, workflowExecutionContext);
         ApplyProperties(state, workflowExecutionContext);
         ApplyActivityExecutionContexts(state, workflowExecutionContext);
         ApplyCompletionCallbacks(state, workflowExecutionContext);

--- a/src/modules/Elsa.Workflows.Core/Services/WorkflowStateExtractor.cs
+++ b/src/modules/Elsa.Workflows.Core/Services/WorkflowStateExtractor.cs
@@ -35,6 +35,24 @@ public class WorkflowStateExtractor : IWorkflowStateExtractor
 
         return state;
     }
+
+    /// <inheritdoc />
+    public WorkflowExecutionContext Apply(WorkflowExecutionContext workflowExecutionContext, WorkflowState state)
+    {
+        workflowExecutionContext.Id = state.Id;
+        workflowExecutionContext.CorrelationId = state.CorrelationId;
+        workflowExecutionContext.SubStatus = state.SubStatus;
+        workflowExecutionContext.Bookmarks = state.Bookmarks;
+        workflowExecutionContext.Output = state.Output;
+        workflowExecutionContext.ExecutionLogSequence = state.ExecutionLogSequence;
+        workflowExecutionContext.CreatedAt = state.CreatedAt;
+        ApplyInput(state, workflowExecutionContext);
+        ApplyProperties(state, workflowExecutionContext);
+        ApplyActivityExecutionContexts(state, workflowExecutionContext);
+        ApplyCompletionCallbacks(state, workflowExecutionContext);
+        ApplyScheduledActivities(state, workflowExecutionContext);
+        return workflowExecutionContext;
+    }
     
     private void ApplyInput(WorkflowState state, WorkflowExecutionContext workflowExecutionContext)
     {
@@ -57,24 +75,6 @@ public class WorkflowStateExtractor : IWorkflowStateExtractor
         }
 
         return filteredInput;
-    }
-
-    /// <inheritdoc />
-    public WorkflowExecutionContext Apply(WorkflowExecutionContext workflowExecutionContext, WorkflowState state)
-    {
-        workflowExecutionContext.Id = state.Id;
-        workflowExecutionContext.CorrelationId = state.CorrelationId;
-        workflowExecutionContext.SubStatus = state.SubStatus;
-        workflowExecutionContext.Bookmarks = state.Bookmarks;
-        workflowExecutionContext.Output = state.Output;
-        workflowExecutionContext.ExecutionLogSequence = state.ExecutionLogSequence;
-        workflowExecutionContext.CreatedAt = state.CreatedAt;
-        ApplyInput(state, workflowExecutionContext);
-        ApplyProperties(state, workflowExecutionContext);
-        ApplyActivityExecutionContexts(state, workflowExecutionContext);
-        ApplyCompletionCallbacks(state, workflowExecutionContext);
-        ApplyScheduledActivities(state, workflowExecutionContext);
-        return workflowExecutionContext;
     }
 
     private void ExtractProperties(WorkflowState state, WorkflowExecutionContext workflowExecutionContext)


### PR DESCRIPTION
A new method ApplyInput has been added to prevent overwriting any existing input in the WorkflowExecutionContext. Now, input items are added to the workflow execution context only if they don't exist there already. The Apply method has been updated as well to add workflow state inputs appropriately.

Fixes #4705
