### PR TITLE
Fix the memory surge caused by script running and not being GC controlled for a long time

### DIFF
--- a/src/modules/Elsa.CSharp/Services/CSharpEvaluator.cs
+++ b/src/modules/Elsa.CSharp/Services/CSharpEvaluator.cs
@@ -51,7 +51,11 @@ public class CSharpEvaluator(INotificationSender notificationSender, IOptions<CS
         script = notification.Script.ContinueWith(expression, scriptOptions);
         script = GetPreCompiledScript(script);
         var scriptState = await script.RunAsync(globals, cancellationToken: cancellationToken);
-        return scriptState.ReturnValue;
+
+        var returnValue = scriptState.ReturnValue;
+        scriptState = null;
+
+        return returnValue;
     }
 
     private Script<object> GetPreCompiledScript(Script<object> script)


### PR DESCRIPTION
When there are a large number of C # scripts, frequent compilation and running of scripts can cause memory to skyrocket and not be released by GC for a long time.It will cause the server to run out of memory and crash.
By pointing scriptState to a null reference to break the reference relationship, it can be released by GC as early as possible, thereby reducing memory resource consumption.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6145)
<!-- Reviewable:end -->
