### PR TITLE
Remove signal capturing phase

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,5 @@
-# Remove the line below if you want to inherit .editorconfig settings from higher directories
 root = true
+# Remove the line below if you want to inherit .editorconfig settings from higher directories
 
 # C# files
 [*.cs]
@@ -228,3 +228,8 @@ dotnet_naming_style.begins_with_i.required_prefix = I
 dotnet_naming_style.begins_with_i.required_suffix = 
 dotnet_naming_style.begins_with_i.word_separator = 
 dotnet_naming_style.begins_with_i.capitalization = pascal_case
+
+# ReSharper properties
+resharper_max_array_initializer_elements_on_line = 50
+resharper_max_initializer_elements_on_line = 1
+resharper_wrap_array_initializer_style = chop_if_long

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -64,25 +64,25 @@ jobs:
           else
             echo "VERSION=3.2.0-${PACKAGE_PREFIX}.${{github.run_number}}" >> $GITHUB_ENV
           fi
-      - name: Set up JDK 17
-        uses: actions/setup-java@v2
-        with:
-          java-version: '17'
-          distribution: 'adopt'
-      - name: Install SonarScanner for .NET
-        run: dotnet tool install --global dotnet-sonarscanner
-      - name: Install Coverlet for code coverage
-        run: dotnet tool install --global coverlet.console
-      - name: Begin SonarCloud analysis
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: dotnet sonarscanner begin /k:"elsa-workflows_elsa-core" /o:"elsa-workflows" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.exclusions=**/obj/**,**/*.dll,build/**,samples/**,src/bundles/** /d:"sonar.verbose=true" /d:sonar.cs.opencover.reportsPaths=**/testresults/**/coverage.opencover.xml
+#      - name: Set up JDK 17
+#        uses: actions/setup-java@v2
+#        with:
+#          java-version: '17'
+#          distribution: 'adopt'
+#      - name: Install SonarScanner for .NET
+#        run: dotnet tool install --global dotnet-sonarscanner
+#      - name: Install Coverlet for code coverage
+#        run: dotnet tool install --global coverlet.console
+#      - name: Begin SonarCloud analysis
+#        env:
+#          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+#        run: dotnet sonarscanner begin /k:"elsa-workflows_elsa-core" /o:"elsa-workflows" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.exclusions=**/obj/**,**/*.dll,build/**,samples/**,src/bundles/** /d:"sonar.verbose=true" /d:sonar.cs.opencover.reportsPaths=**/testresults/**/coverage.opencover.xml
       - name: Compile+Test+Pack
         run: ./build.sh Compile+Test+Pack --version ${VERSION} --analyseCode true
-      - name: End SonarCloud analysis
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: dotnet sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
+#      - name: End SonarCloud analysis
+#        env:
+#          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+#        run: dotnet sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -64,25 +64,25 @@ jobs:
           else
             echo "VERSION=3.2.0-${PACKAGE_PREFIX}.${{github.run_number}}" >> $GITHUB_ENV
           fi
-#      - name: Set up JDK 17
-#        uses: actions/setup-java@v2
-#        with:
-#          java-version: '17'
-#          distribution: 'adopt'
-#      - name: Install SonarScanner for .NET
-#        run: dotnet tool install --global dotnet-sonarscanner
-#      - name: Install Coverlet for code coverage
-#        run: dotnet tool install --global coverlet.console
-#      - name: Begin SonarCloud analysis
-#        env:
-#          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-#        run: dotnet sonarscanner begin /k:"elsa-workflows_elsa-core" /o:"elsa-workflows" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.exclusions=**/obj/**,**/*.dll,build/**,samples/**,src/bundles/** /d:"sonar.verbose=true" /d:sonar.cs.opencover.reportsPaths=**/testresults/**/coverage.opencover.xml
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+      - name: Install SonarScanner for .NET
+        run: dotnet tool install --global dotnet-sonarscanner
+      - name: Install Coverlet for code coverage
+        run: dotnet tool install --global coverlet.console
+      - name: Begin SonarCloud analysis
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: dotnet sonarscanner begin /k:"elsa-workflows_elsa-core" /o:"elsa-workflows" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.exclusions=**/obj/**,**/*.dll,build/**,samples/**,src/bundles/** /d:"sonar.verbose=true" /d:sonar.cs.opencover.reportsPaths=**/testresults/**/coverage.opencover.xml
       - name: Compile+Test+Pack
         run: ./build.sh Compile+Test+Pack --version ${VERSION} --analyseCode true
-#      - name: End SonarCloud analysis
-#        env:
-#          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-#        run: dotnet sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
+      - name: End SonarCloud analysis
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: dotnet sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:

--- a/src/modules/Elsa.Workflows.Core/Abstractions/Behavior.cs
+++ b/src/modules/Elsa.Workflows.Core/Abstractions/Behavior.cs
@@ -7,7 +7,6 @@ namespace Elsa.Workflows;
 public abstract class Behavior : IBehavior
 {
     private readonly ICollection<SignalHandlerRegistration> _signalReceivedHandlers = new List<SignalHandlerRegistration>();
-    private readonly ICollection<SignalHandlerRegistration> _signalCapturedHandlers = new List<SignalHandlerRegistration>();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Behavior"/> class.
@@ -72,54 +71,6 @@ public abstract class Behavior : IBehavior
     }
     
     /// <summary>
-    /// Registers a delegate to be invoked when a signal of the specified type is received.
-    /// </summary>
-    /// <param name="signalType">The type of signal to register a handler for.</param>
-    /// <param name="handler">The delegate to invoke when a signal of the specified type is received.</param>
-    protected void OnSignalCaptured(Type signalType, Func<object, SignalContext, ValueTask> handler) => _signalCapturedHandlers.Add(new SignalHandlerRegistration(signalType, handler));
-    
-    /// <summary>
-    /// Registers a delegate to be invoked when a signal of the specified type is received.
-    /// </summary>
-    /// <param name="handler">The delegate to invoke when a signal of the specified type is received.</param>
-    /// <typeparam name="T">The type of signal to register a handler for.</typeparam>
-    protected void OnSignalCaptured<T>(Func<T, SignalContext, ValueTask> handler) => OnSignalCaptured(typeof(T), (signal, context) => handler((T)signal, context));
-
-    /// <summary>
-    /// Registers a delegate to be invoked when a signal of the specified type is received.
-    /// </summary>
-    /// <param name="handler">The delegate to invoke when a signal of the specified type is received.</param>
-    /// <typeparam name="T">The type of signal to register a handler for.</typeparam>
-    protected void OnSignalCaptured<T>(Action<T, SignalContext> handler)
-    {
-        OnSignalCaptured<T>((signal, context) =>
-        {
-            handler(signal, context);
-            return ValueTask.CompletedTask;
-        });
-    }
-    
-    /// <summary>
-    /// Registers a delegate to be invoked when a signal of the specified type is received.
-    /// </summary>
-    /// <param name="signal">The type of signal to register a handler for.</param>
-    /// <param name="context">The signal context.</param>
-    protected virtual ValueTask OnSignalCapturedAsync(object signal, SignalContext context)
-    {
-        OnSignalCaptured(signal, context);
-        return ValueTask.CompletedTask;
-    }
-
-    /// <summary>
-    /// Registers a delegate to be invoked when a signal of the specified type is received.
-    /// </summary>
-    /// <param name="signal">The signal to register a handler for.</param>
-    /// <param name="context">The signal context.</param>
-    protected virtual void OnSignalCaptured(object signal, SignalContext context)
-    {
-    }
-
-    /// <summary>
     /// 
     /// </summary>
     /// <param name="context"></param>
@@ -137,20 +88,7 @@ public abstract class Behavior : IBehavior
     protected virtual void Execute(ActivityExecutionContext context)
     {
     }
-
-    async ValueTask ISignalHandler.CaptureSignalAsync(object signal, SignalContext context)
-    {
-        // Give derived activity a chance to do something with the signal.
-        await OnSignalCapturedAsync(signal, context);
-
-        // Invoke registered signal delegates for this particular type of signal.
-        var signalType = signal.GetType();
-        var handlers = _signalCapturedHandlers.Where(x => x.SignalType == signalType);
-
-        foreach (var registration in handlers)
-            await registration.Handler(signal, context);
-    }
-
+    
     async ValueTask ISignalHandler.ReceiveSignalAsync(object signal, SignalContext context)
     {
         // Give derived activity a chance to do something with the signal.

--- a/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Activities/Flowchart.cs
+++ b/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Activities/Flowchart.cs
@@ -212,7 +212,7 @@ public class Flowchart : Container
                         };
 
                         if (joinContext != null)
-                            logger.LogDebug("Next activity {ChildActivityId} is a join activity. Attaching to existing context {JoinContext}", activity.Id, joinContext.Id);
+                            logger.LogDebug("Next activity {ChildActivityId} is a join activity. Attaching to existing join context {JoinContext}", activity.Id, joinContext.Id);
                         else
                             logger.LogDebug("Next activity {ChildActivityId} is a join activity", activity.Id);
                         
@@ -237,13 +237,10 @@ public class Flowchart : Container
 
         if (!hasPendingWork)
         {
-            logger.LogDebug("No pending work found");
             var hasFaultedActivities = context.GetActiveChildren().Any(x => x.Status == ActivityStatus.Faulted);
 
             if (!hasFaultedActivities)
             {
-                logger.LogDebug("No faulted activities found");
-                logger.LogDebug("Completing flowchart");
                 await context.CompleteActivityAsync();
             }
         }

--- a/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Activities/Flowchart.cs
+++ b/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Activities/Flowchart.cs
@@ -168,7 +168,6 @@ public class Flowchart : Container
         // If the complete activity is a terminal node, complete the flowchart immediately.
         if (completedActivity is ITerminalNode)
         {
-            logger.LogDebug("Completed activity {ActivityId} is a terminal activity. Completing flowchart", completedActivity.Id);
             await flowchartContext.CompleteActivityAsync();
         }
         else if (scheduleChildren)
@@ -214,7 +213,7 @@ public class Flowchart : Container
                         if (joinContext != null)
                             logger.LogDebug("Next activity {ChildActivityId} is a join activity. Attaching to existing join context {JoinContext}", activity.Id, joinContext.Id);
                         else
-                            logger.LogDebug("Next activity {ChildActivityId} is a join activity", activity.Id);
+                            logger.LogDebug("Next activity {ChildActivityId} is a join activity. Creating new join context", activity.Id);
                         
                         await flowchartContext.ScheduleActivityAsync(activity, scheduleWorkOptions);
                     }

--- a/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Activities/Flowchart.cs
+++ b/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Activities/Flowchart.cs
@@ -167,7 +167,8 @@ public class Flowchart : Container
         var loggerScopeState = new Dictionary<string, object>
         {
             ["ThreadId"] = Thread.CurrentThread.ManagedThreadId,
-            ["ActivityId"] = context
+            ["ActivityId"] = Id,
+            ["ActivityInstanceId"] = context.TargetContext.Id
         };
         using var loggerScope = logger.BeginScope(loggerScopeState);
 

--- a/src/modules/Elsa.Workflows.Core/Contracts/ISignalHandler.cs
+++ b/src/modules/Elsa.Workflows.Core/Contracts/ISignalHandler.cs
@@ -6,11 +6,6 @@ namespace Elsa.Workflows.Contracts;
 public interface ISignalHandler
 {
     /// <summary>
-    /// Captures a signal.
-    /// </summary>
-    ValueTask CaptureSignalAsync(object signal, SignalContext context);
-    
-    /// <summary>
     /// Receives a signal.
     /// </summary>
     ValueTask ReceiveSignalAsync(object signal, SignalContext context);

--- a/src/modules/Elsa.Workflows.Core/Services/WorkflowRunner.cs
+++ b/src/modules/Elsa.Workflows.Core/Services/WorkflowRunner.cs
@@ -6,6 +6,7 @@ using Elsa.Workflows.Models;
 using Elsa.Workflows.Notifications;
 using Elsa.Workflows.Options;
 using Elsa.Workflows.State;
+using Microsoft.Extensions.Logging;
 
 namespace Elsa.Workflows.Services;
 
@@ -17,7 +18,8 @@ public class WorkflowRunner(
     IWorkflowBuilderFactory workflowBuilderFactory,
     IWorkflowGraphBuilder workflowGraphBuilder,
     IIdentityGenerator identityGenerator,
-    INotificationSender notificationSender)
+    INotificationSender notificationSender,
+    ILogger<WorkflowRunner> logger)
     : IWorkflowRunner
 {
     /// <inheritdoc />
@@ -37,7 +39,8 @@ public class WorkflowRunner(
     }
 
     /// <inheritdoc />
-    public async Task<RunWorkflowResult<TResult>> RunAsync<TResult>(WorkflowBase<TResult> workflow, RunWorkflowOptions? options = default, CancellationToken cancellationToken = default)
+    public async Task<RunWorkflowResult<TResult>> RunAsync<TResult>(WorkflowBase<TResult> workflow, RunWorkflowOptions? options = default,
+        CancellationToken cancellationToken = default)
     {
         var result = await RunAsync((IWorkflow)workflow, options, cancellationToken);
         return new RunWorkflowResult<TResult>(result.WorkflowState, result.Workflow, (TResult)result.Result!);
@@ -102,14 +105,16 @@ public class WorkflowRunner(
     }
 
     /// <inheritdoc />
-    public async Task<RunWorkflowResult> RunAsync(Workflow workflow, WorkflowState workflowState, RunWorkflowOptions? options = default, CancellationToken cancellationToken = default)
+    public async Task<RunWorkflowResult> RunAsync(Workflow workflow, WorkflowState workflowState, RunWorkflowOptions? options = default,
+        CancellationToken cancellationToken = default)
     {
         var workflowGraph = await workflowGraphBuilder.BuildAsync(workflow, cancellationToken);
         return await RunAsync(workflowGraph, workflowState, options, cancellationToken);
     }
-    
+
     /// <inheritdoc />
-    public async Task<RunWorkflowResult> RunAsync(WorkflowGraph workflowGraph, WorkflowState workflowState, RunWorkflowOptions? options = default, CancellationToken cancellationToken = default)
+    public async Task<RunWorkflowResult> RunAsync(WorkflowGraph workflowGraph, WorkflowState workflowState, RunWorkflowOptions? options = default,
+        CancellationToken cancellationToken = default)
     {
         // Create workflow execution context.
         var input = options?.Input;
@@ -161,7 +166,8 @@ public class WorkflowRunner(
         }
         else if (activityInstanceId != null)
         {
-            var activityExecutionContext = workflowExecutionContext.ActivityExecutionContexts.FirstOrDefault(x => x.Id == activityInstanceId) ?? throw new Exception("No activity execution context found with the specified ID.");
+            var activityExecutionContext = workflowExecutionContext.ActivityExecutionContexts.FirstOrDefault(x => x.Id == activityInstanceId) ??
+                                           throw new Exception("No activity execution context found with the specified ID.");
             workflowExecutionContext.ScheduleActivityExecutionContext(activityExecutionContext);
         }
         else if (workflowExecutionContext.Scheduler.HasAny)
@@ -180,6 +186,12 @@ public class WorkflowRunner(
     /// <inheritdoc />
     public async Task<RunWorkflowResult> RunAsync(WorkflowExecutionContext workflowExecutionContext)
     {
+        var workflowInstanceId = workflowExecutionContext.Id;
+        var logContext = new Dictionary<string, object>
+        {
+            ["WorkflowInstanceId"] = workflowInstanceId
+        };
+        using var loggingScope = logger.BeginScope(logContext);
         var workflow = workflowExecutionContext.Workflow;
         var applicationCancellationToken = workflowExecutionContext.CancellationTokens.ApplicationCancellationToken;
         var systemCancellationToken = workflowExecutionContext.CancellationTokens.SystemCancellationToken;

--- a/src/modules/Elsa.Workflows.Management/Activities/WorkflowDefinitionActivity/WorkflowDefinitionActivity.cs
+++ b/src/modules/Elsa.Workflows.Management/Activities/WorkflowDefinitionActivity/WorkflowDefinitionActivity.cs
@@ -165,10 +165,10 @@ public class WorkflowDefinitionActivity : Composite, IInitializable
         return workflowGraph;
     }
 
-    private ActivityDescriptor FindActivityDescriptor(IServiceProvider serviceProvider)
+    private ActivityDescriptor? FindActivityDescriptor(IServiceProvider serviceProvider)
     {
         var activityRegistry = serviceProvider.GetRequiredService<IActivityRegistry>();
-        return activityRegistry.Find(Type, Version) ?? activityRegistry.Find(Type) ?? throw new Exception($"Could not find activity descriptor for {Type}.");
+        return activityRegistry.Find(Type, Version) ?? activityRegistry.Find(Type);
     }
 
     async ValueTask IInitializable.InitializeAsync(InitializationContext context)
@@ -188,10 +188,18 @@ public class WorkflowDefinitionActivity : Composite, IInitializable
 
         var activityDescriptor = FindActivityDescriptor(serviceProvider);
 
-        // Declare input and output variables.
-        DeclareInputAsVariables(activityDescriptor, (_, variable) => Variables.Declare(variable));
-        DeclareOutputAsVariables(activityDescriptor, (_, variable) => Variables.Declare(variable));
-
+        if (activityDescriptor == null)
+        {
+            var logger = serviceProvider.GetRequiredService<ILogger<WorkflowDefinitionActivity>>();
+            logger.LogWarning("Could not find activity descriptor for activity type {ActivityType}", Type);
+        }
+        else
+        {
+            // Declare input and output variables.
+            DeclareInputAsVariables(activityDescriptor, (_, variable) => Variables.Declare(variable));
+            DeclareOutputAsVariables(activityDescriptor, (_, variable) => Variables.Declare(variable));
+        }
+        
         // Set the root activity.
         Root = workflowGraph.Workflow;
     }


### PR DESCRIPTION
The signal capturing phase was introduced at some point in the past as an experiment, but is not actively used. Removing this increases activity execution by removing unused looping through activity execution context hierarchies.