### PR TITLE
Update activity ID reference in BroadcastWorkflowProgress

### DIFF
--- a/src/modules/Elsa.Workflows.Api/RealTime/Handlers/BroadcastWorkflowProgress.cs
+++ b/src/modules/Elsa.Workflows.Api/RealTime/Handlers/BroadcastWorkflowProgress.cs
@@ -35,7 +35,7 @@ public class BroadcastWorkflowProgress :
     public async Task HandleAsync(ActivityExecutionLogUpdated notification, CancellationToken cancellationToken)
     {
         var workflowInstanceId = notification.WorkflowExecutionContext.Id;
-        var activityIds = notification.Records.Select(x => x.ActivityId).Distinct().ToList();
+        var activityIds = notification.Records.Select(x => x.ActivityNodeId).Distinct().ToList();
         var stats = (await _activityExecutionStatsService.GetStatsAsync(workflowInstanceId, activityIds, cancellationToken)).ToList();
         var clients = _hubContext.Clients.Group(workflowInstanceId);
         var message = new ActivityExecutionLogUpdatedMessage(stats);


### PR DESCRIPTION
Replaced the use of ActivityId with ActivityNodeId when retrieving distinct activity IDs. This change ensures that we are using the correct node identifier for logging workflow progress.
