### PR TITLE
Update FlowNode status terminology in BulkDispatchWorkflows

### DIFF
--- a/src/modules/Elsa.Workflows.Runtime/Activities/BulkDispatchWorkflows.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Activities/BulkDispatchWorkflows.cs
@@ -19,6 +19,7 @@ using Elsa.Workflows.Runtime.Requests;
 using Elsa.Workflows.Runtime.UIHints;
 using Elsa.Workflows.Services;
 using JetBrains.Annotations;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Elsa.Workflows.Runtime.Activities;
 
@@ -101,6 +102,7 @@ public class BulkDispatchWorkflows : Activity
     public IActivity? ChildFaulted { get; set; }
 
     /// <inheritdoc />
+    [RequiresUnreferencedCode("Calls Elsa.Expressions.Helpers.ObjectConverter.ConvertTo<T>(ObjectConverterOptions)")]
     protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
     {
         var waitForCompletion = WaitForCompletion.GetOrDefault(context);
@@ -203,6 +205,7 @@ public class BulkDispatchWorkflows : Activity
         return instanceId;
     }
 
+    [RequiresUnreferencedCode("Calls Elsa.Expressions.Helpers.ObjectConverter.ConvertTo<T>(ObjectConverterOptions)")]
     private async ValueTask OnChildWorkflowCompletedAsync(ActivityExecutionContext context)
     {
         var input = context.WorkflowInput;
@@ -239,17 +242,17 @@ public class BulkDispatchWorkflows : Activity
                 await context.ScheduleActivityAsync(ChildCompleted, options);
                 return;
             default:
-                await CheckIfFinishedAsync(context);
+                await CheckIfCompletedAsync(context);
                 break;
         }
     }
 
     private async ValueTask OnChildFinishedCompletedAsync(ActivityCompletedContext context)
     {
-        await CheckIfFinishedAsync(context.TargetContext);
+        await CheckIfCompletedAsync(context.TargetContext);
     }
 
-    private async ValueTask CheckIfFinishedAsync(ActivityExecutionContext context)
+    private async ValueTask CheckIfCompletedAsync(ActivityExecutionContext context)
     {
         var dispatchedInstancesCount = context.GetProperty<long>(DispatchedInstancesCountKey);
         var finishedInstancesCount = context.GetProperty<long>(CompletedInstancesCountKey);

--- a/src/modules/Elsa.Workflows.Runtime/Activities/BulkDispatchWorkflows.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Activities/BulkDispatchWorkflows.cs
@@ -26,7 +26,7 @@ namespace Elsa.Workflows.Runtime.Activities;
 /// Creates new workflow instances of the specified workflow for each item in the data source and dispatches them for execution.
 /// </summary>
 [Activity("Elsa", "Composition", "Create new workflow instances for each item in the data source and dispatch them for execution.", Kind = ActivityKind.Task)]
-[FlowNode("Finished", "Canceled", "Done")]
+[FlowNode("Completed", "Canceled", "Done")]
 [UsedImplicitly]
 public class BulkDispatchWorkflows : Activity
 {
@@ -255,6 +255,6 @@ public class BulkDispatchWorkflows : Activity
         var finishedInstancesCount = context.GetProperty<long>(FinishedInstancesCountKey);
 
         if (finishedInstancesCount >= dispatchedInstancesCount)
-            await context.CompleteActivityWithOutcomesAsync("Finished", "Done");
+            await context.CompleteActivityWithOutcomesAsync("Completed", "Done");
     }
 }

--- a/src/modules/Elsa.Workflows.Runtime/Activities/BulkDispatchWorkflows.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Activities/BulkDispatchWorkflows.cs
@@ -73,7 +73,7 @@ public class BulkDispatchWorkflows : Activity
     /// True to wait for the child workflow to complete before completing this activity, false to "fire and forget".
     /// </summary>
     [Input(
-        Description = "Wait for the dispatched workflows to complete before completing this activity. If set, the Finished outcome will not trigger.",
+        Description = "Wait for the dispatched workflows to complete before completing this activity.",
         DefaultValue = true)]
     public Input<bool> WaitForCompletion { get; set; } = new(true);
 


### PR DESCRIPTION
The terminology for the task completion status has been changed in the BulkDispatchWorkflows class. This includes renaming 'Finished' to 'Complete' in the FlowNode attribute, and when calling CompleteActivityWithOutcomesAsync method. This change makes the status names more consistent across the application.

Closes #4946 