### PR TITLE
Switch MemoryStream to Microsoft.IO.RecyclableMemoryStream.

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -56,6 +56,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.11.0" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite.Design" Version="1.1.6" />
     <PackageVersion Include="Microsoft.Identity.Client" Version="4.66.1" />
+    <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="Microsoft.SemanticKernel" Version="1.25.0" />

--- a/Elsa.sln
+++ b/Elsa.sln
@@ -231,9 +231,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Elsa.Workflows.PerformanceT
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "retention", "retention", "{3F20899B-C5E1-485F-808B-ADB1877EB3FD}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Retention", "src\modules\Elsa.Retention\Elsa.Retention.csproj", "{3D42FCA2-5BD0-4624-9FCA-F4BF935B27AE}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Elsa.Retention", "src\modules\Elsa.Retention\Elsa.Retention.csproj", "{3D42FCA2-5BD0-4624-9FCA-F4BF935B27AE}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.MongoDb.UnitTests", "test\unit\Elsa.MongoDb.UnitTests\Elsa.MongoDb.UnitTests.csproj", "{56CAA9F2-1882-4EFA-BAC0-9C3D804553F1}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Elsa.MongoDb.UnitTests", "test\unit\Elsa.MongoDb.UnitTests\Elsa.MongoDb.UnitTests.csproj", "{56CAA9F2-1882-4EFA-BAC0-9C3D804553F1}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Elsa.Workflows.Runtime.Distributed", "src\modules\Elsa.Workflows.Runtime.Distributed\Elsa.Workflows.Runtime.Distributed.csproj", "{0D4A88A1-8AEE-49ED-BC2E-ED68C96F60AD}"
 EndProject
@@ -381,7 +381,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "multitenancy", "multitenanc
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Elsa.Tenants.AspNetCore", "src\modules\Elsa.Tenants.AspNetCore\Elsa.Tenants.AspNetCore.csproj", "{D5720DBC-8C2B-42D5-9D9F-2FF6EAD4001C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Agents.Persistence.EntityFrameworkCore.PostgreSql", "src\modules\Elsa.Agents.Persistence.EntityFrameworkCore.PostgreSql\Elsa.Agents.Persistence.EntityFrameworkCore.PostgreSql.csproj", "{2B939AC9-03A4-479E-AA0D-CB58F4A7F480}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Elsa.Agents.Persistence.EntityFrameworkCore.PostgreSql", "src\modules\Elsa.Agents.Persistence.EntityFrameworkCore.PostgreSql\Elsa.Agents.Persistence.EntityFrameworkCore.PostgreSql.csproj", "{2B939AC9-03A4-479E-AA0D-CB58F4A7F480}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Helpers", "src\common\Elsa.Helpers\Elsa.Helpers.csproj", "{4F159759-B22F-4DA6-BDDF-686E7AD0C9EB}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -815,6 +817,10 @@ Global
 		{2B939AC9-03A4-479E-AA0D-CB58F4A7F480}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2B939AC9-03A4-479E-AA0D-CB58F4A7F480}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2B939AC9-03A4-479E-AA0D-CB58F4A7F480}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4F159759-B22F-4DA6-BDDF-686E7AD0C9EB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4F159759-B22F-4DA6-BDDF-686E7AD0C9EB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4F159759-B22F-4DA6-BDDF-686E7AD0C9EB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4F159759-B22F-4DA6-BDDF-686E7AD0C9EB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -921,6 +927,7 @@ Global
 		{690B0274-291F-4D9E-BA76-54EFF7D3E4BC} = {D92BEAB2-60D6-4BB4-885A-6BA681C6CCF1}
 		{060FD0BA-BD78-48E1-A8A7-4906A5AD5E39} = {D92BEAB2-60D6-4BB4-885A-6BA681C6CCF1}
 		{169A82A5-2DB3-40EA-801E-14C08D743DF7} = {D92BEAB2-60D6-4BB4-885A-6BA681C6CCF1}
+		{2CDF3E1C-267D-4198-B1C7-7E1F548FC120} = {5BA4A8FA-F7F4-45B3-AEC8-8886D35AAC79}
 		{01B96BB9-35E8-4364-ACB8-6D12A14D8DBA} = {5BA4A8FA-F7F4-45B3-AEC8-8886D35AAC79}
 		{47FBCB04-0C2D-453C-BE2F-7052CAC22524} = {EB3A7401-0DE3-476F-9E6F-057F1F4590FB}
 		{B32DB9B2-AD6C-48A5-8682-4373CB045185} = {C80C8231-D35C-4ACC-9ED6-9F3DB221535E}
@@ -958,7 +965,7 @@ Global
 		{2F3E1026-5054-4E1F-899B-F1A7F70F9912} = {5BA4A8FA-F7F4-45B3-AEC8-8886D35AAC79}
 		{D5720DBC-8C2B-42D5-9D9F-2FF6EAD4001C} = {2F3E1026-5054-4E1F-899B-F1A7F70F9912}
 		{2B939AC9-03A4-479E-AA0D-CB58F4A7F480} = {50470834-4CD8-479A-8B58-0A1869BA5D37}
-		{2CDF3E1C-267D-4198-B1C7-7E1F548FC120} = {5BA4A8FA-F7F4-45B3-AEC8-8886D35AAC79}
+		{4F159759-B22F-4DA6-BDDF-686E7AD0C9EB} = {C6658DE0-2B2F-47F0-BB61-2CA66D435C09}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D4B5CEAA-7D70-4FCB-A68E-B03FBE5E0E5E}

--- a/src/common/Elsa.DropIns/Contexts/NuGetPackageAssemblyLoadContext.cs
+++ b/src/common/Elsa.DropIns/Contexts/NuGetPackageAssemblyLoadContext.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using System.Runtime.Loader;
+using Elsa.Helpers;
 using NuGet.Packaging;
 
 namespace Elsa.DropIns.Contexts;
@@ -15,7 +16,7 @@ internal sealed class NuGetPackageAssemblyLoadContext : AssemblyLoadContext
         foreach (var dllFile in packageReader.GetFiles().Where(fileName => fileName.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)))
         {
             using var dllStream = packageReader.GetStream(dllFile);
-            using var memoryStream = new MemoryStream();
+            using var memoryStream = StreamHelpers.RecyclableMemoryStreamManager.GetStream(nameof(Elsa.DropIns.Contexts.NuGetPackageAssemblyLoadContext));
             dllStream.CopyTo(memoryStream);
             memoryStream.Seek(0, SeekOrigin.Begin);
             var assembly = LoadFromStream(memoryStream);

--- a/src/common/Elsa.DropIns/Elsa.DropIns.csproj
+++ b/src/common/Elsa.DropIns/Elsa.DropIns.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <Description>
@@ -19,11 +19,10 @@
 
     <!--Overridden
     for vulnerability reasons with dependencies referencing older versions.-->
-    <ItemGroup>
-    </ItemGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\Elsa.DropIns.Core\Elsa.DropIns.Core.csproj" />
+        <ProjectReference Include="..\Elsa.Helpers\Elsa.Helpers.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/common/Elsa.DropIns/Helpers/AssemblyLoader.cs
+++ b/src/common/Elsa.DropIns/Helpers/AssemblyLoader.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using System.Runtime.Loader;
 using Elsa.DropIns.Contexts;
+using Elsa.Helpers;
 
 namespace Elsa.DropIns.Helpers;
 
@@ -13,7 +14,7 @@ public static class AssemblyLoader
         
         // Copy drop in to memory stream to avoid file locking
         using var fileStream = File.OpenRead(path);
-        using var memoryStream = new MemoryStream();
+        using var memoryStream = StreamHelpers.RecyclableMemoryStreamManager.GetStream(nameof(Elsa.DropIns.Helpers.AssemblyLoader.LoadPath));
         fileStream.CopyTo(memoryStream);
         memoryStream.Seek(0, SeekOrigin.Begin);
         fileStream.Close();

--- a/src/common/Elsa.Helpers/Elsa.Helpers.csproj
+++ b/src/common/Elsa.Helpers/Elsa.Helpers.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <Description>
+            Provides static helper functions.
+        </Description>
+        <PackageTags>elsa common</PackageTags>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" />
+    </ItemGroup>
+
+</Project>

--- a/src/common/Elsa.Helpers/FodyWeavers.xml
+++ b/src/common/Elsa.Helpers/FodyWeavers.xml
@@ -1,0 +1,3 @@
+﻿<Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
+  <ConfigureAwait />
+</Weavers>

--- a/src/common/Elsa.Helpers/StreamHelpers.cs
+++ b/src/common/Elsa.Helpers/StreamHelpers.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.IO;
+
+namespace Elsa.Helpers;
+
+public static class StreamHelpers
+{
+    private static RecyclableMemoryStreamManager? _recyclableMemoryStreamManager;
+
+    public static RecyclableMemoryStreamManager RecyclableMemoryStreamManager
+    {
+        get => _recyclableMemoryStreamManager ?? new(new RecyclableMemoryStreamManager.Options()
+        {
+            BlockSize = RecyclableMemoryStreamManager.DefaultBlockSize,
+            LargeBufferMultiple = RecyclableMemoryStreamManager.DefaultLargeBufferMultiple,
+            MaximumBufferSize = RecyclableMemoryStreamManager.DefaultMaximumBufferSize,
+            GenerateCallStacks = false,
+            AggressiveBufferReturn = false,
+            MaximumLargePoolFreeBytes = 16 * 1024 * 1024 * 4,
+            MaximumSmallPoolFreeBytes = 100 * 1024
+        });
+
+        set
+        {
+            if (_recyclableMemoryStreamManager is not null)
+            {
+                return;
+            }
+            
+            _recyclableMemoryStreamManager = value;
+        }
+    }
+}

--- a/src/modules/Elsa.FileStorage/Elsa.FileStorage.csproj
+++ b/src/modules/Elsa.FileStorage/Elsa.FileStorage.csproj
@@ -16,8 +16,9 @@
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\Elsa.Workflows.Core\Elsa.Workflows.Core.csproj" />
-      <ProjectReference Include="..\Elsa.Workflows.Management\Elsa.Workflows.Management.csproj" />
+        <ProjectReference Include="..\..\common\Elsa.Helpers\Elsa.Helpers.csproj" />
+        <ProjectReference Include="..\Elsa.Workflows.Core\Elsa.Workflows.Core.csproj" />
+        <ProjectReference Include="..\Elsa.Workflows.Management\Elsa.Workflows.Management.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/modules/Elsa.Http/DownloadableContentHandlers/BinaryDownloadableContentHandler.cs
+++ b/src/modules/Elsa.Http/DownloadableContentHandlers/BinaryDownloadableContentHandler.cs
@@ -1,3 +1,4 @@
+using Elsa.Helpers;
 using Elsa.Http.Abstractions;
 using Elsa.Http.Contexts;
 
@@ -15,9 +16,10 @@ public class BinaryDownloadableContentHandler : DownloadableContentHandlerBase
     protected override Downloadable GetDownloadable(DownloadableContext context)
     {
         var bytes = (byte[]) context.Content;
-        var stream = new MemoryStream(bytes);
+        var stream = StreamHelpers.RecyclableMemoryStreamManager.GetStream(nameof(Elsa.Http.DownloadableContentHandlers.BinaryDownloadableContentHandler.GetDownloadable), bytes);
         var fileName = "file.bin";
         var contentType = "application/octet-stream";
         return new(stream, fileName, contentType);
+        // Returned streams are not disposed by the caller. Potential memory leak?! Dowloadable should implement IDisposable and dispose the stream.
     }
 }

--- a/src/modules/Elsa.Http/DownloadableContentHandlers/StringDownloadableContentHandler.cs
+++ b/src/modules/Elsa.Http/DownloadableContentHandlers/StringDownloadableContentHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text;
+using Elsa.Helpers;
 using Elsa.Http.Abstractions;
 using Elsa.Http.Contexts;
 
@@ -15,7 +16,8 @@ public class StringDownloadableContentHandler : DownloadableContentHandlerBase
     /// <inheritdoc />
     protected override Downloadable GetDownloadable(DownloadableContext context)
     {
-        var stream = new MemoryStream(Encoding.UTF8.GetBytes((string)context.Content));
+        var stream = StreamHelpers.RecyclableMemoryStreamManager.GetStream(nameof(Elsa.Http.DownloadableContentHandlers.StringDownloadableContentHandler.GetDownloadable), Encoding.UTF8.GetBytes((string)context.Content));
         return new(stream, "file.txt", "text/plain");
+        // Returned streams are not disposed by the caller. Potential memory leak?! Dowloadable should implement IDisposable and dispose the stream.
     }
 }

--- a/src/modules/Elsa.Http/Elsa.Http.csproj
+++ b/src/modules/Elsa.Http/Elsa.Http.csproj
@@ -12,6 +12,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\..\common\Elsa.Helpers\Elsa.Helpers.csproj" />
         <ProjectReference Include="..\Elsa.Liquid\Elsa.Liquid.csproj" />
         <ProjectReference Include="..\Elsa.Workflows.Runtime.ProtoActor\Elsa.Workflows.Runtime.ProtoActor.csproj" />
         <ProjectReference Include="..\Elsa.SasTokens\Elsa.SasTokens.csproj" />

--- a/src/modules/Elsa.Http/Models/HttpFile.cs
+++ b/src/modules/Elsa.Http/Models/HttpFile.cs
@@ -1,5 +1,7 @@
 using System.Net.Http.Headers;
 using System.Text.Json.Serialization;
+using Elsa.Helpers;
+using FluentStorage.Utils.Extensions;
 
 namespace Elsa.Http;
 
@@ -56,7 +58,7 @@ public class HttpFile
     /// </summary>
     public byte[] GetBytes()
     {
-        using var memoryStream = new MemoryStream();
+        using var memoryStream = StreamHelpers.RecyclableMemoryStreamManager.GetStream(nameof(Elsa.Http.HttpFile.GetBytes), Stream.Length);
         if (Stream.CanSeek) Stream.Seek(0, SeekOrigin.Begin);
         Stream.CopyTo(memoryStream);
         return memoryStream.ToArray();

--- a/src/modules/Elsa.Workflows.Api/Elsa.Workflows.Api.csproj
+++ b/src/modules/Elsa.Workflows.Api/Elsa.Workflows.Api.csproj
@@ -9,6 +9,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\common\Elsa.Api.Common\Elsa.Api.Common.csproj" />
+        <ProjectReference Include="..\..\common\Elsa.Helpers\Elsa.Helpers.csproj" />
         <ProjectReference Include="..\Elsa.Http\Elsa.Http.csproj" />
         <ProjectReference Include="..\Elsa.JavaScript\Elsa.JavaScript.csproj" />
         <ProjectReference Include="..\Elsa.Workflows.Management\Elsa.Workflows.Management.csproj" />

--- a/src/modules/Elsa.Workflows.Management/Elsa.Workflows.Management.csproj
+++ b/src/modules/Elsa.Workflows.Management/Elsa.Workflows.Management.csproj
@@ -20,6 +20,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\common\Elsa.Api.Common\Elsa.Api.Common.csproj" />
+        <ProjectReference Include="..\..\common\Elsa.Helpers\Elsa.Helpers.csproj" />
         <ProjectReference Include="..\Elsa.Caching\Elsa.Caching.csproj" />
         <ProjectReference Include="..\Elsa.Dsl\Elsa.Dsl.csproj" />
         <ProjectReference Include="..\Elsa.Workflows.Core\Elsa.Workflows.Core.csproj" />

--- a/src/modules/Elsa/Elsa.csproj
+++ b/src/modules/Elsa/Elsa.csproj
@@ -12,10 +12,12 @@
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
         <PackageReference Include="Microsoft.Extensions.Logging" />
+        <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" />
     </ItemGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\..\common\Elsa.Api.Common\Elsa.Api.Common.csproj" />
+        <ProjectReference Include="..\..\common\Elsa.Helpers\Elsa.Helpers.csproj" />
         <ProjectReference Include="..\..\modules\Elsa.Workflows.Core\Elsa.Workflows.Core.csproj" />
         <ProjectReference Include="..\..\modules\Elsa.Workflows.Management\Elsa.Workflows.Management.csproj" />
         <ProjectReference Include="..\..\modules\Elsa.Workflows.Runtime\Elsa.Workflows.Runtime.csproj" />

--- a/src/modules/Elsa/Extensions/DependencyInjectionExtensions.cs
+++ b/src/modules/Elsa/Extensions/DependencyInjectionExtensions.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using Elsa.Features;
 using Elsa.Features.Services;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IO;
 
 namespace Elsa.Extensions;
 
@@ -15,15 +16,20 @@ public static class ModuleExtensions
     /// <summary>
     /// Creates a new Elsa module and adds the <see cref="ElsaFeature"/> to it.
     /// </summary>
-    public static IModule AddElsa(this IServiceCollection services, Action<IModule>? configure = default)
+    public static IModule AddElsa(this IServiceCollection services, Action<IModule>? configure = default, RecyclableMemoryStreamManager? recyclableMemoryStreamManager = default)
     {
+        if (recyclableMemoryStreamManager is not null)
+        {
+            Helpers.StreamHelpers.RecyclableMemoryStreamManager = recyclableMemoryStreamManager;
+        }
+
         var module = services.GetOrCreateModule();
         module.Configure<AppFeature>(app => app.Configurator = configure);
         module.Apply();
         
         return module;
     }
-    
+
     /// <summary>
     /// Configures the Elsa module.
     /// </summary>


### PR DESCRIPTION
Closes #6087

Initial commit switching from `MemorySteam` to `Microsoft.IO.RecyclableMemoryStream`.
What do you think about the implementation in general? If OK, I have added a few comments in the code that should be addressed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6093)
<!-- Reviewable:end -->
