### PR TITLE
Add DryRun endpoint and workflow instance finder

### DIFF
--- a/src/modules/Elsa.Alterations.Core/Contracts/IWorkflowInstanceFinder.cs
+++ b/src/modules/Elsa.Alterations.Core/Contracts/IWorkflowInstanceFinder.cs
@@ -1,0 +1,14 @@
+using Elsa.Alterations.Core.Models;
+
+namespace Elsa.Alterations.Core.Contracts;
+
+/// <summary>
+/// Represents a service that can find workflow instances based on specified filters.
+/// </summary>
+public interface IWorkflowInstanceFinder
+{
+    /// <summary>
+    /// Finds workflow instances based on the specified filter.
+    /// </summary>
+    Task<IEnumerable<string>> FindAsync(AlterationWorkflowInstanceFilter filter, CancellationToken cancellationToken = default);
+}

--- a/src/modules/Elsa.Alterations.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/modules/Elsa.Alterations.Core/Extensions/ServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using Elsa.Alterations.Core.Contracts;
 using Elsa.Alterations.Core.Options;
 using Elsa.Alterations.Core.Serialization;
+using Elsa.Alterations.Core.Services;
 using Elsa.Common.Contracts;
 using Elsa.Extensions;
 using Microsoft.Extensions.DependencyInjection;
@@ -19,7 +20,8 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddAlterationsCore(this IServiceCollection services)
     {
         services.Configure<AlterationOptions>(_ => { }); // Ensure that the options are configured even if the application doesn't do so.
-        services.AddScoped<IAlteredWorkflowDispatcher, DefaultAlteredWorkflowDispatcher>();
+        services.AddScoped<IAlteredWorkflowDispatcher, AlteredWorkflowDispatcher>();
+        services.AddScoped<IWorkflowInstanceFinder, WorkflowInstanceFinder>();
         services.AddSingleton<IAlterationSerializer, AlterationSerializer>();
         services.AddSerializationOptionsConfigurator<AlterationSerializationOptionConfigurator>();
         return services;

--- a/src/modules/Elsa.Alterations.Core/Models/ActivityFilter.cs
+++ b/src/modules/Elsa.Alterations.Core/Models/ActivityFilter.cs
@@ -12,7 +12,12 @@ public class ActivityFilter
     /// <summary>
     /// The ID of the activity.
     /// </summary>
-    public string? Id { get; set; }
+    public string? ActivityId { get; set; }
+    
+    /// <summary>
+    /// The ID of the activity instance.
+    /// </summary>
+    public string? ActivityInstanceId { get; set; }
 
     /// <summary>
     /// The node ID of the activity.

--- a/src/modules/Elsa.Alterations.Core/Models/AlterationWorkflowInstanceFilter.cs
+++ b/src/modules/Elsa.Alterations.Core/Models/AlterationWorkflowInstanceFilter.cs
@@ -33,6 +33,11 @@ public class AlterationWorkflowInstanceFilter
     /// Whether the workflow instances to match have incidents.
     /// </summary>
     public bool? HasIncidents { get; set; }
+
+    /// <summary>
+    /// Whether the workflow instances to match are system workflows. Defaults to <c>false</c>.
+    /// </summary>
+    public bool? IsSystem { get; set; } = false;
     
     /// <summary>
     /// Represents a collection of filters for activities.

--- a/src/modules/Elsa.Alterations.Core/Services/AlteredWorkflowDispatcher.cs
+++ b/src/modules/Elsa.Alterations.Core/Services/AlteredWorkflowDispatcher.cs
@@ -1,18 +1,19 @@
+using Elsa.Alterations.Core.Contracts;
 using Elsa.Alterations.Core.Results;
 using Elsa.Workflows.Runtime.Contracts;
 using Elsa.Workflows.Runtime.Requests;
 
-namespace Elsa.Alterations.Core.Contracts;
+namespace Elsa.Alterations.Core.Services;
 
 /// <inheritdoc />
-public class DefaultAlteredWorkflowDispatcher : IAlteredWorkflowDispatcher
+public class AlteredWorkflowDispatcher : IAlteredWorkflowDispatcher
 {
     private readonly IWorkflowDispatcher _workflowDispatcher;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="DefaultAlteredWorkflowDispatcher"/> class.
+    /// Initializes a new instance of the <see cref="AlteredWorkflowDispatcher"/> class.
     /// </summary>
-    public DefaultAlteredWorkflowDispatcher(IWorkflowDispatcher workflowDispatcher)
+    public AlteredWorkflowDispatcher(IWorkflowDispatcher workflowDispatcher)
     {
         _workflowDispatcher = workflowDispatcher;
     }

--- a/src/modules/Elsa.Alterations.Core/Services/WorkflowInstanceFinder.cs
+++ b/src/modules/Elsa.Alterations.Core/Services/WorkflowInstanceFinder.cs
@@ -1,0 +1,54 @@
+using Elsa.Alterations.Core.Contracts;
+using Elsa.Alterations.Core.Models;
+using Elsa.Workflows.Management.Contracts;
+using Elsa.Workflows.Management.Filters;
+using Elsa.Workflows.Runtime.Contracts;
+using Elsa.Workflows.Runtime.Filters;
+
+namespace Elsa.Alterations.Core.Services;
+
+/// <inheritdoc />
+public class WorkflowInstanceFinder(IWorkflowInstanceStore workflowInstanceStore, IActivityExecutionStore activityExecutionStore) : IWorkflowInstanceFinder
+{
+    /// <inheritdoc />
+    public async Task<IEnumerable<string>> FindAsync(AlterationWorkflowInstanceFilter filter, CancellationToken cancellationToken = default)
+    {
+        var workflowInstanceFilter = new WorkflowInstanceFilter
+        {
+            Ids = filter.WorkflowInstanceIds?.ToList(),
+            DefinitionVersionIds = filter.DefinitionVersionIds?.ToList(),
+            CorrelationIds = filter.CorrelationIds?.ToList(),
+            HasIncidents = filter.HasIncidents,
+            IsSystem = filter.IsSystem,
+            TimestampFilters = filter.TimestampFilters?.ToList(),
+        };
+        var activityExecutionFilters = filter.ActivityFilters?.Select(x => new ActivityExecutionRecordFilter
+        {
+            ActivityId = x.ActivityId,
+            Id = x.ActivityInstanceId,
+            ActivityNodeId = x.NodeId,
+            Name = x.Name,
+            Status = x.Status,
+        }).ToList();
+
+        var workflowInstanceIds = workflowInstanceFilter.IsEmpty
+            ? Enumerable.Empty<string>().ToHashSet()
+            : (await workflowInstanceStore.FindManyIdsAsync(workflowInstanceFilter, cancellationToken)).ToHashSet();
+
+        if (activityExecutionFilters == null)
+            return workflowInstanceIds;
+
+        foreach (ActivityExecutionRecordFilter activityExecutionFilter in activityExecutionFilters.Where(x => !x.IsEmpty))
+        {
+            var activityExecutionRecords = await activityExecutionStore.FindManySummariesAsync(activityExecutionFilter, cancellationToken);
+            var matchingWorkflowInstanceIds = activityExecutionRecords.Select(x => x.WorkflowInstanceId).ToHashSet();
+            
+            if (workflowInstanceIds.Count == 0)
+                workflowInstanceIds = matchingWorkflowInstanceIds;
+            else
+                workflowInstanceIds.IntersectWith(matchingWorkflowInstanceIds);
+        }
+
+        return workflowInstanceIds;
+    }
+}

--- a/src/modules/Elsa.Alterations.Core/Services/WorkflowInstanceFinder.cs
+++ b/src/modules/Elsa.Alterations.Core/Services/WorkflowInstanceFinder.cs
@@ -43,7 +43,7 @@ public class WorkflowInstanceFinder(IWorkflowInstanceStore workflowInstanceStore
             var activityExecutionRecords = await activityExecutionStore.FindManySummariesAsync(activityExecutionFilter, cancellationToken);
             var matchingWorkflowInstanceIds = activityExecutionRecords.Select(x => x.WorkflowInstanceId).ToHashSet();
             
-            if (workflowInstanceIds.Count == 0)
+            if (workflowInstanceFilter.IsEmpty)
                 workflowInstanceIds = matchingWorkflowInstanceIds;
             else
                 workflowInstanceIds.IntersectWith(matchingWorkflowInstanceIds);

--- a/src/modules/Elsa.Alterations/Endpoints/Alterations/DryRun/Endpoint.cs
+++ b/src/modules/Elsa.Alterations/Endpoints/Alterations/DryRun/Endpoint.cs
@@ -1,0 +1,30 @@
+using Elsa.Abstractions;
+using Elsa.Alterations.Core.Contracts;
+using Elsa.Alterations.Core.Models;
+using JetBrains.Annotations;
+
+namespace Elsa.Alterations.Endpoints.Alterations.DryRun;
+
+/// <summary>
+/// Executes an alteration plan.
+/// </summary>
+[PublicAPI]
+public class DryRun(IWorkflowInstanceFinder workflowInstanceFinder) : ElsaEndpoint<AlterationWorkflowInstanceFilter, Response>
+{
+    /// <inheritdoc />
+    public override void Configure()
+    {
+        Post("/alterations/dry-run");
+        ConfigurePermissions("run:alterations");
+    }
+
+    /// <inheritdoc />
+    public override async Task HandleAsync(AlterationWorkflowInstanceFilter filter, CancellationToken cancellationToken)
+    {
+        var workflowInstanceIds = await workflowInstanceFinder.FindAsync(filter, cancellationToken);
+
+        // Write response.
+        var response = new Response(workflowInstanceIds.ToList());
+        await SendOkAsync(response, cancellationToken);
+    }
+}

--- a/src/modules/Elsa.Alterations/Endpoints/Alterations/DryRun/Response.cs
+++ b/src/modules/Elsa.Alterations/Endpoints/Alterations/DryRun/Response.cs
@@ -1,0 +1,6 @@
+namespace Elsa.Alterations.Endpoints.Alterations.DryRun;
+
+/// <summary>
+/// The response from the <see cref="DryRun"/> endpoint.
+/// </summary>
+public record Response(ICollection<string> WorkflowInstanceIds);

--- a/src/modules/Elsa.Workflows.Management/Filters/WorkflowInstanceFilter.cs
+++ b/src/modules/Elsa.Workflows.Management/Filters/WorkflowInstanceFilter.cs
@@ -97,7 +97,7 @@ public class WorkflowInstanceFilter
     public ICollection<TimestampFilter>? TimestampFilters { get; set; }
     
     /// <summary>
-    /// Returns true if the filter is empty.
+    /// Returns true if the filter is empty. The filter is empty if all properties are null or empty, except for <see cref="IsSystem"/> to allow filtering on system workflows.
     /// </summary>
     public bool IsEmpty =>
         Id == null &&
@@ -114,7 +114,6 @@ public class WorkflowInstanceFilter
         WorkflowStatuses == null &&
         WorkflowSubStatuses == null &&
         HasIncidents == null &&
-        IsSystem == null &&
         TimestampFilters == null
         && string.IsNullOrWhiteSpace(SearchTerm);
 

--- a/src/modules/Elsa.Workflows.Management/Filters/WorkflowInstanceFilter.cs
+++ b/src/modules/Elsa.Workflows.Management/Filters/WorkflowInstanceFilter.cs
@@ -95,27 +95,6 @@ public class WorkflowInstanceFilter
     /// Filter workflow instances by timestamp.
     /// </summary>
     public ICollection<TimestampFilter>? TimestampFilters { get; set; }
-    
-    /// <summary>
-    /// Returns true if the filter is empty. The filter is empty if all properties are null or empty, except for <see cref="IsSystem"/> to allow filtering on system workflows.
-    /// </summary>
-    public bool IsEmpty =>
-        Id == null &&
-        Ids == null &&
-        DefinitionId == null &&
-        DefinitionVersionId == null &&
-        DefinitionIds == null &&
-        DefinitionVersionIds == null &&
-        Version == null &&
-        CorrelationId == null &&
-        CorrelationIds == null &&
-        WorkflowStatus == null &&
-        WorkflowSubStatus == null &&
-        WorkflowStatuses == null &&
-        WorkflowSubStatuses == null &&
-        HasIncidents == null &&
-        TimestampFilters == null
-        && string.IsNullOrWhiteSpace(SearchTerm);
 
     /// <summary>
     /// Applies the filter to the specified query.


### PR DESCRIPTION
Added a new DryRun endpoint for executing alteration plans and implemented the IWorkflowInstanceFinder interface to search for workflow instances. Refactored existing code to use new workflow instance finder service, resulting in cleaner activity implementation.

Fixes #5109