### PR TITLE
Fix memory leak when using EF Core

### DIFF
--- a/src/modules/Elsa.EntityFrameworkCore.Common/Extensions/ExpressionExtensions.cs
+++ b/src/modules/Elsa.EntityFrameworkCore.Common/Extensions/ExpressionExtensions.cs
@@ -19,7 +19,7 @@ public static class ExpressionExtensions
     public static Expression<Func<TEntity, bool>> BuildContainsExpression<TEntity>(this Expression<Func<TEntity, string>> keySelector, IEnumerable<TEntity> entities) where TEntity : class
     {
         var compiledKeySelector = keySelector.Compile();
-        var list = entities.Select(compiledKeySelector);
+        var list = entities.Select(compiledKeySelector).ToList();
         var property = keySelector.GetProperty()!;
         var param = Expression.Parameter(typeof(TEntity));
         


### PR DESCRIPTION
Converted the result of the Select() operation to a list, within the BuildContainsExpression method. This prevents multiple enumerations of the 'entities' variable, improving the performance of the method by reducing the number of iterations.

Fixes #4884 