### PR TITLE
issues(4893): try register serializer or skip when already registred …

### DIFF
--- a/src/modules/Elsa.MongoDb/Features/MongoDbFeature.cs
+++ b/src/modules/Elsa.MongoDb/Features/MongoDbFeature.cs
@@ -48,16 +48,16 @@ public class MongoDbFeature : FeatureBase
 
     private static void RegisterSerializers()
     {
-        BsonSerializer.TryRegisterSerializer(typeof(object), new PolymorphicSerializer());
-        BsonSerializer.TryRegisterSerializer(typeof(Type), new TypeSerializer());
-        BsonSerializer.TryRegisterSerializer(typeof(Variable), new VariableSerializer());
-        BsonSerializer.TryRegisterSerializer(typeof(Version), new VersionSerializer());
-        BsonSerializer.TryRegisterSerializer(typeof(JsonElement), new JsonElementSerializer());
+        TryRegisterSerializerOrSkipWhenExist(typeof(object), new PolymorphicSerializer());
+        TryRegisterSerializerOrSkipWhenExist(typeof(Type), new TypeSerializer());
+        TryRegisterSerializerOrSkipWhenExist(typeof(Variable), new VariableSerializer());
+        TryRegisterSerializerOrSkipWhenExist(typeof(Version), new VersionSerializer());
+        TryRegisterSerializerOrSkipWhenExist(typeof(JsonElement), new JsonElementSerializer());
     }
 
     private static void RegisterClassMaps()
     {
-        BsonClassMap.RegisterClassMap<StoredBookmark>(cm =>
+        BsonClassMap.TryRegisterClassMap<StoredBookmark>(cm =>
         {
             cm.AutoMap(); // Automatically map other properties
             cm
@@ -66,6 +66,17 @@ public class MongoDbFeature : FeatureBase
         });
     }
 
+    private static void TryRegisterSerializerOrSkipWhenExist(Type type, IBsonSerializer serializer)
+    {
+       try
+       {
+           BsonSerializer.TryRegisterSerializer(type, serializer);
+       }
+       catch (BsonSerializationException ex)
+       {
+       }
+    }
+    
     private static IMongoDatabase CreateDatabase(IServiceProvider sp, string connectionString)
     {
         var options = sp.GetRequiredService<IOptions<MongoDbOptions>>().Value;


### PR DESCRIPTION
Related to this fix https://github.com/elsa-workflows/elsa-core/pull/4886
it appeared that this fix will not resolve the probelem,
because even with a try it will always have a new instance which is totally different from what is registred
see code on MongoDB.Bson.Serialization

```csharp
 public bool TryRegisterSerializer(Type type, IBsonSerializer serializer)
 {
     if (type == null)
     {
         throw new ArgumentNullException(nameof(type));
     }
     if (serializer == null)
     {
         throw new ArgumentNullException(nameof(serializer));
     }
     EnsureRegisteringASerializerForThisTypeIsAllowed(type);

     if (_cache.TryAdd(type, serializer))
     {
         return true;
     }
     else
     {
         var existingSerializer = _cache[type];
         if (!existingSerializer.Equals(serializer)) // with new() ... it's always a different instance.
         {
             var message = $"There is already a different serializer registered for type {BsonUtils.GetFriendlyTypeName(type)}.";
             throw new BsonSerializationException(message);
         }
         return false;
     }
 }
```

To fix it:

```csharp

TryRegisterSerializerOrSkip(typeof(object), new PolymorphicSerializer());
TryRegisterSerializerOrSkip(typeof(Type), new TypeSerializer());
TryRegisterSerializerOrSkip(typeof(Variable), new VariableSerializer());
TryRegisterSerializerOrSkip(typeof(Version), new VersionSerializer());
TryRegisterSerializerOrSkip(typeof(JsonElement), new JsonElementSerializer());

private static void TryRegisterSerializerOrSkip(Type type, IBsonSerializer serializer)
{
	try
	{
		BsonSerializer.TryRegisterSerializer(type, serializer);
	}
	catch (BsonSerializationException ex)
	{
		// should we log the exception ?
	}
}

```