### PR TITLE
Fixed DI registration for MongoAlterationPlanStore

### DIFF
--- a/src/modules/Elsa.MongoDb/Modules/Alterations/Feature.cs
+++ b/src/modules/Elsa.MongoDb/Modules/Alterations/Feature.cs
@@ -3,6 +3,7 @@ using Elsa.Alterations.Features;
 using Elsa.Features.Attributes;
 using Elsa.Features.Services;
 using Elsa.MongoDb.Common;
+using Elsa.MongoDb.Modules.Alterations.Documents;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Elsa.MongoDb.Modules.Alterations;
@@ -23,7 +24,10 @@ public class MongoAlterationsPersistenceFeature(IModule module) : PersistenceFea
     {
         base.Apply();
 
+        AddCollection<AlterationPlanDocument>("alteration_plans");
         AddCollection<AlterationJob>("alteration_jobs");
+
+        AddStore<AlterationPlanDocument, MongoAlterationPlanStore>();
         AddStore<AlterationJob, MongoAlterationJobStore>();
 
         Services.AddHostedService<CreateIndices>();


### PR DESCRIPTION
Fixes DI issue related to `MongoAlterationPlanStore` introduced in #5555.

`MongoDbStore<AlterationPlanDocument>` and `IMongoCollection<AlterationPlanDocument>` weren't actually registered in the DI container, so trying to resolve them from `IServiceProvider` failed.

This was caused by me not committing all changes when I refactored how they were resolved in `MongoAlterationPlanStore`'s constructor: initially I was instantiating them using `IMongoDatabase`, but when I refactored the constructor to resolve them from the DI container I actually forgot to commit and push all the changes I made before opening a PR.

I re-tested everything and it works as expected now. Sorry!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/5564)
<!-- Reviewable:end -->
