### PR TITLE
Add custom properties provider to activity attribute and describer

### DIFF
--- a/src/apps/Elsa.Server.Web/Program.cs
+++ b/src/apps/Elsa.Server.Web/Program.cs
@@ -79,6 +79,7 @@ const bool useTenantsFromConfiguration = false;
 const bool useAgents = false;
 const bool useSecrets = false;
 const bool disableVariableWrappers = false;
+const bool usePython = true;
 
 var builder = WebApplication.CreateBuilder(args);
 var services = builder.Services;
@@ -343,15 +344,6 @@ services
                     engine.Execute("function sayHelloWorld() { return greet('World'); }");
                 });
             })
-            .UsePython(python =>
-            {
-                python.PythonOptions += options =>
-                {
-                    // Make sure to configure the path to the python DLL. E.g. /opt/homebrew/Cellar/python@3.11/3.11.6_1/Frameworks/Python.framework/Versions/3.11/bin/python3.11
-                    // alternatively, you can set the PYTHONNET_PYDLL environment variable.
-                    configuration.GetSection("Scripting:Python").Bind(options);
-                };
-            })
             .UseLiquid(liquid => liquid.FluidOptions = options => options.Encoder = HtmlEncoder.Default)
             .UseHttp(http =>
             {
@@ -396,6 +388,19 @@ services
                 }
             })
             .UseWorkflowContexts();
+
+        if (usePython)
+        {
+            elsa.UsePython(python =>
+            {
+                python.PythonOptions += options =>
+                {
+                    // Make sure to configure the path to the python DLL. E.g. /opt/homebrew/Cellar/python@3.11/3.11.6_1/Frameworks/Python.framework/Versions/3.11/bin/python3.11
+                    // alternatively, you can set the PYTHONNET_PYDLL environment variable.
+                    configuration.GetSection("Scripting:Python").Bind(options);
+                };
+            });
+        }
 
         if (useQuartz)
         {

--- a/src/apps/Elsa.ServerAndStudio.Web/Program.cs
+++ b/src/apps/Elsa.ServerAndStudio.Web/Program.cs
@@ -17,6 +17,7 @@ using WebhooksCore.Options;
 const bool useMassTransit = true;
 const bool useProtoActor = true;
 const bool useCaching = true;
+const bool usePython = true;
 const DistributedCachingTransport distributedCachingTransport = DistributedCachingTransport.MassTransit;
 const MassTransitBroker useMassTransitBroker = MassTransitBroker.Memory;
 
@@ -112,15 +113,6 @@ services
             })
             .UseLiquid()
             .UseCSharp()
-            .UsePython(python =>
-            {
-                python.PythonOptions += options =>
-                {
-                    // Make sure to configure the path to the python DLL. E.g. /opt/homebrew/Cellar/python@3.11/3.11.6_1/Frameworks/Python.framework/Versions/3.11/bin/python3.11
-                    // alternatively, you can set the PYTHONNET_PYDLL environment variable.
-                    configuration.GetSection("Scripting:Python").Bind(options);
-                };
-            })
             .UseHttp(http =>
             {
                 if (useCaching)
@@ -147,6 +139,19 @@ services
             .UseRealTimeWorkflows()
             .AddActivitiesFrom<Program>()
             .AddWorkflowsFrom<Program>();
+
+        if (usePython)
+        {
+            elsa.UsePython(python =>
+            {
+                python.PythonOptions += options =>
+                {
+                    // Make sure to configure the path to the python DLL. E.g. /opt/homebrew/Cellar/python@3.11/3.11.6_1/Frameworks/Python.framework/Versions/3.11/bin/python3.11
+                    // alternatively, you can set the PYTHONNET_PYDLL environment variable.
+                    configuration.GetSection("Scripting:Python").Bind(options);
+                };
+            });
+        }
 
         if (useProtoActor)
         {

--- a/src/modules/Elsa.Workflows.Core/Attributes/ActivityAttribute.cs
+++ b/src/modules/Elsa.Workflows.Core/Attributes/ActivityAttribute.cs
@@ -31,6 +31,11 @@ public class ActivityAttribute : Attribute
     public int Version { get; set; } = 1;
     public string? Description { get; set; }
     public string? DisplayName { get; set; }
-    public string? Category { get; set; }
+    public string? Category { get; set; }   
+    
+    /// <summary>
+    /// A type that implements <see cref="ICustomPropertiesProvider"/> and provides a default value for custom properties.
+    /// </summary>
+    public Type CustomPropertiesTypeProvider { get; set; }
     public ActivityKind Kind { get; set; } = ActivityKind.Action;
 }

--- a/src/modules/Elsa.Workflows.Core/Contracts/ICustomPropertiesProvider.cs
+++ b/src/modules/Elsa.Workflows.Core/Contracts/ICustomPropertiesProvider.cs
@@ -1,0 +1,6 @@
+﻿namespace Elsa.Workflows;
+
+public interface ICustomPropertiesProvider
+{
+    IDictionary<string, object> GetDefaultCustomProperties(Type type);
+}


### PR DESCRIPTION
Add a custom properties provider in the activity attribute to manage them by activity and adapt the activity describer to return them in the API.

See also Elsa Studio PR : https://github.com/elsa-workflows/elsa-studio/pull/332

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6185)
<!-- Reviewable:end -->
