### PR TITLE
Add activity existence check in Flowchart

### DIFF
--- a/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Activities/Flowchart.cs
+++ b/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Activities/Flowchart.cs
@@ -175,11 +175,12 @@ public class Flowchart : Container
         {
             if (children.Any())
             {
-                scope.AddActivities(children);
-
                 // Schedule each child, but only if all of its left inbound activities have already executed.
                 foreach (var activity in children)
                 {
+                    var existingActivity = scope.ContainsActivity(activity);
+                    scope.AddActivity(activity);
+                    
                     var inboundActivities = Connections.LeftInboundActivities(activity).ToList();
 
                     // If the completed activity is not part of the left inbound path, always allow its children to be scheduled.
@@ -213,8 +214,13 @@ public class Flowchart : Container
 
                         if (joinContext != null)
                             logger.LogDebug("Next activity {ChildActivityId} is a join activity. Attaching to existing join context {JoinContext}", activity.Id, joinContext.Id);
-                        else
+                        else if(!existingActivity)
                             logger.LogDebug("Next activity {ChildActivityId} is a join activity. Creating new join context", activity.Id);
+                        else
+                        {
+                            logger.LogDebug("Next activity {ChildActivityId} is a join activity. Join context was not found, but activity is already being created.", activity.Id);
+                            continue;
+                        }
                         
                         await flowchartContext.ScheduleActivityAsync(activity, scheduleWorkOptions);
                     }

--- a/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Models/FlowScope.cs
+++ b/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Models/FlowScope.cs
@@ -45,6 +45,11 @@ internal class FlowScope
         return state;
 
     }
+
+    public bool ContainsActivity(IActivity activity)
+    {
+        return Activities.ContainsKey(activity.Id);
+    }
     
     public void RegisterActivityExecution(IActivity activity)
     {


### PR DESCRIPTION
This update prevents the creation of multiple flow activities by checking if the activity is already set to be created while the activity context has not yet been created.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/5544)
<!-- Reviewable:end -->
