### PR TITLE
Add alteration logs to workflow execution logs (#5897)

### DIFF
--- a/src/modules/Elsa.Alterations.Core/Contexts/AlterationHandlerContext.cs
+++ b/src/modules/Elsa.Alterations.Core/Contexts/AlterationHandlerContext.cs
@@ -74,11 +74,12 @@ public class AlterationContext
     /// <summary>
     /// Logs a message.
     /// </summary>
+    /// <param name="eventName">The event name to log.</param>
     /// <param name="message">The message to log.</param>
     /// <param name="logLevel">The log level.</param>
-    public void Log(string message, LogLevel logLevel = LogLevel.Information)
+    public void Log(string eventName, string message, LogLevel logLevel = LogLevel.Information)
     {
-        AlterationLog.Add(message, logLevel);
+        AlterationLog.Add(message, logLevel, eventName);
     }
 
     /// <summary>
@@ -104,7 +105,7 @@ public class AlterationContext
     public void Succeed(string message)
     {
         HasSucceeded = true;
-        Log(message, LogLevel.Information);
+        Log($"Alteration {Alteration.GetType().Name} succeeded", message, LogLevel.Information);
     }
 
     /// <summary>
@@ -123,6 +124,6 @@ public class AlterationContext
     public void Fail(string? message = default)
     {
         HasFailed = true;
-        Log(message ?? $"{Alteration.GetType().Name} failed", LogLevel.Error);
+        Log($"Alteration {Alteration.GetType().Name} failed", message ?? $"{Alteration.GetType().Name} failed", LogLevel.Error);
     }
 }

--- a/src/modules/Elsa.Alterations.Core/Models/AlterationLog.cs
+++ b/src/modules/Elsa.Alterations.Core/Models/AlterationLog.cs
@@ -24,15 +24,16 @@ public class AlterationLog
     /// Gets the log entries.
     /// </summary>
     public IReadOnlyCollection<AlterationLogEntry> LogEntries => _logEntries.ToList().AsReadOnly();
-    
+
     /// <summary>
     /// Adds a log entry.
     /// </summary>
     /// <param name="message">The message.</param>
     /// <param name="logLevel">The log level.</param>
-    public void Add(string message, LogLevel logLevel = LogLevel.Information)
+    /// <param name="eventName">The event that generated the log entry.</param>
+    public void Add(string message, LogLevel logLevel = LogLevel.Information, string? eventName = null)
     {
-        var entry = new AlterationLogEntry(message, logLevel, _systemClock.UtcNow);
+        var entry = new AlterationLogEntry(message, logLevel, _systemClock.UtcNow, eventName);
         
         _logEntries.Add(entry);
     }

--- a/src/modules/Elsa.Alterations.Core/Models/AlterationLogEntry.cs
+++ b/src/modules/Elsa.Alterations.Core/Models/AlterationLogEntry.cs
@@ -8,4 +8,5 @@ namespace Elsa.Alterations.Core.Models;
 /// <param name="Message">The log message.</param>
 /// <param name="LogLevel">The log level.</param>
 /// <param name="Timestamp">The timestamp when the log entry was created.</param>
-public record AlterationLogEntry(string Message, LogLevel LogLevel, DateTimeOffset Timestamp);
+/// <param name="EventName">The event that generated the log entry.</param>
+public record AlterationLogEntry(string Message, LogLevel LogLevel, DateTimeOffset Timestamp, string? EventName = null);

--- a/src/modules/Elsa.Alterations/Middleware/Workflows/RunAlterationsMiddleware.cs
+++ b/src/modules/Elsa.Alterations/Middleware/Workflows/RunAlterationsMiddleware.cs
@@ -50,5 +50,9 @@ internal class RunAlterationsMiddleware(WorkflowMiddlewareDelegate next, IEnumer
         // Execute commit handlers.
         foreach (var commitAction in commitActions)
             await commitAction();
+
+        // Add alteration logs to the workflow execution log.
+        foreach (var alterationLogEntry in log.LogEntries)
+            workflowExecutionContext.AddExecutionLogEntry(alterationLogEntry.EventName ?? alterationLogEntry.Message, alterationLogEntry.Message);
     }
 }

--- a/src/modules/Elsa.MongoDb/Common/MongoDbStore.cs
+++ b/src/modules/Elsa.MongoDb/Common/MongoDbStore.cs
@@ -45,6 +45,9 @@ public class MongoDbStore<TDocument> where TDocument : class
     /// <param name="cancellationToken">The cancellation token.</param>
     public async Task AddManyAsync(IEnumerable<TDocument> documents, CancellationToken cancellationToken = default)
     {
+        if (!documents.Any())
+            return;
+
         await _collection.InsertManyAsync(documents, new InsertManyOptions(), cancellationToken);
     }
 


### PR DESCRIPTION
This PR addresses issue #5897. The implemented changes are:
- Add check in `MongoDbStore.AddManyAsync(IEnumerable<TDocument> documents, CancellationToken cancellationToken)` to verify that the `documents` collection has elements before trying to save them.
- Add the `EventName` property to class `AlterationLogEntry`. Made it nullable for backwards compatibility, and because it's not applicable in some scenarios.
- Add the alteration logs into the workflow execution context logs in `RunAlterationsMiddleware`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/5911)
<!-- Reviewable:end -->
