### PR TITLE
Refactor serializer options usage and enhance caching in workflow serialization

### DIFF
--- a/src/modules/Elsa.Alterations.Core/Serialization/AlterationSerializer.cs
+++ b/src/modules/Elsa.Alterations.Core/Serialization/AlterationSerializer.cs
@@ -19,7 +19,7 @@ public class AlterationSerializer : ConfigurableSerializer, IAlterationSerialize
     [RequiresUnreferencedCode("The type of the alteration must be known at compile time.")]
     public string Serialize(IAlteration alteration)
     {
-        var options = CreateOptions();
+        var options = GetOptions();
         return JsonSerializer.Serialize(alteration, options);
     }
 
@@ -27,7 +27,7 @@ public class AlterationSerializer : ConfigurableSerializer, IAlterationSerialize
     [RequiresUnreferencedCode("The type of the alteration must be known at compile time.")]
     public string SerializeMany(IEnumerable<IAlteration> alterations)
     {
-        var options = CreateOptions();
+        var options = GetOptions();
         return JsonSerializer.Serialize(alterations.ToArray(), options);
     }
 
@@ -35,7 +35,7 @@ public class AlterationSerializer : ConfigurableSerializer, IAlterationSerialize
     [RequiresUnreferencedCode("The type of the alteration must be known at compile time.")]
     public IAlteration Deserialize(string json)
     {
-        var options = CreateOptions();
+        var options = GetOptions();
         return JsonSerializer.Deserialize<IAlteration>(json, options)!;
     }
 
@@ -43,7 +43,7 @@ public class AlterationSerializer : ConfigurableSerializer, IAlterationSerialize
     [RequiresUnreferencedCode("The type of the alteration must be known at compile time.")]
     public IEnumerable<IAlteration> DeserializeMany(string json)
     {
-        var options = CreateOptions();
+        var options = GetOptions();
         return JsonSerializer.Deserialize<IAlteration[]>(json, options)!;
     }
 }

--- a/src/modules/Elsa.Common/Contracts/IJsonSerializer.cs
+++ b/src/modules/Elsa.Common/Contracts/IJsonSerializer.cs
@@ -11,7 +11,7 @@ public interface IJsonSerializer
     /// <summary>
     /// Returns the serializer options.
     /// </summary>
-    JsonSerializerOptions CreateOptions();
+    JsonSerializerOptions GetOptions();
 
     /// <summary>
     /// Applies the specified options.

--- a/src/modules/Elsa.Common/Extensions/JsonSerializerOptionsExtensions.cs
+++ b/src/modules/Elsa.Common/Extensions/JsonSerializerOptionsExtensions.cs
@@ -19,4 +19,12 @@ public static class JsonSerializerOptionsExtensions
 
         return options;
     }
+
+    /// <summary>
+    /// Clones the options.
+    /// </summary>
+    public static JsonSerializerOptions Clone(this JsonSerializerOptions options)
+    {
+        return new JsonSerializerOptions(options);
+    }
 }

--- a/src/modules/Elsa.Common/Serialization/JsonSerializer.cs
+++ b/src/modules/Elsa.Common/Serialization/JsonSerializer.cs
@@ -18,7 +18,7 @@ public class StandardJsonSerializer : ConfigurableSerializer, IJsonSerializer
     [RequiresUnreferencedCode("The type is not known at compile time.")]
     public string Serialize(object value)
     {
-        var options = CreateOptions();
+        var options = GetOptions();
         return JsonSerializer.Serialize(value, options);
     }
 
@@ -26,7 +26,7 @@ public class StandardJsonSerializer : ConfigurableSerializer, IJsonSerializer
     [RequiresUnreferencedCode("The type is not known at compile time.")]
     public string Serialize(object value, Type type)
     {
-        var options = CreateOptions();
+        var options = GetOptions();
         return JsonSerializer.Serialize(value, type, options);
     }
 
@@ -34,7 +34,7 @@ public class StandardJsonSerializer : ConfigurableSerializer, IJsonSerializer
     [RequiresUnreferencedCode("The type is not known at compile time.")]
     public object Deserialize(string json)
     {
-        var options = CreateOptions();
+        var options = GetOptions();
         return JsonSerializer.Deserialize<object>(json, options)!;
     }
 
@@ -42,7 +42,7 @@ public class StandardJsonSerializer : ConfigurableSerializer, IJsonSerializer
     [RequiresUnreferencedCode("The type is not known at compile time.")]
     public object Deserialize(string json, Type type)
     {
-        var options = CreateOptions();
+        var options = GetOptions();
         return JsonSerializer.Deserialize(json, type, options)!;
     }
 }

--- a/src/modules/Elsa.Expressions/Helpers/ObjectConverter.cs
+++ b/src/modules/Elsa.Expressions/Helpers/ObjectConverter.cs
@@ -29,17 +29,17 @@ public static class ObjectConverter
     /// <summary>
     /// Attempts to convert the source value into the destination type.
     /// </summary>
-    public static Result TryConvertTo<T>(this object? value, ObjectConverterOptions? serializerOptions = null) => value.TryConvertTo(typeof(T), serializerOptions);
+    public static Result TryConvertTo<T>(this object? value, ObjectConverterOptions? converterOptions = null) => value.TryConvertTo(typeof(T), converterOptions);
 
     /// <summary>
     /// Attempts to convert the source value into the destination type.
     /// </summary>
     [RequiresUnreferencedCode("The JsonSerializer type is not trim-compatible.")]
-    public static Result TryConvertTo(this object? value, Type targetType, ObjectConverterOptions? serializerOptions = null)
+    public static Result TryConvertTo(this object? value, Type targetType, ObjectConverterOptions? converterOptions = null)
     {
         try
         {
-            var convertedValue = value.ConvertTo(targetType, serializerOptions);
+            var convertedValue = value.ConvertTo(targetType, converterOptions);
             return new Result(true, convertedValue, null);
         }
         catch (Exception e)
@@ -52,7 +52,18 @@ public static class ObjectConverter
     /// Attempts to convert the source value into the destination type.
     /// </summary>
     [RequiresUnreferencedCode("The JsonSerializer type is not trim-compatible.")]
-    public static T? ConvertTo<T>(this object? value, ObjectConverterOptions? serializerOptions = null) => value != null ? (T?)value.ConvertTo(typeof(T), serializerOptions) : default;
+    public static T? ConvertTo<T>(this object? value, ObjectConverterOptions? converterOptions = null) => value != null ? (T?)value.ConvertTo(typeof(T), converterOptions) : default;
+    
+    private static JsonSerializerOptions? _defaultSerializerOptions;
+    
+    private static JsonSerializerOptions DefaultSerializerOptions => _defaultSerializerOptions ??= new JsonSerializerOptions
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+        ReferenceHandler = ReferenceHandler.Preserve,
+        Converters = { new JsonStringEnumConverter() },
+        Encoder = JavaScriptEncoder.Create(UnicodeRanges.All)
+    };
 
     /// <summary>
     /// Attempts to convert the source value into the destination type.
@@ -68,12 +79,12 @@ public static class ObjectConverter
         if (sourceType == targetType)
             return value;
 
-        var serializerOptions = converterOptions?.SerializerOptions != null ? new JsonSerializerOptions(converterOptions.SerializerOptions) : new JsonSerializerOptions();
-        serializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
-        serializerOptions.ReferenceHandler = ReferenceHandler.Preserve;
-        serializerOptions.PropertyNameCaseInsensitive = true;
-        serializerOptions.Converters.Add(new JsonStringEnumConverter());
-        serializerOptions.Encoder = JavaScriptEncoder.Create(UnicodeRanges.All);
+        var serializerOptions = converterOptions?.SerializerOptions ?? DefaultSerializerOptions;
+        // serializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
+        // serializerOptions.ReferenceHandler = ReferenceHandler.Preserve;
+        // serializerOptions.PropertyNameCaseInsensitive = true;
+        // serializerOptions.Converters.Add(new JsonStringEnumConverter());
+        // serializerOptions.Encoder = JavaScriptEncoder.Create(UnicodeRanges.All);
 
         var internalSerializerOptions = new JsonSerializerOptions
         {

--- a/src/modules/Elsa.Workflows.Core/Expressions/ObjectExpressionHandler.cs
+++ b/src/modules/Elsa.Workflows.Core/Expressions/ObjectExpressionHandler.cs
@@ -1,5 +1,8 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Encodings.Web;
 using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Unicode;
 using Elsa.Common.Converters;
 using Elsa.Expressions.Contracts;
 using Elsa.Expressions.Helpers;
@@ -23,9 +26,16 @@ public class ObjectExpressionHandler : IExpressionHandler
         if (string.IsNullOrWhiteSpace(value))
             return ValueTask.FromResult(default(object?));
 
-        var serializerOptions = new JsonSerializerOptions();
+        var serializerOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            ReferenceHandler = ReferenceHandler.Preserve,
+            PropertyNameCaseInsensitive = true,
+            Encoder = JavaScriptEncoder.Create(UnicodeRanges.All)
+        };
         serializerOptions.Converters.Add(new IntegerJsonConverter());
         serializerOptions.Converters.Add(new DecimalJsonConverter());
+        serializerOptions.Converters.Add(new JsonStringEnumConverter());
         
         var converterOptions = new ObjectConverterOptions(serializerOptions);
         var model = value.ConvertTo(returnType, converterOptions);

--- a/src/modules/Elsa.Workflows.Core/Extensions/VariableExtensions.cs
+++ b/src/modules/Elsa.Workflows.Core/Extensions/VariableExtensions.cs
@@ -1,5 +1,8 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Encodings.Web;
 using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Unicode;
 using Elsa.Expressions.Helpers;
 using Elsa.Workflows.Contracts;
 using Elsa.Workflows.Memory;
@@ -55,9 +58,16 @@ public static class VariableExtensions
     public static object? ParseValue(this Variable variable, object? value)
     {
         var genericType = variable.GetType().GenericTypeArguments.FirstOrDefault();
-        var jsonSerializerOptions = new JsonSerializerOptions();
-        jsonSerializerOptions.Converters.Add(new ExpandoObjectConverterFactory());
-        var converterOptions = new ObjectConverterOptions(jsonSerializerOptions);
+        var serializerOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            ReferenceHandler = ReferenceHandler.Preserve,
+            PropertyNameCaseInsensitive = true,
+            Encoder = JavaScriptEncoder.Create(UnicodeRanges.All)
+        };
+        serializerOptions.Converters.Add(new JsonStringEnumConverter());
+        serializerOptions.Converters.Add(new ExpandoObjectConverterFactory());
+        var converterOptions = new ObjectConverterOptions(serializerOptions);
         return genericType == null ? value : value?.ConvertTo(genericType, converterOptions);
     }
 

--- a/src/modules/Elsa.Workflows.Core/Serialization/Converters/ExcludeFromHashConverter.cs
+++ b/src/modules/Elsa.Workflows.Core/Serialization/Converters/ExcludeFromHashConverter.cs
@@ -11,6 +11,8 @@ namespace Elsa.Workflows.Serialization.Converters;
 /// </summary>
 public class ExcludeFromHashConverter : JsonConverter<object>
 {
+    private JsonSerializerOptions? _options;
+    
     /// <inheritdoc />
     public override object Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
@@ -21,8 +23,7 @@ public class ExcludeFromHashConverter : JsonConverter<object>
     public override void Write(Utf8JsonWriter writer, object value, JsonSerializerOptions options)
     {
         writer.WriteStartObject();
-        var newOptions = new JsonSerializerOptions(options);
-        newOptions.Converters.RemoveWhere(x => x is ExcludeFromHashConverterFactory);
+        var newOptions = GetClonedOptions(options);
 
         foreach (var property in value.GetType().GetProperties())
         {
@@ -38,6 +39,16 @@ public class ExcludeFromHashConverter : JsonConverter<object>
         }
 
         writer.WriteEndObject();
+    }
+    
+    private JsonSerializerOptions GetClonedOptions(JsonSerializerOptions options)
+    {
+        if(_options != null)
+            return _options;
+        
+        var newOptions = new JsonSerializerOptions(options);
+        newOptions.Converters.RemoveWhere(x => x is ExcludeFromHashConverterFactory);
+        return _options = newOptions;
     }
 }
 

--- a/src/modules/Elsa.Workflows.Core/Serialization/Converters/JsonIgnoreCompositeRootConverter.cs
+++ b/src/modules/Elsa.Workflows.Core/Serialization/Converters/JsonIgnoreCompositeRootConverter.cs
@@ -12,8 +12,6 @@ namespace Elsa.Workflows.Serialization.Converters;
 /// </summary>
 public class JsonIgnoreCompositeRootConverter : JsonConverter<IActivity>
 {
-    private JsonSerializerOptions? _options;
-    
     /// <inheritdoc />
     public override IActivity Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
@@ -27,7 +25,6 @@ public class JsonIgnoreCompositeRootConverter : JsonConverter<IActivity>
         writer.WriteStartObject();
 
         var properties = value?.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance) ?? Array.Empty<PropertyInfo>();
-        var newOptions = GetClonedOptions(options);
         
         foreach (var property in properties)
         {
@@ -47,19 +44,9 @@ public class JsonIgnoreCompositeRootConverter : JsonConverter<IActivity>
                 continue;
             }
             
-            JsonSerializer.Serialize(writer, input, newOptions);
+            JsonSerializer.Serialize(writer, input, options);
         }
 
         writer.WriteEndObject();
-    }
-    
-    private JsonSerializerOptions GetClonedOptions(JsonSerializerOptions options)
-    {
-        // if(_options != null)
-        //     return _options;
-        //
-        // var newOptions = new JsonSerializerOptions(options);
-        // _options = newOptions;
-        return options;
     }
 }

--- a/src/modules/Elsa.Workflows.Core/Serialization/Converters/JsonIgnoreCompositeRootConverter.cs
+++ b/src/modules/Elsa.Workflows.Core/Serialization/Converters/JsonIgnoreCompositeRootConverter.cs
@@ -12,6 +12,8 @@ namespace Elsa.Workflows.Serialization.Converters;
 /// </summary>
 public class JsonIgnoreCompositeRootConverter : JsonConverter<IActivity>
 {
+    private JsonSerializerOptions? _options;
+    
     /// <inheritdoc />
     public override IActivity Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
@@ -25,7 +27,7 @@ public class JsonIgnoreCompositeRootConverter : JsonConverter<IActivity>
         writer.WriteStartObject();
 
         var properties = value?.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance) ?? Array.Empty<PropertyInfo>();
-        var newOptions = new JsonSerializerOptions(options);
+        var newOptions = GetClonedOptions(options);
         
         foreach (var property in properties)
         {
@@ -49,5 +51,15 @@ public class JsonIgnoreCompositeRootConverter : JsonConverter<IActivity>
         }
 
         writer.WriteEndObject();
+    }
+    
+    private JsonSerializerOptions GetClonedOptions(JsonSerializerOptions options)
+    {
+        // if(_options != null)
+        //     return _options;
+        //
+        // var newOptions = new JsonSerializerOptions(options);
+        // _options = newOptions;
+        return options;
     }
 }

--- a/src/modules/Elsa.Workflows.Core/Serialization/Converters/PolymorphicObjectConverter.cs
+++ b/src/modules/Elsa.Workflows.Core/Serialization/Converters/PolymorphicObjectConverter.cs
@@ -31,7 +31,7 @@ public class PolymorphicObjectConverter : JsonConverter<object>
     /// <inheritdoc />
     public override object Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
-        var newOptions = new JsonSerializerOptions(options);
+        var newOptions = options.Clone();
 
         if (reader.TokenType != JsonTokenType.StartObject && reader.TokenType != JsonTokenType.StartArray)
             return ReadPrimitive(ref reader, newOptions);
@@ -117,7 +117,7 @@ public class PolymorphicObjectConverter : JsonConverter<object>
             throw new InvalidOperationException($"Cannot determine the element type of array '{targetType}'.");
 
         var model = JsonElement.ParseValue(ref reader);
-        var referenceResolver = (options.ReferenceHandler as CrossScopedReferenceHandler)?.GetResolver();
+        var referenceResolver = (newOptions.ReferenceHandler as CrossScopedReferenceHandler)?.GetResolver();
 
         if (model.TryGetProperty(RefPropertyName, out var refProperty))
         {
@@ -168,7 +168,7 @@ public class PolymorphicObjectConverter : JsonConverter<object>
             return;
         }
 
-        var newOptions = new JsonSerializerOptions(options);
+        var newOptions = options.Clone();
         var type = value.GetType();
 
         if (type.IsPrimitive || value is string or decimal or DateTimeOffset or DateTime or DateOnly or TimeOnly or JsonElement or Guid or TimeSpan or Uri or Version or Enum)
@@ -196,7 +196,7 @@ public class PolymorphicObjectConverter : JsonConverter<object>
         // Determine if the value is going to be serialized for the first time.
         // Later on, we need to know this information to determine if we need to write the type name or not, so that we can reconstruct the actual type when deserializing.
         var shouldWriteTypeField = true;
-        var referenceResolver = (CustomPreserveReferenceResolver?)(options.ReferenceHandler as CrossScopedReferenceHandler)?.GetResolver();
+        var referenceResolver = (CustomPreserveReferenceResolver?)(newOptions.ReferenceHandler as CrossScopedReferenceHandler)?.GetResolver();
 
         if (referenceResolver != null)
         {

--- a/src/modules/Elsa.Workflows.Core/Serialization/Converters/SafeValueConverter.cs
+++ b/src/modules/Elsa.Workflows.Core/Serialization/Converters/SafeValueConverter.cs
@@ -10,10 +10,12 @@ namespace Elsa.Workflows.Serialization.Converters;
 /// </summary>
 public class SafeValueConverter : JsonConverter<object>
 {
+    private JsonSerializerOptions? _options;
+    
     /// <inheritdoc />
     public override object Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
-        var newOptions = CreateNewOptions(options);
+        var newOptions = GetClonedOptions(options);
         return JsonSerializer.Deserialize(ref reader, typeToConvert, newOptions)!;
     }
 
@@ -22,7 +24,7 @@ public class SafeValueConverter : JsonConverter<object>
     {
         try
         {
-            var newOptions = CreateNewOptions(options);
+            var newOptions = GetClonedOptions(options);
             
             // Serialize the value to a temporary string.
             var serializedValue = JsonSerializer.Serialize(value, newOptions);
@@ -40,10 +42,14 @@ public class SafeValueConverter : JsonConverter<object>
         }
     }
 
-    private JsonSerializerOptions CreateNewOptions(JsonSerializerOptions options)
+    private JsonSerializerOptions GetClonedOptions(JsonSerializerOptions options)
     {
+        if(_options != null)
+            return _options;
+        
         var newOptions = new JsonSerializerOptions(options);
         newOptions.Converters.RemoveWhere(x => x is SafeValueConverterFactory);
+        _options = newOptions;
         return newOptions;
     }
 }

--- a/src/modules/Elsa.Workflows.Core/Serialization/Converters/VariableConverter.cs
+++ b/src/modules/Elsa.Workflows.Core/Serialization/Converters/VariableConverter.cs
@@ -14,6 +14,7 @@ namespace Elsa.Workflows.Serialization.Converters;
 public class VariableConverter : JsonConverter<Variable>
 {
     private readonly VariableMapper _mapper;
+    private JsonSerializerOptions? _options;
 
     /// <inheritdoc />
     // ReSharper disable once ContextualLoggerProblem
@@ -25,8 +26,7 @@ public class VariableConverter : JsonConverter<Variable>
     /// <inheritdoc />
     public override Variable Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
-        var newOptions = new JsonSerializerOptions(options);
-        newOptions.Converters.Add(new JsonPrimitiveToStringConverter());
+        var newOptions = GetClonedOptions(options);
         var model = JsonSerializer.Deserialize<VariableModel>(ref reader, newOptions)!;
         var variable = _mapper.Map(model);
 
@@ -38,5 +38,16 @@ public class VariableConverter : JsonConverter<Variable>
     {
         var model = _mapper.Map(value);
         JsonSerializer.Serialize(writer, model, options);
+    }
+    
+    private JsonSerializerOptions GetClonedOptions(JsonSerializerOptions options)
+    {
+        if(_options != null)
+            return _options;
+        
+        var newOptions = new JsonSerializerOptions(options);
+        newOptions.Converters.Add(new JsonPrimitiveToStringConverter());
+        _options = newOptions;
+        return newOptions;
     }
 }

--- a/src/modules/Elsa.Workflows.Core/Serialization/Serializers/ApiSerializer.cs
+++ b/src/modules/Elsa.Workflows.Core/Serialization/Serializers/ApiSerializer.cs
@@ -18,7 +18,7 @@ public class ApiSerializer : ConfigurableSerializer, IApiSerializer
     /// <inheritdoc />
     public string Serialize(object model)
     {
-        var options = CreateOptions();
+        var options = GetOptions();
         return JsonSerializer.Serialize(model, options);
     }
 
@@ -28,7 +28,7 @@ public class ApiSerializer : ConfigurableSerializer, IApiSerializer
     /// <inheritdoc />
     public T Deserialize<T>(string serializedModel)
     {
-        var options = CreateOptions();
+        var options = GetOptions();
         return JsonSerializer.Deserialize<T>(serializedModel, options)!;
     }
 
@@ -44,7 +44,7 @@ public class ApiSerializer : ConfigurableSerializer, IApiSerializer
         options.Converters.Add(CreateInstance<TypeJsonConverter>());
     }
 
-    JsonSerializerOptions IApiSerializer.CreateOptions() => base.CreateOptions();
+    JsonSerializerOptions IApiSerializer.CreateOptions() => GetOptions();
 
     JsonSerializerOptions IApiSerializer.ApplyOptions(JsonSerializerOptions options)
     {

--- a/src/modules/Elsa.Workflows.Core/Serialization/Serializers/JsonActivitySerializer.cs
+++ b/src/modules/Elsa.Workflows.Core/Serialization/Serializers/JsonActivitySerializer.cs
@@ -1,49 +1,53 @@
 using System.Text.Json;
 using Elsa.Common.Serialization;
+using Elsa.Extensions;
 using Elsa.Workflows.Contracts;
 using Elsa.Workflows.Serialization.Converters;
 
 namespace Elsa.Workflows.Serialization.Serializers;
 
 /// <inheritdoc cref="IActivitySerializer" />
-public class JsonActivitySerializer : ConfigurableSerializer, IActivitySerializer
+public class JsonActivitySerializer(IServiceProvider serviceProvider) : ConfigurableSerializer(serviceProvider), IActivitySerializer
 {
-    /// <summary>
-    /// Initializes a new instance of the <see cref="JsonActivitySerializer"/> class.
-    /// </summary>
-    public JsonActivitySerializer(IServiceProvider serviceProvider) : base(serviceProvider)
-    {
-    }
-
+    private JsonSerializerOptions? _options;
+    
     /// <inheritdoc />
     public string Serialize(IActivity activity)
     {
-        var options = CreateOptions();
-        options.Converters.Add(CreateInstance<JsonIgnoreCompositeRootConverterFactory>());
+        var options = GetOptionsInternal();
         return JsonSerializer.Serialize(activity, activity.GetType(), options);
     }
 
     /// <inheritdoc />
     public string Serialize(object value)
     {
-        var options = CreateOptions();
-        options.Converters.Add(CreateInstance<JsonIgnoreCompositeRootConverterFactory>());
+        var options = GetOptionsInternal();
         return JsonSerializer.Serialize(value, options);
     }
 
     /// <inheritdoc />
-    public IActivity Deserialize(string serializedActivity) => JsonSerializer.Deserialize<IActivity>(serializedActivity, CreateOptions())!;
+    public IActivity Deserialize(string serializedActivity) => JsonSerializer.Deserialize<IActivity>(serializedActivity, GetOptions())!;
 
     /// <inheritdoc />
-    public object Deserialize(string serializedValue, Type type) => JsonSerializer.Deserialize(serializedValue, type, CreateOptions())!;
+    public object Deserialize(string serializedValue, Type type) => JsonSerializer.Deserialize(serializedValue, type, GetOptions())!;
 
     /// <inheritdoc />
-    public T Deserialize<T>(string serializedValue) => JsonSerializer.Deserialize<T>(serializedValue, CreateOptions())!;
+    public T Deserialize<T>(string serializedValue) => JsonSerializer.Deserialize<T>(serializedValue, GetOptions())!;
 
     /// <inheritdoc />
     protected override void AddConverters(JsonSerializerOptions options)
     {
         options.Converters.Add(CreateInstance<TypeJsonConverter>());
         options.Converters.Add(CreateInstance<InputJsonConverterFactory>());
+    }
+    
+    private JsonSerializerOptions GetOptionsInternal()
+    {
+        if(_options != null)
+            return _options;
+        
+        var options = GetOptions().Clone();
+        options.Converters.Add(CreateInstance<JsonIgnoreCompositeRootConverterFactory>());
+        return _options = options;
     }
 }

--- a/src/modules/Elsa.Workflows.Core/Serialization/Serializers/JsonWorkflowStateSerializer.cs
+++ b/src/modules/Elsa.Workflows.Core/Serialization/Serializers/JsonWorkflowStateSerializer.cs
@@ -33,7 +33,7 @@ public class JsonWorkflowStateSerializer : ConfigurableSerializer, IWorkflowStat
     [RequiresUnreferencedCode("The type 'T' may be trimmed from the output. The serialization process may require access to the type.")]
     public Task<string> SerializeAsync(WorkflowState workflowState, CancellationToken cancellationToken = default)
     {
-        var options = CreateOptions();
+        var options = GetOptions();
         return Task.FromResult(JsonSerializer.Serialize(workflowState, options));
     }
 
@@ -41,7 +41,7 @@ public class JsonWorkflowStateSerializer : ConfigurableSerializer, IWorkflowStat
     [RequiresUnreferencedCode("The type 'T' may be trimmed from the output. The serialization process may require access to the type.")]
     public Task<byte[]> SerializeToUtfBytesAsync(WorkflowState workflowState, CancellationToken cancellationToken = default)
     {
-        var options = CreateOptions();
+        var options = GetOptions();
         return Task.FromResult(JsonSerializer.SerializeToUtf8Bytes(workflowState, options));
     }
 
@@ -49,7 +49,7 @@ public class JsonWorkflowStateSerializer : ConfigurableSerializer, IWorkflowStat
     [RequiresUnreferencedCode("The type 'T' may be trimmed from the output. The serialization process may require access to the type.")]
     public Task<JsonElement> SerializeToElementAsync(WorkflowState workflowState, CancellationToken cancellationToken = default)
     {
-        var options = CreateOptions();
+        var options = GetOptions();
         return Task.FromResult(JsonSerializer.SerializeToElement(workflowState, options));
     }
 
@@ -57,7 +57,7 @@ public class JsonWorkflowStateSerializer : ConfigurableSerializer, IWorkflowStat
     [RequiresUnreferencedCode("The type 'T' may be trimmed from the output. The deserialization process may require access to the type.")]
     public Task<string> SerializeAsync(object workflowState, CancellationToken cancellationToken = default)
     {
-        var options = CreateOptions();
+        var options = GetOptions();
         var json = JsonSerializer.Serialize(workflowState, workflowState.GetType(), options);
         return Task.FromResult(json);
     }
@@ -66,7 +66,7 @@ public class JsonWorkflowStateSerializer : ConfigurableSerializer, IWorkflowStat
     [RequiresUnreferencedCode("The type 'T' may be trimmed from the output. The deserialization process may require access to the type.")]
     public Task<WorkflowState> DeserializeAsync(string serializedState, CancellationToken cancellationToken = default)
     {
-        var options = CreateOptions();
+        var options = GetOptions();
         var workflowState = JsonSerializer.Deserialize<WorkflowState>(serializedState, options)!;
         return Task.FromResult(workflowState);
     }
@@ -75,7 +75,7 @@ public class JsonWorkflowStateSerializer : ConfigurableSerializer, IWorkflowStat
     [RequiresUnreferencedCode("The type 'T' may be trimmed from the output. The deserialization process may require access to the type.")]
     public Task<WorkflowState> DeserializeAsync(JsonElement serializedState, CancellationToken cancellationToken = default)
     {
-        var options = CreateOptions();
+        var options = GetOptions();
         var workflowState = serializedState.Deserialize<WorkflowState>(options)!;
         return Task.FromResult(workflowState);
     }
@@ -84,9 +84,16 @@ public class JsonWorkflowStateSerializer : ConfigurableSerializer, IWorkflowStat
     [RequiresUnreferencedCode("The type 'T' may be trimmed from the output. The deserialization process may require access to the type.")]
     public Task<T> DeserializeAsync<T>(string serializedState, CancellationToken cancellationToken = default)
     {
-        var options = CreateOptions();
+        var options = GetOptions();
         var workflowState = JsonSerializer.Deserialize<T>(serializedState, options)!;
         return Task.FromResult(workflowState);
+    }
+
+    /// <inheritdoc />
+    public override JsonSerializerOptions GetOptions()
+    {
+        // Bypass cached options to ensure that the reference handler is always fresh.
+        return GetOptionsInternal();
     }
 
     /// <inheritdoc />

--- a/src/modules/Elsa.Workflows.Core/Serialization/Serializers/SafeSerializer.cs
+++ b/src/modules/Elsa.Workflows.Core/Serialization/Serializers/SafeSerializer.cs
@@ -20,7 +20,7 @@ public class SafeSerializer : ConfigurableSerializer, ISafeSerializer
     [RequiresUnreferencedCode("The type T may be trimmed.")]
     public ValueTask<string> SerializeAsync(object? value, CancellationToken cancellationToken = default)
     {
-        var options = CreateOptions();
+        var options = GetOptions();
         return ValueTask.FromResult(JsonSerializer.Serialize(value, options));
     }
 
@@ -28,7 +28,7 @@ public class SafeSerializer : ConfigurableSerializer, ISafeSerializer
     [RequiresUnreferencedCode("The type T may be trimmed.")]
     public ValueTask<JsonElement> SerializeToElementAsync(object? value, CancellationToken cancellationToken = default)
     {
-        var options = CreateOptions();
+        var options = GetOptions();
         return new(JsonSerializer.SerializeToElement(value, options));
     }
 
@@ -36,7 +36,7 @@ public class SafeSerializer : ConfigurableSerializer, ISafeSerializer
     [RequiresUnreferencedCode("The type T may be trimmed.")]
     public ValueTask<T> DeserializeAsync<T>(string json, CancellationToken cancellationToken = default)
     {
-        var options = CreateOptions();
+        var options = GetOptions();
         return new(JsonSerializer.Deserialize<T>(json, options)!);
     }
 
@@ -44,7 +44,7 @@ public class SafeSerializer : ConfigurableSerializer, ISafeSerializer
     [RequiresUnreferencedCode("The type T may be trimmed.")]
     public ValueTask<T> DeserializeAsync<T>(JsonElement element, CancellationToken cancellationToken = default)
     {
-        var options = CreateOptions();
+        var options = GetOptions();
         return new(element.Deserialize<T>(options)!);
     }
 


### PR DESCRIPTION
This update refactors multiple classes dealing with JSON serialization. The usage of serializer options now includes a caching mechanism to avoid unnecessary recomputation. 'CreateOptions' method is replaced by a 'GetOptions' method that considers cached options. Classes are adjusted to clone options when necessary, ensuring a fresh and accurate context each time.

Closes #5144
