### PR TITLE
Add optional refresh parameter

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -62,7 +62,7 @@ jobs:
             TAG_NAME=${TAG_NAME#refs/tags/} # remove the refs/tags/ prefix
             echo "VERSION=${TAG_NAME}" >> $GITHUB_ENV
           else
-            echo "VERSION=3.2.0-rc4.${{github.run_number}}" >> $GITHUB_ENV
+            echo "VERSION=3.2.0-rc5.${{github.run_number}}" >> $GITHUB_ENV
           fi
       - name: Set up JDK 17
         uses: actions/setup-java@v2

--- a/src/clients/Elsa.Api.Client/Resources/ActivityDescriptors/Requests/ListActivityDescriptorsRequest.cs
+++ b/src/clients/Elsa.Api.Client/Resources/ActivityDescriptors/Requests/ListActivityDescriptorsRequest.cs
@@ -1,6 +1,10 @@
+using Refit;
+
 namespace Elsa.Api.Client.Resources.ActivityDescriptors.Requests;
 
-/// <summary>
 /// Represents a request to list activity descriptors.
-/// </summary>
-public record ListActivityDescriptorsRequest;
+public class ListActivityDescriptorsRequest
+{
+    /// Whether to refresh the activity descriptors or not.
+    [Query] public bool Refresh { get; set; }
+}

--- a/src/modules/Elsa.Workflows.Api/Endpoints/ActivityDescriptors/List/Endpoint.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/ActivityDescriptors/List/Endpoint.cs
@@ -1,11 +1,13 @@
 using Elsa.Abstractions;
 using Elsa.Workflows.Contracts;
+using Elsa.Workflows.Management.Activities.WorkflowDefinitionActivity;
+using Elsa.Workflows.Management.Contracts;
 using JetBrains.Annotations;
 
 namespace Elsa.Workflows.Api.Endpoints.ActivityDescriptors.List;
 
 [PublicAPI]
-internal class List(IActivityRegistry registry) : ElsaEndpointWithoutRequest<Response>
+internal class List(IActivityRegistry registry, IActivityRegistryPopulator registryPopulator, WorkflowDefinitionActivityProvider workflowDefinitionActivityProvider) : ElsaEndpointWithoutRequest<Response>
 {
     public override void Configure()
     {
@@ -13,11 +15,16 @@ internal class List(IActivityRegistry registry) : ElsaEndpointWithoutRequest<Res
         ConfigurePermissions("read:*", "read:activity-descriptors");
     }
 
-    public override Task<Response> ExecuteAsync(CancellationToken cancellationToken)
+    public override async Task<Response> ExecuteAsync(CancellationToken cancellationToken)
     {
+        var forceRefresh = Query<bool>("refresh", false);
+
+        if (forceRefresh)
+            await registryPopulator.PopulateRegistryAsync(cancellationToken);
+
         var descriptors = registry.ListAll().ToList();
         var response = new Response(descriptors);
 
-        return Task.FromResult(response);
+        return response;
     }
 }

--- a/src/modules/Elsa.Workflows.Core/Contracts/IActivityRegistry.cs
+++ b/src/modules/Elsa.Workflows.Core/Contracts/IActivityRegistry.cs
@@ -90,5 +90,5 @@ public interface IActivityRegistry : IActivityProvider
     /// <param name="activityProviders">The activity providers used to retrieve the descriptors.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    Task RefreshDescriptors(IEnumerable<IActivityProvider> activityProviders, CancellationToken cancellationToken = default);
+    Task RefreshDescriptorsAsync(IEnumerable<IActivityProvider> activityProviders, CancellationToken cancellationToken = default);
 }

--- a/src/modules/Elsa.Workflows.Core/Services/ActivityRegistry.cs
+++ b/src/modules/Elsa.Workflows.Core/Services/ActivityRegistry.cs
@@ -72,7 +72,7 @@ public class ActivityRegistry(IActivityDescriber activityDescriber, IEnumerable<
     public ValueTask<IEnumerable<ActivityDescriptor>> GetDescriptorsAsync(CancellationToken cancellationToken = default) => new(_manualActivityDescriptors);
 
     /// <inheritdoc />
-    public async Task RefreshDescriptors(IEnumerable<IActivityProvider> activityProviders, CancellationToken cancellationToken = default)
+    public async Task RefreshDescriptorsAsync(IEnumerable<IActivityProvider> activityProviders, CancellationToken cancellationToken = default)
     {
         var providersDictionary = new ConcurrentDictionary<Type, ICollection<ActivityDescriptor>>();
         var activityDescriptors = new ConcurrentDictionary<(string Type, int Version), ActivityDescriptor>();

--- a/src/modules/Elsa.Workflows.Core/Services/ActivityRegistryLookupService.cs
+++ b/src/modules/Elsa.Workflows.Core/Services/ActivityRegistryLookupService.cs
@@ -38,7 +38,7 @@ public class ActivityRegistryLookupService(IActivityRegistry activityRegistry, I
         if (descriptor is not null)
             return descriptor;
 
-        await activityRegistry.RefreshDescriptors(providers);
+        await activityRegistry.RefreshDescriptorsAsync(providers);
         return findPredicate.Invoke();
     }
 }

--- a/src/modules/Elsa.Workflows.Management/Handlers/RefreshActivityRegistry.cs
+++ b/src/modules/Elsa.Workflows.Management/Handlers/RefreshActivityRegistry.cs
@@ -87,7 +87,7 @@ public class RefreshActivityRegistry(IWorkflowDefinitionActivityRegistryUpdater 
 
     private Task UpdateDefinition(string id, bool? usableAsActivity)
     {
-        // Once a workflow has been published it should remain in the activity registry unless no longer being marked as an activity.
+        // Once a workflow has been published, it should remain in the activity registry unless no longer being marked as an activity.
         if (usableAsActivity.GetValueOrDefault())
             return workflowDefinitionActivityRegistryUpdater.AddToRegistry(id);
 

--- a/src/modules/Elsa.Workflows.Management/Services/ActivityRegistryPopulator.cs
+++ b/src/modules/Elsa.Workflows.Management/Services/ActivityRegistryPopulator.cs
@@ -11,6 +11,6 @@ public class ActivityRegistryPopulator(IEnumerable<IActivityProvider> providers,
     /// <inheritdoc />
     public async Task PopulateRegistryAsync(CancellationToken cancellationToken)
     {
-        await registry.RefreshDescriptors(providers, cancellationToken);
+        await registry.RefreshDescriptorsAsync(providers, cancellationToken);
     }
 }


### PR DESCRIPTION
Renamed several `RefreshDescriptors` methods to `RefreshDescriptorsAsync` to reflect their asynchronous nature consistently. Added an optional refresh parameter in the `ListActivityDescriptorsRequest` class and updated related endpoints to handle this parameter, triggering a registry refresh if necessary.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/5876)
<!-- Reviewable:end -->
