### PR TITLE
Added logging to pinpoint issue #5033

### DIFF
--- a/src/modules/Elsa.Workflows.Runtime/Services/DefaultWorkflowDefinitionStorePopulator.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Services/DefaultWorkflowDefinitionStorePopulator.cs
@@ -178,6 +178,18 @@ public class DefaultWorkflowDefinitionStorePopulator : IWorkflowDefinitionStoreP
         workflowDefinition.MaterializerName = materializedWorkflow.MaterializerName;
 
         workflowDefinitionsToSave.Add(workflowDefinition);
+        
+        // Temporary measure to try and find the root cause of https://github.com/elsa-workflows/elsa-core/issues/5033
+        var duplicates = workflowDefinitionsToSave.GroupBy(wd => wd.Id)
+            .Where(g => g.Count() > 1)
+            .Select(g => g.Key)
+            .ToList();
+        
+        if (duplicates.Any())
+        {
+            throw new Exception($"Unable to update WorkflowDefinition with ids {string.Join(',', duplicates)} multiple times.");
+        }
+        
         await _workflowDefinitionStore.SaveManyAsync(workflowDefinitionsToSave, cancellationToken);
     }
 


### PR DESCRIPTION
Since we are unable to find the exact scenario in which issue #5033 occurs, logging has been added to get more information.