### PR TITLE
Introduce job unscheduling functionality

### DIFF
--- a/src/common/Elsa.Mediator/Contracts/IJobQueue.cs
+++ b/src/common/Elsa.Mediator/Contracts/IJobQueue.cs
@@ -24,6 +24,13 @@ public interface IJobQueue
     string Enqueue(Func<CancellationToken, Task> job);
     
     /// <summary>
+    /// Dequeues a job.
+    /// </summary>
+    /// <param name="jobId">The ID of the job to dequeue.</param>
+    /// <returns><c>true</c> if the job was dequeued; otherwise, <c>false</c>.</returns>
+    bool Dequeue(string jobId);
+    
+    /// <summary>
     /// Cancels a job.
     /// </summary>
     /// <param name="jobId">The ID of the job to cancel.</param>

--- a/src/common/Elsa.Mediator/Services/JobQueue.cs
+++ b/src/common/Elsa.Mediator/Services/JobQueue.cs
@@ -41,6 +41,16 @@ public class JobQueue(IJobsChannel jobsChannel, ILogger<JobQueue> logger) : IJob
     }
 
     /// <inheritdoc />
+    public bool Dequeue(string jobId)
+    {
+        if (!_pendingItems.TryRemove(jobId, out _))
+            if (!_scheduledItems.TryRemove(jobId, out _))
+                return false;
+
+        return true;
+    }
+
+    /// <inheritdoc />
     public bool Cancel(string jobId)
     {
         if (!_pendingItems.TryGetValue(jobId, out var jobItem))

--- a/src/modules/Elsa.Hangfire/Services/HangfireBackgroundActivityScheduler.cs
+++ b/src/modules/Elsa.Hangfire/Services/HangfireBackgroundActivityScheduler.cs
@@ -32,6 +32,12 @@ public class HangfireBackgroundActivityScheduler(IBackgroundJobClient background
         return Task.FromResult(jobId);
     }
 
+    public Task UnscheduledAsync(string jobId, CancellationToken cancellationToken = default)
+    {
+        backgroundJobClient.Delete(jobId);
+        return Task.CompletedTask;
+    }
+
     /// <inheritdoc />
     public Task CancelAsync(string jobId, CancellationToken cancellationToken = default)
     {

--- a/src/modules/Elsa.Workflows.Runtime/Contracts/IBackgroundActivityScheduler.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Contracts/IBackgroundActivityScheduler.cs
@@ -26,6 +26,11 @@ public interface IBackgroundActivityScheduler
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A handle representing the asynchronous invocation.</returns>
     Task<string> ScheduleAsync(ScheduledBackgroundActivity scheduledBackgroundActivity, CancellationToken cancellationToken = default);
+    
+    /// <summary>
+    /// Removes the specified job from the schedule.
+    /// </summary>
+    Task UnscheduledAsync(string jobId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Cancels the specified job.

--- a/src/modules/Elsa.Workflows.Runtime/Handlers/CancelBackgroundActivities.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Handlers/CancelBackgroundActivities.cs
@@ -22,7 +22,7 @@ public class CancelBackgroundActivities(IBackgroundActivityScheduler backgroundA
         {
             var payload = removedBookmark.GetPayload<BackgroundActivityStimulus>();
             if (payload.JobId != null)
-                await backgroundActivityScheduler.CancelAsync(payload.JobId, cancellationToken);
+                await backgroundActivityScheduler.UnscheduledAsync(payload.JobId, cancellationToken);
         }
     }
 }

--- a/src/modules/Elsa.Workflows.Runtime/Services/LocalBackgroundActivityScheduler.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Services/LocalBackgroundActivityScheduler.cs
@@ -27,6 +27,12 @@ public class LocalBackgroundActivityScheduler(IJobQueue jobQueue, IServiceScopeF
         return Task.FromResult(jobId);
     }
 
+    public Task UnscheduledAsync(string jobId, CancellationToken cancellationToken = default)
+    {
+        jobQueue.Dequeue(jobId);
+        return Task.CompletedTask;
+    }
+
     /// <inheritdoc />
     public Task CancelAsync(string jobId, CancellationToken cancellationToken = default)
     {


### PR DESCRIPTION
Add a new method `UnscheduledAsync` to unschedule jobs across various components, including the job queue, background activity scheduler, and Hangfire integration. This enhancement provides a more robust way to remove jobs from scheduling, complementing the existing cancellation functionality.

This fixes an issue where a background activity execution job that resumed a workflow, which in turn would remove any associated bookmarks, which in turn would cancel the background job while that job is still executing and has to e.g. persist changes made to the DB.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6183)
<!-- Reviewable:end -->
