### PR TITLE
Enhance error handling in `PolymorphicObjectConverter`

### DIFF
--- a/src/modules/Elsa.Workflows.Core/Serialization/Converters/PolymorphicObjectConverter.cs
+++ b/src/modules/Elsa.Workflows.Core/Serialization/Converters/PolymorphicObjectConverter.cs
@@ -364,13 +364,13 @@ public class PolymorphicObjectConverter(IWellKnownTypeRegistry wellKnownTypeRegi
                         case JsonTokenType.PropertyName:
                             var key = reader.GetString()!;
                             reader.Read();
-                            if (key == RefPropertyName)
+                            if (referenceResolver != null && key == RefPropertyName)
                             {
                                 var referenceId = reader.GetString();
                                 var reference = referenceResolver.ResolveReference(referenceId!);
                                 dict.Add(key, reference);
                             }
-                            else if (key == IdPropertyName)
+                            else if (referenceResolver != null && key == IdPropertyName)
                             {
                                 var referenceId = reader.GetString()!;
 


### PR DESCRIPTION
Add null checks for `referenceResolver` in cases where `RefPropertyName` and `IdPropertyName` are being processed. This prevents potential null reference exceptions and ensures safer deserialization of objects.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6051)
<!-- Reviewable:end -->
