### PR TITLE
Update activity execution mapping in workflow runtime

### DIFF
--- a/src/modules/Elsa.Workflows.Runtime/Services/DefaultActivityExecutionMapper.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Services/DefaultActivityExecutionMapper.cs
@@ -1,4 +1,5 @@
 using Elsa.Extensions;
+using Elsa.Workflows.Activities;
 using Elsa.Workflows.Enums;
 using Elsa.Workflows.Management.Options;
 using Elsa.Workflows.Models;
@@ -28,7 +29,8 @@ public class DefaultActivityExecutionMapper(IOptions<ManagementOptions> options)
          *  }
          */
 
-        var workflowPersistenceProperty = GetDefaultPersistenceMode(source.WorkflowExecutionContext.Workflow.CustomProperties, () => options.Value.LogPersistenceMode);
+        var workflow = (Workflow?)source.GetAncestors().FirstOrDefault(x => x.Activity is Workflow)?.Activity ?? source.WorkflowExecutionContext.Workflow;
+        var workflowPersistenceProperty = GetDefaultPersistenceMode(workflow.CustomProperties, () => options.Value.LogPersistenceMode);
         var activityPersistenceProperties = source.Activity.CustomProperties.GetValueOrDefault<IDictionary<string, object?>>(LogPersistenceModeKey, () => new Dictionary<string, object?>());
         var activityPersistencePropertyDefault = GetDefaultPersistenceMode(source.Activity.CustomProperties, () => workflowPersistenceProperty);
 


### PR DESCRIPTION
The code changes involve updating the activity execution mapper in Elsa.Workflows.Runtime. The updated logic now consider the closest ancestor in the workflow hierarchy when determining the workflow persistence property. This provides a more accurate representation of the workflow's state, rather than relying solely on the workflow execution context.

Fixes #5252
