### PR TITLE
Enh/5943 DropIns - Prevention of File Locks and Unloading

### DIFF
--- a/samples/drop-ins/SampleDropIn/DropIn.cs
+++ b/samples/drop-ins/SampleDropIn/DropIn.cs
@@ -1,9 +1,11 @@
 using Elsa.DropIns.Core;
 using Elsa.Extensions;
 using Elsa.Features.Services;
+using Elsa.Workflows;
 using Elsa.Workflows.Contracts;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using SampleDropIn.Activities;
 
 namespace SampleDropIn;
@@ -20,5 +22,19 @@ public class DropIn : IDropIn
     {
         var activityRegistry = serviceProvider.GetRequiredService<IActivityRegistry>();
         await activityRegistry.RegisterAsync<SampleActivity>(cancellationToken: cancellationToken);
+    }
+
+    public void Unconfigure(IServiceProvider serviceProvider)
+    {
+        var logger = serviceProvider.GetRequiredService<ILogger<DropIn>>();
+        try
+        {
+            var activityRegistry = serviceProvider.GetRequiredService<IActivityRegistry>();
+            activityRegistry.Remove(typeof(ActivityRegistry), activityRegistry.Find<SampleActivity>()!);
+            logger.LogInformation("Drop-in unconfigured.");
+        }catch(Exception ex)
+        {
+            logger.LogError(ex, "Error unconfiguring drop-in.");
+        }
     }
 }

--- a/samples/drop-ins/SampleDropIn/DropIn.cs
+++ b/samples/drop-ins/SampleDropIn/DropIn.cs
@@ -26,15 +26,7 @@ public class DropIn : IDropIn
 
     public void Unconfigure(IServiceProvider serviceProvider)
     {
-        var logger = serviceProvider.GetRequiredService<ILogger<DropIn>>();
-        try
-        {
-            var activityRegistry = serviceProvider.GetRequiredService<IActivityRegistry>();
-            activityRegistry.Remove(typeof(ActivityRegistry), activityRegistry.Find<SampleActivity>()!);
-            logger.LogInformation("Drop-in unconfigured.");
-        }catch(Exception ex)
-        {
-            logger.LogError(ex, "Error unconfiguring drop-in.");
-        }
+        var activityRegistry = serviceProvider.GetRequiredService<IActivityRegistry>();
+        activityRegistry.Remove(typeof(ActivityRegistry), activityRegistry.Find<SampleActivity>()!);
     }
 }

--- a/src/common/Elsa.DropIns.Core/IDropIn.cs
+++ b/src/common/Elsa.DropIns.Core/IDropIn.cs
@@ -17,4 +17,9 @@ public interface IDropIn
     /// Called when the drop-in is being configured.
     /// </summary>
     ValueTask ConfigureAsync(IServiceProvider serviceProvider, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Unconfigure the drop-in when it's deleted.
+    /// </summary>
+    void Unconfigure(IServiceProvider serviceProvider);
 }

--- a/src/common/Elsa.DropIns/Contexts/NuGetPackageAssemblyLoadContext.cs
+++ b/src/common/Elsa.DropIns/Contexts/NuGetPackageAssemblyLoadContext.cs
@@ -22,6 +22,8 @@ internal sealed class NuGetPackageAssemblyLoadContext : AssemblyLoadContext
 
             _loadedAssemblies[assembly.FullName!] = assembly;
         }
+        //Closes the package reader, closing the .nupkg file
+        packageReader.Dispose();
     }
 
     protected override Assembly? Load(AssemblyName assemblyName)

--- a/src/common/Elsa.DropIns/Elsa.DropIns.csproj
+++ b/src/common/Elsa.DropIns/Elsa.DropIns.csproj
@@ -10,13 +10,15 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
         <PackageReference Include="Microsoft.Extensions.Options" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
         <PackageReference Include="NuGet.Packaging" />
         <PackageReference Include="NuGet.Protocol" />
         <PackageReference Include="System.Formats.Asn1" />
         <PackageReference Include="ThrottleDebounce" />
     </ItemGroup>
 
-    <!--Overridden for vulnerability reasons with dependencies referencing older versions.-->
+    <!--Overridden
+    for vulnerability reasons with dependencies referencing older versions.-->
     <ItemGroup>
     </ItemGroup>
 

--- a/src/common/Elsa.DropIns/Helpers/AssemblyLoader.cs
+++ b/src/common/Elsa.DropIns/Helpers/AssemblyLoader.cs
@@ -17,7 +17,7 @@ public static class AssemblyLoader
         fileStream.CopyTo(memoryStream);
         memoryStream.Seek(0, SeekOrigin.Begin);
         fileStream.Close();
-        var assembly = loadContext.LoadFromStream(fileStream);
+        var assembly = loadContext.LoadFromStream(memoryStream);
 
         return assembly;
     }

--- a/src/common/Elsa.DropIns/Helpers/AssemblyLoader.cs
+++ b/src/common/Elsa.DropIns/Helpers/AssemblyLoader.cs
@@ -10,7 +10,14 @@ public static class AssemblyLoader
     {
         var loadContext = new DirectoryAssemblyLoadContext(path);
         var assemblyName = AssemblyLoadContext.GetAssemblyName(path);
-        var assembly = loadContext.LoadFromAssemblyName(assemblyName);
+        
+        // Copy drop in to memory stream to avoid file locking
+        using var fileStream = File.OpenRead(path);
+        using var memoryStream = new MemoryStream();
+        fileStream.CopyTo(memoryStream);
+        memoryStream.Seek(0, SeekOrigin.Begin);
+        fileStream.Close();
+        var assembly = loadContext.LoadFromStream(fileStream);
 
         return assembly;
     }

--- a/src/common/Elsa.DropIns/HostedServices/DropInDirectoryMonitorHostedService.cs
+++ b/src/common/Elsa.DropIns/HostedServices/DropInDirectoryMonitorHostedService.cs
@@ -15,7 +15,11 @@ public class DropInDirectoryMonitorHostedService : BackgroundService
     private readonly IOptions<DropInOptions> _options;
     private readonly IServiceProvider _serviceProvider;
     private readonly RateLimitedFunc<string, Task> _debouncedLoader;
+    private readonly RateLimitedFunc<string, Task> _debouncedUnloader;
     private readonly FileSystemWatcher _watcher;
+
+    private readonly Dictionary<string, List<IDropIn>> _installedDropIns;
+
 
     /// <inheritdoc />
     public DropInDirectoryMonitorHostedService(IOptions<DropInOptions> options, IServiceProvider serviceProvider)
@@ -23,6 +27,9 @@ public class DropInDirectoryMonitorHostedService : BackgroundService
         _options = options;
         _serviceProvider = serviceProvider;
         _debouncedLoader = Debouncer.Debounce<string, Task>(LoadDropInAssemblyAsync, TimeSpan.FromSeconds(2));
+        _debouncedUnloader = Debouncer.Debounce<string, Task>(UnloadDropInAssemblyAsync, TimeSpan.FromSeconds(2));
+
+        _installedDropIns = [];
 
         var rootDirectoryPath = _options.Value.DropInRootDirectory;
 
@@ -38,15 +45,27 @@ public class DropInDirectoryMonitorHostedService : BackgroundService
     }
 
     /// <inheritdoc />
-    protected override Task ExecuteAsync(CancellationToken stoppingToken)
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
+        await LoadDropInAssemblyAsync(_options.Value.DropInRootDirectory);
+
         _watcher.Changed += OnChanged;
-        return Task.CompletedTask;
+        _watcher.Deleted += OnDeleted;
     }
 
     private async void OnChanged(object sender, FileSystemEventArgs e)
     {
         var task = _debouncedLoader.Invoke(e.FullPath);
+
+        if (task == null)
+            return;
+
+        await task;
+    }
+
+    private async void OnDeleted(object sender, FileSystemEventArgs e)
+    {
+        var task = _debouncedUnloader.Invoke(e.FullPath);
 
         if (task == null)
             return;
@@ -63,7 +82,25 @@ public class DropInDirectoryMonitorHostedService : BackgroundService
         foreach (var dropInDescriptor in dropInDescriptors)
         {
             var dropIn = (IDropIn)Activator.CreateInstance(dropInDescriptor.Type)!;
+            if(_installedDropIns.TryGetValue(fullPath, out var installedDropIns))
+            {
+                installedDropIns.Add(dropIn);
+            }
+            else
+            {
+                _installedDropIns[fullPath] = [dropIn];
+            }
             await dropIn.ConfigureAsync(_serviceProvider, CancellationToken.None);
         }
+    }
+
+    private Task UnloadDropInAssemblyAsync(string fullPath)
+    {
+        if (_installedDropIns.TryGetValue(fullPath, out var installedDropIn))
+        {
+            installedDropIn.ForEach(dropIn => dropIn.Unconfigure(_serviceProvider));
+            _installedDropIns.Remove(fullPath);
+        }
+        return Task.CompletedTask;
     }
 }

--- a/src/common/Elsa.DropIns/Models/DropInDescriptor.cs
+++ b/src/common/Elsa.DropIns/Models/DropInDescriptor.cs
@@ -1,3 +1,13 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace Elsa.DropIns.Models;
 
-public record DropInDescriptor(Type Type);
+public class DropInDescriptor([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type)
+{
+    /// <summary>
+    /// Gets or sets the type of the drop-in. 
+    /// The DynamicallyAccessedMembers attribute ensures that the IL2072 warning is suppressed.
+    /// </summary>
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+    public Type Type { get; set; } = type;
+}


### PR DESCRIPTION
#### PR Classification
New feature and code improvement.

#### PR Summary
Introduces an `Unconfigure` method for drop-ins and improves assembly loading to avoid file locking issues.
- `DropIn.cs` and `IDropIn.cs`: Added `Unconfigure` method for drop-ins.
- `NuGetPackageAssemblyLoadContext.cs`: Disposed `packageReader` to close `.nupkg` file.
- `AssemblyLoader.cs`: Modified to load assemblies from a memory stream.
- `DropInDirectoryMonitorHostedService.cs`: Added debounced unloader, async loading, and handling of file deletion events.
- `DropInDescriptor.cs`: Changed to class with `DynamicallyAccessedMembers` attribute to suppress IL2072 warning.

Fixes #5943

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/5944)
<!-- Reviewable:end -->
