### PR TITLE
Make workflow runtime methods accept nullable options

### DIFF
--- a/samples/console/Elsa.Samples.ConsoleApp.HelloWorld/Program.cs
+++ b/samples/console/Elsa.Samples.ConsoleApp.HelloWorld/Program.cs
@@ -1,4 +1,4 @@
-﻿using Elsa.Extensions;
+using Elsa.Extensions;
 using Elsa.Workflows.Activities;
 using Elsa.Workflows.Contracts;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/modules/Elsa.Workflows.Runtime/Contracts/IWorkflowRuntime.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Contracts/IWorkflowRuntime.cs
@@ -16,42 +16,42 @@ public interface IWorkflowRuntime
     /// <summary>
     /// Returns a value whether or not the specified workflow definition can create a new instance.
     /// </summary>
-    Task<CanStartWorkflowResult> CanStartWorkflowAsync(string definitionId, StartWorkflowRuntimeOptions options);
+    Task<CanStartWorkflowResult> CanStartWorkflowAsync(string definitionId, StartWorkflowRuntimeOptions? options = default);
 
     /// <summary>
     /// Creates a new workflow instance of the specified definition ID and executes it.
     /// </summary>
     /// <param name="definitionId">The workflow definition ID to run.</param>
     /// <param name="options">Options for starting the workflow.</param>
-    Task<WorkflowExecutionResult> StartWorkflowAsync(string definitionId, StartWorkflowRuntimeOptions options);
+    Task<WorkflowExecutionResult> StartWorkflowAsync(string definitionId, StartWorkflowRuntimeOptions? options = default);
 
     /// <summary>
     /// Starts all workflows with triggers matching the specified activity type and bookmark payload.
     /// </summary>
     /// <returns></returns>
-    Task<ICollection<WorkflowExecutionResult>> StartWorkflowsAsync(string activityTypeName, object bookmarkPayload, TriggerWorkflowsOptions options);
+    Task<ICollection<WorkflowExecutionResult>> StartWorkflowsAsync(string activityTypeName, object bookmarkPayload, TriggerWorkflowsOptions? options = default);
 
     /// <summary>
     /// Tries to start a workflow and returns the result if successful.
     /// </summary>
-    Task<WorkflowExecutionResult?> TryStartWorkflowAsync(string definitionId, StartWorkflowRuntimeOptions options);
+    Task<WorkflowExecutionResult?> TryStartWorkflowAsync(string definitionId, StartWorkflowRuntimeOptions? options = default);
 
     /// <summary>
     /// Resumes an existing workflow instance.
     /// </summary>
     /// <param name="workflowInstanceId">The ID of the workflow instance to resume.</param>
     /// <param name="options">Options for resuming the workflow.</param>
-    Task<WorkflowExecutionResult?> ResumeWorkflowAsync(string workflowInstanceId, ResumeWorkflowRuntimeOptions options);
+    Task<WorkflowExecutionResult?> ResumeWorkflowAsync(string workflowInstanceId, ResumeWorkflowRuntimeOptions? options = default);
 
     /// <summary>
     /// Resumes all workflows that are bookmarked on the specified activity type. 
     /// </summary>
-    Task<ICollection<WorkflowExecutionResult>> ResumeWorkflowsAsync(string activityTypeName, object bookmarkPayload, TriggerWorkflowsOptions options);
+    Task<ICollection<WorkflowExecutionResult>> ResumeWorkflowsAsync(string activityTypeName, object bookmarkPayload, TriggerWorkflowsOptions? options = default);
 
     /// <summary>
     /// Starts all workflows and resumes existing workflow instances based on the specified activity type and bookmark payload.
     /// </summary>
-    Task<TriggerWorkflowsResult> TriggerWorkflowsAsync(string activityTypeName, object bookmarkPayload, TriggerWorkflowsOptions options);
+    Task<TriggerWorkflowsResult> TriggerWorkflowsAsync(string activityTypeName, object bookmarkPayload, TriggerWorkflowsOptions? options = default);
 
     /// <summary>
     /// Executes a pending workflow.


### PR DESCRIPTION
The methods in the workflow runtime now accept nullable runtime options. Providing workflow options is now optional - if no options are provided, default values are used. Changes have been applied across all relevant methods in IWorkflowRuntime, ProtoActorWorkflowRuntime and DefaultWorkflowRuntime classes, thus ensuring consistent behavior and null safety across the workflow runtime.
