### PR TITLE
Add log message sanitization for PostgreSQL

### DIFF
--- a/src/modules/Elsa.EntityFrameworkCore/Modules/Runtime/ActivityExecutionLogStore.cs
+++ b/src/modules/Elsa.EntityFrameworkCore/Modules/Runtime/ActivityExecutionLogStore.cs
@@ -8,6 +8,7 @@ using Elsa.Workflows.Management.Contracts;
 using Elsa.Workflows.Management.Options;
 using Elsa.Workflows.Runtime.Contracts;
 using Elsa.Workflows.Runtime.Entities;
+using Elsa.Workflows.Runtime.Extensions;
 using Elsa.Workflows.Runtime.Filters;
 using Elsa.Workflows.Runtime.OrderDefinitions;
 using Elsa.Workflows.State;
@@ -80,6 +81,7 @@ public class EFCoreActivityExecutionStore(
 
     private async ValueTask OnSaveAsync(RuntimeElsaDbContext dbContext, ActivityExecutionRecord entity, CancellationToken cancellationToken)
     {
+        entity = entity.SanitizeLogMessage();
         var compressionAlgorithm = options.Value.CompressionAlgorithm ?? nameof(None);
         var serializedActivityState = entity.ActivityState != null ? await safeSerializer.SerializeAsync(entity.ActivityState, cancellationToken) : default;
         var compressedSerializedActivityState = serializedActivityState != null ? await compressionCodecResolver.Resolve(compressionAlgorithm).CompressAsync(serializedActivityState, cancellationToken) : default;

--- a/src/modules/Elsa.EntityFrameworkCore/Modules/Runtime/WorkflowExecutionLogStore.cs
+++ b/src/modules/Elsa.EntityFrameworkCore/Modules/Runtime/WorkflowExecutionLogStore.cs
@@ -5,6 +5,7 @@ using Elsa.Extensions;
 using Elsa.Workflows.Contracts;
 using Elsa.Workflows.Runtime.Contracts;
 using Elsa.Workflows.Runtime.Entities;
+using Elsa.Workflows.Runtime.Extensions;
 using Elsa.Workflows.Runtime.Filters;
 using Elsa.Workflows.Runtime.OrderDefinitions;
 using Open.Linq.AsyncExtensions;
@@ -73,6 +74,7 @@ public class EFCoreWorkflowExecutionLogStore : IWorkflowExecutionLogStore
 
     private async ValueTask OnSaveAsync(RuntimeElsaDbContext dbContext, WorkflowExecutionLogRecord entity, CancellationToken cancellationToken)
     {
+        entity = entity.SanitizeLogMessage();
         dbContext.Entry(entity).Property("SerializedActivityState").CurrentValue = entity.ActivityState != null ? await _safeSerializer.SerializeAsync(entity.ActivityState, cancellationToken) : default;
         dbContext.Entry(entity).Property("SerializedPayload").CurrentValue = entity.Payload != null ? await _safeSerializer.SerializeAsync(entity.Payload, cancellationToken) : default;
     }

--- a/src/modules/Elsa.Workflows.Core/Contexts/ActivityExecutionContext.cs
+++ b/src/modules/Elsa.Workflows.Core/Contexts/ActivityExecutionContext.cs
@@ -659,7 +659,7 @@ public partial class ActivityExecutionContext : IExecutionContext
     /// </summary>
     public void ClearCompletionCallbacks()
     {
-        var entriesToRemove = WorkflowExecutionContext.CompletionCallbacks.Where(x => x.Owner == this);
+        var entriesToRemove = WorkflowExecutionContext.CompletionCallbacks.Where(x => x.Owner == this).ToList();
         WorkflowExecutionContext.RemoveCompletionCallbacks(entriesToRemove);
     }
 

--- a/src/modules/Elsa.Workflows.Runtime/Extensions/LogExtensions.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Extensions/LogExtensions.cs
@@ -3,9 +3,9 @@ using Elsa.Workflows.Runtime.Entities;
 namespace Elsa.Workflows.Runtime.Extensions;
 
 /// <summary>
-/// Provides a set of extension methods for <see cref="string"/>.
+/// Provides extension methods for sanitizing log messages.
 /// </summary>
-public static class LogStringExtensions
+public static class LogExtensions
 {
     /// <summary>
     /// Sanitizes a log message by replacing null characters with the string "\0".

--- a/src/modules/Elsa.Workflows.Runtime/Extensions/LogStringExtensions.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Extensions/LogStringExtensions.cs
@@ -1,0 +1,43 @@
+using Elsa.Workflows.Runtime.Entities;
+
+namespace Elsa.Workflows.Runtime.Extensions;
+
+/// <summary>
+/// Provides a set of extension methods for <see cref="string"/>.
+/// </summary>
+public static class LogStringExtensions
+{
+    /// <summary>
+    /// Sanitizes a log message by replacing null characters with the string "\0".
+    /// This is especially useful when storing messages in PostgreSQL, which does not allow null characters in strings.
+    /// </summary>
+    public static WorkflowExecutionLogRecord SanitizeLogMessage(this WorkflowExecutionLogRecord record)
+    {
+        record.Message = record.Message.SanitizeLogMessage();
+        return record;
+    }
+
+    /// <summary>
+    /// Sanitizes a log message by replacing null characters with the string "\0".
+    /// This is especially useful when storing messages in PostgreSQL, which does not allow null characters in strings.
+    /// </summary>
+    public static ActivityExecutionRecord SanitizeLogMessage(this ActivityExecutionRecord record)
+    {
+        if (record.Exception != null)
+            record.Exception = record.Exception with
+            {
+                Message = record.Exception.Message.SanitizeLogMessage()!
+            };
+
+        return record;
+    }
+
+    /// <summary>
+    /// Sanitizes a log message by replacing null characters with the string "\0".
+    /// This is especially useful when storing messages in PostgreSQL, which does not allow null characters in strings.
+    /// </summary>
+    public static string? SanitizeLogMessage(this string? message)
+    {
+        return message?.Replace("\0", "\\0");
+    }
+}


### PR DESCRIPTION
The new LogStringExtensions class provides methods to sanitize log messages, ensuring that null characters are replaced with "\0". These changes prevent issues with PostgreSQL's inability to store null characters in strings, improving log data compatibility with the database.

Fixes #5102