### PR TITLE
Fix : Change to parameter after update to Elsa.Studio packages to version 3.3.0-preview.524

### DIFF
--- a/src/apps/ElsaStudioWebAssembly/Program.cs
+++ b/src/apps/ElsaStudioWebAssembly/Program.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using Microsoft.Extensions.Options;
 using Microsoft.JSInterop;
+using Elsa.Studio.Models;
 
 // Build the host.
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
@@ -24,9 +25,15 @@ builder.RootComponents.Add<HeadOutlet>("head::after");
 builder.RootComponents.RegisterCustomElsaStudioElements();
 
 // Register shell services and modules.
+var backendApiConfig = new BackendApiConfig
+{
+    ConfigureBackendOptions = options => builder.Configuration.GetSection("Backend").Bind(options),
+    ConfigureHttpClientBuilder = options => options.AuthenticationHandler = typeof(AuthenticatingApiHttpMessageHandler)
+};
+
 builder.Services.AddCore();
 builder.Services.AddShell();
-builder.Services.AddRemoteBackend(elsaClient => elsaClient.AuthenticationHandler = typeof(AuthenticatingApiHttpMessageHandler));
+builder.Services.AddRemoteBackend(backendApiConfig);
 builder.Services.AddLoginModule();
 builder.Services.AddDashboardModule();
 builder.Services.AddWorkflowsModule();


### PR DESCRIPTION
After updating solution to use Elsa.Studio packages to version 3.3.0-preview.524, one project doesn't compile du to signature change (`AddRemoteBackend`).

This PR fix the call to the method with the right parameters.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/5945)
<!-- Reviewable:end -->
