### PR TITLE
Update MongoDb collection service retrieval

### DIFF
--- a/src/modules/Elsa.MongoDb/Modules/Management/CreateIndices.cs
+++ b/src/modules/Elsa.MongoDb/Modules/Management/CreateIndices.cs
@@ -27,7 +27,7 @@ internal class CreateIndices : IHostedService
 
     private static Task CreateWorkflowDefinitionIndices(IServiceScope serviceScope, CancellationToken cancellationToken)
     {
-        var workflowDefinitionCollection = serviceScope.ServiceProvider.GetService<MongoCollectionBase<WorkflowDefinition>>();
+        var workflowDefinitionCollection = serviceScope.ServiceProvider.GetService<IMongoCollection<WorkflowDefinition>>();
         if (workflowDefinitionCollection == null) return Task.CompletedTask;
 
         return IndexHelpers.CreateAsync(
@@ -51,7 +51,7 @@ internal class CreateIndices : IHostedService
 
     private static Task CreateWorkflowInstanceIndices(IServiceScope serviceScope, CancellationToken cancellationToken)
     {
-        var workflowInstanceCollection = serviceScope.ServiceProvider.GetService<MongoCollectionBase<WorkflowInstance>>();
+        var workflowInstanceCollection = serviceScope.ServiceProvider.GetService<IMongoCollection<WorkflowInstance>>();
         if (workflowInstanceCollection == null) return Task.CompletedTask;
 
         return IndexHelpers.CreateAsync(
@@ -87,3 +87,4 @@ internal class CreateIndices : IHostedService
                     cancellationToken));
     }
 }
+


### PR DESCRIPTION
The previous implementation used the generic MongoCollectionBase service to retrieve workflow definition and instance collections. Now, the code has been updated to use IMongoCollection specifically designed for WorkflowDefinition and WorkflowInstance. This change ensures better typing and possibly performance improvements.

This tackles issue #4658

in addition, the indexes documented in CreateIndices.cs were never created until this change was made.

