### PR TITLE
Drop LinqKit dependency

### DIFF
--- a/src/modules/Elsa.EntityFrameworkCore.Common/Elsa.EntityFrameworkCore.Common.csproj
+++ b/src/modules/Elsa.EntityFrameworkCore.Common/Elsa.EntityFrameworkCore.Common.csproj
@@ -12,7 +12,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="LinqKit" Version="1.2.5" />
         <PackageReference Include="Open.Linq.AsyncExtensions" Version="1.2.0"/>
         <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     </ItemGroup>


### PR DESCRIPTION
It is unused and brings in EF6