### PR TITLE
Update VersionOptions.LatestAndPublished to set correct property

### DIFF
--- a/src/modules/Elsa.Common/Models/VersionOptions.cs
+++ b/src/modules/Elsa.Common/Models/VersionOptions.cs
@@ -31,7 +31,7 @@ public struct VersionOptions
     /// <summary>
     /// Gets the latest, published version.
     /// </summary>
-    public static readonly VersionOptions LatestAndPublished = new() { IsLatestOrPublished = true };
+    public static readonly VersionOptions LatestAndPublished = new() { IsLatestAndPublished = true };
 
     /// <summary>
     /// Gets the draft version.


### PR DESCRIPTION
`VersionOptions.LatestAndPublished` was incorrectly setting the `LatestOrPublished` property to true rather than the `LatestAndPublished` property.