### PR TITLE
Add Functionality to Copy Entire Path from HTTP Endpoint Activity #133

### DIFF
--- a/src/clients/Elsa.Api.Client/Shared/UIHints/SingleLine/SingleLineProps.cs
+++ b/src/clients/Elsa.Api.Client/Shared/UIHints/SingleLine/SingleLineProps.cs
@@ -9,4 +9,9 @@ public class SingleLineProps
     /// Gets or sets adornment text.
     /// </summary>
     public string? AdornmentText { get; set; }
+
+    /// <summary>
+    /// Gets or sets enabling or disabling the copy adornment.
+    /// </summary>
+    public bool EnableCopyAdornment { get; set; } = false;
 }

--- a/src/modules/Elsa.Http/UIHints/HttpEndpointPathUIHandler.cs
+++ b/src/modules/Elsa.Http/UIHints/HttpEndpointPathUIHandler.cs
@@ -23,7 +23,8 @@ public class HttpEndpointPathUIHandler(IOptions<HttpActivityOptions> options) : 
         {
             [InputUIHints.SingleLine] = new SingleLineProps
             {
-                AdornmentText = completeBaseUrl.ToString().TrimEnd('/') + '/'
+                AdornmentText = completeBaseUrl.ToString().TrimEnd('/') + '/',
+                EnableCopyAdornment = true
             },
         });
     }

--- a/src/modules/Elsa.Workflows.Core/UIHints/SingleLine/SingleLineProps.cs
+++ b/src/modules/Elsa.Workflows.Core/UIHints/SingleLine/SingleLineProps.cs
@@ -9,4 +9,9 @@ public class SingleLineProps
     /// Gets or sets adornment text.
     /// </summary>
     public string? AdornmentText { get; set; }
+
+    /// <summary>
+    /// Gets or sets enabling or disabling the copy adornment.
+    /// </summary>
+    public bool EnableCopyAdornment { get; set; } = false;
 }


### PR DESCRIPTION
This PR introduces a "copy full path" feature for the `httpendpoint` activity in Elsa [#133](https://github.com/elsa-workflows/elsa-studio/issues/133) , utilizing the `MudExtension` component to enable start and end adornments. This feature has been integrated into the `SingleLineComponent`, allowing it to be toggled on or off through a flag in elsa-core. Currently, the Blazor text field has a limitation where both start and end adornments cannot be added to the same component, an issue acknowledged in the MudBlazor repository ([Issue #8945](https://github.com/MudBlazor/MudBlazor/issues/8945)).

### Key Points of this PR:
1. Leverages `MudExtension` to support both start and end adornments.
2. Adds a copy icon as an end adornment, with the flexibility to support more adornments in the future.
3. Integrates the feature into the `SingleLineComponent` with a toggle flag in elsa-core.

<img width="712" alt="image" src="https://github.com/user-attachments/assets/d0fac7ad-f8c0-4b4a-b992-80b1a04ae885">


**Please note a side effect: the placeholder text appears at the top of the textbox rather than centered, due to both adornment slots being added by default.**
![image](https://github.com/user-attachments/assets/b1d84bad-3127-4f3e-87b8-de268a4b75bd)

I believe this enhancement adds valuable functionality, but I would appreciate your feedback on whether this approach aligns with the project’s goals and standards. As this is my first PR for this library, look forward to future contributions. I welcome any suggestions or modifications to improve this implementation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6037)
<!-- Reviewable:end -->
