### PR TITLE
Fix MT consumer registration when DisableConsumers is set

### DIFF
--- a/src/bundles/Elsa.Server.Web/Elsa.Server.Web.csproj
+++ b/src/bundles/Elsa.Server.Web/Elsa.Server.Web.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\modules\Elsa.Caching.Distributed.MassTransit\Elsa.Caching.Distributed.MassTransit.csproj" />
+        <ProjectReference Include="..\..\modules\Elsa.Caching.Distributed.MassTransit\Elsa.Caching.Distributed.MassTransit.csproj"/>
         <ProjectReference Include="..\..\modules\Elsa.EntityFrameworkCore.PostgreSql\Elsa.EntityFrameworkCore.PostgreSql.csproj"/>
         <ProjectReference Include="..\..\modules\Elsa.MassTransit.AzureServiceBus\Elsa.MassTransit.AzureServiceBus.csproj"/>
         <ProjectReference Include="..\Elsa\Elsa.csproj"/>
@@ -52,14 +52,10 @@
         <PackageReference Include="Proto.Persistence.Sqlite"/>
         <PackageReference Include="Proto.Persistence.SqlServer"/>
     </ItemGroup>
-
+    
+    <!--Overridden for vulnaribility reasons with dependencies referencing older versions of Npgsql.-->
     <ItemGroup>
-        <PackageReference Include="Npgsql" VersionOverride="8.0.3" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <Folder Include="App_Data\"/>
-        <Folder Include="Workflows\" />
+        <PackageReference Include="Npgsql" VersionOverride="8.0.3"/>
     </ItemGroup>
 
 </Project>

--- a/src/modules/Elsa.Caching.Distributed.MassTransit/Features/MassTransitDistributedCacheFeature.cs
+++ b/src/modules/Elsa.Caching.Distributed.MassTransit/Features/MassTransitDistributedCacheFeature.cs
@@ -20,7 +20,7 @@ public class MassTransitDistributedCacheFeature(IModule module) : FeatureBase(mo
     /// <inheritdoc />
     public override void Configure()
     {
-        Module.AddMassTransitConsumer<TriggerChangeTokenSignalConsumer>("elsa-trigger-change-token-signal", true);
+        Module.AddMassTransitConsumer<TriggerChangeTokenSignalConsumer>("elsa-trigger-change-token-signal", true, true);
         Module.Use<DistributedCacheFeature>(feature => feature.WithChangeTokenSignalPublisher(sp => sp.GetRequiredService<MassTransitChangeTokenSignalPublisher>()));
     }
 

--- a/src/modules/Elsa.MassTransit.AzureServiceBus/Features/AzureServiceBusFeature.cs
+++ b/src/modules/Elsa.MassTransit.AzureServiceBus/Features/AzureServiceBusFeature.cs
@@ -82,7 +82,6 @@ public class AzureServiceBusFeature : FeatureBase
                     configurator.ConcurrentMessageLimit = options.ConcurrentMessageLimit;
                     
                     configurator.UseServiceBusMessageScheduler();
-                    configurator.SetupWorkflowDispatcherEndpoints(context);
                     ConfigureServiceBus?.Invoke(configurator);
                     var instanceNameProvider = context.GetRequiredService<IApplicationInstanceNameProvider>();
 
@@ -98,6 +97,10 @@ public class AzureServiceBusFeature : FeatureBase
                                 endpointConfigurator.ConfigureConsumer(context, consumer.ConsumerType);
                             });
                         }
+                        
+                        // Only configure the dispatcher endpoints if the Masstransit Workflow Dispatcher feature is enabled.
+                        if (Module.HasFeature<MassTransitWorkflowDispatcherFeature>())
+                            configurator.SetupWorkflowDispatcherEndpoints(context);
 
                         configurator.ConfigureEndpoints(context, new KebabCaseEndpointNameFormatter("Elsa", false));
                     }

--- a/src/modules/Elsa.MassTransit/Extensions/MassTransitFeatureExtensions.cs
+++ b/src/modules/Elsa.MassTransit/Extensions/MassTransitFeatureExtensions.cs
@@ -18,27 +18,28 @@ public static class MassTransitFeatureExtensions
     /// <summary>
     /// Registers the specified type for MassTransit service bus consumer discovery.
     /// </summary>
-    public static MassTransitFeature AddConsumer<T>(this MassTransitFeature feature, string? name, bool isTemporary) where T : IConsumer => feature.AddConsumer(typeof(T), name, isTemporary);
+    public static MassTransitFeature AddConsumer<T>(this MassTransitFeature feature, string? name, bool isTemporary, bool ignoreConsumersDisabled = false) where T : IConsumer =>
+        feature.AddConsumer(typeof(T), name, isTemporary, ignoreConsumersDisabled: ignoreConsumersDisabled);
 
     /// <summary>
     /// Registers the specified type for MassTransit service bus consumer discovery.
     /// </summary>
     /// <typeparam name="T">The consumer type.</typeparam>
     /// <typeparam name="TDefinition">The consumer definition type.</typeparam>
-    public static MassTransitFeature AddConsumer<T, TDefinition>(this MassTransitFeature feature, string? name, bool isTemporary) 
-        where T : IConsumer 
+    public static MassTransitFeature AddConsumer<T, TDefinition>(this MassTransitFeature feature, string? name, bool isTemporary, bool ignoreConsumersDisabled = false)
+        where T : IConsumer
         where TDefinition : IConsumerDefinition
     {
-        return feature.AddConsumer(typeof(T), name, isTemporary, typeof(TDefinition));
+        return feature.AddConsumer(typeof(T), name, isTemporary, typeof(TDefinition), ignoreConsumersDisabled);
     }
 
     /// <summary>
     /// Registers the specified type for MassTransit service bus consumer discovery.
     /// </summary>
-    public static MassTransitFeature AddConsumer(this MassTransitFeature feature, Type type, string? name, bool isTemporary, Type? consumerDefinitionType = default)
+    public static MassTransitFeature AddConsumer(this MassTransitFeature feature, Type type, string? name, bool isTemporary, Type? consumerDefinitionType = default, bool ignoreConsumersDisabled = false)
     {
         var types = feature.Module.Properties.GetOrAdd(ServiceBusConsumerTypesKey, () => new HashSet<ConsumerTypeDefinition>());
-        types.Add(new ConsumerTypeDefinition(type, consumerDefinitionType, name, isTemporary));
+        types.Add(new ConsumerTypeDefinition(type, consumerDefinitionType, name, isTemporary, ignoreConsumersDisabled));
         return feature;
     }
 
@@ -60,7 +61,12 @@ public static class MassTransitFeatureExtensions
     /// <summary>
     /// Returns all collected consumer types.
     /// </summary>
-    public static IEnumerable<ConsumerTypeDefinition> GetConsumers(this MassTransitFeature feature) => feature.Module.Properties.GetOrAdd(ServiceBusConsumerTypesKey, () => new HashSet<ConsumerTypeDefinition>());
+    public static IEnumerable<ConsumerTypeDefinition> GetConsumers(this MassTransitFeature feature)
+    {
+        var definitions = feature.Module.Properties.GetOrAdd(ServiceBusConsumerTypesKey, () => new HashSet<ConsumerTypeDefinition>());
+        var disableConsumers = feature.DisableConsumers;
+        return !disableConsumers ? definitions : definitions.Where(x => x.IgnoreConsumersDisabled).ToList();
+    }
 
     /// <summary>
     /// Returns all collected message types.

--- a/src/modules/Elsa.MassTransit/Extensions/ModuleExtensions.cs
+++ b/src/modules/Elsa.MassTransit/Extensions/ModuleExtensions.cs
@@ -18,20 +18,20 @@ public static class ModuleExtensions
     /// <summary>
     /// Registers the specified consumer with MassTransit.
     /// </summary>
-    public static IModule AddMassTransitConsumer<T>(this IModule module, string? name = null, bool isTemporary = false) where T : IConsumer
+    public static IModule AddMassTransitConsumer<T>(this IModule module, string? name = null, bool isTemporary = false, bool ignoreConsumersDisabled = false) where T : IConsumer
     {
-        module.Configure<MassTransitFeature>(massTransit => massTransit.AddConsumer<T>(name, isTemporary));
+        module.Configure<MassTransitFeature>(massTransit => massTransit.AddConsumer<T>(name, isTemporary, ignoreConsumersDisabled));
         return module;
     }
     
     /// <summary>
     /// Registers the specified consumer and consumer definition with MassTransit.
     /// </summary>
-    public static IModule AddMassTransitConsumer<T, TDefinition>(this IModule module, string? name = null, bool isTemporary = false) 
+    public static IModule AddMassTransitConsumer<T, TDefinition>(this IModule module, string? name = null, bool isTemporary = false, bool ignoreConsumersDisabled = false) 
         where T : IConsumer 
         where TDefinition : IConsumerDefinition
     {
-        module.Configure<MassTransitFeature>(massTransit => massTransit.AddConsumer<T, TDefinition>(name, isTemporary));
+        module.Configure<MassTransitFeature>(massTransit => massTransit.AddConsumer<T, TDefinition>(name, isTemporary, ignoreConsumersDisabled));
         return module;
     }
 }

--- a/src/modules/Elsa.MassTransit/Features/MassTransitFeature.cs
+++ b/src/modules/Elsa.MassTransit/Features/MassTransitFeature.cs
@@ -132,7 +132,6 @@ public class MassTransitFeature : FeatureBase
         {
             var options = context.GetRequiredService<IOptions<MassTransitWorkflowDispatcherOptions>>().Value;
 
-            // Temporary consumers are used for pub/sub, which is used for invalidating local caches and should therefore not be disabled.
             foreach (var consumer in temporaryConsumers)
             {
                 busFactoryConfigurator.ReceiveEndpoint(consumer.Name!, endpoint =>
@@ -142,15 +141,13 @@ public class MassTransitFeature : FeatureBase
                 });
             }
 
-            // Other consumers that represent workers should be disabled when configured as such.
             if (!DisableConsumers)
             {
-                // Only configure the dispatcher endpoints if the Masstransit Workflow Dispatcher feature is enabled.
                 if (Module.HasFeature<MassTransitWorkflowDispatcherFeature>())
                     busFactoryConfigurator.SetupWorkflowDispatcherEndpoints(context);
-
-                busFactoryConfigurator.ConfigureEndpoints(context, new KebabCaseEndpointNameFormatter("Elsa", false));
             }
+
+            busFactoryConfigurator.ConfigureEndpoints(context, new KebabCaseEndpointNameFormatter("Elsa", false));
 
             busFactoryConfigurator.ConfigureJsonSerializerOptions(serializerOptions =>
             {

--- a/src/modules/Elsa.MassTransit/Features/MassTransitFeature.cs
+++ b/src/modules/Elsa.MassTransit/Features/MassTransitFeature.cs
@@ -35,7 +35,7 @@ public class MassTransitFeature : FeatureBase
     /// The number of messages to prefetch.
     [Obsolete("PrefetchCount has been moved to be included in MassTransitOptions")]
     public int? PrefetchCount { get; set; }
-    
+
     public bool DisableConsumers { get; set; }
 
     /// <summary>
@@ -132,7 +132,7 @@ public class MassTransitFeature : FeatureBase
         {
             var options = context.GetRequiredService<IOptions<MassTransitWorkflowDispatcherOptions>>().Value;
 
-            if(!DisableConsumers)
+            if (!DisableConsumers)
             {
                 foreach (var consumer in temporaryConsumers)
                 {
@@ -142,11 +142,14 @@ public class MassTransitFeature : FeatureBase
                         endpoint.ConfigureConsumer(context, consumer.ConsumerType);
                     });
                 }
-                
-                busFactoryConfigurator.SetupWorkflowDispatcherEndpoints(context);
+
+                // Only configure the dispatcher endpoints if the Masstransit Workflow Dispatcher feature is enabled.
+                if (Module.HasFeature<MassTransitWorkflowDispatcherFeature>())
+                    busFactoryConfigurator.SetupWorkflowDispatcherEndpoints(context);
+
                 busFactoryConfigurator.ConfigureEndpoints(context, new KebabCaseEndpointNameFormatter("Elsa", false));
             }
-            
+
             busFactoryConfigurator.ConfigureJsonSerializerOptions(serializerOptions =>
             {
                 var serializer = context.GetRequiredService<IJsonSerializer>();

--- a/src/modules/Elsa.MassTransit/Features/MassTransitWorkflowManagementFeature.cs
+++ b/src/modules/Elsa.MassTransit/Features/MassTransitWorkflowManagementFeature.cs
@@ -22,7 +22,7 @@ public class MassTransitWorkflowManagementFeature(IModule module) : FeatureBase(
     [RequiresUnreferencedCode("The assembly containing the specified marker type will be scanned for activity types.")]
     public override void Configure()
     {
-        Module.AddMassTransitConsumer<WorkflowDefinitionEventsConsumer>("elsa-workflow-definition-updates", true);
+        Module.AddMassTransitConsumer<WorkflowDefinitionEventsConsumer>("elsa-workflow-definition-updates", true, true);
     }
 
     /// <inheritdoc />

--- a/src/modules/Elsa.MassTransit/Models/ConsumerTypeDefinition.cs
+++ b/src/modules/Elsa.MassTransit/Models/ConsumerTypeDefinition.cs
@@ -7,4 +7,5 @@ public record ConsumerTypeDefinition(
     Type ConsumerType,
     Type? ConsumerDefinitionType = default,
     string? Name = null,
-    bool IsTemporary = false);
+    bool IsTemporary = false,
+    bool IgnoreConsumersDisabled = false);

--- a/src/modules/Elsa.Workflows.Management/Services/WorkflowDefinitionActivityRegistryUpdater.cs
+++ b/src/modules/Elsa.Workflows.Management/Services/WorkflowDefinitionActivityRegistryUpdater.cs
@@ -17,7 +17,7 @@ public class WorkflowDefinitionActivityRegistryUpdater(WorkflowDefinitionActivit
     {
         var descriptors = await provider.GetDescriptorsAsync(cancellationToken);
         var descriptorToAdd = descriptors
-            .SingleOrDefault(d =>
+            .FirstOrDefault(d =>
                 d.CustomProperties.TryGetValue("WorkflowDefinitionVersionId", out var val) &&
                 val.ToString() == workflowDefinitionVersionId);
         
@@ -47,7 +47,7 @@ public class WorkflowDefinitionActivityRegistryUpdater(WorkflowDefinitionActivit
         var providerDescriptors = registry.ListByProvider(_providerType);
         
         var descriptorToRemove = providerDescriptors
-            .SingleOrDefault(d =>
+            .FirstOrDefault(d =>
                 d.CustomProperties.TryGetValue("WorkflowDefinitionVersionId", out var val) &&
                 val.ToString() == workflowDefinitionVersionId);
 


### PR DESCRIPTION
This PR fixes two issues:

1. Consumers related to background work such as invoking dispatch workflows were still active when using the Azure Service Bus transport.
2. Consumers related to pub/sub in order to invalidate caches and similar constructs were also disabled. They are now excluded from being disabled.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/5578)
<!-- Reviewable:end -->
