### PR TITLE
Remove obsolete package MassTransit.Extensions.DependencyInjection

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -49,7 +49,6 @@
     <PackageVersion Include="MailKit" Version="4.7.1.1" />
     <PackageVersion Include="MassTransit" Version="8.2.3" />
     <PackageVersion Include="MassTransit.Azure.ServiceBus.Core" Version="8.2.3" />
-    <PackageVersion Include="MassTransit.Extensions.DependencyInjection" Version="7.3.1" />
     <PackageVersion Include="MassTransit.RabbitMQ" Version="8.2.3" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.7" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.10.0" />

--- a/src/modules/Elsa.MassTransit/Elsa.MassTransit.csproj
+++ b/src/modules/Elsa.MassTransit/Elsa.MassTransit.csproj
@@ -12,7 +12,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="MassTransit.Extensions.DependencyInjection" />
         <PackageReference Include="MassTransit" />
     </ItemGroup>
 


### PR DESCRIPTION
After updating to Masstransit 8, ```MassTransit.Extensions.DependencyInjection``` has become obsolete and is recommended for removal. It is not used in the code, but adds incompatibility with Masstransit 8.

https://masstransit.io/support/upgrade#version-8

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/5955)
<!-- Reviewable:end -->
