### PR TITLE
Add ActivityNodeIds filter to journal requests

### DIFF
--- a/src/clients/Elsa.Api.Client/Resources/WorkflowInstances/Requests/JournalFilter.cs
+++ b/src/clients/Elsa.Api.Client/Resources/WorkflowInstances/Requests/JournalFilter.cs
@@ -1,22 +1,17 @@
 namespace Elsa.Api.Client.Resources.WorkflowInstances.Requests;
 
-/// <summary>
 /// Represents a request to list journal records.
-/// </summary>
 public class JournalFilter
 {
-    /// <summary>
     /// Gets or sets the activity IDs to filter by.
-    /// </summary>
     public ICollection<string>? ActivityIds { get; set; }
-    
-    /// <summary>
+
+    /// Gets or sets the activity node IDs to filter by.
+    public ICollection<string>? ActivityNodeIds { get; set; }
+
     /// Gets or sets the activity types to filter out.
-    /// </summary>
     public ICollection<string>? ExcludedActivityTypes { get; set; }
 
-    /// <summary>
     /// Gets or sets the event types to filter by.
-    /// </summary>
     public ICollection<string>? EventNames { get; set; }
 }

--- a/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowInstances/Journal/FilteredList/Endpoint.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowInstances/Journal/FilteredList/Endpoint.cs
@@ -39,6 +39,7 @@ internal class Get : ElsaEndpoint<Request, Response>
         {
             WorkflowInstanceId = request.WorkflowInstanceId,
             ActivityIds = request.Filter?.ActivityIds,
+            ActivityNodeIds = request.Filter?.ActivityNodeIds,
             ExcludeActivityTypes = request.Filter?.ExcludedActivityTypes,
             EventNames = request.Filter?.EventNames,
         };

--- a/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowInstances/Journal/FilteredList/Models.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowInstances/Journal/FilteredList/Models.cs
@@ -5,45 +5,32 @@ using FastEndpoints;
 
 namespace Elsa.Workflows.Api.Endpoints.WorkflowInstances.Journal.FilteredList;
 
-/// <summary>
 /// Represents a request for a page of workflow execution log records.
-/// </summary>
 internal class Request
 {
-    /// <summary>
     /// The ID of the workflow instance to get the execution log for.
-    /// </summary>
     [BindFrom("id")] public string WorkflowInstanceId { get; set; } = default!;
     
-    /// <summary>
     /// The filter to apply.
-    /// </summary>
     public JournalFilter? Filter { get; set; }
     
-    /// <summary>
     /// The zero-based page number to get.
-    /// </summary>
     public int? Page { get; set; }
     
-    /// <summary>
     /// The size of the page to get.
-    /// </summary>
     public int? PageSize { get; set; }
-
-    /// <summary>
+    
     /// The number of records to skip.
-    /// </summary>
     public int? Skip { get; set; }
     
-    /// <summary>
     /// The number of records to take.
-    /// </summary>
     public int? Take { get; set; }
 }
 
 internal class JournalFilter
 {
     public ICollection<string>? ActivityIds { get; set; }
+    public ICollection<string>? ActivityNodeIds { get; set; }
     public ICollection<string>? ExcludedActivityTypes { get; set; }
     public ICollection<string>? EventNames { get; set; }
 }


### PR DESCRIPTION
This commit introduces the ActivityNodeIds filter to the journal request models. This enhancement allows filtering logs based on specific activity node IDs, providing more granular control over workflow instance logs. Additionally, unnecessary summary comments have been removed for clarity.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/5741)
<!-- Reviewable:end -->
