### PR TITLE
Fix variable serialization

### DIFF
--- a/.github/workflows/elsa-server-and-studio.yml
+++ b/.github/workflows/elsa-server-and-studio.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           # list of Docker images to use as base name for tags
           images: |
-            elsaworkflows/elsa-server-and-studio-v3-2-0-rc3
+            elsaworkflows/elsa-server-and-studio-v3-2-1-preview
           flavor: |
             latest=true
           # generate Docker tags based on the following events/attributes

--- a/.github/workflows/elsa-server.yml
+++ b/.github/workflows/elsa-server.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           # list of Docker images to use as base name for tags
           images: |
-            elsaworkflows/elsa-server-v3-2-0-rc3
+            elsaworkflows/elsa-server-v3-2-1-preview
           flavor: |
             latest=true
           # generate Docker tags based on the following events/attributes

--- a/.github/workflows/elsa-studio.yml
+++ b/.github/workflows/elsa-studio.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           # list of Docker images to use as base name for tags
           images: |
-            elsaworkflows/elsa-studio-v3-2-0-rc3
+            elsaworkflows/elsa-studio-v3-2-1-preview
           flavor: |
             latest=true
           # generate Docker tags based on the following events/attributes

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -62,7 +62,7 @@ jobs:
             TAG_NAME=${TAG_NAME#refs/tags/} # remove the refs/tags/ prefix
             echo "VERSION=${TAG_NAME}" >> $GITHUB_ENV
           else
-            echo "VERSION=3.2.1.${{github.run_number}}" >> $GITHUB_ENV
+            echo "VERSION=3.2.1-preview.${{github.run_number}}" >> $GITHUB_ENV
           fi
       - name: Set up JDK 17
         uses: actions/setup-java@v2

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -62,7 +62,7 @@ jobs:
             TAG_NAME=${TAG_NAME#refs/tags/} # remove the refs/tags/ prefix
             echo "VERSION=${TAG_NAME}" >> $GITHUB_ENV
           else
-            echo "VERSION=3.2.0-rc6.${{github.run_number}}" >> $GITHUB_ENV
+            echo "VERSION=3.2.1.${{github.run_number}}" >> $GITHUB_ENV
           fi
       - name: Set up JDK 17
         uses: actions/setup-java@v2

--- a/Elsa.sln.DotSettings
+++ b/Elsa.sln.DotSettings
@@ -14,6 +14,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=initializable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=materializer/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=materializers/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=persistable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Persister/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Populator/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Postgre/@EntryIndexedValue">True</s:Boolean>

--- a/src/bundles/Elsa.Server.Web/Elsa.Server.Web.csproj
+++ b/src/bundles/Elsa.Server.Web/Elsa.Server.Web.csproj
@@ -57,5 +57,8 @@
     <ItemGroup>
         <PackageReference Include="System.Text.Json" VersionOverride="8.0.4" />
     </ItemGroup>
+    <ItemGroup>
+      <Folder Include="App_Data\" />
+    </ItemGroup>
 
 </Project>

--- a/src/bundles/Elsa.Server.Web/Elsa.Server.Web.csproj
+++ b/src/bundles/Elsa.Server.Web/Elsa.Server.Web.csproj
@@ -57,8 +57,5 @@
     <ItemGroup>
         <PackageReference Include="System.Text.Json" VersionOverride="8.0.4" />
     </ItemGroup>
-    <ItemGroup>
-      <Folder Include="App_Data\" />
-    </ItemGroup>
 
 </Project>

--- a/src/bundles/Elsa.Server.Web/Program.cs
+++ b/src/bundles/Elsa.Server.Web/Program.cs
@@ -50,7 +50,7 @@ const bool useCaching = true;
 const bool useReadOnlyMode = false;
 const bool useSignalR = true;
 const DistributedCachingTransport distributedCachingTransport = DistributedCachingTransport.MassTransit;
-const MassTransitBroker useMassTransitBroker = MassTransitBroker.AzureServiceBus;
+const MassTransitBroker useMassTransitBroker = MassTransitBroker.Memory;
 
 var builder = WebApplication.CreateBuilder(args);
 var services = builder.Services;

--- a/src/bundles/Elsa.Server.Web/Program.cs
+++ b/src/bundles/Elsa.Server.Web/Program.cs
@@ -50,7 +50,7 @@ const bool useCaching = true;
 const bool useReadOnlyMode = false;
 const bool useSignalR = true;
 const DistributedCachingTransport distributedCachingTransport = DistributedCachingTransport.MassTransit;
-const MassTransitBroker useMassTransitBroker = MassTransitBroker.Memory;
+const MassTransitBroker useMassTransitBroker = MassTransitBroker.AzureServiceBus;
 
 var builder = WebApplication.CreateBuilder(args);
 var services = builder.Services;

--- a/src/clients/Elsa.Api.Client/Resources/StorageDrivers/Models/StorageDriverDescriptor.cs
+++ b/src/clients/Elsa.Api.Client/Resources/StorageDrivers/Models/StorageDriverDescriptor.cs
@@ -5,4 +5,4 @@ namespace Elsa.Api.Client.Resources.StorageDrivers.Models;
 /// </summary>
 /// <param name="TypeName">The type name of the storage driver.</param>
 /// <param name="DisplayName">The display name of the storage driver.</param>
-public record StorageDriverDescriptor(string TypeName, string DisplayName);
+public record StorageDriverDescriptor(string TypeName, string DisplayName, double Priority = 0, bool Deprecated = false);

--- a/src/modules/Elsa.Expressions/Helpers/ObjectConverter.cs
+++ b/src/modules/Elsa.Expressions/Helpers/ObjectConverter.cs
@@ -99,13 +99,13 @@ public static class ObjectConverter
             return jsonElement.Deserialize(targetType, serializerOptions);
         }
 
-        if (value is JsonObject jsonObject)
+        if (value is JsonNode jsonObject)
         {
             return underlyingTargetType switch
             {
                 { } t when t == typeof(string) => jsonObject.ToString(),
                 { } t when t != typeof(object) => jsonObject.Deserialize(targetType, serializerOptions),
-                _ => jsonObject,
+                _ => jsonObject
             };
         }
 
@@ -240,7 +240,7 @@ public static class ObjectConverter
     }
 
     /// <summary>
-    /// Returns true if the specified type is date-like type, false otherwise.
+    /// Returns true if the specified type is a date-like type, false otherwise.
     /// </summary>
     private static bool IsDateType(Type type)
     {

--- a/src/modules/Elsa.MassTransit.AzureServiceBus/Features/AzureServiceBusFeature.cs
+++ b/src/modules/Elsa.MassTransit.AzureServiceBus/Features/AzureServiceBusFeature.cs
@@ -1,4 +1,5 @@
 using Azure.Messaging.ServiceBus.Administration;
+using Elsa.Common.Contracts;
 using Elsa.Extensions;
 using Elsa.Features.Abstractions;
 using Elsa.Features.Attributes;
@@ -121,6 +122,13 @@ public class AzureServiceBusFeature : FeatureBase
                     }
 
                     configurator.ConfigureEndpoints(context, new KebabCaseEndpointNameFormatter("Elsa", false));
+                    
+                    configurator.ConfigureJsonSerializerOptions(serializerOptions =>
+                    {
+                        var serializer = context.GetRequiredService<IJsonSerializer>();
+                        serializer.ApplyOptions(serializerOptions);
+                        return serializerOptions;
+                    });
                 });
             };
         });

--- a/src/modules/Elsa.MassTransit.RabbitMq/Features/RabbitMqServiceBusFeature.cs
+++ b/src/modules/Elsa.MassTransit.RabbitMq/Features/RabbitMqServiceBusFeature.cs
@@ -1,10 +1,10 @@
+using Elsa.Common.Contracts;
 using Elsa.Extensions;
 using Elsa.Features.Abstractions;
 using Elsa.Features.Attributes;
 using Elsa.Features.Services;
 using Elsa.Hosting.Management.Contracts;
 using Elsa.Hosting.Management.Features;
-using Elsa.MassTransit.Consumers;
 using Elsa.MassTransit.Extensions;
 using Elsa.MassTransit.Features;
 using Elsa.MassTransit.Options;
@@ -88,6 +88,13 @@ public class RabbitMqServiceBusFeature : FeatureBase
                     }
 
                     configurator.ConfigureEndpoints(context, new KebabCaseEndpointNameFormatter("Elsa", false));
+                    
+                    configurator.ConfigureJsonSerializerOptions(serializerOptions =>
+                    {
+                        var serializer = context.GetRequiredService<IJsonSerializer>();
+                        serializer.ApplyOptions(serializerOptions);
+                        return serializerOptions;
+                    });
                 });
             };
         });

--- a/src/modules/Elsa.MassTransit/Messages/DispatchResumeWorkflows.cs
+++ b/src/modules/Elsa.MassTransit/Messages/DispatchResumeWorkflows.cs
@@ -14,6 +14,10 @@ public class DispatchResumeWorkflows(string activityTypeName, object bookmarkPay
     public string? CorrelationId { get; set; }
     public string? WorkflowInstanceId { get; set; }
     public string? ActivityInstanceId { get; set; }
+
+    [Obsolete("This property is no longer used and will be removed in a future version. Use the SerializedInput property instead.")]
     public IDictionary<string, object>? Input { get; set; }
+
+    public string? SerializedInput { get; set; }
     public IDictionary<string, object>? Properties { get; set; }
 }

--- a/src/modules/Elsa.MassTransit/Messages/DispatchTriggerWorkflowsRequest.cs
+++ b/src/modules/Elsa.MassTransit/Messages/DispatchTriggerWorkflowsRequest.cs
@@ -14,6 +14,10 @@ public class DispatchTriggerWorkflows(string activityTypeName, object bookmarkPa
     public string? CorrelationId { get; set; }
     public string? WorkflowInstanceId { get; set; }
     public string? ActivityInstanceId { get; set; }
+    
+    [Obsolete("This property is no longer used and will be removed in a future version. Use the SerializedInput property instead.")]
     public IDictionary<string, object>? Input { get; set; }
+
+    public string? SerializedInput { get; set; }
     public IDictionary<string, object>? Properties { get; set; }
 }

--- a/src/modules/Elsa.MassTransit/Messages/DispatchWorkflowDefinition.cs
+++ b/src/modules/Elsa.MassTransit/Messages/DispatchWorkflowDefinition.cs
@@ -1,4 +1,3 @@
-using System.Text.Json.Serialization;
 using Elsa.Common.Models;
 
 namespace Elsa.MassTransit.Messages;
@@ -36,7 +35,7 @@ public record DispatchWorkflowDefinition
         string? definitionId,
         VersionOptions? versionOptions,
         string? parentWorkflowInstanceId,
-        IDictionary<string, object>? input,
+        string? serializedInput,
         IDictionary<string, object>? properties,
         string? correlationId,
         string? instanceId,
@@ -47,7 +46,7 @@ public record DispatchWorkflowDefinition
             DefinitionId = definitionId,
             VersionOptions = versionOptions,
             ParentWorkflowInstanceId = parentWorkflowInstanceId,
-            Input = input,
+            SerializedInput = serializedInput,
             Properties = properties,
             CorrelationId = correlationId,
             InstanceId = instanceId,
@@ -64,8 +63,14 @@ public record DispatchWorkflowDefinition
     /// The ID of the parent workflow instance.
     public string? ParentWorkflowInstanceId { get; init; }
 
+    /// Deprecated. Use the <see cref="SerializedInput"/> property instead.
+    [Obsolete("This property is no longer used and will be removed in a future version. Use the SerializedInput property instead.")]
+    public IDictionary<string, object>? Input { get; set; }
+
+    /// <summary>
     /// Any input to pass to the workflow.
-    public IDictionary<string, object>? Input { get; init; }
+    /// </summary>
+    public string? SerializedInput { get; set; }
 
     /// Any properties to attach to the workflow.
     public IDictionary<string, object>? Properties { get; init; }

--- a/src/modules/Elsa.MassTransit/Messages/DispatchWorkflowDefinition.cs
+++ b/src/modules/Elsa.MassTransit/Messages/DispatchWorkflowDefinition.cs
@@ -26,7 +26,7 @@ public record DispatchWorkflowDefinition
     /// <param name="definitionId">The ID of the workflow definition to dispatch.</param>
     /// <param name="versionOptions">The version options to use when dispatching the workflow definition.</param>
     /// <param name="parentWorkflowInstanceId">The ID of the parent workflow instance.</param>
-    /// <param name="input">Any input to pass to the workflow.</param>
+    /// <param name="serializedInput">Any input to pass to the workflow.</param>
     /// <param name="properties">Any properties to attach to the workflow.</param>
     /// <param name="correlationId">A correlation ID to associate the workflow with.</param>
     /// <param name="instanceId">The ID to use when creating an instance of the workflow to dispatch.</param>

--- a/src/modules/Elsa.MassTransit/Messages/DispatchWorkflowInstance.cs
+++ b/src/modules/Elsa.MassTransit/Messages/DispatchWorkflowInstance.cs
@@ -8,7 +8,11 @@ public class DispatchWorkflowInstance(string instanceId)
     public string? ActivityNodeId { get; set; }
     public string? ActivityInstanceId { get; set; }
     public string? ActivityHash { get; set; }
+
+    [Obsolete("This property is no longer used and will be removed in a future version. Use the SerializedInput property instead.")]
     public IDictionary<string, object>? Input { get; set; }
+
+    public string? SerializedInput { get; set; }
     public IDictionary<string, object>? Properties { get; set; }
     public string? CorrelationId { get; set; }
 }

--- a/src/modules/Elsa.Workflows.Api/Endpoints/StorageDrivers/List/Endpoint.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/StorageDrivers/List/Endpoint.cs
@@ -31,7 +31,7 @@ public class List : ElsaEndpointWithoutRequest<Response>
     public override Task<Response> ExecuteAsync(CancellationToken ct)
     {
         var drivers = _registry.List();
-        var descriptors = drivers.Select(FromDriver).ToList();
+        var descriptors = drivers.Select(FromDriver).OrderByDescending(x => x.Priority).ToList();
         var response = new Response(descriptors);
 
         return Task.FromResult(response);
@@ -40,7 +40,9 @@ public class List : ElsaEndpointWithoutRequest<Response>
     private static StorageDriverDescriptor FromDriver(IStorageDriver driver)
     {
         var type = driver.GetType();
+        var deprecated = type.GetCustomAttribute<ObsoleteAttribute>() != null;
         var displayName = type.GetCustomAttribute<DisplayAttribute>()?.Name ?? type.GetCustomAttribute<DisplayNameAttribute>()?.DisplayName ?? type.Name.Replace("StorageDriver", "");
-        return new StorageDriverDescriptor(type.GetSimpleAssemblyQualifiedName(), displayName);
+        var priority = driver.Priority;
+        return new StorageDriverDescriptor(type.GetSimpleAssemblyQualifiedName(), displayName, priority, deprecated);
     }
 }

--- a/src/modules/Elsa.Workflows.Api/Endpoints/StorageDrivers/List/Models.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/StorageDrivers/List/Models.cs
@@ -5,4 +5,4 @@ public class Response(ICollection<StorageDriverDescriptor> items)
     public ICollection<StorageDriverDescriptor> Items  { get; set; } = items;
 }
 
-public record StorageDriverDescriptor(string TypeName, string DisplayName);
+public record StorageDriverDescriptor(string TypeName, string DisplayName, double Priority = 0, bool Deprecated = false);

--- a/src/modules/Elsa.Workflows.Core/Activities/ParallelForEachT.cs
+++ b/src/modules/Elsa.Workflows.Core/Activities/ParallelForEachT.cs
@@ -53,10 +53,10 @@ public class ParallelForEach<T> : Activity
             var currentValueVariable = new Variable<T>("CurrentValue", item)
             {
                 // TODO: This should be configurable, because this won't work for e.g. file streams and other non-serializable types.
-                StorageDriverType = typeof(WorkflowStorageDriver)
+                StorageDriverType = typeof(WorkflowInstanceStorageDriver)
             };
 
-            var currentIndexVariable = new Variable<int>("CurrentIndex", currentIndex++) { StorageDriverType = typeof(WorkflowStorageDriver) };
+            var currentIndexVariable = new Variable<int>("CurrentIndex", currentIndex++) { StorageDriverType = typeof(WorkflowInstanceStorageDriver) };
             var variables = new List<Variable> { currentValueVariable, currentIndexVariable };
 
             // Schedule a body of work for each item.

--- a/src/modules/Elsa.Workflows.Core/Contracts/IStorageDriver.cs
+++ b/src/modules/Elsa.Workflows.Core/Contracts/IStorageDriver.cs
@@ -6,6 +6,11 @@ namespace Elsa.Workflows.Contracts;
 public interface IStorageDriver
 {
     /// <summary>
+    /// The priority of the storage driver. Drivers with higher priority are used before drivers with lower priority.
+    /// </summary>
+    double Priority { get; }
+    
+    /// <summary>
     /// Writes a value to the storage driver.
     /// </summary>
     /// <param name="id">The ID of the value to write.</param>

--- a/src/modules/Elsa.Workflows.Core/Extensions/ExpressionExecutionContextExtensions.cs
+++ b/src/modules/Elsa.Workflows.Core/Extensions/ExpressionExecutionContextExtensions.cs
@@ -141,7 +141,7 @@ public static class ExpressionExecutionContextExtensions
 
         var variable = new Variable(name, value)
         {
-            StorageDriverType = storageDriverType ?? typeof(WorkflowStorageDriver)
+            StorageDriverType = storageDriverType ?? typeof(WorkflowInstanceStorageDriver)
         };
 
         // Find the first parent context that has a variable container.

--- a/src/modules/Elsa.Workflows.Core/Extensions/VariableExtensions.cs
+++ b/src/modules/Elsa.Workflows.Core/Extensions/VariableExtensions.cs
@@ -31,14 +31,14 @@ public static class VariableExtensions
             new ExpandoObjectConverterFactory());
 
     /// <summary>
-    /// Configures the variable to use the <see cref="WorkflowStorageDriver"/>.
+    /// Configures the variable to use the <see cref="WorkflowInstanceStorageDriver"/>.
     /// </summary>
-    public static Variable WithWorkflowStorage(this Variable variable) => variable.WithStorage<WorkflowStorageDriver>();
+    public static Variable WithWorkflowStorage(this Variable variable) => variable.WithStorage<WorkflowInstanceStorageDriver>();
 
     /// <summary>
-    /// Configures the variable to use the <see cref="WorkflowStorageDriver"/>.
+    /// Configures the variable to use the <see cref="WorkflowInstanceStorageDriver"/>.
     /// </summary>
-    public static Variable<T> WithWorkflowStorage<T>(this Variable<T> variable) => (Variable<T>)variable.WithStorage<WorkflowStorageDriver>();
+    public static Variable<T> WithWorkflowStorage<T>(this Variable<T> variable) => (Variable<T>)variable.WithStorage<WorkflowInstanceStorageDriver>();
 
     /// <summary>
     /// Configures the variable to use the <see cref="MemoryStorageDriver"/>.

--- a/src/modules/Elsa.Workflows.Core/Features/WorkflowsFeature.cs
+++ b/src/modules/Elsa.Workflows.Core/Features/WorkflowsFeature.cs
@@ -171,6 +171,7 @@ public class WorkflowsFeature : FeatureBase
             // Storage drivers.
             .AddScoped<IStorageDriverManager, StorageDriverManager>()
             .AddStorageDriver<WorkflowStorageDriver>()
+            .AddStorageDriver<WorkflowInstanceStorageDriver>()
             .AddStorageDriver<MemoryStorageDriver>()
 
             // Serialization.

--- a/src/modules/Elsa.Workflows.Core/Serialization/Converters/PolymorphicObjectConverterFactory.cs
+++ b/src/modules/Elsa.Workflows.Core/Serialization/Converters/PolymorphicObjectConverterFactory.cs
@@ -9,23 +9,8 @@ namespace Elsa.Workflows.Serialization.Converters;
 /// <summary>
 /// A JSON converter factory that creates <see cref="PolymorphicObjectConverter"/> instances.
 /// </summary>
-public class PolymorphicObjectConverterFactory : JsonConverterFactory
+public class PolymorphicObjectConverterFactory(IWellKnownTypeRegistry wellKnownTypeRegistry) : JsonConverterFactory
 {
-    private readonly IWellKnownTypeRegistry _wellKnownTypeRegistry;
-    
-    /// <inheritdoc />
-    public PolymorphicObjectConverterFactory() : this(WellKnownTypeRegistry.CreateDefault())
-    {
-    }
-
-    /// <summary>
-    /// A JSON converter factory that creates <see cref="PolymorphicObjectConverter"/> instances.
-    /// </summary>
-    public PolymorphicObjectConverterFactory(IWellKnownTypeRegistry wellKnownTypeRegistry)
-    {
-        _wellKnownTypeRegistry = wellKnownTypeRegistry;
-    }
-
     /// <inheritdoc />
     public override bool CanConvert(Type typeToConvert)
     {
@@ -42,8 +27,8 @@ public class PolymorphicObjectConverterFactory : JsonConverterFactory
     public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
     {
         if (typeof(IDictionary<string, object>).IsAssignableFrom(typeToConvert))
-            return new PolymorphicDictionaryConverter(options, _wellKnownTypeRegistry);
+            return new PolymorphicDictionaryConverter(options, wellKnownTypeRegistry);
 
-        return new PolymorphicObjectConverter(_wellKnownTypeRegistry);
+        return new PolymorphicObjectConverter(wellKnownTypeRegistry);
     }
 }

--- a/src/modules/Elsa.Workflows.Core/Serialization/Converters/PolymorphicObjectConverterFactory.cs
+++ b/src/modules/Elsa.Workflows.Core/Serialization/Converters/PolymorphicObjectConverterFactory.cs
@@ -2,21 +2,38 @@ using System.Dynamic;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Elsa.Expressions.Contracts;
+using Elsa.Expressions.Services;
 
 namespace Elsa.Workflows.Serialization.Converters;
 
 /// <summary>
 /// A JSON converter factory that creates <see cref="PolymorphicObjectConverter"/> instances.
 /// </summary>
-public class PolymorphicObjectConverterFactory(IWellKnownTypeRegistry wellKnownTypeRegistry) : JsonConverterFactory
+public class PolymorphicObjectConverterFactory : JsonConverterFactory
 {
+    private readonly IWellKnownTypeRegistry _wellKnownTypeRegistry;
+    
+    /// <inheritdoc />
+    public PolymorphicObjectConverterFactory() : this(WellKnownTypeRegistry.CreateDefault())
+    {
+    }
+
+    /// <summary>
+    /// A JSON converter factory that creates <see cref="PolymorphicObjectConverter"/> instances.
+    /// </summary>
+    public PolymorphicObjectConverterFactory(IWellKnownTypeRegistry wellKnownTypeRegistry)
+    {
+        _wellKnownTypeRegistry = wellKnownTypeRegistry;
+    }
+
     /// <inheritdoc />
     public override bool CanConvert(Type typeToConvert)
     {
         var canConvert = typeToConvert.IsClass
                && typeToConvert == typeof(object)
                || typeToConvert == typeof(ExpandoObject)
-               || typeToConvert == typeof(Dictionary<string, object>);
+               || typeToConvert == typeof(Dictionary<string, object>)
+               || typeToConvert == typeof(IDictionary<string, object>);
         
         return canConvert;
     }
@@ -25,8 +42,8 @@ public class PolymorphicObjectConverterFactory(IWellKnownTypeRegistry wellKnownT
     public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
     {
         if (typeof(IDictionary<string, object>).IsAssignableFrom(typeToConvert))
-            return new PolymorphicDictionaryConverter(options, wellKnownTypeRegistry);
+            return new PolymorphicDictionaryConverter(options, _wellKnownTypeRegistry);
 
-        return new PolymorphicObjectConverter(wellKnownTypeRegistry);
+        return new PolymorphicObjectConverter(_wellKnownTypeRegistry);
     }
 }

--- a/src/modules/Elsa.Workflows.Core/Services/MemoryStorageDriver.cs
+++ b/src/modules/Elsa.Workflows.Core/Services/MemoryStorageDriver.cs
@@ -11,6 +11,8 @@ public class MemoryStorageDriver : IStorageDriver
 {
     private readonly IDictionary<string, object> _dictionary = new Dictionary<string, object>();
 
+    public double Priority => 0;
+
     /// <inheritdoc />
     public ValueTask WriteAsync(string id, object value, StorageDriverContext context)
     {

--- a/src/modules/Elsa.Workflows.Core/Services/WorkflowInstanceStorageDriver.cs
+++ b/src/modules/Elsa.Workflows.Core/Services/WorkflowInstanceStorageDriver.cs
@@ -1,0 +1,55 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Elsa.Extensions;
+using Elsa.Workflows.Contracts;
+using JetBrains.Annotations;
+
+namespace Elsa.Workflows.Services;
+
+/// A storage driver that stores objects in the workflow state itself.
+[Display(Name = "Workflow Instance")]
+[UsedImplicitly]
+public class WorkflowInstanceStorageDriver : IStorageDriver
+{
+    /// The key used to store the variables in the workflow state.
+    public const string VariablesDictionaryStateKey = "Variables";
+
+    /// <inheritdoc />
+    public ValueTask WriteAsync(string id, object value, StorageDriverContext context)
+    {
+        UpdateVariablesDictionary(context, dictionary =>
+        {
+            var node = JsonSerializer.SerializeToNode(value);
+            dictionary[id] = node;
+        });
+        return ValueTask.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public ValueTask<object?> ReadAsync(string id, StorageDriverContext context)
+    {
+        var dictionary = GetVariablesDictionary(context);
+        var node = dictionary.GetValueOrDefault(id);
+        return new(node);
+    }
+
+    /// <inheritdoc />
+    public ValueTask DeleteAsync(string id, StorageDriverContext context)
+    {
+        UpdateVariablesDictionary(context, dictionary => dictionary.Remove(id));
+        return ValueTask.CompletedTask;
+    }
+
+    private VariablesDictionary GetVariablesDictionary(StorageDriverContext context) => context.ExecutionContext.Properties.GetOrAdd(VariablesDictionaryStateKey, () => new VariablesDictionary());
+    private void SetVariablesDictionary(StorageDriverContext context, VariablesDictionary dictionary) => context.ExecutionContext.Properties[VariablesDictionaryStateKey] = dictionary;
+
+    private void UpdateVariablesDictionary(StorageDriverContext context, Action<VariablesDictionary> update)
+    {
+        var dictionary = GetVariablesDictionary(context);
+        update(dictionary);
+        SetVariablesDictionary(context, dictionary);
+    }
+}
+
+public class VariablesDictionary : Dictionary<string, JsonNode>;

--- a/src/modules/Elsa.Workflows.Core/Services/WorkflowInstanceStorageDriver.cs
+++ b/src/modules/Elsa.Workflows.Core/Services/WorkflowInstanceStorageDriver.cs
@@ -16,6 +16,9 @@ public class WorkflowInstanceStorageDriver : IStorageDriver
     public const string VariablesDictionaryStateKey = "Variables";
 
     /// <inheritdoc />
+    public double Priority => 1;
+
+    /// <inheritdoc />
     public ValueTask WriteAsync(string id, object value, StorageDriverContext context)
     {
         UpdateVariablesDictionary(context, dictionary =>

--- a/src/modules/Elsa.Workflows.Core/Services/WorkflowStateExtractor.cs
+++ b/src/modules/Elsa.Workflows.Core/Services/WorkflowStateExtractor.cs
@@ -71,7 +71,7 @@ public class WorkflowStateExtractor : IWorkflowStateExtractor
     private IDictionary<string, object> GetPersistableInput(WorkflowExecutionContext workflowExecutionContext)
     {
         // TODO: This is a temporary solution. We need to find a better way to handle this.
-        var persistableInput = workflowExecutionContext.Workflow.Inputs.Where(x => x.StorageDriverType == typeof(WorkflowStorageDriver)).ToList();
+        var persistableInput = workflowExecutionContext.Workflow.Inputs.Where(x => x.StorageDriverType == typeof(WorkflowStorageDriver) || x.StorageDriverType == typeof(WorkflowInstanceStorageDriver)).ToList();
         var input = workflowExecutionContext.Input;
         var filteredInput = new Dictionary<string, object>();
 

--- a/src/modules/Elsa.Workflows.Core/Services/WorkflowStorageDriver.cs
+++ b/src/modules/Elsa.Workflows.Core/Services/WorkflowStorageDriver.cs
@@ -8,12 +8,16 @@ namespace Elsa.Workflows.Services;
 /// A storage driver that stores objects in the workflow state itself.
 /// </summary>
 [Display(Name = "Workflow")]
+[Obsolete("This is no longer used and will be removed in a future version. Use the WorkflowInstanceStorageDriver instead.")]
 public class WorkflowStorageDriver : IStorageDriver
 {
     /// <summary>
     /// The key used to store the variables in the workflow state.
     /// </summary>
     public const string VariablesDictionaryStateKey = "PersistentVariablesDictionary";
+
+    /// <inheritdoc />
+    public double Priority => -1;
 
     /// <inheritdoc />
     public ValueTask WriteAsync(string id, object value, StorageDriverContext context)

--- a/src/modules/Elsa.Workflows.Runtime/Activities/BulkDispatchWorkflows.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Activities/BulkDispatchWorkflows.cs
@@ -237,7 +237,7 @@ public class BulkDispatchWorkflows : Activity
 
         var childInstanceId = new Variable<string>("ChildInstanceId", workflowInstanceId)
         {
-            StorageDriverType = typeof(WorkflowStorageDriver)
+            StorageDriverType = typeof(WorkflowInstanceStorageDriver)
         };
 
         var variables = new List<Variable>

--- a/src/modules/Elsa.Workflows.Runtime/Services/DefaultBackgroundActivityInvoker.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Services/DefaultBackgroundActivityInvoker.cs
@@ -97,7 +97,7 @@ public class DefaultBackgroundActivityInvoker : IBackgroundActivityInvoker
             var driver = variableMetadata?.StorageDriverType;
 
             // We only capture output written to the workflow itself. Other drivers like blob storage, etc. will be ignored since the foreground context will be loading those.
-            if (driver != typeof(WorkflowStorageDriver))
+            if (driver != typeof(WorkflowStorageDriver) && driver != typeof(WorkflowInstanceStorageDriver))
                 continue;
 
             var outputValue = activityExecutionContext.Get(memoryBlockReference);

--- a/test/component/Elsa.Workflows.ComponentTests/Scenarios/Variables/CountdownWorkflowTests.cs
+++ b/test/component/Elsa.Workflows.ComponentTests/Scenarios/Variables/CountdownWorkflowTests.cs
@@ -48,6 +48,8 @@ public class CountdownWorkflowTests(App app) : AppComponentTest(app)
         }
     }
 
-    private IDictionary<string, object> GetVariablesDictionary(ActivityExecutionContextState context) =>
-        context.Properties.GetOrAdd(WorkflowStorageDriver.VariablesDictionaryStateKey, () => new Dictionary<string, object>());
+    private VariablesDictionary GetVariablesDictionary(ActivityExecutionContextState context)
+    {
+        return context.Properties.GetOrAdd(WorkflowInstanceStorageDriver.VariablesDictionaryStateKey, () => new VariablesDictionary());
+    }
 }


### PR DESCRIPTION
This PR fixes variable serialization through the introduction of a non-polymorphic variable storage driver and by separting input serialization when sending messages through MassTransit. This ensures that dynamic objects are serialized "as-is" without also serializing their .NET type name, which would break the expected JSON format when serializing an expando object.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/5974)
<!-- Reviewable:end -->
