### PR TITLE
Add Variable Name Validation and Wrapper Control  

### DIFF
--- a/src/apps/Elsa.Server.Web/Program.cs
+++ b/src/apps/Elsa.Server.Web/Program.cs
@@ -71,6 +71,7 @@ const MassTransitBroker massTransitBroker = MassTransitBroker.Memory;
 const bool useMultitenancy = false;
 const bool useAgents = false;
 const bool useSecrets = true;
+const bool disableVariableWrappers = false;
 
 var builder = WebApplication.CreateBuilder(args);
 var services = builder.Services;
@@ -314,6 +315,7 @@ services
             .UseJavaScript(options =>
             {
                 options.AllowClrAccess = true;
+                options.DisableWrappers = disableVariableWrappers;
                 options.ConfigureEngine(engine =>
                 {
                     engine.Execute("function greet(name) { return `Hello ${name}!`; }");

--- a/src/modules/Elsa.CSharp/Extensions/VariableNameExtensions.cs
+++ b/src/modules/Elsa.CSharp/Extensions/VariableNameExtensions.cs
@@ -1,0 +1,19 @@
+namespace Elsa.CSharp.Extensions;
+
+public static class VariableNameExtensions
+{
+    public static bool IsValidVariableName(this string name)
+    {
+        return !string.IsNullOrWhiteSpace(name) && name.All(char.IsLetterOrDigit);
+    }
+    
+    public static bool IsInvalidVariableName(this string name)
+    {
+        return !IsValidVariableName(name);
+    }
+    
+    public static IEnumerable<string> FilterInvalidVariableNames(this IEnumerable<string> names)
+    {
+        return names.Where(IsValidVariableName);
+    }
+}

--- a/src/modules/Elsa.CSharp/Handlers/GenerateWorkflowVariableAccessors.cs
+++ b/src/modules/Elsa.CSharp/Handlers/GenerateWorkflowVariableAccessors.cs
@@ -1,10 +1,13 @@
 using System.Text;
+using Elsa.CSharp.Extensions;
 using Elsa.CSharp.Notifications;
+using Elsa.CSharp.Options;
 using Elsa.Expressions.Models;
 using Elsa.Extensions;
 using Elsa.Mediator.Contracts;
 using Humanizer;
 using JetBrains.Annotations;
+using Microsoft.Extensions.Options;
 
 namespace Elsa.CSharp.Handlers;
 
@@ -12,7 +15,7 @@ namespace Elsa.CSharp.Handlers;
 /// Configures the C# evaluator with methods to access workflow variables.
 /// </summary>
 [UsedImplicitly]
-public class GenerateWorkflowVariableAccessors : INotificationHandler<EvaluatingCSharp>
+public class GenerateWorkflowVariableAccessors(IOptions<CSharpOptions> options) : INotificationHandler<EvaluatingCSharp>
 {
     /// <inheritdoc />
     public Task HandleAsync(EvaluatingCSharp notification, CancellationToken cancellationToken)
@@ -28,16 +31,20 @@ public class GenerateWorkflowVariableAccessors : INotificationHandler<Evaluating
         sb.AppendLine("\tpublic object? Get(string name) => ExecutionContext.GetVariable(name);");
         sb.AppendLine("\tpublic void Set(string name, object? value) => ExecutionContext.SetVariable(name, value);");
         sb.AppendLine();
-        foreach (var variable in variables)
+
+        if (!options.Value.DisableWrappers)
         {
-            var variableName = variable.Name.Pascalize();
-            var variableType = variable.GetVariableType();
-            var friendlyTypeName = variableType.GetFriendlyTypeName(Brackets.Angle);
-            sb.AppendLine($"\tpublic {friendlyTypeName} {variableName}");
-            sb.AppendLine("\t{");
-            sb.AppendLine($"\t\tget => Get<{friendlyTypeName}>(\"{variableName}\");");
-            sb.AppendLine($"\t\tset => Set(\"{variableName}\", value);");
-            sb.AppendLine("\t}");
+            foreach (var variable in variables.Where(x => x.Name.IsValidVariableName()))
+            {
+                var variableName = variable.Name.Pascalize();
+                var variableType = variable.GetVariableType();
+                var friendlyTypeName = variableType.GetFriendlyTypeName(Brackets.Angle);
+                sb.AppendLine($"\tpublic {friendlyTypeName} {variableName}");
+                sb.AppendLine("\t{");
+                sb.AppendLine($"\t\tget => Get<{friendlyTypeName}>(\"{variableName}\");");
+                sb.AppendLine($"\t\tset => Set(\"{variableName}\", value);");
+                sb.AppendLine("\t}");
+            }
         }
 
         sb.AppendLine("}");

--- a/src/modules/Elsa.CSharp/Options/CSharpOptions.cs
+++ b/src/modules/Elsa.CSharp/Options/CSharpOptions.cs
@@ -49,6 +49,12 @@ public class CSharpOptions
         typeof(JsonNode).Namespace!, // System.Text.Json.Nodes
         typeof(IDictionary<string, object>).Namespace!, // System.Collections.Generic
     });
+    
+    /// <summary>
+    /// Disables the generation of variable wrappers. E.g. <c>Variables.MyVariable</c> will no longer be available for variables. Instead, you can only access variables using <c>Variables.Get("MyVariable")</c> and the typed <c>Variables.Get&lt;T&gt;("MyVariable")</c> function.
+    /// This is useful if your application requires the use of invalid JavaScript variable names.
+    /// </summary>
+    public bool DisableWrappers { get; set; }
 
     /// <summary>
     /// Configures the <see cref="ScriptOptions"/>.

--- a/src/modules/Elsa.JavaScript/Elsa.JavaScript.csproj
+++ b/src/modules/Elsa.JavaScript/Elsa.JavaScript.csproj
@@ -18,4 +18,8 @@
         <PackageReference Include="Jint" />
     </ItemGroup>
 
+    <ItemGroup>
+      <Folder Include="TypeDefinitions\Providers\" />
+    </ItemGroup>
+
 </Project>

--- a/src/modules/Elsa.JavaScript/Elsa.JavaScript.csproj
+++ b/src/modules/Elsa.JavaScript/Elsa.JavaScript.csproj
@@ -18,8 +18,4 @@
         <PackageReference Include="Jint" />
     </ItemGroup>
 
-    <ItemGroup>
-      <Folder Include="TypeDefinitions\Providers\" />
-    </ItemGroup>
-
 </Project>

--- a/src/modules/Elsa.JavaScript/Extensions/VariableNameExtensions.cs
+++ b/src/modules/Elsa.JavaScript/Extensions/VariableNameExtensions.cs
@@ -1,0 +1,21 @@
+using Elsa.JavaScript.Helpers;
+
+namespace Elsa.JavaScript.Extensions;
+
+public static class VariableNameExtensions
+{
+    public static bool IsValidVariableName(this string name)
+    {
+        return VariableNameValidator.IsValidVariableName(name);
+    }
+    
+    public static bool IsInvalidVariableName(this string name)
+    {
+        return !VariableNameValidator.IsValidVariableName(name);
+    }
+    
+    public static IEnumerable<string> FilterInvalidVariableNames(this IEnumerable<string> names)
+    {
+        return names.Where(IsValidVariableName);
+    }
+}

--- a/src/modules/Elsa.JavaScript/Features/JavaScriptFeature.cs
+++ b/src/modules/Elsa.JavaScript/Features/JavaScriptFeature.cs
@@ -13,7 +13,6 @@ using Elsa.JavaScript.Options;
 using Elsa.JavaScript.Providers;
 using Elsa.JavaScript.Services;
 using Elsa.JavaScript.TypeDefinitions.Contracts;
-using Elsa.JavaScript.TypeDefinitions.Providers;
 using Elsa.JavaScript.TypeDefinitions.Services;
 using Elsa.Workflows;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/modules/Elsa.JavaScript/Helpers/VariableNameValidator.cs
+++ b/src/modules/Elsa.JavaScript/Helpers/VariableNameValidator.cs
@@ -1,0 +1,9 @@
+namespace Elsa.JavaScript.Helpers;
+
+public static class VariableNameValidator
+{
+    public static bool IsValidVariableName(string name)
+    {
+        return !string.IsNullOrWhiteSpace(name) && name.All(char.IsLetterOrDigit);
+    }
+}

--- a/src/modules/Elsa.JavaScript/Options/JintOptions.cs
+++ b/src/modules/Elsa.JavaScript/Options/JintOptions.cs
@@ -40,6 +40,12 @@ public class JintOptions
     /// If the value of <c>ScriptCacheTimeout</c> is <c>null</c>, the scripts are cached indefinitely. If a time value is specified, the scripts will be recompiled after the specified duration has elapsed.
     /// </remarks>
     public TimeSpan? ScriptCacheTimeout { get; set; } = TimeSpan.FromDays(1);
+
+    /// <summary>
+    /// Disables the generation of variable wrappers. E.g. <c>getMyVariable()</c> will no longer be available for variables. Instead, you can only access variables using <c>getVariable("MyVariable")</c> function.
+    /// This is useful if your application requires the use of invalid JavaScript variable names.
+    /// </summary>
+    public bool DisableWrappers { get; set; }
     
     /// <summary>
     /// Configures the Jint engine options.

--- a/src/modules/Elsa.JavaScript/Providers/ActivityOutputFunctionsDefinitionProvider.cs
+++ b/src/modules/Elsa.JavaScript/Providers/ActivityOutputFunctionsDefinitionProvider.cs
@@ -1,25 +1,31 @@
 using Elsa.Extensions;
+using Elsa.JavaScript.Extensions;
+using Elsa.JavaScript.Options;
 using Elsa.JavaScript.TypeDefinitions.Abstractions;
 using Elsa.JavaScript.TypeDefinitions.Models;
 using Elsa.Workflows;
 using Humanizer;
 using JetBrains.Annotations;
+using Microsoft.Extensions.Options;
 
-namespace Elsa.JavaScript.TypeDefinitions.Providers;
+namespace Elsa.JavaScript.Providers;
 
 /// Produces <see cref="FunctionDefinition"/>s for common functions.
 [UsedImplicitly]
-internal class ActivityOutputFunctionsDefinitionProvider(IActivityRegistryLookupService activityRegistryLookup) : FunctionDefinitionProvider
+internal class ActivityOutputFunctionsDefinitionProvider(IActivityRegistryLookupService activityRegistryLookup, IOptions<JintOptions> options) : FunctionDefinitionProvider
 {
     protected override async ValueTask<IEnumerable<FunctionDefinition>> GetFunctionDefinitionsAsync(TypeDefinitionContext context)
     {
+        if(options.Value.DisableWrappers)
+            return [];
+        
         var nodes = context.WorkflowGraph.Nodes;
-        var activitiesWithOutputs = nodes.GetActivitiesWithOutputs(activityRegistryLookup).Where(x => x.activity.Name != null);
+        var activitiesWithOutputs = nodes.GetActivitiesWithOutputs(activityRegistryLookup).Where(x => x.activity.Name != null && x.activity.Name.IsValidVariableName());
         var definitions = new List<FunctionDefinition>();
 
         await foreach (var (activity, activityDescriptor) in activitiesWithOutputs)
         {
-            definitions.AddRange(from output in activityDescriptor.Outputs
+            definitions.AddRange(from output in activityDescriptor.Outputs.Where(x => x.Name.IsValidVariableName())
                 select output.Name.Pascalize()
                 into outputPascalName
                 let activityNamePascalName = activity.Name.Pascalize()

--- a/src/modules/Elsa.JavaScript/Providers/CommonTypesDefinitionProvider.cs
+++ b/src/modules/Elsa.JavaScript/Providers/CommonTypesDefinitionProvider.cs
@@ -3,7 +3,7 @@ using Elsa.JavaScript.TypeDefinitions.Abstractions;
 using Elsa.JavaScript.TypeDefinitions.Contracts;
 using Elsa.JavaScript.TypeDefinitions.Models;
 
-namespace Elsa.JavaScript.TypeDefinitions.Providers;
+namespace Elsa.JavaScript.Providers;
 
 /// <summary>
 /// Produces <see cref="FunctionDefinition"/>s for common functions.

--- a/src/modules/Elsa.JavaScript/Providers/InputFunctionsDefinitionProvider.cs
+++ b/src/modules/Elsa.JavaScript/Providers/InputFunctionsDefinitionProvider.cs
@@ -1,18 +1,24 @@
 using Elsa.JavaScript.Contracts;
+using Elsa.JavaScript.Helpers;
+using Elsa.JavaScript.Options;
 using Elsa.JavaScript.TypeDefinitions.Abstractions;
 using Elsa.JavaScript.TypeDefinitions.Models;
 using Elsa.Workflows.Activities;
 using Humanizer;
 using JetBrains.Annotations;
+using Microsoft.Extensions.Options;
 
 namespace Elsa.JavaScript.Providers;
 
 /// Produces <see cref="FunctionDefinition"/>s for common functions.
 [UsedImplicitly]
-internal class InputFunctionsDefinitionProvider(ITypeAliasRegistry typeAliasRegistry) : FunctionDefinitionProvider
+internal class InputFunctionsDefinitionProvider(ITypeAliasRegistry typeAliasRegistry, IOptions<JintOptions> options) : FunctionDefinitionProvider
 {
     protected override ValueTask<IEnumerable<FunctionDefinition>> GetFunctionDefinitionsAsync(TypeDefinitionContext context)
     {
+        if(options.Value.DisableWrappers)
+            return ValueTask.FromResult<IEnumerable<FunctionDefinition>>([]);
+        
         var workflow = context.WorkflowGraph.Workflow;
         return ValueTask.FromResult(GetFunctionDefinitionsAsync(workflow));
     }
@@ -20,7 +26,7 @@ internal class InputFunctionsDefinitionProvider(ITypeAliasRegistry typeAliasRegi
     private IEnumerable<FunctionDefinition> GetFunctionDefinitionsAsync(Workflow workflow)
     {
         // Input argument getters.
-        foreach (var input in workflow.Inputs)
+        foreach (var input in workflow.Inputs.Where(x => VariableNameValidator.IsValidVariableName(x.Name)))
         {
             var pascalName = input.Name.Pascalize();
             var variableType = input.Type;

--- a/src/modules/Elsa.JavaScript/Providers/VariableTypeDefinitionProvider.cs
+++ b/src/modules/Elsa.JavaScript/Providers/VariableTypeDefinitionProvider.cs
@@ -4,7 +4,7 @@ using Elsa.JavaScript.TypeDefinitions.Abstractions;
 using Elsa.JavaScript.TypeDefinitions.Contracts;
 using Elsa.JavaScript.TypeDefinitions.Models;
 
-namespace Elsa.JavaScript.TypeDefinitions.Providers;
+namespace Elsa.JavaScript.Providers;
 
 /// <summary>
 /// Produces <see cref="TypeDefinition"/>s for variable types.

--- a/src/modules/Elsa.JavaScript/Providers/WorkflowVariablesTypeDefinitionProvider.cs
+++ b/src/modules/Elsa.JavaScript/Providers/WorkflowVariablesTypeDefinitionProvider.cs
@@ -1,15 +1,21 @@
 using Elsa.Extensions;
+using Elsa.JavaScript.Extensions;
+using Elsa.JavaScript.Options;
 using Elsa.JavaScript.TypeDefinitions.Abstractions;
 using Elsa.JavaScript.TypeDefinitions.Models;
 using JetBrains.Annotations;
+using Microsoft.Extensions.Options;
 
-namespace Elsa.JavaScript.TypeDefinitions.Providers;
+namespace Elsa.JavaScript.Providers;
 
 [UsedImplicitly]
-internal class WorkflowVariablesTypeDefinitionProvider : TypeDefinitionProvider
+internal class WorkflowVariablesTypeDefinitionProvider(IOptions<JintOptions> options) : TypeDefinitionProvider
 {
     protected override IEnumerable<TypeDefinition> GetTypeDefinitions(TypeDefinitionContext context)
     {
+        if(options.Value.DisableWrappers)
+            yield break;
+        
         var variables = context.WorkflowGraph.Workflow.Variables;
         
         var workflowTypeDefinition = new TypeDefinition
@@ -18,7 +24,7 @@ internal class WorkflowVariablesTypeDefinitionProvider : TypeDefinitionProvider
             DeclarationKeyword = "class"
         };
 
-        foreach (var variable in variables)
+        foreach (var variable in variables.Where(x => x.Name.IsValidVariableName()))
         {
             var variableType = variable.GetVariableType();
             workflowTypeDefinition.Properties.Add(new PropertyDefinition

--- a/src/modules/Elsa.JavaScript/Providers/WorkflowVariablesVariableProvider.cs
+++ b/src/modules/Elsa.JavaScript/Providers/WorkflowVariablesVariableProvider.cs
@@ -1,14 +1,19 @@
+using Elsa.JavaScript.Options;
 using Elsa.JavaScript.TypeDefinitions.Abstractions;
 using Elsa.JavaScript.TypeDefinitions.Models;
 using JetBrains.Annotations;
+using Microsoft.Extensions.Options;
 
-namespace Elsa.JavaScript.TypeDefinitions.Providers;
+namespace Elsa.JavaScript.Providers;
 
 [UsedImplicitly]
-internal class WorkflowVariablesVariableProvider : VariableDefinitionProvider
+internal class WorkflowVariablesVariableProvider(IOptions<JintOptions> options) : VariableDefinitionProvider
 {
     protected override IEnumerable<VariableDefinition> GetVariableDefinitions(TypeDefinitionContext context)
     {
+        if(options.Value.DisableWrappers)
+            yield break;
+        
         yield return CreateVariableDefinition(x => x.Name("variables").Type("WorkflowVariables"));
     }
 }


### PR DESCRIPTION
This PR adds an option to disable the automatic wrapper generation of C# and JavaScript functions for workflow variables.  

### Changes:  
- **C# Syntax:**  
  When opting out, `Variables.MyVariable` will no longer be available. Variables can only be accessed using:  
  - `Variables.Get("MyVariable")`  
  - `Variables.Get<T>("MyVariable")`  

- **JavaScript Syntax:**  
  When opting out, `variables.MyVariable` and `getMyVariable()` will no longer be available. Variables can only be accessed using:  
  - `getVariable("MyVariable")`  

### Use Case:  
This feature is helpful for applications requiring the use of variable names that are invalid in JavaScript or C#.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6117)
<!-- Reviewable:end -->
