### PR TITLE
Update VersionOptions.cs

### DIFF
--- a/src/clients/Elsa.Api.Client/Shared/Models/VersionOptions.cs
+++ b/src/clients/Elsa.Api.Client/Shared/Models/VersionOptions.cs
@@ -31,7 +31,7 @@ public struct VersionOptions
     /// <summary>
     /// Gets the latest, published version.
     /// </summary>
-    public static readonly VersionOptions LatestAndPublished = new() { IsLatestOrPublished = true };
+    public static readonly VersionOptions LatestAndPublished = new() { IsLatestAndPublished = true };
 
     /// <summary>
     /// Gets the draft version.


### PR DESCRIPTION
When setting the VersionOptions with the TryParse function to LatestAndPublished, it sets IsLatestOrPublished to true instead of IsLatestAndPublished.