### PR TITLE
Fix Security Bug: No permissions applied to version endpoints

### DIFF
--- a/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/Version/Delete.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/Version/Delete.cs
@@ -1,4 +1,5 @@
-﻿using Elsa.Workflows.Management.Contracts;
+﻿using Elsa.Abstractions;
+using Elsa.Workflows.Management.Contracts;
 using FastEndpoints;
 using JetBrains.Annotations;
 
@@ -8,7 +9,7 @@ namespace Elsa.Workflows.Api.Endpoints.WorkflowDefinitions.Version;
 /// Deletes a specific version of a workflow definition.
 /// </summary>
 [PublicAPI]
-public class DeleteVersion : EndpointWithoutRequest
+public class DeleteVersion : ElsaEndpointWithoutRequest
 {
     private readonly IWorkflowDefinitionManager _workflowDefinitionManager;
 
@@ -22,7 +23,7 @@ public class DeleteVersion : EndpointWithoutRequest
     public override void Configure()
     {
         Delete("workflow-definitions/{definitionId}/version/{version}");
-        AllowAnonymous();
+        ConfigurePermissions("delete:workflow-definitions");
     }
 
     /// <inheritdoc />

--- a/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/Version/List.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/Version/List.cs
@@ -1,4 +1,5 @@
-﻿using Elsa.Common.Entities;
+﻿using Elsa.Abstractions;
+using Elsa.Common.Entities;
 using Elsa.Common.Models;
 using Elsa.Workflows.Management.Contracts;
 using Elsa.Workflows.Management.Filters;
@@ -9,7 +10,7 @@ using Microsoft.AspNetCore.Http;
 namespace Elsa.Workflows.Api.Endpoints.WorkflowDefinitions.Version;
 
 [PublicAPI]
-internal class ListVersions : EndpointWithoutRequest
+internal class ListVersions : ElsaEndpointWithoutRequest
 {
     private readonly IWorkflowDefinitionStore _store;
     
@@ -21,7 +22,7 @@ internal class ListVersions : EndpointWithoutRequest
     public override void Configure()
     {
         Get("workflow-definitions/{definitionId}/versions");
-        AllowAnonymous();
+        ConfigurePermissions("read:workflow-definitions");
     }
 
     public override async Task HandleAsync(CancellationToken cancellationToken)

--- a/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/Version/Revert.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/Version/Revert.cs
@@ -1,11 +1,12 @@
-﻿using Elsa.Workflows.Management.Contracts;
+﻿using Elsa.Abstractions;
+using Elsa.Workflows.Management.Contracts;
 using FastEndpoints;
 using JetBrains.Annotations;
 
 namespace Elsa.Workflows.Api.Endpoints.WorkflowDefinitions.Version;
 
 [PublicAPI]
-internal class RevertVersion : EndpointWithoutRequest
+internal class RevertVersion : ElsaEndpointWithoutRequest
 {
     private readonly IWorkflowDefinitionManager _workflowDefinitionManager;
 
@@ -17,7 +18,7 @@ internal class RevertVersion : EndpointWithoutRequest
     public override void Configure()
     {
         Post("workflow-definitions/{definitionId}/revert/{version}");
-        AllowAnonymous();
+        ConfigurePermissions("publish:workflow-definitions");
     }
 
     public override async Task HandleAsync(CancellationToken ct)


### PR DESCRIPTION
List,Delete, and Revert endpoints for editing endpoints by version were set to allow anonymous, meaning no authorisation policies were applied.

I have changed these to apply permissions as per the rest of the API.