### PR TITLE
Register scheduler as singleton to avoid multiple starts of same task

### DIFF
--- a/src/modules/Elsa.Scheduling/Features/SchedulingFeature.cs
+++ b/src/modules/Elsa.Scheduling/Features/SchedulingFeature.cs
@@ -43,10 +43,10 @@ public class SchedulingFeature : FeatureBase
         Services
             .AddScoped<ITriggerScheduler, DefaultTriggerScheduler>()
             .AddScoped<IBookmarkScheduler, DefaultBookmarkScheduler>()
-            .AddScoped<IScheduler, LocalScheduler>()
+            .AddSingleton<IScheduler, LocalScheduler>()
             .AddScoped<DefaultWorkflowScheduler>()
-            .AddScoped<CronosCronParser>()
-            .AddScoped(CronParser)
+            .AddSingleton<CronosCronParser>()
+            .AddSingleton(CronParser)
             .AddScoped(WorkflowScheduler)
             .AddHandlersFrom<ScheduleWorkflows>();
 


### PR DESCRIPTION
Scoped scheduler can't detect start duplicates because it's called from different scopes and doesn't have shared registry for tasks. (#5499)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/5687)
<!-- Reviewable:end -->
