### PR TITLE
Remove Persistence of Completed Activity Execution Contexts

### DIFF
--- a/Elsa.sln.DotSettings
+++ b/Elsa.sln.DotSettings
@@ -10,4 +10,5 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Populator/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Postgre/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=startable/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=Telnyx/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Telnyx/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Unschedule/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/modules/Elsa.JavaScript/Services/JintJavaScriptEvaluator.cs
+++ b/src/modules/Elsa.JavaScript/Services/JintJavaScriptEvaluator.cs
@@ -132,7 +132,11 @@ public class JintJavaScriptEvaluator : IJavaScriptEvaluator
             return;
 
         var inputs = context.GetWorkflowInputs().ToDictionary(x => x.Name);
-        var inputDefinitions = context.GetWorkflowExecutionContext().Workflow.Inputs;
+
+        if (!context.TryGetWorkflowExecutionContext(out var workflowExecutionContext))
+            return;
+
+        var inputDefinitions = workflowExecutionContext.Workflow.Inputs;
 
         foreach (var inputDefinition in inputDefinitions)
         {

--- a/src/modules/Elsa.Quartz/Services/QuartzWorkflowScheduler.cs
+++ b/src/modules/Elsa.Quartz/Services/QuartzWorkflowScheduler.cs
@@ -47,7 +47,9 @@ public class QuartzWorkflowScheduler : IWorkflowScheduler
             .WithIdentity(taskName)
             .StartAt(at)
             .Build();
-        await scheduler.ScheduleJob(trigger, cancellationToken);
+        
+        if(!await scheduler.CheckExists(trigger.Key, cancellationToken))
+            await scheduler.ScheduleJob(trigger, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -77,7 +79,9 @@ public class QuartzWorkflowScheduler : IWorkflowScheduler
             .StartAt(startAt)
             .WithSimpleSchedule(schedule => schedule.WithInterval(interval).RepeatForever())
             .Build();
-        await scheduler.ScheduleJob(trigger, cancellationToken);
+        
+        if(!await scheduler.CheckExists(trigger.Key, cancellationToken))
+            await scheduler.ScheduleJob(trigger, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -99,7 +103,9 @@ public class QuartzWorkflowScheduler : IWorkflowScheduler
             .UsingJobData(CreateJobDataMap(request))
             .WithIdentity(taskName)
             .WithCronSchedule(cronExpression).Build();
-        await scheduler.ScheduleJob(trigger, cancellationToken);
+        
+        if(!await scheduler.CheckExists(trigger.Key, cancellationToken))
+            await scheduler.ScheduleJob(trigger, cancellationToken);
     }
 
     /// <inheritdoc />

--- a/src/modules/Elsa.Workflows.Core/Contexts/ActivityExecutionContext.Cancel.cs
+++ b/src/modules/Elsa.Workflows.Core/Contexts/ActivityExecutionContext.Cancel.cs
@@ -36,9 +36,10 @@ public partial class ActivityExecutionContext
         // Add an execution log entry.
         AddExecutionLogEntry("Canceled", payload: JournalData, includeActivityState: true);
         
-        _cancellationRegistration.Dispose();
-        
+        await _cancellationRegistration.DisposeAsync();
         await this.SendSignalAsync(new CancelSignal());
+        
+        // ReSharper disable once MethodSupportsCancellation
         await _publisher.SendAsync(new ActivityCancelled(this));
     }
 }

--- a/src/modules/Elsa.Workflows.Core/Services/WorkflowStateExtractor.cs
+++ b/src/modules/Elsa.Workflows.Core/Services/WorkflowStateExtractor.cs
@@ -253,14 +253,9 @@ public class WorkflowStateExtractor : IWorkflowStateExtractor
 
     private static IEnumerable<ActivityExecutionContext> GetActiveActivityExecutionContexts(IEnumerable<ActivityExecutionContext> activityExecutionContexts)
     {
-        var contexts = activityExecutionContexts.ToList();
-
-        // Remove all child contexts of completed contexts.
-        foreach (var context in contexts.ToList().Where(context => context.IsCompleted))
-        {
-            contexts.RemoveAll(x => x.ParentActivityExecutionContext == context);
-        }
-        
-        return contexts;
+        // Filter out completed activity execution contexts.
+        // This will currently break scripts accessing activity output directly, but there's a workaround for that via variable capturing.
+        // We may ultimately restore direct output access, but in a different way.
+        return activityExecutionContexts.Where(x => !x.IsCompleted).ToList();
     }
 }

--- a/src/modules/Elsa.Workflows.Core/Services/WorkflowStateExtractor.cs
+++ b/src/modules/Elsa.Workflows.Core/Services/WorkflowStateExtractor.cs
@@ -255,12 +255,12 @@ public class WorkflowStateExtractor : IWorkflowStateExtractor
     {
         var contexts = activityExecutionContexts.ToList();
 
-        // // If there are any faulted contexts, keep everything so that the user can fix the issue and potentially reschedule existing instances.
-        // if (contexts.Any(x => x.Status == ActivityStatus.Faulted))
+        // Remove all child contexts of completed contexts.
+        foreach (var context in contexts.ToList().Where(context => context.IsCompleted))
+        {
+            contexts.RemoveAll(x => x.ParentActivityExecutionContext == context);
+        }
+        
         return contexts;
-
-        // return contexts
-        //     .Where(x => !x.IsCompleted)
-        //     .ToList();
     }
 }

--- a/test/integration/Elsa.IntegrationTests/Scenarios/JavaScriptListsAndArrays/Tests.cs
+++ b/test/integration/Elsa.IntegrationTests/Scenarios/JavaScriptListsAndArrays/Tests.cs
@@ -1,12 +1,8 @@
-using System;
-using System.Collections.Generic;
 using System.Dynamic;
-using System.Threading.Tasks;
 using Elsa.Expressions.Models;
 using Elsa.Extensions;
 using Elsa.JavaScript.Contracts;
 using Elsa.Testing.Shared;
-using Jint;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 using Xunit.Abstractions;


### PR DESCRIPTION
This PR introduces an optimization to the workflow instance storage by eliminating the need to persist completed activity execution contexts. This change leverages the previously introduced `ActivityExecutionRecord` storage, which has made the persistence of these contexts redundant. The primary reason for retaining completed activity execution contexts was to facilitate direct access to activity outputs. However, this requirement is now addressed through a recommended workaround that involves capturing activity outputs using variables.

The benefits of this optimization include:

- A significant reduction in the storage size of workflow instances, leading to improved performance in workflow instance viewing.
- Enhanced efficiency in serializing and deserializing workflow instances during the resume process.

By adopting this change, we aim to streamline workflow execution and management, focusing on efficiency and performance improvements.