### PR TITLE
Refactor journal data access and improve byte[] handling

### DIFF
--- a/src/modules/Elsa.Expressions/Helpers/ObjectConverter.cs
+++ b/src/modules/Elsa.Expressions/Helpers/ObjectConverter.cs
@@ -112,7 +112,13 @@ public static class ObjectConverter
         if (underlyingSourceType == typeof(string) && !underlyingTargetType.IsPrimitive && underlyingTargetType != typeof(object))
         {
             var stringValue = (string)value;
-
+            
+            if (underlyingTargetType == typeof(byte[]))
+            {
+                // Byte arrays are serialized to base64, so in this case, we convert the string back to the requested target type of byte[].
+                return Convert.FromBase64String(stringValue);
+            }
+            
             try
             {
                 var firstChar = stringValue.TrimStart().FirstOrDefault();

--- a/src/modules/Elsa.Scheduling/Activities/Delay.cs
+++ b/src/modules/Elsa.Scheduling/Activities/Delay.cs
@@ -78,7 +78,7 @@ public class Delay : Activity, IActivityPropertyDefaultValueProvider
         var resumeAt = clock.UtcNow.Add(timeSpan);
         var payload = new DelayPayload(resumeAt);
 
-        context.JournalData.Add("ResumeAt", resumeAt);
+        context.JournalData["ResumeAt"] = resumeAt;
         context.CreateBookmark(payload);
     }
 


### PR DESCRIPTION
Switched to dictionary index access for "ResumeAt" in Delay.cs to ensure more efficient updating. Added handling for byte[] in ObjectConverter.cs to correctly deserialize from base64 strings.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/5878)
<!-- Reviewable:end -->
