### PR TITLE
feature: Add created date time to filter

### DIFF
--- a/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowInstances/List/Endpoint.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowInstances/List/Endpoint.cs
@@ -39,7 +39,9 @@ internal class List : ElsaEndpoint<Request, Response>
             WorkflowStatus = request.Status,
             WorkflowSubStatus = request.SubStatus,
             WorkflowStatuses = request.Statuses?.Select(Enum.Parse<WorkflowStatus>).ToList(),
-            WorkflowSubStatuses = request.SubStatuses?.Select(Enum.Parse<WorkflowSubStatus>).ToList()
+            WorkflowSubStatuses = request.SubStatuses?.Select(Enum.Parse<WorkflowSubStatus>).ToList(),
+            ToCreatedAt = request.ToCreatedAt,
+            FromCreatedAt = request.FromCreatedAt,
         };
 
         var summaries = await FindAsync(request, filter, pageArgs, cancellationToken);

--- a/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowInstances/List/Models.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowInstances/List/Models.cs
@@ -19,6 +19,8 @@ public class Request
     public ICollection<string>? SubStatuses { get; set; }
     public OrderByWorkflowInstance? OrderBy { get; set; }
     public OrderDirection? OrderDirection { get; set; }
+    public DateTimeOffset? FromCreatedAt { get; set; }
+    public DateTimeOffset? ToCreatedAt { get; set; }
 }
 
 public class Response

--- a/src/modules/Elsa.Workflows.Management/Filters/WorkflowInstanceFilter.cs
+++ b/src/modules/Elsa.Workflows.Management/Filters/WorkflowInstanceFilter.cs
@@ -78,6 +78,16 @@ public class WorkflowInstanceFilter
     public ICollection<WorkflowSubStatus>? WorkflowSubStatuses { get; set; }
 
     /// <summary>
+    ///  Filter workflow instances by created date time, start from this date time.
+    /// </summary>
+    public DateTimeOffset? FromCreatedAt { get; set; }
+
+    /// <summary>
+    ///  Filter workflow instances by created date time, to this date time.
+    /// </summary>
+    public DateTimeOffset? ToCreatedAt { get; set; }
+
+    /// <summary>
     /// Applies the filter to the specified query.
     /// </summary>
     public IQueryable<WorkflowInstance> Apply(IQueryable<WorkflowInstance> query)
@@ -96,6 +106,8 @@ public class WorkflowInstanceFilter
         if (filter.WorkflowSubStatus != null) query = query.Where(x => x.SubStatus == filter.WorkflowSubStatus);
         if (filter.WorkflowStatuses != null) query = query.Where(x => filter.WorkflowStatuses.Contains(x.Status));
         if (filter.WorkflowSubStatuses != null) query = query.Where(x => filter.WorkflowSubStatuses.Contains(x.SubStatus));
+        if (filter.ToCreatedAt is not null) query = query.Where(x => filter.ToCreatedAt >= x.CreatedAt);
+        if (filter.FromCreatedAt is not null) query = query.Where(x => filter.FromCreatedAt <= x.CreatedAt);
 
         var searchTerm = filter.SearchTerm;
         if (!string.IsNullOrWhiteSpace(searchTerm))


### PR DESCRIPTION
Issue: https://github.com/elsa-workflows/elsa-core/issues/4937
Need:

Current: 
At the endpoint **elsa/api/workflow-instances** currently return all workflow instances even we have millions of instances !!

Target:
Add two properties to filters, FromCreatedAt and ToCreatedAt to help us to get instances between 2 date times.
