### PR TITLE
Make WorkflowContext Storage Backward Compatible

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -62,7 +62,7 @@ jobs:
             TAG_NAME=${TAG_NAME#refs/tags/} # remove the refs/tags/ prefix
             echo "VERSION=${TAG_NAME}" >> $GITHUB_ENV
           else
-            echo "VERSION=3.2.0-rc3.${{github.run_number}}" >> $GITHUB_ENV
+            echo "VERSION=3.2.0-rc4.${{github.run_number}}" >> $GITHUB_ENV
           fi
       - name: Set up JDK 17
         uses: actions/setup-java@v2

--- a/src/modules/Elsa.Common/Extensions/PropertyBagExtensions.cs
+++ b/src/modules/Elsa.Common/Extensions/PropertyBagExtensions.cs
@@ -52,6 +52,20 @@ public static class PropertyBagExtensions
     }
 
     /// <summary>
+    /// Retrieves a value from the PropertyBag based on the provided key.
+    /// </summary>
+    /// <typeparam name="T">The type of the value to retrieve.</typeparam>
+    /// <param name="propertyBag">The PropertyBag to retrieve the value from.</param>
+    /// <param name="key">The key of the value to retrieve.</param>
+    /// <param name="options">Optional JSON serializer options.</param>
+    /// <returns>The value associated with the key.</returns>
+    public static T GetValue<T>(this PropertyBag propertyBag, string key, JsonSerializerOptions? options = null)
+    {
+        var json = propertyBag[key].ToString();
+        return JsonSerializer.Deserialize<T>(json, options);
+    }
+
+    /// <summary>
     /// Sets a value in the PropertyBag based on the provided key.
     /// The value is serialized using JSON.
     /// </summary>

--- a/src/modules/Elsa.WorkflowContexts/Extensions/WorkflowContextWorkflowDefinitionExtensions.cs
+++ b/src/modules/Elsa.WorkflowContexts/Extensions/WorkflowContextWorkflowDefinitionExtensions.cs
@@ -14,6 +14,17 @@ public static class WorkflowContextWorkflowDefinitionExtensions
     /// <returns>The workflow context provider types.</returns>
     public static IEnumerable<Type> GetWorkflowContextProviderTypes(this WorkflowDefinition workflowDefinition)
     {
-        return workflowDefinition.PropertyBag.GetOrAdd(Constants.WorkflowContextProviderTypesKey, () => new List<Type>());
+        // Use customProperties for backward compatibility.
+        var key = Constants.WorkflowContextProviderTypesKey;
+        var bag = workflowDefinition.CustomProperties.ContainsKey(key) ? workflowDefinition.CustomProperties : workflowDefinition.PropertyBag;
+        var contextProviderTypes = bag.GetOrAdd(Constants.WorkflowContextProviderTypesKey, () => new List<Type>());
+        
+        // Copy value into property-bag.
+        workflowDefinition.PropertyBag[key] = contextProviderTypes;
+        
+        // Delete value from custom properties.
+        workflowDefinition.CustomProperties.Remove(key);
+
+        return contextProviderTypes;
     }
 }

--- a/src/modules/Elsa.WorkflowContexts/Extensions/WorkflowExtensions.cs
+++ b/src/modules/Elsa.WorkflowContexts/Extensions/WorkflowExtensions.cs
@@ -16,7 +16,16 @@ public static class WorkflowExtensions
     /// <returns>The workflow context provider types.</returns>
     public static IEnumerable<Type> GetWorkflowContextProviderTypes(this Workflow workflow)
     {
-        var contextProviderTypes = workflow.PropertyBag.GetOrAdd(Constants.WorkflowContextProviderTypesKey, () => new List<String>());
+        // Use customProperties for backward compatibility.
+        var key = Constants.WorkflowContextProviderTypesKey;
+        var bag = workflow.CustomProperties.ContainsKey(key) ? workflow.CustomProperties : workflow.PropertyBag;
+        var contextProviderTypes = bag.GetOrAdd(Constants.WorkflowContextProviderTypesKey, () => new List<string>());
+        
+        // Copy value into property-bag.
+        workflow.PropertyBag[key] = contextProviderTypes;
+        
+        // Delete value from custom properties.
+        workflow.CustomProperties.Remove(key);
 
         var result = new List<Type>();
 


### PR DESCRIPTION
This PR updates the retrieval of workflow context types by first checking the CustomProperties dictionary before checking the PropertyBag (new storage) dictionary. This should ensure that existing workflow definitions continue to operate on workflow context types stored in CustomProperties after upgrading to 3.2.0.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/5850)
<!-- Reviewable:end -->
