### PR TITLE
Removed references to packages that are not used

### DIFF
--- a/src/modules/Elsa.Http/Elsa.Http.csproj
+++ b/src/modules/Elsa.Http/Elsa.Http.csproj
@@ -8,14 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AspNetCore.Authentication.ApiKey" />
         <PackageReference Include="FluentStorage" />
-        <PackageReference Include="Microsoft.AspNetCore.Authorization" />
-        <PackageReference Include="Microsoft.AspNetCore.Http" />
-        <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" />
-        <PackageReference Include="Microsoft.AspNetCore.Routing" />
-        <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" />
-        <PackageReference Include="Microsoft.Extensions.Http" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Related to: [https://github.com/elsa-workflows/elsa-core/issues/4951](https://github.com/elsa-workflows/elsa-core/issues/4951)

Removed references to multiple packages that are not used within the project and some (Microsoft.AspNetCore.X) packages were deprecated and should not be used.

Please ensure that the changes does not break anything unforeseen.