### PR TITLE
Correct ForEach : The activity ForEach take one Variable in enter to …

### DIFF
--- a/src/modules/Elsa.Workflows.Core/Activities/ForEach.cs
+++ b/src/modules/Elsa.Workflows.Core/Activities/ForEach.cs
@@ -1,4 +1,8 @@
 using Elsa.Workflows.Attributes;
+using Elsa.Extensions;
+using Elsa.Workflows.Contracts;
+using Elsa.Workflows.Memory;
+using Elsa.Workflows.Models;
 
 namespace Elsa.Workflows.Activities;
 
@@ -6,6 +10,77 @@ namespace Elsa.Workflows.Activities;
 /// Iterate over a set of values.
 /// </summary>
 [Activity("Elsa", "Looping", "Iterate over a set of values.")]
-public class ForEach : ForEach<object>
+public class ForEach : Activity
 {
+    private const string _currentIndexProperty = "CurrentIndex";
+
+    /// <summary>
+    /// The set of values to iterate.
+    /// </summary>
+    [Input(Description = "The set of values to iterate.")]
+    public Variable Items { get; set; } = default!;
+
+    /// <summary>
+    /// The activity to execute for each iteration.
+    /// </summary>
+    [Port]
+    public IActivity Body { get; set; }
+
+    /// <summary>
+    /// The current value being iterated will be assigned to the specified <see cref="MemoryBlockReference"/>.
+    /// </summary>
+    [Output(Description = "Assign the current value to the specified variable.")]
+    public Output CurrentValue { get; set; }
+
+    protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
+    {
+        // Execute first iteration.
+        await HandleIteration(context);
+    }
+
+    private async Task HandleIteration(ActivityExecutionContext context)
+    {
+        var isBreaking = context.GetIsBreaking();
+
+        if (isBreaking)
+        {
+            await context.CompleteActivityAsync();
+            return;
+        }
+
+        var currentIndex = context.GetProperty<int>(_currentIndexProperty);
+
+        List<object> items = (context.Get(Items) as IEnumerable<object>).ToList();
+
+        if (currentIndex >= items.Count)
+        {
+            await context.CompleteActivityAsync();
+            return;
+        }
+
+        var currentValue = items[currentIndex];
+        context.Set(CurrentValue, currentValue);
+
+        if (Body != null)
+        {
+            var variables = new[]
+            {
+                new Variable("CurrentIndex", currentIndex),
+                new Variable("CurrentValue", currentValue)
+            };
+            await context.ScheduleActivityAsync(Body, OnChildCompleted, variables: variables);
+        }
+        else
+        {
+            await context.CompleteActivityAsync();
+        }
+
+        // Increment index.
+        context.UpdateProperty<int>(_currentIndexProperty, x => x + 1);
+    }
+
+    private async ValueTask OnChildCompleted(ActivityCompletedContext context)
+    {
+        await HandleIteration(context.TargetContext);
+    }
 }

--- a/src/modules/Elsa.Workflows.Core/Activities/ForEachT.cs
+++ b/src/modules/Elsa.Workflows.Core/Activities/ForEachT.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using Elsa.Expressions.Models;
 using Elsa.Extensions;
@@ -6,12 +7,16 @@ using Elsa.Workflows.Behaviors;
 using Elsa.Workflows.Contracts;
 using Elsa.Workflows.Memory;
 using Elsa.Workflows.Models;
+using JetBrains.Annotations;
 
 namespace Elsa.Workflows.Activities;
 
 /// <summary>
 /// A strongly-typed for-each construct where <see cref="T"/> is the item type.
 /// </summary>
+[Browsable(false)]
+[Activity("Stereograph.TeiaWorkflow.Modules.TeiaSuite.Activities", "Looping", "Iterate over a set of values.")]
+[PublicAPI]
 public class ForEach<T> : Activity
 {
     private const string CurrentIndexProperty = "CurrentIndex";
@@ -20,7 +25,7 @@ public class ForEach<T> : Activity
     public ForEach(Func<ExpressionExecutionContext, ICollection<T>> @delegate, [CallerFilePath] string? source = default, [CallerLineNumber] int? line = default) : this(new Input<ICollection<T>>(@delegate), source, line)
     {
     }
-    
+
     /// <inheritdoc />
     public ForEach(Func<ICollection<T>> @delegate, [CallerFilePath] string? source = default, [CallerLineNumber] int? line = default) : this(new Input<ICollection<T>>(@delegate), source, line)
     {
@@ -30,13 +35,13 @@ public class ForEach<T> : Activity
     public ForEach(ICollection<T> items, [CallerFilePath] string? source = default, [CallerLineNumber] int? line = default) : this(new Input<ICollection<T>>(items), source, line)
     {
     }
-    
+
     /// <inheritdoc />
     public ForEach(Input<ICollection<T>> items, [CallerFilePath] string? source = default, [CallerLineNumber] int? line = default) : this(source, line)
     {
         Items = items;
     }
-    
+
     /// <inheritdoc />
     public ForEach([CallerFilePath] string? source = default, [CallerLineNumber] int? line = default)
     {
@@ -71,13 +76,13 @@ public class ForEach<T> : Activity
     private async Task HandleIteration(ActivityExecutionContext context)
     {
         var isBreaking = context.GetIsBreaking();
-        
+
         if (isBreaking)
         {
             await context.CompleteActivityAsync();
             return;
         }
-        
+
         var currentIndex = context.GetProperty<int>(CurrentIndexProperty);
         var items = context.Get(Items)!.ToList();
 


### PR DESCRIPTION
Currently, the ForEach activity cannot be used because we cannot choose the input; we always end up with an empty list. To correct this issue, I have decided to use an input of the Variable type, which allows me to avoid having an empty list.

https://github.com/elsa-workflows/elsa-core/issues/4784