### PR TITLE
Revert sending input as global state instead of parameter

### DIFF
--- a/src/modules/Elsa.MassTransit/Services/MassTransitWorkflowDispatcher.cs
+++ b/src/modules/Elsa.MassTransit/Services/MassTransitWorkflowDispatcher.cs
@@ -26,7 +26,6 @@ public class MassTransitWorkflowDispatcher(
     IBookmarkHasher bookmarkHasher,
     ITriggerStore triggerStore,
     IBookmarkStore bookmarkStore,
-    IDistributedLockProvider distributedLockProvider,
     ILogger<MassTransitWorkflowDispatcher> logger)
     : IWorkflowDispatcher
 {

--- a/src/modules/Elsa.MassTransit/Services/MassTransitWorkflowDispatcher.cs
+++ b/src/modules/Elsa.MassTransit/Services/MassTransitWorkflowDispatcher.cs
@@ -11,6 +11,7 @@ using Elsa.Workflows.Runtime.Models;
 using Elsa.Workflows.Runtime.Requests;
 using Elsa.Workflows.Runtime.Responses;
 using MassTransit;
+using Medallion.Threading;
 using Microsoft.Extensions.Logging;
 
 namespace Elsa.MassTransit.Services;
@@ -26,6 +27,7 @@ public class MassTransitWorkflowDispatcher(
     IBookmarkHasher bookmarkHasher,
     ITriggerStore triggerStore,
     IBookmarkStore bookmarkStore,
+    IDistributedLockProvider distributedLockProvider,
     ILogger<MassTransitWorkflowDispatcher> logger)
     : IWorkflowDispatcher
 {
@@ -163,6 +165,8 @@ public class MassTransitWorkflowDispatcher(
 
             if (input != null || properties != null)
             {
+                // Need to acquire a lock on the workflow instance to prevent concurrent updates.
+                await using var distributedLock = await distributedLockProvider.AcquireLockAsync(workflowInstanceId, TimeSpan.FromMinutes(2), cancellationToken);
                 var workflowInstance = await workflowInstanceManager.FindByIdAsync(workflowInstanceId, cancellationToken);
 
                 if (workflowInstance == null)

--- a/test/component/Elsa.Workflows.ComponentTests/Scenarios/BulkDispatchWorkflows/BulkDispatchWorkflowsTests.cs
+++ b/test/component/Elsa.Workflows.ComponentTests/Scenarios/BulkDispatchWorkflows/BulkDispatchWorkflowsTests.cs
@@ -1,0 +1,47 @@
+﻿using Elsa.Workflows.ComponentTests.Scenarios.BulkDispatchWorkflows.Workflows;
+using Elsa.Workflows.Runtime.Contracts;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Elsa.Workflows.ComponentTests.Scenarios.BulkDispatchWorkflows;
+
+public class BulkDispatchWorkflowsTests : AppComponentTest
+{
+    private readonly IWorkflowEvents _workflowEvents;
+    private readonly ISignalManager _signalManager;
+    private readonly IWorkflowRuntime _workflowRuntime;
+    private static readonly object ParentWorkflowCompletedSignal = new();
+
+    public BulkDispatchWorkflowsTests(App app) : base(app)
+    {
+        _workflowRuntime = Scope.ServiceProvider.GetRequiredService<IWorkflowRuntime>();
+        _workflowEvents = Scope.ServiceProvider.GetRequiredService<IWorkflowEvents>();
+        _signalManager = Scope.ServiceProvider.GetRequiredService<ISignalManager>();
+        _workflowEvents.WorkflowInstanceSaved += OnWorkflowInstanceSaved;
+    }
+
+    /// <summary>
+    /// Dispatches and waits for child workflows to complete.
+    /// </summary>
+    [Fact]
+    public async Task DispatchAndWaitWorkflow_ShouldWaitForChildWorkflowToComplete()
+    {
+        await _workflowRuntime.StartWorkflowAsync(GreetEmployeesWorkflow.DefinitionId);
+        var parentWorkflowInstanceArgs = await _signalManager.WaitAsync<WorkflowInstanceSavedEventArgs>(ParentWorkflowCompletedSignal);
+        
+        Assert.Equal(WorkflowStatus.Finished, parentWorkflowInstanceArgs.WorkflowInstance.Status);
+    }
+
+    private void OnWorkflowInstanceSaved(object? sender, WorkflowInstanceSavedEventArgs e)
+    {
+        if(e.WorkflowInstance.Status != WorkflowStatus.Finished)
+            return;
+        
+        if(e.WorkflowInstance.DefinitionId == GreetEmployeesWorkflow.DefinitionId)
+            _signalManager.Trigger(ParentWorkflowCompletedSignal, e);
+    }
+
+    protected override void OnDispose()
+    {
+        _workflowEvents.WorkflowInstanceSaved -= OnWorkflowInstanceSaved;
+    }
+}

--- a/test/component/Elsa.Workflows.ComponentTests/Scenarios/BulkDispatchWorkflows/Workflows/EmployeeGreetingWorkflow.cs
+++ b/test/component/Elsa.Workflows.ComponentTests/Scenarios/BulkDispatchWorkflows/Workflows/EmployeeGreetingWorkflow.cs
@@ -1,0 +1,25 @@
+using Elsa.Extensions;
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Contracts;
+using Hangfire.Annotations;
+
+namespace Elsa.Workflows.ComponentTests.Scenarios.BulkDispatchWorkflows.Workflows;
+
+[UsedImplicitly]
+public class EmployeeGreetingWorkflow : WorkflowBase
+{
+    public static readonly string DefinitionId = Guid.NewGuid().ToString();
+
+    protected override void Build(IWorkflowBuilder builder)
+    {
+        builder.WithDefinitionId(DefinitionId);
+        var employeeName = builder.WithInput<string>("Employee");
+        builder.Root = new Sequence
+        {
+            Activities =
+            {
+                new WriteLine(x => $"Hello {x.GetInput<string>(employeeName)}")
+            }
+        };
+    }
+}

--- a/test/component/Elsa.Workflows.ComponentTests/Scenarios/BulkDispatchWorkflows/Workflows/GreetEmployeesWorkflow.cs
+++ b/test/component/Elsa.Workflows.ComponentTests/Scenarios/BulkDispatchWorkflows/Workflows/GreetEmployeesWorkflow.cs
@@ -1,0 +1,36 @@
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Contracts;
+
+namespace Elsa.Workflows.ComponentTests.Scenarios.BulkDispatchWorkflows.Workflows;
+
+public class GreetEmployeesWorkflow : WorkflowBase
+{
+    public static readonly string DefinitionId = Guid.NewGuid().ToString();
+
+    protected override void Build(IWorkflowBuilder builder)
+    {
+        var employeeNames = new[]
+        {
+            "Alice", "Bob", "Charlie"
+        };
+
+        var inputEntries = employeeNames.Select(x => new Dictionary<string, object>
+        {
+            ["Employee"] = x
+        });
+
+        builder.WithDefinitionId(DefinitionId);
+        builder.Root = new Sequence
+        {
+            Activities =
+            {
+                new Runtime.Activities.BulkDispatchWorkflows
+                {
+                    WorkflowDefinitionId = new(EmployeeGreetingWorkflow.DefinitionId),
+                    Items = new(inputEntries),
+                    WaitForCompletion = new(true)
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
This PR fixes a concurrency issue when sending concurrent workflow execution requests to the same workflow instance with different inputs.

Originally, this change was made to add support for sending large inputs from a parent workflow to a dispatched child workflow via a service bus.

However, that doesn't work when sending multiple messages concurrently, which we are seeing when using BulkDispatchWorkflow where multiple child workflows complete close to one another, overriding the "global" input state associated with the workflow input.

This PR attempts to only store the input with the workflow instance upon instance creation, while sending input alongside the dispatch message when resuming existing ones. The assumption here being that those messages include smaller input payloads.

The correct fix will be to revise the need for associating workflow input with the workflow instance, and instead provide mechanism to stash input externally from the workflow instance and instead passing in an identifier to that input.

Fixes #5417