### PR TITLE
Enhance BulkDispatchWorkflows Activity with Support for Multiple Input Keys and Customizable Input Key

### DIFF
--- a/src/modules/Elsa.Workflows.Core/Contexts/ActivityExecutionContext.Complete.cs
+++ b/src/modules/Elsa.Workflows.Core/Contexts/ActivityExecutionContext.Complete.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using Elsa.Extensions;
 using Elsa.Workflows.Activities.Flowchart.Models;
 using Elsa.Workflows.Contracts;
@@ -11,7 +10,6 @@ public partial class ActivityExecutionContext
     /// <summary>
     /// Complete the current activity. This should only be called by activities that explicitly suppress automatic-completion.
     /// </summary>
-    [RequiresUnreferencedCode("The activity may be serialized and executed in a different context.")]
     public async ValueTask CompleteActivityAsync(object? result = default)
     {
         var outcomes = result as Outcomes;
@@ -93,7 +91,6 @@ public partial class ActivityExecutionContext
     /// <summary>
     /// Complete the current activity with the specified outcomes.
     /// </summary>
-    [RequiresUnreferencedCode("The activity may be serialized and executed in a different context.")]
     public ValueTask CompleteActivityWithOutcomesAsync(params string[] outcomes)
     {
         return CompleteActivityAsync(new Outcomes(outcomes));

--- a/src/modules/Elsa.Workflows.Core/Contexts/ActivityExecutionContext.cs
+++ b/src/modules/Elsa.Workflows.Core/Contexts/ActivityExecutionContext.cs
@@ -10,12 +10,14 @@ using Elsa.Workflows.Memory;
 using Elsa.Workflows.Models;
 using Elsa.Workflows.Options;
 using Elsa.Workflows.Services;
+using JetBrains.Annotations;
 
 namespace Elsa.Workflows;
 
 /// <summary>
 /// Represents the context of an activity execution.
 /// </summary>
+[PublicAPI]
 public partial class ActivityExecutionContext : IExecutionContext
 {
     private readonly ISystemClock _systemClock;

--- a/src/modules/Elsa.Workflows.Core/Extensions/DictionaryExtensions.cs
+++ b/src/modules/Elsa.Workflows.Core/Extensions/DictionaryExtensions.cs
@@ -65,6 +65,15 @@ public static class DictionaryExtensions
         dictionary.Add(key, value);
         return dictionary;
     }
+    
+    /// <summary>
+    /// Merges the specified dictionary with the other dictionary.
+    /// </summary>
+    public static void Merge(this IDictionary<string, object> dictionary, IDictionary<string, object> other)
+    {
+        foreach (var (key, value) in other)
+            dictionary[key] = value;
+    }
 
     private static T? ConvertValue<T>(object? value) => value.ConvertTo<T>();
 }

--- a/src/modules/Elsa.Workflows.Core/Extensions/DictionaryExtensions.cs
+++ b/src/modules/Elsa.Workflows.Core/Extensions/DictionaryExtensions.cs
@@ -68,6 +68,7 @@ public static class DictionaryExtensions
     
     /// <summary>
     /// Merges the specified dictionary with the other dictionary.
+    /// When a key exists in both dictionaries, the value in the other dictionary will overwrite the value in the specified dictionary.
     /// </summary>
     public static void Merge(this IDictionary<string, object> dictionary, IDictionary<string, object> other)
     {


### PR DESCRIPTION
This PR introduces significant improvements to the BulkDispatchWorkflows activity by enabling the support for multiple input keys. Specifically, it allows users to provide a list of items, with each item being a dictionary. This change permits each dictionary key to act as the input name for the dispatched workflow, providing users with precise control over the inputs of the child workflow.

Furthermore, this update includes the flexibility to configure a different key for the workflow input, moving beyond the previously hardcoded "Item" key. This enhancement ensures backward compatibility for users who prefer not to adopt the "list of dictionaries" method, maintaining the activity's utility in existing workflows without requiring any modifications.

Sample Items JS expression:

```javascript
return [{
    Order: { 
        id: 1,
        customerId: 1
    }
},
{
    Order: { 
        id: 2,
        customerId: 2
    }
}];
```

The dispatched workflows will each now receive an input called "Order".

Fixes #5132