### PR TITLE
Manually register SerializedKeyValuePair.Key to BsonClassMap to prevent index creation failure

### DIFF
--- a/src/modules/Elsa.MongoDb/Features/MongoDbFeature.cs
+++ b/src/modules/Elsa.MongoDb/Features/MongoDbFeature.cs
@@ -80,6 +80,7 @@ public class MongoDbFeature : FeatureBase
         {
             map.AutoMap();
             map.SetIgnoreExtraElements(true); // Needed for missing ID property
+            map.MapProperty(x => x.Key); // Needed for non-setter property
         });
     }
 


### PR DESCRIPTION
This PR resolves the issue proposed in https://github.com/elsa-workflows/elsa-core/issues/6001. It manually registers SerializedKeyValuePair.Key to BsonClassMap to prevent index creation failure.
Given that the SerializedKeyValuePair class is used by other persistence implementations, I believe manually registering its SerializedKeyValuePair.Key to BsonClassMap in the Mongo feature is a more appropriate solution. This approach avoids modifying the definition of SerializedKeyValuePair, which could potentially impact other persistence implementations.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6036)
<!-- Reviewable:end -->
