### PR TITLE
Introduce UniqueKeyConstraintViolationException

### DIFF
--- a/src/modules/Elsa.EntityFrameworkCore.PostgreSql/Handlers/DbExceptionTransformer.cs
+++ b/src/modules/Elsa.EntityFrameworkCore.PostgreSql/Handlers/DbExceptionTransformer.cs
@@ -20,8 +20,9 @@ public class DbExceptionTransformer : IDbExceptionHandler<AlterationsElsaDbConte
     /// Transforms database exceptions encountered when using a postgreSQL database into more generic exceptions.
     public void Handle(DbUpdateException exception)
     {
-        var ex = exception.InnerException as PostgresException;
+        if (exception.InnerException is PostgresException { SqlState: "23505" })
+            throw new UniqueKeyConstraintViolationException("Unable to save data", exception);
 
-        throw new DataProcessingException(ex?.SqlState == "23505", "Unable to save data", exception);
+        throw new DataProcessingException("Unable to save data", exception);
     }
 }

--- a/src/modules/Elsa.Workflows.Core/Exceptions/DataProcessingException.cs
+++ b/src/modules/Elsa.Workflows.Core/Exceptions/DataProcessingException.cs
@@ -1,8 +1,4 @@
 namespace Elsa.Workflows.Exceptions;
 
 /// An exception that occurs during data processing.
-public class DataProcessingException(bool isUkViolation, string message, Exception exception) : Exception(message, exception)
-{
-    /// Gets a value indicating whether the exception is a Unique Key violation.
-    public bool IsUkViolation { get; } = isUkViolation;
-}
+public class DataProcessingException(string message, Exception exception) : Exception(message, exception);

--- a/src/modules/Elsa.Workflows.Core/Exceptions/UniqueKeyConstraintViolationException.cs
+++ b/src/modules/Elsa.Workflows.Core/Exceptions/UniqueKeyConstraintViolationException.cs
@@ -1,0 +1,4 @@
+namespace Elsa.Workflows.Exceptions;
+
+/// An exception that when a unique key constraint has been violated.
+public class UniqueKeyConstraintViolationException(string message, Exception exception) : Exception(message, exception);


### PR DESCRIPTION
Refactor DataProcessingException to remove unique key logic and create a dedicated UniqueKeyConstraintViolationException. Update DbExceptionTransformer to use the new exception for unique key violations, improving code clarity and separation of concerns.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/5917)
<!-- Reviewable:end -->
