### PR TITLE
Fix workflow definition finder

### DIFF
--- a/src/modules/Elsa.Workflows.Management/Services/WorkflowReferenceUpdater.cs
+++ b/src/modules/Elsa.Workflows.Management/Services/WorkflowReferenceUpdater.cs
@@ -26,20 +26,20 @@ public class WorkflowReferenceUpdater(
 
         // Find all workflow graphs that contain the updated workflow definition.
         var consumingWorkflowGraphs = await FindWorkflowsContainingUpdatedWorkflowDefinitionAsync(referencedDefinition.DefinitionId, cancellationToken);
-        
+
         // Update consuming workflows.
         var updatedWorkflows = new List<WorkflowDefinition>();
         foreach (var workflowGraph in consumingWorkflowGraphs)
         {
             var newDefinition = await UpdateConsumingWorkflowAsync(workflowGraph, referencedDefinition, cancellationToken);
-            
+
             if (newDefinition != null)
                 updatedWorkflows.Add(newDefinition);
         }
 
         return new UpdateWorkflowReferencesResult(updatedWorkflows);
     }
-    
+
     private async Task<WorkflowDefinition?> UpdateConsumingWorkflowAsync(WorkflowGraph workflowGraph, WorkflowDefinition definition, CancellationToken cancellationToken)
     {
         // Create a new version of the published workflow definition or get the existing draft.
@@ -102,9 +102,11 @@ public class WorkflowReferenceUpdater(
         {
             if (child.Activity is WorkflowDefinitionActivity workflowDefinitionActivity)
                 yield return workflowDefinitionActivity;
-
-            foreach (var grandChild in FindWorkflowActivityDefinitionActivityNodes(child))
-                yield return grandChild;
+            else
+            {
+                foreach (var grandChild in FindWorkflowActivityDefinitionActivityNodes(child))
+                    yield return grandChild;
+            }
         }
     }
 


### PR DESCRIPTION
Fixes that the workflow reference updater would collect child workflows from child workflows, instead of collecting only immediate children.
