### PR TITLE
Fix JS Variable Setting Bug in Workflow Variable Sync Logic  

### DIFF
--- a/src/modules/Elsa.JavaScript/Extensions/EngineExtensions.cs
+++ b/src/modules/Elsa.JavaScript/Extensions/EngineExtensions.cs
@@ -1,5 +1,8 @@
+using Elsa.JavaScript.Helpers;
+using Elsa.JavaScript.Options;
 using Jint;
 using Jint.Runtime.Interop;
+using Microsoft.Extensions.Options;
 
 // ReSharper disable once CheckNamespace
 namespace Elsa.Extensions;
@@ -18,4 +21,15 @@ public static class EngineExtensions
     /// Register the specified type <c>T</c> with the engine.
     /// </summary>
     public static void RegisterType(this Engine engine, Type type) => engine.SetValue(type.Name, TypeReference.CreateTypeReference(engine, type));
+
+    internal static void SyncVariablesContainer(this Engine engine, IOptions<JintOptions> options, string name, object? value)
+    {
+        if (!options.Value.DisableWrappers)
+        {
+            // To ensure both variable accessor syntaxes work, we need to update the variables container in the engine as well as the context to keep them in sync.
+            var variablesContainer = (IDictionary<string, object?>)engine.GetValue("variables").ToObject()!;
+            variablesContainer[name] = ObjectConverterHelper.ProcessVariableValue(engine, value);
+            engine.SetValue("variables", variablesContainer);
+        }
+    }
 }

--- a/src/modules/Elsa.JavaScript/Handlers/ConfigureEngineWithCommonFunctions.cs
+++ b/src/modules/Elsa.JavaScript/Handlers/ConfigureEngineWithCommonFunctions.cs
@@ -5,9 +5,12 @@ using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 using System.Text.Unicode;
 using Elsa.Extensions;
+using Elsa.JavaScript.Helpers;
 using Elsa.JavaScript.Notifications;
+using Elsa.JavaScript.Options;
 using Elsa.Mediator.Contracts;
 using JetBrains.Annotations;
+using Microsoft.Extensions.Options;
 
 namespace Elsa.JavaScript.Handlers;
 
@@ -15,7 +18,7 @@ namespace Elsa.JavaScript.Handlers;
 /// A handler that configures the Jint engine with common functions.
 /// </summary>
 [UsedImplicitly]
-public class ConfigureEngineWithCommonFunctions : INotificationHandler<EvaluatingJavaScript>
+public class ConfigureEngineWithCommonFunctions(IOptions<JintOptions> options) : INotificationHandler<EvaluatingJavaScript>
 {
     private readonly JsonSerializerOptions _jsonSerializerOptions = CreateJsonSerializerOptions();
 
@@ -32,7 +35,11 @@ public class ConfigureEngineWithCommonFunctions : INotificationHandler<Evaluatin
         engine.SetValue("getWorkflowInstanceId", (Func<string>)(() => context.GetActivityExecutionContext().WorkflowExecutionContext.Id));
         engine.SetValue("setCorrelationId", (Action<string?>)(value => context.GetActivityExecutionContext().WorkflowExecutionContext.CorrelationId = value));
         engine.SetValue("getCorrelationId", (Func<string?>)(() => context.GetActivityExecutionContext().WorkflowExecutionContext.CorrelationId));
-        engine.SetValue("setVariable", (Action<string, object>)((name, value) => context.SetVariableInScope(name, value)));
+        engine.SetValue("setVariable", (Action<string, object>)((name, value) =>
+        {
+            engine.SyncVariablesContainer(options, name, value);
+            context.SetVariableInScope(name, value);
+        }));
         engine.SetValue("getVariable", (Func<string, object?>)(name => context.GetVariableInScope(name)));
         engine.SetValue("getInput", (Func<string, object?>)(name => context.GetInput(name)));
         engine.SetValue("getOutputFrom", (Func<string, string?, object?>)((activityIdName, outputName) => context.GetOutput(activityIdName, outputName)));

--- a/src/modules/Elsa.JavaScript/Helpers/ObjectConverterHelper.cs
+++ b/src/modules/Elsa.JavaScript/Helpers/ObjectConverterHelper.cs
@@ -1,14 +1,30 @@
 using System.Collections;
+using System.Dynamic;
 using Elsa.Extensions;
+using Elsa.JavaScript.Options;
 using Jint;
 using Jint.Native;
 using Jint.Native.Object;
 using Jint.Runtime.Descriptors;
+using Microsoft.Extensions.Options;
 
 namespace Elsa.JavaScript.Helpers;
 
 internal static class ObjectConverterHelper
 {
+    
+    
+    public static object? ProcessVariableValue(Engine engine, object? variableValue)
+    {
+        if (variableValue == null)
+            return null;
+
+        if (variableValue is not ExpandoObject expandoObject)
+            return variableValue;
+
+        return ConvertToJsObject(engine, expandoObject);
+    }
+    
     public static ObjectInstance ConvertToJsObject(Engine engine, IDictionary<string, object?> expando)
     {
         var jsObject = engine.Intrinsics.Object.Construct([]);

--- a/src/modules/Elsa.Tenants/Features/TenantsFeature.cs
+++ b/src/modules/Elsa.Tenants/Features/TenantsFeature.cs
@@ -1,6 +1,7 @@
 using Elsa.Common.Features;
 using Elsa.Common.Multitenancy;
 using Elsa.Features.Abstractions;
+using Elsa.Features.Attributes;
 using Elsa.Features.Services;
 using Elsa.Tenants.Options;
 using Elsa.Tenants.Providers;
@@ -11,6 +12,7 @@ namespace Elsa.Tenants.Features;
 /// <summary>
 /// Configures multi-tenancy features.
 /// </summary>
+[DependencyOf(typeof(MultitenancyFeature))]
 public class TenantsFeature(IModule serviceConfiguration) : FeatureBase(serviceConfiguration)
 {
     /// <summary>

--- a/test/component/Elsa.Workflows.ComponentTests/Scenarios/JavaScriptVariables/JavaScriptVariablesWorkflow1.cs
+++ b/test/component/Elsa.Workflows.ComponentTests/Scenarios/JavaScriptVariables/JavaScriptVariablesWorkflow1.cs
@@ -1,0 +1,16 @@
+using Elsa.Extensions;
+using Elsa.JavaScript.Activities;
+
+namespace Elsa.Workflows.ComponentTests.Scenarios.JavaScriptVariables;
+
+public class JavaScriptVariablesWorkflow1 : WorkflowBase
+{
+    public static readonly string DefinitionId = Guid.NewGuid().ToString();
+
+    protected override void Build(IWorkflowBuilder builder)
+    {
+        builder.WithDefinitionId(DefinitionId);
+        builder.WithVariable("MagicNumber", 3).WithWorkflowStorage();
+        builder.Root = new RunJavaScript("setMagicNumber(42)", default, default);
+    }
+}

--- a/test/component/Elsa.Workflows.ComponentTests/Scenarios/JavaScriptVariables/JavaScriptVariablesWorkflow2.cs
+++ b/test/component/Elsa.Workflows.ComponentTests/Scenarios/JavaScriptVariables/JavaScriptVariablesWorkflow2.cs
@@ -1,0 +1,16 @@
+using Elsa.Extensions;
+using Elsa.JavaScript.Activities;
+
+namespace Elsa.Workflows.ComponentTests.Scenarios.JavaScriptVariables;
+
+public class JavaScriptVariablesWorkflow2 : WorkflowBase
+{
+    public static readonly string DefinitionId = Guid.NewGuid().ToString();
+
+    protected override void Build(IWorkflowBuilder builder)
+    {
+        builder.WithDefinitionId(DefinitionId);
+        builder.WithVariable("MagicNumber", 3).WithWorkflowStorage();
+        builder.Root = new RunJavaScript("variables.MagicNumber = 42", default, default);
+    }
+}

--- a/test/component/Elsa.Workflows.ComponentTests/Scenarios/JavaScriptVariables/JavaScriptVariablesWorkflow3.cs
+++ b/test/component/Elsa.Workflows.ComponentTests/Scenarios/JavaScriptVariables/JavaScriptVariablesWorkflow3.cs
@@ -1,0 +1,16 @@
+using Elsa.Extensions;
+using Elsa.JavaScript.Activities;
+
+namespace Elsa.Workflows.ComponentTests.Scenarios.JavaScriptVariables;
+
+public class JavaScriptVariablesWorkflow3 : WorkflowBase
+{
+    public static readonly string DefinitionId = Guid.NewGuid().ToString();
+
+    protected override void Build(IWorkflowBuilder builder)
+    {
+        builder.WithDefinitionId(DefinitionId);
+        builder.WithVariable("MagicNumber", 3).WithWorkflowStorage();
+        builder.Root = new RunJavaScript("setVariable('MagicNumber', 42)", default, default);
+    }
+}

--- a/test/component/Elsa.Workflows.ComponentTests/Scenarios/JavaScriptVariables/JavaScriptVariablesWorkflowTests.cs
+++ b/test/component/Elsa.Workflows.ComponentTests/Scenarios/JavaScriptVariables/JavaScriptVariablesWorkflowTests.cs
@@ -39,7 +39,8 @@ public class JavaScriptVariablesWorkflowTests(App app) : AppComponentTest(app)
         return
         [
             [JavaScriptVariablesWorkflow1.DefinitionId],
-            [JavaScriptVariablesWorkflow2.DefinitionId]
+            [JavaScriptVariablesWorkflow2.DefinitionId],
+            [JavaScriptVariablesWorkflow3.DefinitionId]
         ];
     }
 

--- a/test/component/Elsa.Workflows.ComponentTests/Scenarios/JavaScriptVariables/JavaScriptVariablesWorkflowTests.cs
+++ b/test/component/Elsa.Workflows.ComponentTests/Scenarios/JavaScriptVariables/JavaScriptVariablesWorkflowTests.cs
@@ -1,0 +1,50 @@
+using Elsa.Expressions.Helpers;
+using Elsa.Extensions;
+using Elsa.Workflows.ComponentTests.Abstractions;
+using Elsa.Workflows.ComponentTests.Fixtures;
+using Elsa.Workflows.Management;
+using Elsa.Workflows.Models;
+using Elsa.Workflows.Runtime;
+using Elsa.Workflows.Runtime.Messages;
+using Elsa.Workflows.State;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Elsa.Workflows.ComponentTests.Scenarios.JavaScriptVariables;
+
+public class JavaScriptVariablesWorkflowTests(App app) : AppComponentTest(app)
+{
+    [Theory(DisplayName = "SetVariable JS function sets a variable and does not get overridden by variables API")]
+    [MemberData(nameof(GetWorkflowDefinitions))]
+    public async Task SetVariableRetainsValue(string workflowDefinitionId)
+    {
+        var workflowRuntime = Scope.ServiceProvider.GetRequiredService<IWorkflowRuntime>();
+        var workflowInstanceStore = Scope.ServiceProvider.GetRequiredService<IWorkflowInstanceStore>();
+        var workflowClient = await workflowRuntime.CreateClientAsync();
+        var runAndCreateRequest = new CreateAndRunWorkflowInstanceRequest
+        {
+            WorkflowDefinitionHandle = WorkflowDefinitionHandle.ByDefinitionId(workflowDefinitionId)
+        };
+        var runResponse = await workflowClient.CreateAndRunInstanceAsync(runAndCreateRequest);
+        var workflowInstanceId = runResponse.WorkflowInstanceId;
+        var workflowInstance = await workflowInstanceStore.FindAsync(workflowInstanceId);
+        var workflowState = workflowInstance!.WorkflowState;
+        var rootWorkflowActivityExecutionContext = workflowState.ActivityExecutionContexts.Single(x => x.ParentContextId == null);
+        var variables = GetVariablesDictionary(rootWorkflowActivityExecutionContext);
+        var magicNumber = variables["Workflow1:variable-1"].ConvertTo<int>();
+        Assert.Equal(42, magicNumber);
+    }
+
+    public static IEnumerable<object[]> GetWorkflowDefinitions()
+    {
+        return
+        [
+            [JavaScriptVariablesWorkflow1.DefinitionId],
+            [JavaScriptVariablesWorkflow2.DefinitionId]
+        ];
+    }
+
+    private VariablesDictionary GetVariablesDictionary(ActivityExecutionContextState context)
+    {
+        return context.Properties.GetOrAdd(WorkflowInstanceStorageDriver.VariablesDictionaryStateKey, () => new VariablesDictionary());
+    }
+}


### PR DESCRIPTION
This PR addresses a bug where variables set using the `set{VariableName}` JavaScript syntax were being overridden during the workflow variable synchronization process. The issue occurred because the `variables` object, which serves as a copy of the workflow variables, was empty and incorrectly copied back, overwriting the manually set values.

### Fix:  
- Added logic to check if copied variables have been modified.  
- Only modified variables are copied back into the workflow variables.  
- Retains values set using `set{VariableName}` syntax, ensuring expected behavior.

This ensures that user-defined variable values persist without interference from the synchronization logic.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6175)
<!-- Reviewable:end -->
