### PR TITLE
Replace ScheduleOutcomesAsync with CompleteActivityWithOutcomesAsync

### DIFF
--- a/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Activities/FlowFork.cs
+++ b/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Activities/FlowFork.cs
@@ -33,6 +33,6 @@ public class FlowFork : Activity
     {
         var outcomes = Branches.GetOrDefault(context)?.ToArray() ?? ["Done"];
 
-        await context.ScheduleOutcomesAsync(outcomes);
+        await context.CompleteActivityWithOutcomesAsync(outcomes);
     }
 }


### PR DESCRIPTION
In the FlowFork.cs file of the Elsa.Workflows.Core module, the method ScheduleOutcomesAsync has been replaced with CompleteActivityWithOutcomesAsync. This fixes the issue of the activity not completing.

Fixes #5204
