### PR TITLE
Fix: Resolve Python.Runtime.BadPythonDllException in Elsa.ServerAndStudio.Web

### DIFF
--- a/src/apps/Elsa.ServerAndStudio.Web/Program.cs
+++ b/src/apps/Elsa.ServerAndStudio.Web/Program.cs
@@ -108,7 +108,15 @@ services
             })
             .UseLiquid()
             .UseCSharp()
-            .UsePython()
+            .UsePython(python =>
+            {
+                python.PythonOptions += options =>
+                {
+                    // Make sure to configure the path to the python DLL. E.g. /opt/homebrew/Cellar/python@3.11/3.11.6_1/Frameworks/Python.framework/Versions/3.11/bin/python3.11
+                    // alternatively, you can set the PYTHONNET_PYDLL environment variable.
+                    configuration.GetSection("Scripting:Python").Bind(options);
+                };
+            })
             .UseHttp(http =>
             {
                 if (useCaching)


### PR DESCRIPTION
This PR addresses the Python.Runtime.BadPythonDllException error encountered in the Elsa.ServerAndStudio.Web solution. The error occurs because Runtime.PythonDLL path was not set

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6151)
<!-- Reviewable:end -->
