### PR TITLE
Update method call in BulkDispatchWorkflows

### DIFF
--- a/src/modules/Elsa.Workflows.Runtime/Activities/BulkDispatchWorkflows.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Activities/BulkDispatchWorkflows.cs
@@ -141,7 +141,7 @@ public class BulkDispatchWorkflows : Activity
         else
         {
             // Otherwise, we can complete immediately.
-            await context.CompleteActivityAsync();
+            await context.CompleteActivityWithOutcomesAsync("Done");
         }
     }
 


### PR DESCRIPTION
The method call used to complete an activity in the BulkDispatchWorkflows has been changed. Previously, the CompleteActivityAsync method was used, but it was replaced with the CompleteActivityWithOutcomesAsync method providing "Done" as the outcome.

Fixes #5184
