### PR TITLE
issues(4885)

### DIFF
--- a/src/modules/Elsa.MongoDb/Features/MongoDbFeature.cs
+++ b/src/modules/Elsa.MongoDb/Features/MongoDbFeature.cs
@@ -48,11 +48,11 @@ public class MongoDbFeature : FeatureBase
 
     private static void RegisterSerializers()
     {
-        BsonSerializer.RegisterSerializer(typeof(object), new PolymorphicSerializer());
-        BsonSerializer.RegisterSerializer(typeof(Type), new TypeSerializer());
-        BsonSerializer.RegisterSerializer(typeof(Variable), new VariableSerializer());
-        BsonSerializer.RegisterSerializer(typeof(Version), new VersionSerializer());
-        BsonSerializer.RegisterSerializer(typeof(JsonElement), new JsonElementSerializer());
+        BsonSerializer.TryRegisterSerializer(typeof(object), new PolymorphicSerializer());
+        BsonSerializer.TryRegisterSerializer(typeof(Type), new TypeSerializer());
+        BsonSerializer.TryRegisterSerializer(typeof(Variable), new VariableSerializer());
+        BsonSerializer.TryRegisterSerializer(typeof(Version), new VersionSerializer());
+        BsonSerializer.TryRegisterSerializer(typeof(JsonElement), new JsonElementSerializer());
     }
 
     private static void RegisterClassMaps()


### PR DESCRIPTION
Hello,
See issue: 
https://github.com/elsa-workflows/elsa-core/issues/4885

Based on the context provided, it appears that we are encountering a serialization registration issue when running integration tests with Elsa and MongoDB. The error message indicates that a serializer for the Object type is being registered multiple times, which is not allowed by the MongoDB driver.

The code snippet provided suggests a solution to use BsonSerializer.TryRegisterSerializer instead of BsonSerializer.RegisterSerializer.

```csharp
private static void RegisterSerializers()
{
    BsonSerializer.TryRegisterSerializer(typeof(object), new PolymorphicSerializer());
    BsonSerializer.TryRegisterSerializer(typeof(Type), new TypeSerializer());
    BsonSerializer.TryRegisterSerializer(typeof(Variable), new VariableSerializer());
    BsonSerializer.TryRegisterSerializer(typeof(Version), new VersionSerializer());
    BsonSerializer.TryRegisterSerializer(typeof(JsonElement), new JsonElementSerializer());
}
```