### PR TITLE
Update WriteHttpResponse.cs to call response.CompleteAsync()

### DIFF
--- a/src/modules/Elsa.Http/Activities/WriteHttpResponse.cs
+++ b/src/modules/Elsa.Http/Activities/WriteHttpResponse.cs
@@ -133,6 +133,7 @@ public class WriteHttpResponse : Activity
                     await response.WriteAsync("The response includes a type that cannot be serialized.");
                 }
             }
+            await response.CompleteAsync();
         }
 
         // Complete activity.


### PR DESCRIPTION
I think this is the fix to bug #5267 

If we call the CompleteAsync() on the response it will flush the response to the client. This fixes the issue in our testing and the response is written immediately.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/5268)
<!-- Reviewable:end -->
