### PR TITLE
Update workflow definition registry and retraction handling

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,9 +23,9 @@
     <PackageVersion Include="DistributedLock.Postgres" Version="1.1.0" />
     <PackageVersion Include="DistributedLock.Redis" Version="1.0.3" />
     <PackageVersion Include="Elastic.Clients.Elasticsearch" Version="8.14.0" />
-    <PackageVersion Include="Elsa.Studio" Version="3.2.0-rc2.351" />
-    <PackageVersion Include="Elsa.Studio.Core.BlazorWasm" Version="3.2.0-rc2.351" />
-    <PackageVersion Include="Elsa.Studio.Login.BlazorWasm" Version="3.2.0-rc2.351" />
+    <PackageVersion Include="Elsa.Studio" Version="3.2.0-rc2.369" />
+    <PackageVersion Include="Elsa.Studio.Core.BlazorWasm" Version="3.2.0-rc2.369" />
+    <PackageVersion Include="Elsa.Studio.Login.BlazorWasm" Version="3.2.0-rc2.369" />
     <PackageVersion Include="FastEndpoints" Version="5.26.0" />
     <PackageVersion Include="FastEndpoints.Security" Version="5.26.0" />
     <PackageVersion Include="FastEndpoints.Swagger" Version="5.26.0" />

--- a/src/modules/Elsa.MassTransit/Contracts/IDistributedWorkflowDefinitionEventsDispatcher.cs
+++ b/src/modules/Elsa.MassTransit/Contracts/IDistributedWorkflowDefinitionEventsDispatcher.cs
@@ -18,6 +18,11 @@ public interface IDistributedWorkflowDefinitionEventsDispatcher
     Task DispatchAsync(WorkflowDefinitionRetracted request, CancellationToken cancellationToken);
 
     /// <summary>
+    /// Dispatches a workflow definition version retracted event.
+    /// </summary>
+    Task DispatchAsync(WorkflowDefinitionVersionRetracted request, CancellationToken cancellationToken);
+
+    /// <summary>
     /// Dispatches a workflow definition deleted event.
     /// </summary>
     Task DispatchAsync(WorkflowDefinitionDeleted request, CancellationToken cancellationToken);

--- a/src/modules/Elsa.MassTransit/Handlers/DistributedWorkflowDefinitionNotificationsHandler.cs
+++ b/src/modules/Elsa.MassTransit/Handlers/DistributedWorkflowDefinitionNotificationsHandler.cs
@@ -9,6 +9,7 @@ namespace Elsa.MassTransit.Handlers;
 public class DistributedWorkflowDefinitionNotificationsHandler(IDistributedWorkflowDefinitionEventsDispatcher distributedEventsDispatcher) :
     INotificationHandler<WorkflowDefinitionPublished>,
     INotificationHandler<WorkflowDefinitionRetracted>,
+    INotificationHandler<WorkflowDefinitionVersionRetracted>,
     INotificationHandler<WorkflowDefinitionDeleted>,
     INotificationHandler<WorkflowDefinitionsDeleted>,
     INotificationHandler<WorkflowDefinitionVersionDeleted>,
@@ -21,8 +22,14 @@ public class DistributedWorkflowDefinitionNotificationsHandler(IDistributedWorkf
             notification.WorkflowDefinition.Options.UsableAsActivity.GetValueOrDefault()), cancellationToken);
 
     /// <inheritdoc />
-    public Task HandleAsync(WorkflowDefinitionRetracted notification, CancellationToken cancellationToken) => 
-        distributedEventsDispatcher.DispatchAsync(new Distributed.WorkflowDefinitionRetracted(notification.WorkflowDefinition.Id), cancellationToken);
+    public Task HandleAsync(WorkflowDefinitionRetracted notification, CancellationToken cancellationToken) =>
+        distributedEventsDispatcher.DispatchAsync(new Distributed.WorkflowDefinitionRetracted(notification.WorkflowDefinition.Id, 
+                notification.WorkflowDefinition.Options.UsableAsActivity.GetValueOrDefault()), cancellationToken);
+
+    /// <inheritdoc />
+    public Task HandleAsync(WorkflowDefinitionVersionRetracted notification, CancellationToken cancellationToken) => 
+        distributedEventsDispatcher.DispatchAsync(new Distributed.WorkflowDefinitionVersionRetracted(notification.WorkflowDefinition.Id, 
+            notification.WorkflowDefinition.Options.UsableAsActivity.GetValueOrDefault()), cancellationToken);
 
     /// <inheritdoc />
     public Task HandleAsync(WorkflowDefinitionDeleted notification, CancellationToken cancellationToken) => 

--- a/src/modules/Elsa.MassTransit/Messages/WorkflowDefinitionVersionRetracted.cs
+++ b/src/modules/Elsa.MassTransit/Messages/WorkflowDefinitionVersionRetracted.cs
@@ -1,9 +1,9 @@
 namespace Elsa.MassTransit.Messages;
 
 /// <summary>
-/// Represents a distributed message that a workflow definition has been retracted.
+/// Represents a distributed message that a workflow definition version has been retracted.
 /// </summary>
-public class WorkflowDefinitionRetracted(string id, bool usableAsActivity)
+public class WorkflowDefinitionVersionRetracted(string id, bool usableAsActivity)
 {
     public string Id { get; set; } = id;
     public bool UsableAsActivity { get; set; } = usableAsActivity;

--- a/src/modules/Elsa.MassTransit/Services/MassTransitDistributedEventsDispatcher.cs
+++ b/src/modules/Elsa.MassTransit/Services/MassTransitDistributedEventsDispatcher.cs
@@ -22,6 +22,12 @@ public class MassTransitDistributedEventsDispatcher(IBus bus) : IDistributedWork
     }
 
     /// <inheritdoc />
+    public Task DispatchAsync(WorkflowDefinitionVersionRetracted request, CancellationToken cancellationToken)
+    {
+        return bus.Publish(request, cancellationToken);
+    }
+
+    /// <inheritdoc />
     public Task DispatchAsync(WorkflowDefinitionDeleted request, CancellationToken cancellationToken)
     {
         return bus.Publish(request, cancellationToken);

--- a/src/modules/Elsa.Workflows.Management/Notifications/WorkflowDefinitionVersionRetracted.cs
+++ b/src/modules/Elsa.Workflows.Management/Notifications/WorkflowDefinitionVersionRetracted.cs
@@ -1,0 +1,12 @@
+using Elsa.Mediator.Contracts;
+using Elsa.Workflows.Management.Entities;
+using JetBrains.Annotations;
+
+namespace Elsa.Workflows.Management.Notifications;
+
+/// <summary>
+/// A notification that is sent when a workflow definition version is retracted.
+/// </summary>
+/// <param name="WorkflowDefinition">The workflow definition.</param>
+[PublicAPI]
+public record WorkflowDefinitionVersionRetracted(WorkflowDefinition WorkflowDefinition) : INotification;

--- a/src/modules/Elsa.Workflows.Management/Services/WorkflowDefinitionPublisher.cs
+++ b/src/modules/Elsa.Workflows.Management/Services/WorkflowDefinitionPublisher.cs
@@ -107,9 +107,13 @@ public class WorkflowDefinitionPublisher : IWorkflowDefinitionPublisher
 
         foreach (var publishedAndOrLatestWorkflow in publishedWorkflows)
         {
+            var isPublished = publishedAndOrLatestWorkflow.IsPublished; 
             publishedAndOrLatestWorkflow.IsPublished = false;
             publishedAndOrLatestWorkflow.IsLatest = false;
             await _workflowDefinitionStore.SaveAsync(publishedAndOrLatestWorkflow, cancellationToken);
+            
+            if (isPublished)
+                await _notificationSender.SendAsync(new WorkflowDefinitionVersionRetracted(publishedAndOrLatestWorkflow), cancellationToken);
         }
 
         // Save the new published definition.


### PR DESCRIPTION
This update enhances the handling of workflow definition retraction across multiple files and includes new notifications for workflow definition version retraction. The logic for updating the workflow definition registry has been adapted to keep published workflows in the registry unless they are no longer marked as an activity.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/5650)
<!-- Reviewable:end -->
