### PR TITLE
Update script source path in _Host.cshtml

### DIFF
--- a/src/bundles/Elsa.ServerAndStudio.Web/Pages/_Host.cshtml
+++ b/src/bundles/Elsa.ServerAndStudio.Web/Pages/_Host.cshtml
@@ -56,7 +56,7 @@
         "basePath": "@basePath"
      } };
 </script>
-<script src="_framework/blazor.webassembly.js"></script>
+<script src="@basePath/_framework/blazor.webassembly.js"></script>
 </body>
 
 </html>

--- a/src/bundles/Elsa.Studio.Web/Pages/_Host.cshtml
+++ b/src/bundles/Elsa.Studio.Web/Pages/_Host.cshtml
@@ -60,7 +60,7 @@
         "basePath": "@basePath"
      } };
 </script>
-<script src="_framework/blazor.webassembly.js"></script>
+<script src="@basePath/_framework/blazor.webassembly.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
The script source paths in both "Elsa.Studio.Web" and "Elsa.ServerAndStudio.Web" _Host.cshtml files have been modified to use the defined base path. This change is necessary for correctly loading the "blazor.webassembly.js" script from the appropriate directory.
