### PR TITLE
Fix Race Condition in WorkflowDefinitionActivity

### DIFF
--- a/src/bundles/Elsa.Server.Web/Program.cs
+++ b/src/bundles/Elsa.Server.Web/Program.cs
@@ -1,6 +1,7 @@
 using System.Text.Encodings.Web;
 using Elsa.Alterations.Extensions;
 using Elsa.Alterations.MassTransit.Extensions;
+using Elsa.Caching.Options;
 using Elsa.Common.DistributedLocks.Noop;
 using Elsa.Dapper.Extensions;
 using Elsa.Dapper.Services;
@@ -357,6 +358,8 @@ services
         elsa.AddFastEndpointsAssembly<Program>();
         ConfigureForTest?.Invoke(elsa);
     });
+
+services.Configure<CachingOptions>(options => options.CacheDuration = TimeSpan.FromDays(1));
 
 services.AddHealthChecks();
 services.AddControllers();

--- a/src/modules/Elsa.Alterations/AlterationHandlers/MigrateHandler.cs
+++ b/src/modules/Elsa.Alterations/AlterationHandlers/MigrateHandler.cs
@@ -30,7 +30,7 @@ public class MigrateHandler : AlterationHandlerBase<Migrate>
         }
         
         var targetWorkflow = await workflowDefinitionService.MaterializeWorkflowAsync(targetWorkflowDefinition, cancellationToken);
-        await context.WorkflowExecutionContext.SetWorkflowAsync(targetWorkflow);
+        await context.WorkflowExecutionContext.SetWorkflowGraphAsync(targetWorkflow);
         
         context.Succeed();
     }

--- a/src/modules/Elsa.Http/Models/HttpWorkflowLookupResult.cs
+++ b/src/modules/Elsa.Http/Models/HttpWorkflowLookupResult.cs
@@ -1,6 +1,9 @@
-using Elsa.Workflows.Activities;
+using Elsa.Workflows.Models;
 using Elsa.Workflows.Runtime.Entities;
 
 namespace Elsa.Http.Models;
 
-public record HttpWorkflowLookupResult(Workflow? Workflow, ICollection<StoredTrigger> Triggers);
+/// <summary>
+/// Represents the result of a workflow lookup.
+/// </summary>
+public record HttpWorkflowLookupResult(WorkflowGraph? WorkflowGraph, ICollection<StoredTrigger> Triggers);

--- a/src/modules/Elsa.Http/Services/CachingHttpWorkflowLookupService.cs
+++ b/src/modules/Elsa.Http/Services/CachingHttpWorkflowLookupService.cs
@@ -29,8 +29,8 @@ public class CachingHttpWorkflowLookupService(
             if (result == null)
                 return null;
 
-            var workflow = result.Workflow!;
-            var changeTokenKey = cacheManager.GetWorkflowChangeTokenKey(workflow.Identity.DefinitionId);
+            var workflowGraph = result.WorkflowGraph!;
+            var changeTokenKey = cacheManager.GetWorkflowChangeTokenKey(workflowGraph.Workflow.Identity.DefinitionId);
             var changeToken = cache.GetToken(changeTokenKey);
             entry.AddExpirationToken(changeToken);
 

--- a/src/modules/Elsa.Http/Services/HttpBookmarkProcessor.cs
+++ b/src/modules/Elsa.Http/Services/HttpBookmarkProcessor.cs
@@ -80,7 +80,7 @@ public class HttpBookmarkProcessor : IHttpBookmarkProcessor
                 continue;
             }
 
-            var workflow = await _workflowDefinitionService.FindWorkflowAsync(
+            var workflow = await _workflowDefinitionService.FindWorkflowGraphAsync(
                 workflowState.DefinitionId,
                 VersionOptions.SpecificVersion(workflowState.DefinitionVersion),
                 systemCancellationToken);

--- a/src/modules/Elsa.Http/Services/HttpWorkflowLookupService.cs
+++ b/src/modules/Elsa.Http/Services/HttpWorkflowLookupService.cs
@@ -1,7 +1,7 @@
 using Elsa.Http.Contracts;
 using Elsa.Http.Models;
-using Elsa.Workflows.Activities;
 using Elsa.Workflows.Management.Contracts;
+using Elsa.Workflows.Models;
 using Elsa.Workflows.Runtime.Contracts;
 using Elsa.Workflows.Runtime.Entities;
 using Elsa.Workflows.Runtime.Filters;
@@ -25,12 +25,12 @@ public class HttpWorkflowLookupService(ITriggerStore triggerStore, IWorkflowDefi
         if (trigger == null)
             return default;
 
-        var workflow = await FindWorkflowAsync(trigger, cancellationToken);
+        var workflowGraph = await FindWorkflowGraphAsync(trigger, cancellationToken);
 
-        if (workflow == null)
+        if (workflowGraph == null)
             return default;
 
-        return new(workflow, triggers);
+        return new(workflowGraph, triggers);
     }
 
     private async Task<IEnumerable<StoredTrigger>> FindTriggersAsync(string bookmarkHash, CancellationToken cancellationToken)
@@ -42,9 +42,9 @@ public class HttpWorkflowLookupService(ITriggerStore triggerStore, IWorkflowDefi
         return await triggerStore.FindManyAsync(triggerFilter, cancellationToken);
     }
 
-    private async Task<Workflow?> FindWorkflowAsync(StoredTrigger trigger, CancellationToken cancellationToken)
+    private async Task<WorkflowGraph?> FindWorkflowGraphAsync(StoredTrigger trigger, CancellationToken cancellationToken)
     {
         var workflowDefinitionVersionId = trigger.WorkflowDefinitionVersionId;
-        return await workflowDefinitionService.FindWorkflowAsync(workflowDefinitionVersionId, cancellationToken);
+        return await workflowDefinitionService.FindWorkflowGraphAsync(workflowDefinitionVersionId, cancellationToken);
     }
 }

--- a/src/modules/Elsa.JavaScript/Endpoints/TypeDefinitions/Endpoint.cs
+++ b/src/modules/Elsa.JavaScript/Endpoints/TypeDefinitions/Endpoint.cs
@@ -3,8 +3,8 @@ using Elsa.Abstractions;
 using Elsa.Common.Models;
 using Elsa.JavaScript.TypeDefinitions.Contracts;
 using Elsa.JavaScript.TypeDefinitions.Models;
-using Elsa.Workflows.Activities;
 using Elsa.Workflows.Management.Contracts;
+using Elsa.Workflows.Models;
 using JetBrains.Annotations;
 
 namespace Elsa.JavaScript.Endpoints.TypeDefinitions;
@@ -35,15 +35,16 @@ internal class Get : ElsaEndpoint<Request>
     /// <inheritdoc />
     public override async Task HandleAsync(Request request, CancellationToken cancellationToken)
     {
-        var workflow = await GetWorkflowAsync(request.WorkflowDefinitionId, cancellationToken);
+        var workflowGraph = await GetWorkflowGraphAsync(request.WorkflowDefinitionId, cancellationToken);
 
-        if (workflow == null)
+        if (workflowGraph == null)
         {
             AddError($"Workflow definition {request.WorkflowDefinitionId} not found");
             await SendErrorsAsync(cancellation: cancellationToken);
             return;
         }
         
+        var workflow = workflowGraph.Workflow;
         var typeDefinitionContext = new TypeDefinitionContext(workflow, request.ActivityTypeName, request.PropertyName, cancellationToken);
         var typeDefinitions = await _typeDefinitionService.GenerateTypeDefinitionsAsync(typeDefinitionContext);
         var fileName = $"elsa.{request.WorkflowDefinitionId}.d.ts";
@@ -52,9 +53,9 @@ internal class Get : ElsaEndpoint<Request>
         await SendBytesAsync(data, fileName, "application/x-typescript", cancellation: cancellationToken);
     }
 
-    private async Task<Workflow?> GetWorkflowAsync(string workflowDefinitionId, CancellationToken cancellationToken)
+    private async Task<WorkflowGraph?> GetWorkflowGraphAsync(string workflowDefinitionId, CancellationToken cancellationToken)
     {
-        return await _workflowDefinitionService.FindWorkflowAsync(workflowDefinitionId, VersionOptions.Latest, cancellationToken);
+        return await _workflowDefinitionService.FindWorkflowGraphAsync(workflowDefinitionId, VersionOptions.Latest, cancellationToken);
     }
 }
 

--- a/src/modules/Elsa.JavaScript/Services/JintJavaScriptEvaluator.cs
+++ b/src/modules/Elsa.JavaScript/Services/JintJavaScriptEvaluator.cs
@@ -1,4 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -12,8 +14,6 @@ using Elsa.JavaScript.Helpers;
 using Elsa.JavaScript.Notifications;
 using Elsa.JavaScript.Options;
 using Elsa.Mediator.Contracts;
-using Esprima;
-using Esprima.Ast;
 using Humanizer;
 using Jint;
 using Jint.Runtime.Interop;
@@ -182,7 +182,7 @@ public class JintJavaScriptEvaluator : IJavaScriptEvaluator
 
     private object? ExecuteExpressionAndGetResult(Engine engine, string expression)
     {
-        var cacheKey = "jint:script:" + expression.GetHashCode(StringComparison.Ordinal);
+        var cacheKey = "jint:script:" + Hash(expression);
 
         var parsedScript = _memoryCache.GetOrCreate(cacheKey, entry =>
         {
@@ -213,5 +213,12 @@ public class JintJavaScriptEvaluator : IJavaScriptEvaluator
         options.Converters.Add(new JsonStringEnumConverter());
 
         return JsonSerializer.Serialize(value, options);
+    }
+    
+    private string Hash(string input)
+    {
+        var bytes = Encoding.UTF8.GetBytes(input);
+        var hash = SHA256.HashData(bytes);
+        return Convert.ToBase64String(hash);
     }
 }

--- a/src/modules/Elsa.ProtoActor/Grains/WorkflowInstance.cs
+++ b/src/modules/Elsa.ProtoActor/Grains/WorkflowInstance.cs
@@ -82,12 +82,14 @@ internal class WorkflowInstance : WorkflowInstanceBase
         using var scope = _scopeFactory.CreateScope();
         var workflowDefinitionService = scope.ServiceProvider.GetRequiredService<IWorkflowDefinitionService>();
 
-        // Load the workflow definition.
-        var workflow = await workflowDefinitionService.FindWorkflowAsync(_definitionId, VersionOptions.SpecificVersion(_version), cancellationToken);
+        // Get the workflow.
+        var workflowGraph = await workflowDefinitionService.FindWorkflowGraphAsync(_definitionId, VersionOptions.SpecificVersion(_version), cancellationToken);
 
-        if (workflow == null)
+        if (workflowGraph == null)
             throw new Exception("Workflow definition is no longer available");
 
+        var workflow = workflowGraph.Workflow;
+        
         // Create an initial workflow state.
         if (_workflowState == null!)
         {
@@ -100,7 +102,7 @@ internal class WorkflowInstance : WorkflowInstanceBase
 
         // Create a workflow host.
         var workflowHostFactory = scope.ServiceProvider.GetRequiredService<IWorkflowHostFactory>();
-        _workflowHost = await workflowHostFactory.CreateAsync(workflow, _workflowState, cancellationToken);
+        _workflowHost = await workflowHostFactory.CreateAsync(workflowGraph, _workflowState, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -416,7 +418,7 @@ internal class WorkflowInstance : WorkflowInstanceBase
     {
         using var scope = _scopeFactory.CreateScope();
         var workflowDefinitionService = scope.ServiceProvider.GetRequiredService<IWorkflowDefinitionService>();
-        var workflow = await workflowDefinitionService.FindWorkflowAsync(definitionId, versionOptions, cancellationToken);
+        var workflow = await workflowDefinitionService.FindWorkflowGraphAsync(definitionId, versionOptions, cancellationToken);
 
         if (workflow == null)
             throw new Exception("Specified workflow definition and version does not exist");
@@ -438,7 +440,7 @@ internal class WorkflowInstance : WorkflowInstanceBase
         var versionOptions = VersionOptions.SpecificVersion(workflowState.DefinitionVersion);
         using var scope = _scopeFactory.CreateScope();
         var workflowDefinitionService = scope.ServiceProvider.GetRequiredService<IWorkflowDefinitionService>();
-        var workflow = await workflowDefinitionService.FindWorkflowAsync(definitionId, versionOptions, cancellationToken);
+        var workflow = await workflowDefinitionService.FindWorkflowGraphAsync(definitionId, versionOptions, cancellationToken);
 
         if (workflow == null)
             throw new Exception("Specified workflow definition and version does not exist");

--- a/src/modules/Elsa.ProtoActor/Services/ProtoActorWorkflowRuntime.cs
+++ b/src/modules/Elsa.ProtoActor/Services/ProtoActorWorkflowRuntime.cs
@@ -386,14 +386,15 @@ internal class ProtoActorWorkflowRuntime : IWorkflowRuntime
             };
 
             var canStartResult = await CanStartWorkflowAsync(definitionId, startOptions);
-            var workflow = await _workflowDefinitionService.FindWorkflowAsync(trigger.WorkflowDefinitionVersionId, cancellationToken);
+            var workflowGraph = await _workflowDefinitionService.FindWorkflowGraphAsync(trigger.WorkflowDefinitionVersionId, cancellationToken);
 
-            if (workflow == null)
+            if (workflowGraph == null)
             {
                 _logger.LogWarning("Workflow version ID {DefinitionVersionId} not found", trigger.WorkflowDefinitionVersionId);
                 continue;
             }
 
+            var workflow = workflowGraph.Workflow;
             var createWorkflowInstanceRequest = new CreateWorkflowInstanceRequest
             {
                 Workflow = workflow,

--- a/src/modules/Elsa.Workflows.Core/Contracts/IWorkflowGraphBuilder.cs
+++ b/src/modules/Elsa.Workflows.Core/Contracts/IWorkflowGraphBuilder.cs
@@ -1,0 +1,15 @@
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Models;
+
+namespace Elsa.Workflows.Contracts;
+
+/// <summary>
+/// Builds a workflow graph from a workflow.
+/// </summary>
+public interface IWorkflowGraphBuilder
+{
+    /// <summary>
+    /// Builds a workflow graph from a workflow.
+    /// </summary>
+    Task<WorkflowGraph> BuildAsync(Workflow workflow, CancellationToken cancellationToken = default);
+}

--- a/src/modules/Elsa.Workflows.Core/Contracts/IWorkflowRunner.cs
+++ b/src/modules/Elsa.Workflows.Core/Contracts/IWorkflowRunner.cs
@@ -17,5 +17,7 @@ public interface IWorkflowRunner
     Task<TResult> RunAsync<T, TResult>(RunWorkflowOptions? options = default, CancellationToken cancellationToken = default) where T : WorkflowBase<TResult>, new();
     Task<RunWorkflowResult> RunAsync(Workflow workflow, RunWorkflowOptions? options = default, CancellationToken cancellationToken = default);
     Task<RunWorkflowResult> RunAsync(Workflow workflow, WorkflowState workflowState, RunWorkflowOptions? options = default, CancellationToken cancellationToken = default);
+    Task<RunWorkflowResult> RunAsync(WorkflowGraph workflowGraph, RunWorkflowOptions? options = default, CancellationToken cancellationToken = default);
+    Task<RunWorkflowResult> RunAsync(WorkflowGraph workflowGraph, WorkflowState workflowState, RunWorkflowOptions? options = default, CancellationToken cancellationToken = default);
     Task<RunWorkflowResult> RunAsync(WorkflowExecutionContext workflowExecutionContext);
 }

--- a/src/modules/Elsa.Workflows.Core/Extensions/WorkflowExecutionContextExtensions.cs
+++ b/src/modules/Elsa.Workflows.Core/Extensions/WorkflowExecutionContextExtensions.cs
@@ -99,6 +99,10 @@ public static class WorkflowExecutionContextExtensions
         ActivityExecutionContext owner,
         ScheduleWorkOptions? options = default)
     {
+        // Validate that the specified activity is part of the workflow.
+        if (!workflowExecutionContext.NodeActivityLookup.ContainsKey(activityNode.Activity))
+            throw new InvalidOperationException("The specified activity is not part of the workflow.");
+        
         var scheduler = workflowExecutionContext.Scheduler;
 
         if (options?.PreventDuplicateScheduling == true)

--- a/src/modules/Elsa.Workflows.Core/Features/WorkflowsFeature.cs
+++ b/src/modules/Elsa.Workflows.Core/Features/WorkflowsFeature.cs
@@ -127,6 +127,7 @@ public class WorkflowsFeature : FeatureBase
             .AddScoped<IWorkflowRunner, WorkflowRunner>()
             .AddScoped<IActivityVisitor, ActivityVisitor>()
             .AddScoped<IIdentityGraphService, IdentityGraphService>()
+            .AddScoped<IWorkflowGraphBuilder, WorkflowGraphBuilder>()
             .AddScoped<IWorkflowStateExtractor, WorkflowStateExtractor>()
             .AddScoped<IActivitySchedulerFactory, ActivitySchedulerFactory>()
             .AddSingleton<IHasher, Hasher>()

--- a/src/modules/Elsa.Workflows.Core/Models/WorkflowGraph.cs
+++ b/src/modules/Elsa.Workflows.Core/Models/WorkflowGraph.cs
@@ -1,0 +1,39 @@
+using System.Security.Cryptography;
+using System.Text;
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Contracts;
+
+namespace Elsa.Workflows.Models;
+
+/// <summary>
+/// Represents a workflow graph, which is a collection of activity nodes that form a directed graph.
+/// </summary>
+public record WorkflowGraph
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WorkflowGraph"/> class.
+    /// </summary>
+    public WorkflowGraph(Workflow workflow, ActivityNode root, IEnumerable<ActivityNode> nodes)
+    {
+        using var hashAlgorithm = SHA256.Create();
+        Workflow = workflow;
+        Root = root;
+        Nodes = nodes.ToList();
+        NodeIdLookup = Nodes.ToDictionary(x => x.NodeId);
+        NodeHashLookup = Nodes.ToDictionary(x => Hash(hashAlgorithm, x.NodeId));
+        NodeActivityLookup = Nodes.ToDictionary(x => x.Activity);
+    }
+
+    public Workflow Workflow { get; }
+    public ActivityNode Root { get; }
+    public ICollection<ActivityNode> Nodes { get; }
+    public IDictionary<IActivity, ActivityNode> NodeActivityLookup { get; }
+    public IDictionary<string, ActivityNode> NodeHashLookup { get; }
+    public IDictionary<string, ActivityNode> NodeIdLookup { get; }
+
+    private static string Hash(HashAlgorithm hashAlgorithm, string input)
+    {
+        var data = hashAlgorithm.ComputeHash(Encoding.UTF8.GetBytes(input));
+        return Convert.ToHexString(data);
+    }
+}

--- a/src/modules/Elsa.Workflows.Core/Services/Hasher.cs
+++ b/src/modules/Elsa.Workflows.Core/Services/Hasher.cs
@@ -33,8 +33,8 @@ public class Hasher : IHasher
     /// <inheritdoc />
     public string Hash(string value)
     {
-        using var sha = SHA256.Create();
-        return Hash(sha, value);
+        var data = SHA256.HashData(Encoding.UTF8.GetBytes(value));
+        return Convert.ToHexString(data);
     }
 
     /// <inheritdoc />
@@ -44,12 +44,6 @@ public class Hasher : IHasher
         var strings = values.Select(Serialize).Where(x => !string.IsNullOrWhiteSpace(x)).ToList();
         var input = string.Join("|", strings);
         return Hash(input);
-    }
-
-    private static string Hash(HashAlgorithm hashAlgorithm, string input)
-    {
-        var data = hashAlgorithm.ComputeHash(Encoding.UTF8.GetBytes(input));
-        return Convert.ToHexString(data);
     }
     
     [RequiresUnreferencedCode("Calls System.Text.Json.JsonSerializer.Serialize(Object, Type, JsonSerializerOptions)")]

--- a/src/modules/Elsa.Workflows.Core/Services/WorkflowGraphBuilder.cs
+++ b/src/modules/Elsa.Workflows.Core/Services/WorkflowGraphBuilder.cs
@@ -1,0 +1,20 @@
+using Elsa.Extensions;
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Contracts;
+using Elsa.Workflows.Models;
+
+namespace Elsa.Workflows.Services;
+
+/// <inheritdoc />
+public class WorkflowGraphBuilder(IActivityVisitor activityVisitor, IIdentityGraphService identityGraphService, IServiceProvider serviceProvider) : IWorkflowGraphBuilder
+{
+    /// <inheritdoc />
+    public async Task<WorkflowGraph> BuildAsync(Workflow workflow, CancellationToken cancellationToken = default)
+    {
+        var graph = await activityVisitor.VisitAsync(workflow, cancellationToken);
+        var nodes = graph.Flatten().ToList();
+        
+        identityGraphService.AssignIdentities(nodes);
+        return new WorkflowGraph(workflow, graph, nodes);
+    }
+}

--- a/src/modules/Elsa.Workflows.Core/Services/WorkflowRunner.cs
+++ b/src/modules/Elsa.Workflows.Core/Services/WorkflowRunner.cs
@@ -10,45 +10,28 @@ using Elsa.Workflows.State;
 namespace Elsa.Workflows.Services;
 
 /// <inheritdoc />
-public class WorkflowRunner : IWorkflowRunner
+public class WorkflowRunner(
+    IServiceProvider serviceProvider,
+    IWorkflowExecutionPipeline pipeline,
+    IWorkflowStateExtractor workflowStateExtractor,
+    IWorkflowBuilderFactory workflowBuilderFactory,
+    IWorkflowGraphBuilder workflowGraphBuilder,
+    IIdentityGenerator identityGenerator,
+    INotificationSender notificationSender)
+    : IWorkflowRunner
 {
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IWorkflowExecutionPipeline _pipeline;
-    private readonly IWorkflowStateExtractor _workflowStateExtractor;
-    private readonly IWorkflowBuilderFactory _workflowBuilderFactory;
-    private readonly IIdentityGenerator _identityGenerator;
-    private readonly INotificationSender _notificationSender;
-
-    /// <summary>
-    /// Constructor.
-    /// </summary>
-    public WorkflowRunner(
-        IServiceProvider serviceProvider,
-        IWorkflowExecutionPipeline pipeline,
-        IWorkflowStateExtractor workflowStateExtractor,
-        IWorkflowBuilderFactory workflowBuilderFactory,
-        IIdentityGenerator identityGenerator,
-        INotificationSender notificationSender)
-    {
-        _serviceProvider = serviceProvider;
-        _pipeline = pipeline;
-        _workflowStateExtractor = workflowStateExtractor;
-        _workflowBuilderFactory = workflowBuilderFactory;
-        _identityGenerator = identityGenerator;
-        _notificationSender = notificationSender;
-    }
-
     /// <inheritdoc />
     public async Task<RunWorkflowResult> RunAsync(IActivity activity, RunWorkflowOptions? options = default, CancellationToken cancellationToken = default)
     {
         var workflow = Workflow.FromActivity(activity);
-        return await RunAsync(workflow, options, cancellationToken);
+        var workflowGraph = await workflowGraphBuilder.BuildAsync(workflow, cancellationToken);
+        return await RunAsync(workflowGraph, options, cancellationToken);
     }
 
     /// <inheritdoc />
     public async Task<RunWorkflowResult> RunAsync(IWorkflow workflow, RunWorkflowOptions? options = default, CancellationToken cancellationToken = default)
     {
-        var builder = _workflowBuilderFactory.CreateBuilder();
+        var builder = workflowBuilderFactory.CreateBuilder();
         var workflowDefinition = await builder.BuildWorkflowAsync(workflow, cancellationToken);
         return await RunAsync(workflowDefinition, options, cancellationToken);
     }
@@ -65,7 +48,7 @@ public class WorkflowRunner : IWorkflowRunner
         RunWorkflowOptions? options = default,
         CancellationToken cancellationToken = default) where T : IWorkflow, new()
     {
-        var builder = _workflowBuilderFactory.CreateBuilder();
+        var builder = workflowBuilderFactory.CreateBuilder();
         var workflowDefinition = await builder.BuildWorkflowAsync<T>(cancellationToken);
         return await RunAsync(workflowDefinition, options, cancellationToken);
     }
@@ -75,17 +58,17 @@ public class WorkflowRunner : IWorkflowRunner
         RunWorkflowOptions? options = default,
         CancellationToken cancellationToken = default) where T : WorkflowBase<TResult>, new()
     {
-        var builder = _workflowBuilderFactory.CreateBuilder();
+        var builder = workflowBuilderFactory.CreateBuilder();
         var workflow = await builder.BuildWorkflowAsync<T>(cancellationToken);
         var result = await RunAsync(workflow, options, cancellationToken);
         return (TResult)result.Result!;
     }
 
     /// <inheritdoc />
-    public async Task<RunWorkflowResult> RunAsync(Workflow workflow, RunWorkflowOptions? options = default, CancellationToken cancellationToken = default)
+    public async Task<RunWorkflowResult> RunAsync(WorkflowGraph workflowGraph, RunWorkflowOptions? options = default, CancellationToken cancellationToken = default)
     {
         // Set up a workflow execution context.
-        var instanceId = options?.WorkflowInstanceId ?? _identityGenerator.GenerateId();
+        var instanceId = options?.WorkflowInstanceId ?? identityGenerator.GenerateId();
         var input = options?.Input;
         var properties = options?.Properties;
         var correlationId = options?.CorrelationId;
@@ -93,8 +76,8 @@ public class WorkflowRunner : IWorkflowRunner
         var parentWorkflowInstanceId = options?.ParentWorkflowInstanceId;
         var statusUpdatedCallback = options?.StatusUpdatedCallback;
         var workflowExecutionContext = await WorkflowExecutionContext.CreateAsync(
-            _serviceProvider,
-            workflow,
+            serviceProvider,
+            workflowGraph,
             instanceId,
             correlationId,
             parentWorkflowInstanceId,
@@ -112,7 +95,21 @@ public class WorkflowRunner : IWorkflowRunner
     }
 
     /// <inheritdoc />
+    public async Task<RunWorkflowResult> RunAsync(Workflow workflow, RunWorkflowOptions? options = default, CancellationToken cancellationToken = default)
+    {
+        var workflowGraph = await workflowGraphBuilder.BuildAsync(workflow, cancellationToken);
+        return await RunAsync(workflowGraph, options, cancellationToken);
+    }
+
+    /// <inheritdoc />
     public async Task<RunWorkflowResult> RunAsync(Workflow workflow, WorkflowState workflowState, RunWorkflowOptions? options = default, CancellationToken cancellationToken = default)
+    {
+        var workflowGraph = await workflowGraphBuilder.BuildAsync(workflow, cancellationToken);
+        return await RunAsync(workflowGraph, workflowState, options, cancellationToken);
+    }
+    
+    /// <inheritdoc />
+    public async Task<RunWorkflowResult> RunAsync(WorkflowGraph workflowGraph, WorkflowState workflowState, RunWorkflowOptions? options = default, CancellationToken cancellationToken = default)
     {
         // Create workflow execution context.
         var input = options?.Input;
@@ -122,8 +119,8 @@ public class WorkflowRunner : IWorkflowRunner
         var parentWorkflowInstanceId = options?.ParentWorkflowInstanceId;
         var statusUpdatedCallback = options?.StatusUpdatedCallback;
         var workflowExecutionContext = await WorkflowExecutionContext.CreateAsync(
-            _serviceProvider,
-            workflow,
+            serviceProvider,
+            workflowGraph,
             workflowState,
             correlationId,
             parentWorkflowInstanceId,
@@ -187,25 +184,25 @@ public class WorkflowRunner : IWorkflowRunner
         var applicationCancellationToken = workflowExecutionContext.CancellationTokens.ApplicationCancellationToken;
         var systemCancellationToken = workflowExecutionContext.CancellationTokens.SystemCancellationToken;
 
-        await _notificationSender.SendAsync(new WorkflowExecuting(workflow, workflowExecutionContext), applicationCancellationToken);
+        await notificationSender.SendAsync(new WorkflowExecuting(workflow, workflowExecutionContext), applicationCancellationToken);
 
         // If the status is Pending, it means the workflow is started for the first time.
         if (workflowExecutionContext.SubStatus == WorkflowSubStatus.Pending)
         {
             workflowExecutionContext.TransitionTo(WorkflowSubStatus.Executing);
-            await _notificationSender.SendAsync(new WorkflowStarted(workflow, workflowExecutionContext), applicationCancellationToken);
+            await notificationSender.SendAsync(new WorkflowStarted(workflow, workflowExecutionContext), applicationCancellationToken);
         }
 
-        await _pipeline.ExecuteAsync(workflowExecutionContext);
-        var workflowState = _workflowStateExtractor.Extract(workflowExecutionContext);
+        await pipeline.ExecuteAsync(workflowExecutionContext);
+        var workflowState = workflowStateExtractor.Extract(workflowExecutionContext);
 
         if (workflowState.Status == WorkflowStatus.Finished)
         {
-            await _notificationSender.SendAsync(new WorkflowFinished(workflow, workflowState, workflowExecutionContext), applicationCancellationToken);
+            await notificationSender.SendAsync(new WorkflowFinished(workflow, workflowState, workflowExecutionContext), applicationCancellationToken);
         }
 
         var result = workflow.ResultVariable?.Get(workflowExecutionContext.MemoryRegister);
-        await _notificationSender.SendAsync(new WorkflowExecuted(workflow, workflowState, workflowExecutionContext), systemCancellationToken);
+        await notificationSender.SendAsync(new WorkflowExecuted(workflow, workflowState, workflowExecutionContext), systemCancellationToken);
         return new RunWorkflowResult(workflowState, workflowExecutionContext.Workflow, result);
     }
 }

--- a/src/modules/Elsa.Workflows.Management/Activities/WorkflowDefinitionActivity/WorkflowDefinitionActivityPortResolver.cs
+++ b/src/modules/Elsa.Workflows.Management/Activities/WorkflowDefinitionActivity/WorkflowDefinitionActivityPortResolver.cs
@@ -5,7 +5,7 @@ namespace Elsa.Workflows.Management.Activities.WorkflowDefinitionActivity;
 /// <summary>
 /// Returns the root activity for a given <see cref="WorkflowDefinitionActivity"/>.
 /// </summary>
-public class WorkflowDefinitionActivityResolver : IActivityResolver
+public class WorkflowDefinitionActivityResolver() : IActivityResolver
 {
     /// <inheritdoc />
     public int Priority => 0;
@@ -19,6 +19,6 @@ public class WorkflowDefinitionActivityResolver : IActivityResolver
         var definitionActivity = (WorkflowDefinitionActivity)activity;
         var root = definitionActivity.Root;
 
-        return new(new[] { root });
+        return new([root]);
     }
 }

--- a/src/modules/Elsa.Workflows.Management/Contracts/IWorkflowDefinitionService.cs
+++ b/src/modules/Elsa.Workflows.Management/Contracts/IWorkflowDefinitionService.cs
@@ -2,6 +2,7 @@ using Elsa.Common.Models;
 using Elsa.Workflows.Activities;
 using Elsa.Workflows.Management.Entities;
 using Elsa.Workflows.Management.Filters;
+using Elsa.Workflows.Models;
 
 namespace Elsa.Workflows.Management.Contracts;
 
@@ -13,7 +14,7 @@ public interface IWorkflowDefinitionService
     /// <summary>
     /// Constructs an executable <see cref="Workflow"/> from the specified <see cref="WorkflowDefinition"/>.
     /// </summary>
-    Task<Workflow> MaterializeWorkflowAsync(WorkflowDefinition definition, CancellationToken cancellationToken = default);
+    Task<WorkflowGraph> MaterializeWorkflowAsync(WorkflowDefinition definition, CancellationToken cancellationToken = default);
     
     /// <summary>
     /// Looks for a <see cref="WorkflowDefinition"/> by the specified definition ID and <see cref="VersionOptions"/>.
@@ -33,15 +34,15 @@ public interface IWorkflowDefinitionService
     /// <summary>
     /// Looks for a <see cref="Workflow"/> by the specified definition ID and <see cref="VersionOptions"/>.
     /// </summary>
-    Task<Workflow?> FindWorkflowAsync(string definitionId, VersionOptions versionOptions, CancellationToken cancellationToken = default);
+    Task<WorkflowGraph?> FindWorkflowGraphAsync(string definitionId, VersionOptions versionOptions, CancellationToken cancellationToken = default);
     
     /// <summary>
     /// Looks for a <see cref="Workflow"/> by the specified version ID.
     /// </summary>
-    Task<Workflow?> FindWorkflowAsync(string definitionVersionId, CancellationToken cancellationToken = default);
+    Task<WorkflowGraph?> FindWorkflowGraphAsync(string definitionVersionId, CancellationToken cancellationToken = default);
     
     /// <summary>
     /// Looks for a <see cref="Workflow"/> by the specified <see cref="WorkflowDefinitionFilter"/>.
     /// </summary>
-    Task<Workflow?> FindWorkflowAsync(WorkflowDefinitionFilter filter, CancellationToken cancellationToken = default);
+    Task<WorkflowGraph?> FindWorkflowGraphAsync(WorkflowDefinitionFilter filter, CancellationToken cancellationToken = default);
 }

--- a/src/modules/Elsa.Workflows.Management/Features/WorkflowManagementFeature.cs
+++ b/src/modules/Elsa.Workflows.Management/Features/WorkflowManagementFeature.cs
@@ -206,6 +206,7 @@ public class WorkflowManagementFeature : FeatureBase
             .AddScoped<IActivityResolver, WorkflowDefinitionActivityResolver>()
             .AddActivityProvider<WorkflowDefinitionActivityProvider>()
             .AddScoped<WorkflowDefinitionMapper>()
+            .AddScoped<ScopedWorkflowDefinitionLookup>()
             .AddSingleton<VariableDefinitionMapper>()
             .AddSingleton<WorkflowStateMapper>()
             .AddSingleton<ICompressionCodecResolver, CompressionCodecResolver>()

--- a/src/modules/Elsa.Workflows.Management/Mappers/WorkflowDefinitionMapper.cs
+++ b/src/modules/Elsa.Workflows.Management/Mappers/WorkflowDefinitionMapper.cs
@@ -99,7 +99,8 @@ public class WorkflowDefinitionMapper
     /// <returns>The mapped <see cref="Workflow"/>.</returns>
     public async Task<WorkflowDefinitionModel> MapAsync(WorkflowDefinition workflowDefinition, CancellationToken cancellationToken = default)
     {
-        var workflow = await _workflowDefinitionService.MaterializeWorkflowAsync(workflowDefinition, cancellationToken);
+        var workflowGraph = await _workflowDefinitionService.MaterializeWorkflowAsync(workflowDefinition, cancellationToken);
+        var workflow = workflowGraph.Workflow;
         var variables = _variableDefinitionMapper.Map(workflow.Variables).ToList();
 
         return new(
@@ -120,7 +121,7 @@ public class WorkflowDefinitionMapper
             workflowDefinition.IsLatest,
             workflowDefinition.IsPublished,
             workflow.Options,
-            default,
+            null,
             workflow.Root);
     }
     
@@ -151,7 +152,7 @@ public class WorkflowDefinitionMapper
             workflow.Publication.IsLatest,
             workflow.Publication.IsPublished,
             workflow.Options,
-            default,
+            null,
             workflow.Root);
     }
 }

--- a/src/modules/Elsa.Workflows.Management/Services/CachingWorkflowDefinitionService.cs
+++ b/src/modules/Elsa.Workflows.Management/Services/CachingWorkflowDefinitionService.cs
@@ -1,8 +1,8 @@
 using Elsa.Common.Models;
-using Elsa.Workflows.Activities;
 using Elsa.Workflows.Management.Contracts;
 using Elsa.Workflows.Management.Entities;
 using Elsa.Workflows.Management.Filters;
+using Elsa.Workflows.Models;
 using JetBrains.Annotations;
 using Microsoft.Extensions.Caching.Memory;
 
@@ -15,7 +15,7 @@ namespace Elsa.Workflows.Management.Services;
 public class CachingWorkflowDefinitionService(IWorkflowDefinitionService decoratedService, IWorkflowDefinitionCacheManager cacheManager) : IWorkflowDefinitionService
 {
     /// <inheritdoc />
-    public async Task<Workflow> MaterializeWorkflowAsync(WorkflowDefinition definition, CancellationToken cancellationToken = default)
+    public async Task<WorkflowGraph> MaterializeWorkflowAsync(WorkflowDefinition definition, CancellationToken cancellationToken = default)
     {
         return await decoratedService.MaterializeWorkflowAsync(definition, cancellationToken);
     }
@@ -49,30 +49,30 @@ public class CachingWorkflowDefinitionService(IWorkflowDefinitionService decorat
     }
 
     /// <inheritdoc />
-    public async Task<Workflow?> FindWorkflowAsync(string definitionId, VersionOptions versionOptions, CancellationToken cancellationToken = default)
+    public async Task<WorkflowGraph?> FindWorkflowGraphAsync(string definitionId, VersionOptions versionOptions, CancellationToken cancellationToken = default)
     {
         var cacheKey = cacheManager.CreateWorkflowVersionCacheKey(definitionId, versionOptions);
         return await GetFromCacheAsync(cacheKey,
-            () => decoratedService.FindWorkflowAsync(definitionId, versionOptions, cancellationToken),
-            x => x.Identity.DefinitionId);
+            () => decoratedService.FindWorkflowGraphAsync(definitionId, versionOptions, cancellationToken),
+            x => x.Workflow.Identity.DefinitionId);
     }
 
     /// <inheritdoc />
-    public async Task<Workflow?> FindWorkflowAsync(string definitionVersionId, CancellationToken cancellationToken = default)
+    public async Task<WorkflowGraph?> FindWorkflowGraphAsync(string definitionVersionId, CancellationToken cancellationToken = default)
     {
         var cacheKey = cacheManager.CreateWorkflowVersionCacheKey(definitionVersionId);
         return await GetFromCacheAsync(cacheKey,
-            () => decoratedService.FindWorkflowAsync(definitionVersionId, cancellationToken),
-            x => x.Identity.DefinitionId);
+            () => decoratedService.FindWorkflowGraphAsync(definitionVersionId, cancellationToken),
+            x => x.Workflow.Identity.DefinitionId);
     }
 
     /// <inheritdoc />
-    public async Task<Workflow?> FindWorkflowAsync(WorkflowDefinitionFilter filter, CancellationToken cancellationToken = default)
+    public async Task<WorkflowGraph?> FindWorkflowGraphAsync(WorkflowDefinitionFilter filter, CancellationToken cancellationToken = default)
     {
         var cacheKey = cacheManager.CreateWorkflowFilterCacheKey(filter);
         return await GetFromCacheAsync(cacheKey,
-            () => decoratedService.FindWorkflowAsync(filter, cancellationToken),
-            x => x.Identity.DefinitionId);
+            () => decoratedService.FindWorkflowGraphAsync(filter, cancellationToken),
+            x => x.Workflow.Identity.DefinitionId);
     }
 
     private async Task<T?> GetFromCacheAsync<T>(string cacheKey, Func<Task<T?>> getObjectFunc, Func<T, string> getChangeTokenKeyFunc)

--- a/src/modules/Elsa.Workflows.Management/Services/ScopedWorkflowDefinitionLookup.cs
+++ b/src/modules/Elsa.Workflows.Management/Services/ScopedWorkflowDefinitionLookup.cs
@@ -1,0 +1,8 @@
+using Elsa.Workflows.Activities;
+
+namespace Elsa.Workflows.Management.Services;
+
+public class ScopedWorkflowDefinitionLookup
+{
+    public HashSet<Workflow> Workflows { get; set; } = new();
+}

--- a/src/modules/Elsa.Workflows.Management/Services/WorkflowDefinitionPublisher.cs
+++ b/src/modules/Elsa.Workflows.Management/Services/WorkflowDefinitionPublisher.cs
@@ -85,8 +85,8 @@ public class WorkflowDefinitionPublisher : IWorkflowDefinitionPublisher
     /// <inheritdoc />
     public async Task<PublishWorkflowDefinitionResult> PublishAsync(WorkflowDefinition definition, CancellationToken cancellationToken = default)
     {
-        var workflow = await _workflowDefinitionService.MaterializeWorkflowAsync(definition, cancellationToken);
-        var responses = await _requestSender.SendAsync(new ValidateWorkflowRequest(workflow), cancellationToken);
+        var workflowGraph = await _workflowDefinitionService.MaterializeWorkflowAsync(definition, cancellationToken);
+        var responses = await _requestSender.SendAsync(new ValidateWorkflowRequest(workflowGraph.Workflow), cancellationToken);
         var validationErrors = responses.SelectMany(r => r.ValidationErrors).ToList();
 
         if (validationErrors.Any())

--- a/src/modules/Elsa.Workflows.Management/Services/WorkflowDefinitionService.cs
+++ b/src/modules/Elsa.Workflows.Management/Services/WorkflowDefinitionService.cs
@@ -1,75 +1,61 @@
 using Elsa.Common.Models;
-using Elsa.Extensions;
-using Elsa.Workflows.Activities;
 using Elsa.Workflows.Contracts;
 using Elsa.Workflows.Management.Contracts;
 using Elsa.Workflows.Management.Entities;
 using Elsa.Workflows.Management.Filters;
+using Elsa.Workflows.Models;
 
 namespace Elsa.Workflows.Management.Services;
 
 /// <inheritdoc />
-public class WorkflowDefinitionService : IWorkflowDefinitionService
+public class WorkflowDefinitionService(
+    IWorkflowDefinitionStore workflowDefinitionStore,
+    IWorkflowGraphBuilder workflowGraphBuilder,
+    Func<IEnumerable<IWorkflowMaterializer>> materializers)
+    : IWorkflowDefinitionService
 {
-    private readonly IWorkflowDefinitionStore _workflowDefinitionStore;
-    private readonly IActivityVisitor _activityVisitor;
-    private readonly IIdentityGraphService _identityGraphService;
-    private readonly Func<IEnumerable<IWorkflowMaterializer>> _materializers;
-
-    /// <summary>
-    /// Constructor.
-    /// </summary>
-    public WorkflowDefinitionService(
-        IWorkflowDefinitionStore workflowDefinitionStore,
-        IActivityVisitor activityVisitor,
-        IIdentityGraphService identityGraphService,
-        Func<IEnumerable<IWorkflowMaterializer>> materializers)
-    {
-        _workflowDefinitionStore = workflowDefinitionStore;
-        _activityVisitor = activityVisitor;
-        _identityGraphService = identityGraphService;
-        _materializers = materializers;
-    }
-
     /// <inheritdoc />
-    public async Task<Workflow> MaterializeWorkflowAsync(WorkflowDefinition definition, CancellationToken cancellationToken = default)
+    public async Task<WorkflowGraph> MaterializeWorkflowAsync(WorkflowDefinition definition, CancellationToken cancellationToken = default)
     {
-        var materializers = _materializers();
-        var materializer = materializers.FirstOrDefault(x => x.Name == definition.MaterializerName);
+        var workflowMaterializers = materializers();
+        var materializer = workflowMaterializers.FirstOrDefault(x => x.Name == definition.MaterializerName);
 
         if (materializer == null)
             throw new Exception("Provider not found");
 
         var workflow = await materializer.MaterializeAsync(definition, cancellationToken);
-        var graph = (await _activityVisitor.VisitAsync(workflow, cancellationToken)).Flatten().ToList();
-
-        _identityGraphService.AssignIdentities(graph);
-
-        return workflow;
+        return await workflowGraphBuilder.BuildAsync(workflow, cancellationToken);
     }
 
     /// <inheritdoc />
     public async Task<WorkflowDefinition?> FindWorkflowDefinitionAsync(string definitionId, VersionOptions versionOptions, CancellationToken cancellationToken = default)
     {
-        var filter = new WorkflowDefinitionFilter { DefinitionId = definitionId, VersionOptions = versionOptions };
-        return await _workflowDefinitionStore.FindAsync(filter, cancellationToken);
+        var filter = new WorkflowDefinitionFilter
+        {
+            DefinitionId = definitionId,
+            VersionOptions = versionOptions
+        };
+        return await workflowDefinitionStore.FindAsync(filter, cancellationToken);
     }
 
     /// <inheritdoc />
     public async Task<WorkflowDefinition?> FindWorkflowDefinitionAsync(string definitionVersionId, CancellationToken cancellationToken = default)
     {
-        var filter = new WorkflowDefinitionFilter { Id = definitionVersionId };
-        return await _workflowDefinitionStore.FindAsync(filter, cancellationToken);
+        var filter = new WorkflowDefinitionFilter
+        {
+            Id = definitionVersionId
+        };
+        return await workflowDefinitionStore.FindAsync(filter, cancellationToken);
     }
 
     /// <inheritdoc />
     public async Task<WorkflowDefinition?> FindWorkflowDefinitionAsync(WorkflowDefinitionFilter filter, CancellationToken cancellationToken = default)
     {
-        return await _workflowDefinitionStore.FindAsync(filter, cancellationToken);
+        return await workflowDefinitionStore.FindAsync(filter, cancellationToken);
     }
 
     /// <inheritdoc />
-    public async Task<Workflow?> FindWorkflowAsync(string definitionId, VersionOptions versionOptions, CancellationToken cancellationToken = default)
+    public async Task<WorkflowGraph?> FindWorkflowGraphAsync(string definitionId, VersionOptions versionOptions, CancellationToken cancellationToken = default)
     {
         var definition = await FindWorkflowDefinitionAsync(definitionId, versionOptions, cancellationToken);
 
@@ -80,7 +66,7 @@ public class WorkflowDefinitionService : IWorkflowDefinitionService
     }
 
     /// <inheritdoc />
-    public async Task<Workflow?> FindWorkflowAsync(string definitionVersionId, CancellationToken cancellationToken = default)
+    public async Task<WorkflowGraph?> FindWorkflowGraphAsync(string definitionVersionId, CancellationToken cancellationToken = default)
     {
         var definition = await FindWorkflowDefinitionAsync(definitionVersionId, cancellationToken);
 
@@ -91,7 +77,7 @@ public class WorkflowDefinitionService : IWorkflowDefinitionService
     }
 
     /// <inheritdoc />
-    public async Task<Workflow?> FindWorkflowAsync(WorkflowDefinitionFilter filter, CancellationToken cancellationToken = default)
+    public async Task<WorkflowGraph?> FindWorkflowGraphAsync(WorkflowDefinitionFilter filter, CancellationToken cancellationToken = default)
     {
         var definition = await FindWorkflowDefinitionAsync(filter, cancellationToken);
 

--- a/src/modules/Elsa.Workflows.Management/Services/WorkflowInstanceManager.cs
+++ b/src/modules/Elsa.Workflows.Management/Services/WorkflowInstanceManager.cs
@@ -8,7 +8,6 @@ using Elsa.Workflows.Management.Mappers;
 using Elsa.Workflows.Management.Notifications;
 using Elsa.Workflows.Management.Requests;
 using Elsa.Workflows.State;
-using Exception = System.Exception;
 
 namespace Elsa.Workflows.Management.Services;
 

--- a/src/modules/Elsa.Workflows.Runtime/Contracts/ITriggerIndexer.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Contracts/ITriggerIndexer.cs
@@ -12,11 +12,6 @@ namespace Elsa.Workflows.Runtime.Contracts;
 public interface ITriggerIndexer
 {
     /// <summary>
-    /// Removes triggers for the specified workflow.
-    /// </summary>
-    Task<IndexedWorkflowTriggers> DeleteTriggersAsync(Workflow workflow, CancellationToken cancellationToken = default);
-    
-    /// <summary>
     /// Removes triggers matching the specified filter.
     /// </summary>
     Task DeleteTriggersAsync(TriggerFilter filter, CancellationToken cancellationToken = default);
@@ -30,14 +25,6 @@ public interface ITriggerIndexer
     /// Indexes triggers of the specified workflow.
     /// </summary>
     Task<IndexedWorkflowTriggers> IndexTriggersAsync(Workflow workflow, CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Returns triggers for the specified workflow definition.
-    /// </summary>
-    /// <param name="definition">The workflow definition.</param>
-    /// <param name="cancellationToken">An optional cancellation token.</param>
-    /// <returns>A collection of triggers.</returns>
-    Task<IEnumerable<StoredTrigger>> GetTriggersAsync(WorkflowDefinition definition, CancellationToken cancellationToken = default);
     
     /// <summary>
     /// Returns triggers for the specified workflow definition.

--- a/src/modules/Elsa.Workflows.Runtime/Contracts/IWorkflowHost.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Contracts/IWorkflowHost.cs
@@ -1,4 +1,5 @@
 using Elsa.Workflows.Activities;
+using Elsa.Workflows.Models;
 using Elsa.Workflows.Runtime.Parameters;
 using Elsa.Workflows.Runtime.Results;
 using Elsa.Workflows.State;
@@ -11,9 +12,14 @@ namespace Elsa.Workflows.Runtime.Contracts;
 public interface IWorkflowHost
 {
     /// <summary>
-    /// The workflow definition.
+    /// The workflow graph.
     /// </summary>
-    Workflow Workflow { get; set; }
+    WorkflowGraph WorkflowGraph { get; }
+    
+    /// <summary>
+    /// The workflow.
+    /// </summary>
+    Workflow Workflow { get; }
 
     /// <summary>
     /// The workflow state.

--- a/src/modules/Elsa.Workflows.Runtime/Contracts/IWorkflowHostFactory.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Contracts/IWorkflowHostFactory.cs
@@ -1,6 +1,5 @@
 using Elsa.Common.Models;
-using Elsa.Workflows.Activities;
-using Elsa.Workflows.Management.Entities;
+using Elsa.Workflows.Models;
 using Elsa.Workflows.State;
 
 namespace Elsa.Workflows.Runtime.Contracts;
@@ -21,15 +20,15 @@ public interface IWorkflowHostFactory
     /// <summary>
     /// Creates a new <see cref="IWorkflowHost"/> object.
     /// </summary>
-    /// <param name="workflow">The workflow.</param>
+    /// <param name="workflowGraph">The workflow.</param>
     /// <param name="workflowState">The workflow state to initialize the workflow host with.</param>
     /// <param name="cancellationToken">An optional cancellation token.</param>
-    Task<IWorkflowHost> CreateAsync(Workflow workflow, WorkflowState workflowState, CancellationToken cancellationToken = default);
+    Task<IWorkflowHost> CreateAsync(WorkflowGraph workflowGraph, WorkflowState workflowState, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Creates a new <see cref="IWorkflowHost"/> object.
     /// </summary>
-    /// <param name="workflow">The workflow.</param>
+    /// <param name="workflowGraph">The workflow.</param>
     /// <param name="cancellationToken">An optional cancellation token.</param>
-    Task<IWorkflowHost> CreateAsync(Workflow workflow, CancellationToken cancellationToken = default);
+    Task<IWorkflowHost> CreateAsync(WorkflowGraph workflowGraph, CancellationToken cancellationToken = default);
 }

--- a/src/modules/Elsa.Workflows.Runtime/Services/DefaultBackgroundActivityInvoker.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Services/DefaultBackgroundActivityInvoker.cs
@@ -58,12 +58,12 @@ public class DefaultBackgroundActivityInvoker : IBackgroundActivityInvoker
         if (workflowState == null)
             throw new Exception("Workflow state not found");
 
-        var workflow = await _workflowDefinitionService.FindWorkflowAsync(workflowState.DefinitionId, VersionOptions.SpecificVersion(workflowState.DefinitionVersion), cancellationToken);
+        var workflowGraph = await _workflowDefinitionService.FindWorkflowGraphAsync(workflowState.DefinitionId, VersionOptions.SpecificVersion(workflowState.DefinitionVersion), cancellationToken);
 
-        if (workflow == null)
+        if (workflowGraph == null)
             throw new Exception("Workflow definition not found");
         
-        var workflowExecutionContext = await WorkflowExecutionContext.CreateAsync(_serviceProvider, workflow, workflowState, cancellationTokens: cancellationToken);
+        var workflowExecutionContext = await WorkflowExecutionContext.CreateAsync(_serviceProvider, workflowGraph, workflowState, cancellationTokens: cancellationToken);
         var activityNodeId = scheduledBackgroundActivity.ActivityNodeId;
         var activityExecutionContext = workflowExecutionContext.ActivityExecutionContexts.First(x => x.NodeId == activityNodeId);
 

--- a/src/modules/Elsa.Workflows.Runtime/Services/DefaultWorkflowDefinitionStorePopulator.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Services/DefaultWorkflowDefinitionStorePopulator.cs
@@ -242,7 +242,7 @@ public class DefaultWorkflowDefinitionStorePopulator : IWorkflowDefinitionStoreP
         }
     }
 
-    private async Task IndexTriggersAsync(MaterializedWorkflow workflow, CancellationToken cancellationToken) => await _triggerIndexer.IndexTriggersAsync(workflow.Workflow, cancellationToken);
+    private async Task IndexTriggersAsync(MaterializedWorkflow materializedWorkflow, CancellationToken cancellationToken) => await _triggerIndexer.IndexTriggersAsync(materializedWorkflow.Workflow, cancellationToken);
 
     /// <summary>
     /// Syncs the items in the primary list with existing items in the secondary list, even when the object instances are not the same (but their IDs are).

--- a/src/modules/Elsa.Workflows.Runtime/Services/DefaultWorkflowRuntime.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Services/DefaultWorkflowRuntime.cs
@@ -140,7 +140,7 @@ public class DefaultWorkflowRuntime(
             var definitionId = workflowInstance.DefinitionId;
             var version = workflowInstance.Version;
 
-            var workflow = await workflowDefinitionService.FindWorkflowAsync(
+            var workflow = await workflowDefinitionService.FindWorkflowGraphAsync(
                 definitionId,
                 VersionOptions.SpecificVersion(version),
                 systemCancellationToken);
@@ -267,7 +267,7 @@ public class DefaultWorkflowRuntime(
             if (workflowState == null)
                 throw new Exception("Workflow state not found");
 
-            var workflow = await workflowDefinitionService.FindWorkflowAsync(workflowState.DefinitionId, VersionOptions.SpecificVersion(workflowState.DefinitionVersion), cancellationToken);
+            var workflow = await workflowDefinitionService.FindWorkflowGraphAsync(workflowState.DefinitionId, VersionOptions.SpecificVersion(workflowState.DefinitionVersion), cancellationToken);
 
             if (workflow == null)
                 throw new Exception("Workflow definition not found");
@@ -385,7 +385,7 @@ public class DefaultWorkflowRuntime(
         if (options?.IsExistingInstance == true)
         {
             var workflowState = await LoadWorkflowStateAsync(options.InstanceId!, cancellationToken);
-            var workflow = await workflowDefinitionService.FindWorkflowAsync(workflowState.DefinitionVersionId, cancellationToken) ?? throw new Exception("Specified workflow definition and version does not exist");
+            var workflow = await workflowDefinitionService.FindWorkflowGraphAsync(workflowState.DefinitionVersionId, cancellationToken) ?? throw new Exception("Specified workflow definition and version does not exist");
             return await workflowHostFactory.CreateAsync(workflow, workflowState, cancellationToken);
         }
 
@@ -465,14 +465,14 @@ public class DefaultWorkflowRuntime(
                     InstanceId = workflowsFilter.Options.WorkflowInstanceId
                 };
                 var canStartResult = await CanStartWorkflowAsync(definitionId, startOptions);
-                var workflow = await workflowDefinitionService.FindWorkflowAsync(definitionId, startOptions.VersionOptions, cancellationToken);
+                var workflowGraph = await workflowDefinitionService.FindWorkflowGraphAsync(definitionId, startOptions.VersionOptions, cancellationToken);
 
-                if (workflow == null)
+                if (workflowGraph == null)
                     throw new Exception($"The workflow definition {definitionId} was not found");
 
                 var createWorkflowInstanceRequest = new CreateWorkflowInstanceRequest
                 {
-                    Workflow = workflow,
+                    Workflow = workflowGraph.Workflow,
                     CorrelationId = workflowsFilter.Options.CorrelationId,
                     Properties = workflowsFilter.Options.Properties,
                     Input = workflowsFilter.Options.Input,

--- a/src/modules/Elsa.Workflows.Runtime/Services/TriggerIndexer.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Services/TriggerIndexer.cs
@@ -63,21 +63,20 @@ public class TriggerIndexer : ITriggerIndexer
 
         foreach (string workflowDefinitionVersionId in workflowDefinitionVersionIds)
         {
-            var workflowDefinition = await _workflowDefinitionService.FindWorkflowDefinitionAsync(workflowDefinitionVersionId, cancellationToken);
+            var workflowGraph = await _workflowDefinitionService.FindWorkflowGraphAsync(workflowDefinitionVersionId, cancellationToken);
 
-            if (workflowDefinition == null)
+            if (workflowGraph == null)
                 continue;
-
-            var workflow = await _workflowDefinitionService.MaterializeWorkflowAsync(workflowDefinition, cancellationToken);
-            await DeleteTriggersAsync(workflow, cancellationToken);
+            
+            await DeleteTriggersAsync(workflowGraph.Workflow, cancellationToken);
         }
     }
 
     /// <inheritdoc />
     public async Task<IndexedWorkflowTriggers> IndexTriggersAsync(WorkflowDefinition definition, CancellationToken cancellationToken = default)
     {
-        var workflow = await _workflowDefinitionService.MaterializeWorkflowAsync(definition, cancellationToken);
-        return await IndexTriggersAsync(workflow, cancellationToken);
+        var workflowGraph = await _workflowDefinitionService.MaterializeWorkflowAsync(definition, cancellationToken);
+        return await IndexTriggersAsync(workflowGraph.Workflow, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -105,20 +104,12 @@ public class TriggerIndexer : ITriggerIndexer
     }
 
     /// <inheritdoc />
-    public async Task<IEnumerable<StoredTrigger>> GetTriggersAsync(WorkflowDefinition definition, CancellationToken cancellationToken = default)
-    {
-        var workflow = await _workflowDefinitionService.MaterializeWorkflowAsync(definition, cancellationToken);
-        return await GetTriggersAsync(workflow, cancellationToken);
-    }
-
-    /// <inheritdoc />
     public async Task<IEnumerable<StoredTrigger>> GetTriggersAsync(Workflow workflow, CancellationToken cancellationToken)
     {
         return await GetTriggersInternalAsync(workflow, cancellationToken).ToListAsync(cancellationToken);
     }
-
-    /// <inheritdoc />
-    public async Task<IndexedWorkflowTriggers> DeleteTriggersAsync(Workflow workflow, CancellationToken cancellationToken = default)
+    
+    private async Task DeleteTriggersAsync(Workflow workflow, CancellationToken cancellationToken = default)
     {
         var emptyTriggerList = new List<StoredTrigger>(0);
         var currentTriggers = await GetCurrentTriggersAsync(workflow.Identity.DefinitionId, cancellationToken).ToList();
@@ -126,7 +117,6 @@ public class TriggerIndexer : ITriggerIndexer
         await _triggerStore.ReplaceAsync(diff.Removed, diff.Added, cancellationToken);
         var indexedWorkflow = new IndexedWorkflowTriggers(workflow, emptyTriggerList, currentTriggers, emptyTriggerList);
         await _notificationSender.SendAsync(new WorkflowTriggersIndexed(indexedWorkflow), cancellationToken);
-        return indexedWorkflow;
     }
 
     private async Task<IEnumerable<StoredTrigger>> GetCurrentTriggersAsync(string workflowDefinitionId, CancellationToken cancellationToken)

--- a/src/modules/Elsa.Workflows.Runtime/Services/WorkflowHost.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Services/WorkflowHost.cs
@@ -27,12 +27,12 @@ public class WorkflowHost : IWorkflowHost
     /// </summary>
     public WorkflowHost(
         IServiceScopeFactory serviceScopeFactory,
-        Workflow workflow,
+        WorkflowGraph workflowGraph,
         WorkflowState workflowState,
         IIdentityGenerator identityGenerator,
         ILogger<WorkflowHost> logger)
     {
-        Workflow = workflow;
+        WorkflowGraph = workflowGraph;
         WorkflowState = workflowState;
         _serviceScopeFactory = serviceScopeFactory;
         _identityGenerator = identityGenerator;
@@ -40,7 +40,10 @@ public class WorkflowHost : IWorkflowHost
     }
 
     /// <inheritdoc />
-    public Workflow Workflow { get; set; }
+    public WorkflowGraph WorkflowGraph { get; }
+
+    /// <inheritdoc />
+    public Workflow Workflow => WorkflowGraph.Workflow;
 
     /// <inheritdoc />
     public WorkflowState WorkflowState { get; set; }
@@ -90,8 +93,8 @@ public class WorkflowHost : IWorkflowHost
         using var scope = _serviceScopeFactory.CreateScope();
         var workflowRunner = scope.ServiceProvider.GetRequiredService<IWorkflowRunner>();
         var workflowResult = @params?.IsExistingInstance == true
-            ? await workflowRunner.RunAsync(Workflow, WorkflowState, runOptions, cancellationToken)
-            : await workflowRunner.RunAsync(Workflow, runOptions, cancellationToken);
+            ? await workflowRunner.RunAsync(WorkflowGraph, WorkflowState, runOptions, cancellationToken)
+            : await workflowRunner.RunAsync(WorkflowGraph, runOptions, cancellationToken);
 
         WorkflowState = workflowResult.WorkflowState;
 
@@ -133,7 +136,7 @@ public class WorkflowHost : IWorkflowHost
 
         using var scope = _serviceScopeFactory.CreateScope();
         var workflowRunner = scope.ServiceProvider.GetRequiredService<IWorkflowRunner>();
-        var workflowResult = await workflowRunner.RunAsync(Workflow, WorkflowState, runOptions, cancellationToken);
+        var workflowResult = await workflowRunner.RunAsync(WorkflowGraph, WorkflowState, runOptions, cancellationToken);
 
         WorkflowState = workflowResult.WorkflowState;
 

--- a/test/component/Elsa.Workflows.ComponentTests/Elsa.Workflows.ComponentTests.csproj
+++ b/test/component/Elsa.Workflows.ComponentTests/Elsa.Workflows.ComponentTests.csproj
@@ -47,6 +47,15 @@
         <None Update="Scenarios\WorkflowCompletion\hello-world.json">
           <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </None>
+        <None Update="Scenarios\CachingAndWorkflowDefinitionActivity\Workflows\workflow-definition-child.json">
+          <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
+        <None Update="Scenarios\CachingAndWorkflowDefinitionActivity\Workflows\workflow-definition-grand-child.json">
+          <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
+        <None Update="Scenarios\CachingAndWorkflowDefinitionActivity\Workflows\workflow-definition-parent.json">
+          <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
     </ItemGroup>
 
 </Project>

--- a/test/component/Elsa.Workflows.ComponentTests/Helpers/Fixtures/WorkflowServer.cs
+++ b/test/component/Elsa.Workflows.ComponentTests/Helpers/Fixtures/WorkflowServer.cs
@@ -22,6 +22,7 @@ public class WorkflowServer(Infrastructure infrastructure, string url) : WebAppl
     {
         var client = CreateClient();
         client.BaseAddress = new Uri(client.BaseAddress!, "/elsa/api");
+        client.Timeout = TimeSpan.FromMinutes(1);
         return RestService.For<TClient>(client, CreateRefitSettings());
     }
 
@@ -29,6 +30,7 @@ public class WorkflowServer(Infrastructure infrastructure, string url) : WebAppl
     {
         var client = CreateClient();
         client.BaseAddress = new Uri(client.BaseAddress!, "/workflows/");
+        client.Timeout = TimeSpan.FromMinutes(1);
         return client;
     }
 

--- a/test/component/Elsa.Workflows.ComponentTests/Scenarios/CachingAndWorkflowDefinitionActivity/TestWorkflowDefinitionService.cs
+++ b/test/component/Elsa.Workflows.ComponentTests/Scenarios/CachingAndWorkflowDefinitionActivity/TestWorkflowDefinitionService.cs
@@ -1,0 +1,46 @@
+using Elsa.Common.Models;
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Management.Contracts;
+using Elsa.Workflows.Management.Entities;
+using Elsa.Workflows.Management.Filters;
+using Elsa.Workflows.Models;
+
+namespace Elsa.Workflows.ComponentTests.Scenarios.CachingAndWorkflowDefinitionActivity;
+
+public class TestWorkflowDefinitionService(IWorkflowDefinitionService decoratedService) : IWorkflowDefinitionService
+{
+    public Task<WorkflowGraph> MaterializeWorkflowAsync(WorkflowDefinition definition, CancellationToken cancellationToken = default)
+    {
+        return decoratedService.MaterializeWorkflowAsync(definition, cancellationToken);
+    }
+
+    public Task<WorkflowDefinition?> FindWorkflowDefinitionAsync(string definitionId, VersionOptions versionOptions, CancellationToken cancellationToken = default)
+    {
+        return decoratedService.FindWorkflowDefinitionAsync(definitionId, versionOptions, cancellationToken);
+    }
+
+    public Task<WorkflowDefinition?> FindWorkflowDefinitionAsync(string definitionVersionId, CancellationToken cancellationToken = default)
+    {
+        return decoratedService.FindWorkflowDefinitionAsync(definitionVersionId, cancellationToken);
+    }
+
+    public Task<WorkflowDefinition?> FindWorkflowDefinitionAsync(WorkflowDefinitionFilter filter, CancellationToken cancellationToken = default)
+    {
+        return decoratedService.FindWorkflowDefinitionAsync(filter, cancellationToken);
+    }
+
+    public Task<WorkflowGraph?> FindWorkflowGraphAsync(string definitionId, VersionOptions versionOptions, CancellationToken cancellationToken = default)
+    {
+        return decoratedService.FindWorkflowGraphAsync(definitionId, versionOptions, cancellationToken);
+    }
+
+    public Task<WorkflowGraph?> FindWorkflowGraphAsync(string definitionVersionId, CancellationToken cancellationToken = default)
+    {
+        return decoratedService.FindWorkflowGraphAsync(definitionVersionId, cancellationToken);
+    }
+
+    public Task<WorkflowGraph?> FindWorkflowGraphAsync(WorkflowDefinitionFilter filter, CancellationToken cancellationToken = default)
+    {
+        return decoratedService.FindWorkflowGraphAsync(filter, cancellationToken);
+    }
+}

--- a/test/component/Elsa.Workflows.ComponentTests/Scenarios/CachingAndWorkflowDefinitionActivity/WorkflowDefinitionActivityTests.cs
+++ b/test/component/Elsa.Workflows.ComponentTests/Scenarios/CachingAndWorkflowDefinitionActivity/WorkflowDefinitionActivityTests.cs
@@ -1,0 +1,51 @@
+﻿using Elsa.Workflows.Management.Contracts;
+using Elsa.Workflows.Management.Filters;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit.Abstractions;
+
+namespace Elsa.Workflows.ComponentTests.Scenarios.CachingAndWorkflowDefinitionActivity;
+
+public class WorkflowDefinitionActivityTests : AppComponentTest
+{
+    private readonly ITestOutputHelper _testOutputHelper;
+    private const string GrandChildDefinitionId = "29595e7b37a4836d";
+
+    private readonly IWorkflowDefinitionCacheManager _workflowDefinitionCacheManager;
+    private readonly IWorkflowInstanceStore _workflowInstanceStore;
+    private readonly HttpClient _httpWorkflowClient;
+
+    public WorkflowDefinitionActivityTests(App app, ITestOutputHelper testOutputHelper) : base(app)
+    {
+        _testOutputHelper = testOutputHelper;
+        _httpWorkflowClient = WorkflowServer.CreateHttpWorkflowClient();
+        _workflowDefinitionCacheManager = Scope.ServiceProvider.GetRequiredService<IWorkflowDefinitionCacheManager>();
+        _workflowInstanceStore = Scope.ServiceProvider.GetRequiredService<IWorkflowInstanceStore>();
+    }
+
+    [Fact]
+    public async Task SendHttpRequest_WhileEvictingCache_ShouldNotGenerateFaults()
+    {
+        var requestTasks = Enumerable.Range(0, 200).Select(SendRequestAsync).ToList();
+        await Task.WhenAll(requestTasks);
+
+        var filter = new WorkflowInstanceFilter
+        {
+            WorkflowSubStatus = WorkflowSubStatus.Faulted
+        };
+        var faultedWorkflows = (await _workflowInstanceStore.FindManyAsync(filter)).ToList();
+        var faultCount = faultedWorkflows.Count;
+
+        foreach (var faultedWorkflow in faultedWorkflows)
+        foreach (var incident in faultedWorkflow.WorkflowState.Incidents)
+            _testOutputHelper.WriteLine(incident.Message);
+
+        Assert.Equal(0, faultCount);
+    }
+
+    private async Task SendRequestAsync(int index = 0)
+    {
+        var requestTask = _httpWorkflowClient.PostAsync("parent", new StringContent("{}"));
+        var evictionTask = _workflowDefinitionCacheManager.EvictWorkflowDefinitionAsync(GrandChildDefinitionId);
+        await Task.WhenAll(requestTask, evictionTask);
+    }
+}

--- a/test/component/Elsa.Workflows.ComponentTests/Scenarios/CachingAndWorkflowDefinitionActivity/Workflows/workflow-definition-child.json
+++ b/test/component/Elsa.Workflows.ComponentTests/Scenarios/CachingAndWorkflowDefinitionActivity/Workflows/workflow-definition-child.json
@@ -1,0 +1,64 @@
+{
+  "id": "26d186d68deb1250",
+  "definitionId": "a3390d1f4c2594a8",
+  "name": "Child",
+  "createdAt": "2024-04-30T08:22:44.543407+00:00",
+  "version": 1,
+  "toolVersion": "3.2.0.0",
+  "variables": [],
+  "inputs": [],
+  "outputs": [],
+  "outcomes": [],
+  "customProperties": {},
+  "isReadonly": false,
+  "isSystem": false,
+  "isLatest": true,
+  "isPublished": true,
+  "options": {
+    "usableAsActivity": true,
+    "autoUpdateConsumingWorkflows": true
+  },
+  "root": {
+    "type": "Elsa.Flowchart",
+    "version": 1,
+    "id": "e6c941b6f2292fcf",
+    "nodeId": "Workflow2:e6c941b6f2292fcf",
+    "metadata": {},
+    "customProperties": {
+      "source": "FlowchartJsonConverter.cs:45",
+      "notFoundConnections": [],
+      "canStartWorkflow": false,
+      "runAsynchronously": false
+    },
+    "activities": [
+      {
+        "workflowDefinitionId": "29595e7b37a4836d",
+        "workflowDefinitionVersionId": "f36dc264f14be3c6",
+        "latestAvailablePublishedVersion": 1,
+        "latestAvailablePublishedVersionId": "f36dc264f14be3c6",
+        "id": "377b23f4235ec26d",
+        "nodeId": "Workflow2:e6c941b6f2292fcf:377b23f4235ec26d",
+        "name": "GrandChild1",
+        "type": "GrandChild",
+        "version": 1,
+        "customProperties": {
+          "canStartWorkflow": false,
+          "runAsynchronously": false
+        },
+        "metadata": {
+          "designer": {
+            "position": {
+              "x": -193.95703125,
+              "y": 23
+            },
+            "size": {
+              "width": 115.1875,
+              "height": 50
+            }
+          }
+        }
+      }
+    ],
+    "connections": []
+  }
+}

--- a/test/component/Elsa.Workflows.ComponentTests/Scenarios/CachingAndWorkflowDefinitionActivity/Workflows/workflow-definition-grand-child.json
+++ b/test/component/Elsa.Workflows.ComponentTests/Scenarios/CachingAndWorkflowDefinitionActivity/Workflows/workflow-definition-grand-child.json
@@ -1,0 +1,67 @@
+{
+  "id": "f36dc264f14be3c6",
+  "definitionId": "29595e7b37a4836d",
+  "name": "Grand Child",
+  "createdAt": "2024-04-30T08:22:44.537237+00:00",
+  "version": 1,
+  "toolVersion": "3.2.0.0",
+  "variables": [],
+  "inputs": [],
+  "outputs": [],
+  "outcomes": [],
+  "customProperties": {},
+  "isReadonly": false,
+  "isSystem": false,
+  "isLatest": true,
+  "isPublished": true,
+  "options": {
+    "usableAsActivity": true,
+    "autoUpdateConsumingWorkflows": true
+  },
+  "root": {
+    "type": "Elsa.Flowchart",
+    "version": 1,
+    "id": "29044d8e2ba192c0",
+    "nodeId": "Workflow1:29044d8e2ba192c0",
+    "metadata": {},
+    "customProperties": {
+      "source": "FlowchartJsonConverter.cs:45",
+      "notFoundConnections": [],
+      "canStartWorkflow": false,
+      "runAsynchronously": false
+    },
+    "activities": [
+      {
+        "text": {
+          "typeName": "String",
+          "expression": {
+            "type": "Literal",
+            "value": "Grand Child"
+          }
+        },
+        "id": "fb00878500fde1d3",
+        "nodeId": "Workflow1:29044d8e2ba192c0:fb00878500fde1d3",
+        "name": "WriteLine1",
+        "type": "Elsa.WriteLine",
+        "version": 1,
+        "customProperties": {
+          "canStartWorkflow": false,
+          "runAsynchronously": false
+        },
+        "metadata": {
+          "designer": {
+            "position": {
+              "x": -234.796875,
+              "y": -191
+            },
+            "size": {
+              "width": 139.296875,
+              "height": 50
+            }
+          }
+        }
+      }
+    ],
+    "connections": []
+  }
+}

--- a/test/component/Elsa.Workflows.ComponentTests/Scenarios/CachingAndWorkflowDefinitionActivity/Workflows/workflow-definition-parent.json
+++ b/test/component/Elsa.Workflows.ComponentTests/Scenarios/CachingAndWorkflowDefinitionActivity/Workflows/workflow-definition-parent.json
@@ -1,0 +1,142 @@
+{
+  "id": "9178b94f961b1cf",
+  "definitionId": "189be5173f90b1f6",
+  "name": "Parent",
+  "createdAt": "2024-04-30T08:42:17.838484+00:00",
+  "version": 6,
+  "toolVersion": "3.2.0.0",
+  "variables": [],
+  "inputs": [],
+  "outputs": [],
+  "outcomes": [],
+  "customProperties": {
+    "Elsa:WorkflowContextProviderTypes": []
+  },
+  "isReadonly": false,
+  "isSystem": false,
+  "isLatest": true,
+  "isPublished": true,
+  "options": {
+    "autoUpdateConsumingWorkflows": false
+  },
+  "root": {
+    "type": "Elsa.Flowchart",
+    "version": 1,
+    "id": "96f60810318a6a89",
+    "nodeId": "Workflow3:96f60810318a6a89",
+    "metadata": {},
+    "customProperties": {
+      "source": "FlowchartJsonConverter.cs:45",
+      "notFoundConnections": [],
+      "canStartWorkflow": false,
+      "runAsynchronously": false
+    },
+    "activities": [
+      {
+        "path": {
+          "typeName": "String",
+          "expression": {
+            "type": "Literal",
+            "value": "parent"
+          }
+        },
+        "supportedMethods": {
+          "typeName": "String[]",
+          "expression": {
+            "type": "Object",
+            "value": "[\u0022POST\u0022]"
+          }
+        },
+        "authorize": {
+          "typeName": "Boolean",
+          "expression": {
+            "type": "Literal",
+            "value": false
+          }
+        },
+        "policy": {
+          "typeName": "String",
+          "expression": {
+            "type": "Literal"
+          }
+        },
+        "requestTimeout": null,
+        "requestSizeLimit": null,
+        "fileSizeLimit": null,
+        "allowedFileExtensions": null,
+        "blockedFileExtensions": null,
+        "allowedMimeTypes": null,
+        "exposeRequestTooLargeOutcome": false,
+        "exposeFileTooLargeOutcome": false,
+        "exposeInvalidFileExtensionOutcome": false,
+        "exposeInvalidFileMimeTypeOutcome": false,
+        "parsedContent": null,
+        "files": null,
+        "routeData": null,
+        "queryStringData": null,
+        "headers": null,
+        "result": null,
+        "id": "7e20498ffc94dbc6",
+        "nodeId": "Workflow3:96f60810318a6a89:7e20498ffc94dbc6",
+        "name": "HttpEndpoint1",
+        "type": "Elsa.HttpEndpoint",
+        "version": 1,
+        "customProperties": {
+          "canStartWorkflow": true,
+          "runAsynchronously": false
+        },
+        "metadata": {
+          "designer": {
+            "position": {
+              "x": -520,
+              "y": -120
+            },
+            "size": {
+              "width": 176.390625,
+              "height": 50
+            }
+          }
+        }
+      },
+      {
+        "workflowDefinitionId": "a3390d1f4c2594a8",
+        "workflowDefinitionVersionId": "26d186d68deb1250",
+        "latestAvailablePublishedVersion": 1,
+        "latestAvailablePublishedVersionId": "26d186d68deb1250",
+        "id": "ed6a03040f651906",
+        "nodeId": "Workflow3:96f60810318a6a89:ed6a03040f651906",
+        "name": "Child1",
+        "type": "Child",
+        "version": 1,
+        "customProperties": {
+          "canStartWorkflow": false,
+          "runAsynchronously": false
+        },
+        "metadata": {
+          "designer": {
+            "position": {
+              "x": -236.5810546875,
+              "y": -120
+            },
+            "size": {
+              "width": 67.7734375,
+              "height": 50
+            }
+          }
+        }
+      }
+    ],
+    "connections": [
+      {
+        "source": {
+          "activity": "7e20498ffc94dbc6",
+          "port": "Done"
+        },
+        "target": {
+          "activity": "ed6a03040f651906",
+          "port": "In"
+        }
+      }
+    ]
+  }
+}

--- a/test/unit/Elsa.Workflows.Core.UnitTests/ScheduleActivityExecutionContextTests.cs
+++ b/test/unit/Elsa.Workflows.Core.UnitTests/ScheduleActivityExecutionContextTests.cs
@@ -1,0 +1,30 @@
+using Elsa.Testing.Shared;
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Contracts;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit.Abstractions;
+
+namespace Elsa.Workflows.Core.UnitTests;
+
+public class ScheduleActivityExecutionContextTests(ITestOutputHelper testOutputHelper)
+{
+    private readonly IServiceProvider _serviceProvider = new TestApplicationBuilder(testOutputHelper).Build();
+
+    [Fact(DisplayName = "Scheduling an activity that is not part of the workflow should throw an exception")]
+    public async Task ScheduleActivityAsync_WithActivityNotPartOfWorkflow_ShouldThrowException()
+    {
+        await _serviceProvider.PopulateRegistriesAsync();
+        var writeLineA = new WriteLine("Test");
+        var writeLineB = new WriteLine("Test");
+        var workflow = new Workflow
+        {
+            Root = writeLineA
+        };
+        var workflowGraphBuilder = _serviceProvider.GetRequiredService<IWorkflowGraphBuilder>();
+        var workflowGraph = await workflowGraphBuilder.BuildAsync(workflow);
+        var workflowExecutionContext = await WorkflowExecutionContext.CreateAsync(_serviceProvider, workflowGraph, "test");
+        var activityExecutionContext = workflowExecutionContext.CreateActivityExecutionContext(writeLineA);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => activityExecutionContext.ScheduleActivityAsync(writeLineB).AsTask());
+    }
+}


### PR DESCRIPTION
This PR fixes #5314

It also fixes a potential hash collision issue with the JINT JavaScript evaluator and improves hashing operations by relying on the on-shot `HashData` static method  instead of instantiating SHA256 repeatedly.