### PR TITLE
Add application roles and configure them in MassTransit

### DIFF
--- a/src/bundles/Elsa.Server.Web/Enums/ApplicationRole.cs
+++ b/src/bundles/Elsa.Server.Web/Enums/ApplicationRole.cs
@@ -1,0 +1,8 @@
+namespace Elsa.Server.Web;
+
+public enum ApplicationRole
+{
+    Hybrid,
+    Api,
+    Worker
+}

--- a/src/bundles/Elsa.Server.Web/Program.cs
+++ b/src/bundles/Elsa.Server.Web/Program.cs
@@ -48,7 +48,7 @@ const bool useMemoryStores = false;
 const bool useCaching = true;
 const bool useReadOnlyMode = false;
 const DistributedCachingTransport distributedCachingTransport = DistributedCachingTransport.MassTransit;
-const MassTransitBroker useMassTransitBroker = MassTransitBroker.Memory;
+const MassTransitBroker useMassTransitBroker = MassTransitBroker.RabbitMq;
 
 var builder = WebApplication.CreateBuilder(args);
 var services = builder.Services;
@@ -64,6 +64,7 @@ var azureServiceBusConnectionString = configuration.GetConnectionString("AzureSe
 var rabbitMqConnectionString = configuration.GetConnectionString("RabbitMq")!;
 var redisConnectionString = configuration.GetConnectionString("Redis")!;
 var distributedLockProviderName = configuration.GetSection("Runtime")["DistributedLockProvider"];
+var appRole = Enum.Parse<ApplicationRole>(configuration["AppRole"]);
 
 // Add Elsa services.
 services
@@ -324,6 +325,9 @@ services
         {
             elsa.UseMassTransit(massTransit =>
             {
+                if (appRole == ApplicationRole.Api)
+                    massTransit.DisableConsumers = true;
+
                 if (useMassTransitBroker == MassTransitBroker.AzureServiceBus)
                 {
                     massTransit.UseAzureServiceBus(azureServiceBusConnectionString, serviceBusFeature => serviceBusFeature.ConfigureServiceBus = bus =>

--- a/src/bundles/Elsa.Server.Web/appsettings.json
+++ b/src/bundles/Elsa.Server.Web/appsettings.json
@@ -96,6 +96,7 @@
       }
     ]
   },
+  "AppRole": "Hybrid",
   "Runtime": {
     "WorkflowInboxCleanup": {
       "SweepInterval": "00:00:10:00",

--- a/src/modules/Elsa.MassTransit.AzureServiceBus/Features/AzureServiceBusFeature.cs
+++ b/src/modules/Elsa.MassTransit.AzureServiceBus/Features/AzureServiceBusFeature.cs
@@ -85,19 +85,22 @@ public class AzureServiceBusFeature : FeatureBase
                     configurator.SetupWorkflowDispatcherEndpoints(context);
                     ConfigureServiceBus?.Invoke(configurator);
                     var instanceNameProvider = context.GetRequiredService<IApplicationInstanceNameProvider>();
-                    
-                    foreach (var consumer in temporaryConsumers)
-                    {
-                        var queueName = $"{consumer.Name}-{instanceNameProvider.GetName()}";
-                        configurator.ReceiveEndpoint(queueName, endpointConfigurator =>
-                        {
-                            endpointConfigurator.AutoDeleteOnIdle = options.TemporaryQueueTtl ?? TimeSpan.FromHours(1);
-                            endpointConfigurator.ConcurrentMessageLimit = options.ConcurrentMessageLimit;
-                            endpointConfigurator.ConfigureConsumer(context, consumer.ConsumerType);
-                        });
-                    }
 
-                    configurator.ConfigureEndpoints(context, new KebabCaseEndpointNameFormatter("Elsa", false));
+                    if (!massTransitFeature.DisableConsumers)
+                    {
+                        foreach (var consumer in temporaryConsumers)
+                        {
+                            var queueName = $"{consumer.Name}-{instanceNameProvider.GetName()}";
+                            configurator.ReceiveEndpoint(queueName, endpointConfigurator =>
+                            {
+                                endpointConfigurator.AutoDeleteOnIdle = options.TemporaryQueueTtl ?? TimeSpan.FromHours(1);
+                                endpointConfigurator.ConcurrentMessageLimit = options.ConcurrentMessageLimit;
+                                endpointConfigurator.ConfigureConsumer(context, consumer.ConsumerType);
+                            });
+                        }
+
+                        configurator.ConfigureEndpoints(context, new KebabCaseEndpointNameFormatter("Elsa", false));
+                    }
                 });
             };
         });

--- a/src/modules/Elsa.MassTransit.RabbitMq/Features/RabbitMqServiceBusFeature.cs
+++ b/src/modules/Elsa.MassTransit.RabbitMq/Features/RabbitMqServiceBusFeature.cs
@@ -68,24 +68,27 @@ public class RabbitMqServiceBusFeature : FeatureBase
                     
                     ConfigureServiceBus?.Invoke(configurator);
 
-                    foreach (var consumer in temporaryConsumers)
+                    if (!massTransitFeature.DisableConsumers)
                     {
-                        configurator.ReceiveEndpoint($"{instanceNameProvider.GetName()}-{consumer.Name}",
-                            endpointConfigurator =>
-                            {
-                                endpointConfigurator.QueueExpiration = options.TemporaryQueueTtl ?? TimeSpan.FromHours(1);
-                                endpointConfigurator.ConcurrentMessageLimit = options.ConcurrentMessageLimit;
-                                endpointConfigurator.Durable = false;
-                                endpointConfigurator.AutoDelete = true;
-                                endpointConfigurator.ConfigureConsumer(context, consumer.ConsumerType);
-                            });
-                    }
+                        foreach (var consumer in temporaryConsumers)
+                        {
+                            configurator.ReceiveEndpoint($"{instanceNameProvider.GetName()}-{consumer.Name}",
+                                endpointConfigurator =>
+                                {
+                                    endpointConfigurator.QueueExpiration = options.TemporaryQueueTtl ?? TimeSpan.FromHours(1);
+                                    endpointConfigurator.ConcurrentMessageLimit = options.ConcurrentMessageLimit;
+                                    endpointConfigurator.Durable = false;
+                                    endpointConfigurator.AutoDelete = true;
+                                    endpointConfigurator.ConfigureConsumer(context, consumer.ConsumerType);
+                                });
+                        }
 
-                    // Only configure the dispatcher endpoints if the Masstransit Workflow Dispatcher feature is enabled.
-                    if (Module.HasFeature<MassTransitWorkflowDispatcherFeature>())
-                        configurator.SetupWorkflowDispatcherEndpoints(context);
-                    
-                    configurator.ConfigureEndpoints(context, new KebabCaseEndpointNameFormatter("Elsa", false));
+                        // Only configure the dispatcher endpoints if the Masstransit Workflow Dispatcher feature is enabled.
+                        if (Module.HasFeature<MassTransitWorkflowDispatcherFeature>())
+                            configurator.SetupWorkflowDispatcherEndpoints(context);
+
+                        configurator.ConfigureEndpoints(context, new KebabCaseEndpointNameFormatter("Elsa", false));
+                    }
                 });
             };
         });


### PR DESCRIPTION
A new enum ApplicationRole has been added for distinguishing among different roles (Hybrid, Api, Worker) an application can take. In the configuration of MassTransit, it is now possible to disable the consumers based on application role, which can help optimize the usage of resources and increase application efficiency.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/5561)
<!-- Reviewable:end -->
