### PR TITLE
Add MongoDB collection naming strategy

### DIFF
--- a/src/modules/Elsa.MongoDb/Contracts/ICollectionNamingStrategy.cs
+++ b/src/modules/Elsa.MongoDb/Contracts/ICollectionNamingStrategy.cs
@@ -1,0 +1,12 @@
+﻿namespace Elsa.MongoDb.Contracts;
+
+/// <summary>
+/// Represents a naming strategy to use when creating the name of a MongoDB collection.
+/// </summary>
+public interface ICollectionNamingStrategy
+{
+    /// <summary>
+    /// Returns a collection name from the specified base collection name.
+    /// </summary>
+    string GetCollectionName(string collectionName);
+}

--- a/src/modules/Elsa.MongoDb/Features/MongoDbFeature.cs
+++ b/src/modules/Elsa.MongoDb/Features/MongoDbFeature.cs
@@ -2,11 +2,14 @@ using System.Text.Json;
 using Elsa.Features.Abstractions;
 using Elsa.Features.Services;
 using Elsa.KeyValues.Entities;
+using Elsa.MongoDb.Contracts;
+using Elsa.MongoDb.NamingStrategies;
 using Elsa.MongoDb.Options;
 using Elsa.MongoDb.Serializers;
 using Elsa.Workflows.Memory;
 using Elsa.Workflows.Runtime.Entities;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
@@ -36,12 +39,20 @@ public class MongoDbFeature : FeatureBase
     /// </summary>
     public Action<MongoDbOptions> Options { get; set; } = _ => { };
 
+    /// <summary>
+    /// A delegate that creates an instance of an implementation of <see cref="ICollectionNamingStrategy"/>.
+    /// </summary>
+    public Func<IServiceProvider, ICollectionNamingStrategy> CollectionNamingStrategy { get; set; } = sp => sp.GetRequiredService<DefaultNamingStrategy>();
+
     /// <inheritdoc />
     public override void Apply()
     {
         Services.Configure(Options);
 
         Services.AddScoped(sp => CreateDatabase(sp, ConnectionString));
+        
+        Services.TryAddScoped<DefaultNamingStrategy>();
+        Services.AddScoped(CollectionNamingStrategy);
 
         RegisterSerializers();
         RegisterClassMaps();

--- a/src/modules/Elsa.MongoDb/NamingStrategies/DefaultNamingStrategy.cs
+++ b/src/modules/Elsa.MongoDb/NamingStrategies/DefaultNamingStrategy.cs
@@ -1,0 +1,17 @@
+﻿using Elsa.MongoDb.Contracts;
+
+namespace Elsa.MongoDb.NamingStrategies;
+
+/// <summary>
+/// Returns the same collection name, without modifying it.
+/// </summary>
+public class DefaultNamingStrategy : ICollectionNamingStrategy
+{
+    /// <summary>
+    /// Returns the same collection name, without modifying it.
+    /// </summary>
+    public string GetCollectionName(string collectionName)
+    {
+        return collectionName;
+    }
+}


### PR DESCRIPTION
Hello! This PR addresses issue #6004.

I created a `ICollectionNamingStrategy` interface, to allow customizing the names of the MongoDB collections created by Elsa Workflows. By creating their own implementation for this interface, users would be able to add a prefix etc. to the names of the collections. I used DI for resolving the `ICollectionNamingStrategy` implementation to allow users to inject `IConfiguration` or `IOptions<T>` in their implementations, in case for instance they want to get their prefix from a config file.

The scenario that inspired this PR was multiple services that use Elsa Workflows using the same MongoDB database. So they needed a way to differentiate between each service's Elsa collections. Also, I noticed the EF Core and Elasticsearch implementations already offer something similar to this (through `IElsaDbContextSchema` and respectively `IIndexNamingStrategy`).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6005)
<!-- Reviewable:end -->
