### PR TITLE
Refactor connection traversal to use visitedConnections set

### DIFF
--- a/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Extensions/ConnectionsExtensions.cs
+++ b/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Extensions/ConnectionsExtensions.cs
@@ -12,10 +12,10 @@ public static class ConnectionsExtensions
     /// </summary>
     public static IEnumerable<Connection> Descendants(this ICollection<Connection> connections, IActivity parent)
     {
-        var visitedActivities = new HashSet<IActivity>();
-        return connections.Descendants(parent, visitedActivities);
+        var visitedConnections = new HashSet<Connection>();
+        return connections.Descendants(parent, visitedConnections);
     }
-    
+
     /// <summary>
     /// Returns all ancestor connections of the specified parent activity.
     /// </summary>
@@ -41,7 +41,7 @@ public static class ConnectionsExtensions
 
         return filteredConnections;
     }
-    
+
     /// <summary>
     /// Returns all "left" ancestor connections of the specified activity. "Left" means "not a descendant of the activity".
     /// </summary>
@@ -58,27 +58,27 @@ public static class ConnectionsExtensions
     /// Returns all inbound activities of the specified activity.
     /// </summary>
     public static IEnumerable<IActivity> InboundActivities(this ICollection<Connection> connections, IActivity activity) => connections.InboundConnections(activity).Select(x => x.Source.Activity);
-    
+
     /// <summary>
     /// Returns all "left" inbound activities of the specified activity. "Left" means "not a descendant of the activity".
     /// </summary>
     public static IEnumerable<IActivity> LeftInboundActivities(this ICollection<Connection> connections, IActivity activity) => connections.LeftInboundConnections(activity).Select(x => x.Source.Activity);
-    
+
     /// <summary>
     /// Returns all "left" ancestor activities of the specified activity. "Left" means "not a descendant of the activity".
     /// </summary>
     public static IEnumerable<IActivity> LeftAncestorActivities(this ICollection<Connection> connections, IActivity activity) => connections.LeftAncestorConnections(activity).Select(x => x.Source.Activity);
 
-    private static IEnumerable<Connection> Descendants(this ICollection<Connection> connections, IActivity parent, ISet<IActivity> visitedActivities)
+    private static IEnumerable<Connection> Descendants(this ICollection<Connection> connections, IActivity parent, ISet<Connection> visitedConnections)
     {
-        var children = connections.Where(x => parent == x.Source.Activity && !visitedActivities.Contains(x.Target.Activity)).ToList();
+        var children = connections.Where(x => parent == x.Source.Activity && !visitedConnections.Contains(x)).ToList();
 
         foreach (var child in children)
         {
-            visitedActivities.Add(child.Target.Activity);
+            visitedConnections.Add(child);
             yield return child;
 
-            var descendants = connections.Descendants(child.Target.Activity, visitedActivities).ToList();
+            var descendants = connections.Descendants(child.Target.Activity, visitedConnections).ToList();
 
             foreach (var descendant in descendants)
             {
@@ -86,7 +86,7 @@ public static class ConnectionsExtensions
             }
         }
     }
-    
+
     private static IEnumerable<Connection> Ancestors(this ICollection<Connection> connections, IActivity activity, ISet<IActivity> visitedActivities)
     {
         var parents = connections.Where(x => activity == x.Target.Activity && !visitedActivities.Contains(x.Source.Activity)).ToList();


### PR DESCRIPTION
Replaced visitedActivities with visitedConnections to ensure accuracy and clarity in tracking visited connections rather than activities. This change fixes #5865

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6138)
<!-- Reviewable:end -->
