### PR TITLE
Add WorkflowExecutionLogRecordExtractor

### DIFF
--- a/src/modules/Elsa.Workflows.Runtime/Contracts/IWorkflowExecutionLogRecordExtractor.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Contracts/IWorkflowExecutionLogRecordExtractor.cs
@@ -1,0 +1,10 @@
+using Elsa.Workflows.Runtime.Entities;
+
+namespace Elsa.Workflows.Runtime;
+
+/// Extracts workflow execution log records.
+public interface IWorkflowExecutionLogRecordExtractor
+{
+    /// Extracts workflow execution logs from a workflow execution context.
+    IEnumerable<WorkflowExecutionLogRecord> ExtractWorkflowExecutionLogs(WorkflowExecutionContext context);
+}

--- a/src/modules/Elsa.Workflows.Runtime/Features/WorkflowRuntimeFeature.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Features/WorkflowRuntimeFeature.cs
@@ -231,6 +231,7 @@ public class WorkflowRuntimeFeature : FeatureBase
             .AddScoped<IBookmarkUpdater, BookmarkUpdater>()
             .AddScoped<IBookmarksPersister, BookmarksPersister>()
             .AddScoped<IWorkflowCancellationService, WorkflowCancellationService>()
+            .AddScoped<IWorkflowExecutionLogRecordExtractor, WorkflowExecutionLogRecordExtractor>()
             
             // Stores.
             .AddScoped(BookmarkStore)

--- a/src/modules/Elsa.Workflows.Runtime/Services/StoreWorkflowExecutionLogSink.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Services/StoreWorkflowExecutionLogSink.cs
@@ -1,5 +1,4 @@
 using Elsa.Mediator.Contracts;
-using Elsa.Workflows.Contracts;
 using Elsa.Workflows.Runtime.Contracts;
 using Elsa.Workflows.Runtime.Entities;
 using Elsa.Workflows.Runtime.Notifications;
@@ -9,34 +8,12 @@ namespace Elsa.Workflows.Runtime.Services;
 /// <summary>
 /// This implementation saves <see cref="WorkflowExecutionLogRecord"/> directly through the store.
 /// </summary>
-public class StoreWorkflowExecutionLogSink(IWorkflowExecutionLogStore store, IIdentityGenerator identityGenerator, INotificationSender notificationSender) : IWorkflowExecutionLogSink
+public class StoreWorkflowExecutionLogSink(IWorkflowExecutionLogStore store, IWorkflowExecutionLogRecordExtractor extractor, INotificationSender notificationSender) : IWorkflowExecutionLogSink
 {
     /// <inheritdoc />
     public async Task PersistExecutionLogsAsync(WorkflowExecutionContext context, CancellationToken cancellationToken)
     {
-        var records = context.ExecutionLog.Select(x => new WorkflowExecutionLogRecord
-        {
-            Id = identityGenerator.GenerateId(),
-            ActivityInstanceId = x.ActivityInstanceId,
-            ParentActivityInstanceId = x.ParentActivityInstanceId,
-            ActivityNodeId = x.NodeId,
-            ActivityId = x.ActivityId,
-            ActivityType = x.ActivityType,
-            ActivityTypeVersion = x.ActivityTypeVersion,
-            ActivityName = x.ActivityName,
-            Message = x.Message,
-            EventName = x.EventName,
-            WorkflowDefinitionId = context.Workflow.Identity.DefinitionId,
-            WorkflowDefinitionVersionId = context.Workflow.Identity.Id,
-            WorkflowInstanceId = context.Id,
-            WorkflowVersion = context.Workflow.Version,
-            Source = x.Source,
-            ActivityState = x.ActivityState,
-            Payload = x.Payload,
-            Timestamp = x.Timestamp,
-            Sequence = x.Sequence
-        }).ToList();
-        
+        var records = extractor.ExtractWorkflowExecutionLogs(context).ToList();
         await store.AddManyAsync(records, context.CancellationTokens.SystemCancellationToken);
         await notificationSender.SendAsync(new WorkflowExecutionLogUpdated(context), context.CancellationTokens.SystemCancellationToken);
     }

--- a/src/modules/Elsa.Workflows.Runtime/Services/WorkflowExecutionContext.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Services/WorkflowExecutionContext.cs
@@ -1,7 +1,7 @@
 using Elsa.Workflows.Contracts;
 using Elsa.Workflows.Runtime.Entities;
 
-namespace Elsa.Workflows.Runtime.Mappers;
+namespace Elsa.Workflows.Runtime.Services;
 
 /// <inheritdoc />
 public class WorkflowExecutionLogRecordExtractor(IIdentityGenerator identityGenerator) : IWorkflowExecutionLogRecordExtractor

--- a/src/modules/Elsa.Workflows.Runtime/Services/WorkflowExecutionContext.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Services/WorkflowExecutionContext.cs
@@ -1,0 +1,35 @@
+using Elsa.Workflows.Contracts;
+using Elsa.Workflows.Runtime.Entities;
+
+namespace Elsa.Workflows.Runtime.Mappers;
+
+/// <inheritdoc />
+public class WorkflowExecutionLogRecordExtractor(IIdentityGenerator identityGenerator) : IWorkflowExecutionLogRecordExtractor
+{
+    /// <inheritdoc />
+    public IEnumerable<WorkflowExecutionLogRecord> ExtractWorkflowExecutionLogs(WorkflowExecutionContext context)
+    {
+        return context.ExecutionLog.Select(x => new WorkflowExecutionLogRecord
+        {
+            Id = identityGenerator.GenerateId(),
+            ActivityInstanceId = x.ActivityInstanceId,
+            ParentActivityInstanceId = x.ParentActivityInstanceId,
+            ActivityNodeId = x.NodeId,
+            ActivityId = x.ActivityId,
+            ActivityType = x.ActivityType,
+            ActivityTypeVersion = x.ActivityTypeVersion,
+            ActivityName = x.ActivityName,
+            Message = x.Message,
+            EventName = x.EventName,
+            WorkflowDefinitionId = context.Workflow.Identity.DefinitionId,
+            WorkflowDefinitionVersionId = context.Workflow.Identity.Id,
+            WorkflowInstanceId = context.Id,
+            WorkflowVersion = context.Workflow.Version,
+            Source = x.Source,
+            ActivityState = x.ActivityState,
+            Payload = x.Payload,
+            Timestamp = x.Timestamp,
+            Sequence = x.Sequence
+        });
+    }
+}


### PR DESCRIPTION
Introduced a new service, WorkflowExecutionLogRecordExtractor, to abstract the logic for extracting workflow execution logs records from the WorkflowExecutionContext. Updated StoreWorkflowExecutionLogSink to use this new service, which simplifies the execution log persistence method. This modification enhances code readability and enables potential reuse of the extraction logic.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/5728)
<!-- Reviewable:end -->
