### PR TITLE
Add Unicode encoding support to serializers

### DIFF
--- a/src/modules/Elsa.Common/Serialization/ConfigurableSerializer.cs
+++ b/src/modules/Elsa.Common/Serialization/ConfigurableSerializer.cs
@@ -1,6 +1,8 @@
+using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
+using System.Text.Unicode;
 using Elsa.Common.Contracts;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -53,7 +55,8 @@ public abstract class ConfigurableSerializer
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
             PropertyNameCaseInsensitive = true,
-            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            Encoder = JavaScriptEncoder.Create(UnicodeRanges.All)
         };
         
         options.Converters.Add(new JsonStringEnumConverter());

--- a/src/modules/Elsa.Http/ContentWriters/JsonContentFactory.cs
+++ b/src/modules/Elsa.Http/ContentWriters/JsonContentFactory.cs
@@ -1,6 +1,9 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Mime;
 using System.Text;
+using System.Text.Encodings.Web;
 using System.Text.Json;
+using System.Text.Unicode;
 
 namespace Elsa.Http.ContentWriters;
 
@@ -13,6 +16,7 @@ public class JsonContentFactory : IHttpContentFactory
     public IEnumerable<string> SupportedContentTypes => new[] { MediaTypeNames.Application.Json, "text/json" };
 
     /// <inheritdoc />
+    [RequiresUnreferencedCode("The JsonSerializer type is not trim-compatible.")]
     public HttpContent CreateHttpContent(object content, string contentType)
     {
         var text = content as string ?? JsonSerializer.Serialize(content);


### PR DESCRIPTION
The update enriches the serializers with Unicode encoding to handle a wider range of characters. Classes such as ConfigurableSerializer, ObjectConverter, and JsonContentFactory have been modified to use JavaScriptEncoder with UnicodeRanges.All, supporting serialization and deserialization of all Unicode characters. Furthermore, any unreferenced code now carries a note for JSON serializer stating that it's incompatible with .NET's trimming feature.

Fixes #5048
