### PR TITLE
#5107 Add framework reference & package removal

### DIFF
--- a/src/modules/Elsa.FileStorage/Elsa.FileStorage.csproj
+++ b/src/modules/Elsa.FileStorage/Elsa.FileStorage.csproj
@@ -2,16 +2,19 @@
 
     <PropertyGroup>
         <Description>
-            Provides activities to save and load files to and from a confogurable storage provider. 
+            Provides activities to save and load files to and from a confogurable storage provider.
         </Description>
         <PackageTags>elsa module activities storage</PackageTags>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentStorage" />
-        <PackageReference Include="Microsoft.AspNetCore.Http" />
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
     </ItemGroup>
-    
+
+    <ItemGroup>
+        <PackageReference Include="FluentStorage" />
+    </ItemGroup>
+
     <ItemGroup>
       <ProjectReference Include="..\Elsa.Workflows.Core\Elsa.Workflows.Core.csproj" />
       <ProjectReference Include="..\Elsa.Workflows.Management\Elsa.Workflows.Management.csproj" />


### PR DESCRIPTION
This change introduces a framework reference to the file storage project so that the deprecated package can be removed.

Closes #5107 