### PR TITLE
add text/html content parser as string content

### DIFF
--- a/src/modules/Elsa.Http/Features/HttpFeature.cs
+++ b/src/modules/Elsa.Http/Features/HttpFeature.cs
@@ -162,6 +162,7 @@ public class HttpFeature : FeatureBase
             .AddSingleton<IHttpContentParser, JsonHttpContentParser>()
             .AddSingleton<IHttpContentParser, XmlHttpContentParser>()
             .AddSingleton<IHttpContentParser, PlainTextHttpContentParser>()
+            .AddSingleton<IHttpContentParser, TextHtmlHttpContentParser>()
 
             // HTTP content factories.
             .AddScoped<IHttpContentFactory, TextContentFactory>()

--- a/src/modules/Elsa.Http/Parsers/TextHtmlHttpContentParser.cs
+++ b/src/modules/Elsa.Http/Parsers/TextHtmlHttpContentParser.cs
@@ -1,0 +1,24 @@
+﻿using Elsa.Http.Contracts;
+
+namespace Elsa.Http.Parsers;
+
+/// <summary>
+/// Reads text/html content type streams.
+/// </summary>
+// TODO: found a library to use a Html Content Parser and use a complexe object Type, until this, this class allow to accept request send using text/html content-type
+public class TextHtmlHttpContentParser : IHttpContentParser
+{
+    /// <inheritdoc />
+    public int Priority => 0;
+
+    /// <inheritdoc />
+    public bool GetSupportsContentType(string contentType) => contentType.Contains("text/html", StringComparison.InvariantCultureIgnoreCase);
+
+    /// <inheritdoc />
+    public async Task<object> ReadAsync(Stream content, Type? returnType, CancellationToken cancellationToken)
+    {
+        using var reader = new StreamReader(content, leaveOpen: true);
+        var stringContent = await reader.ReadToEndAsync();
+        return stringContent;
+    }
+}


### PR DESCRIPTION

First iteration of a text/html http content parser, this parser handle the request as string but this allow to accept the request.(instead of reject it or set a null value because parser doesn't exist)

fix #5115

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/5460)
<!-- Reviewable:end -->
