### PR TITLE
Fix Quartz scheduler implementation

### DIFF
--- a/src/modules/Elsa.Identity/Features/IdentityFeature.cs
+++ b/src/modules/Elsa.Identity/Features/IdentityFeature.cs
@@ -17,7 +17,7 @@ using Microsoft.Extensions.DependencyInjection;
 namespace Elsa.Identity.Features;
 
 /// <summary>
-/// Provides identity feature to authenticate & authorize API requests.
+/// Provides identity feature to authenticate &amp; authorize API requests.
 /// </summary>
 [DependsOn(typeof(SystemClockFeature))]
 [PublicAPI]

--- a/src/modules/Elsa.Quartz/Contracts/IJobKeyProvider.cs
+++ b/src/modules/Elsa.Quartz/Contracts/IJobKeyProvider.cs
@@ -1,0 +1,9 @@
+using Quartz;
+
+namespace Elsa.Quartz.Contracts;
+
+internal interface IJobKeyProvider
+{
+    JobKey GetJobKey<TJob>() where TJob : IJob;
+    string GetGroupName();
+}

--- a/src/modules/Elsa.Quartz/Features/QuartzSchedulerFeature.cs
+++ b/src/modules/Elsa.Quartz/Features/QuartzSchedulerFeature.cs
@@ -1,9 +1,11 @@
+using Elsa.Extensions;
 using Elsa.Features.Abstractions;
 using Elsa.Features.Attributes;
 using Elsa.Features.Services;
+using Elsa.Quartz.Contracts;
 using Elsa.Quartz.Handlers;
-using Elsa.Quartz.Jobs;
 using Elsa.Quartz.Services;
+using Elsa.Quartz.Tasks;
 using Elsa.Scheduling;
 using Elsa.Scheduling.Features;
 using Elsa.Workflows;
@@ -34,9 +36,12 @@ public class QuartzSchedulerFeature(IModule module) : FeatureBase(module)
     /// <inheritdoc />
     public override void Apply()
     {
-        Services.AddSingleton<IActivityDescriptorModifier, CronActivityDescriptorModifier>();
-        Services.AddSingleton<QuartzCronParser>();
-        Services.AddSingleton<QuartzWorkflowScheduler>();
-        Services.AddQuartz();
+        Services
+            .AddSingleton<IActivityDescriptorModifier, CronActivityDescriptorModifier>()
+            .AddSingleton<QuartzCronParser>()
+            .AddScoped<QuartzWorkflowScheduler>()
+            .AddScoped<IJobKeyProvider, JobKeyProvider>()
+            .AddStartupTask<RegisterJobsTask>()
+            .AddQuartz();
     }
 }

--- a/src/modules/Elsa.Quartz/Services/JobKeyProvider.cs
+++ b/src/modules/Elsa.Quartz/Services/JobKeyProvider.cs
@@ -1,0 +1,19 @@
+using Elsa.Common.Multitenancy;
+using Elsa.Quartz.Contracts;
+using Quartz;
+
+namespace Elsa.Quartz.Services;
+
+internal class JobKeyProvider(ITenantAccessor tenantAccessor) : IJobKeyProvider
+{
+    public JobKey GetJobKey<TJob>() where TJob : IJob
+    {
+        return new(typeof(TJob).Name, GetGroupName());
+    }
+
+    public string GetGroupName()
+    {
+        var tenantId = tenantAccessor.Tenant?.Id;
+        return string.IsNullOrWhiteSpace(tenantId) ? "Default" : tenantId;
+    }
+}

--- a/src/modules/Elsa.Quartz/Tasks/RegisterJobsTask.cs
+++ b/src/modules/Elsa.Quartz/Tasks/RegisterJobsTask.cs
@@ -1,0 +1,35 @@
+using Elsa.Common;
+using Elsa.Quartz.Contracts;
+using Elsa.Quartz.Jobs;
+using JetBrains.Annotations;
+using Quartz;
+
+namespace Elsa.Quartz.Tasks;
+
+/// <summary>
+/// Registers the Quartz jobs.
+/// </summary>
+/// <param name="schedulerFactoryFactory"></param>
+/// <param name="jobKeyProvider"></param>
+[UsedImplicitly]
+internal class RegisterJobsTask(ISchedulerFactory schedulerFactoryFactory, IJobKeyProvider jobKeyProvider) : IStartupTask
+{
+    public async Task ExecuteAsync(CancellationToken cancellationToken)
+    {
+        var scheduler = await schedulerFactoryFactory.GetScheduler(cancellationToken);
+        await CreateJobAsync<RunWorkflowJob>(scheduler, cancellationToken);
+        await CreateJobAsync<ResumeWorkflowJob>(scheduler, cancellationToken);
+    }
+    
+    private async Task CreateJobAsync<TJobType>(IScheduler scheduler, CancellationToken cancellationToken) where TJobType : IJob
+    {
+        var key = jobKeyProvider.GetJobKey<TJobType>();
+        var job = JobBuilder.Create<TJobType>()
+            .WithIdentity(key)
+            .StoreDurably()
+            .Build();
+        
+        if (!await scheduler.CheckExists(job.Key, cancellationToken))
+            await scheduler.AddJob(job, false, cancellationToken);
+    }
+}


### PR DESCRIPTION
This PR fixes an issue where jobs would scheduled only once because their key would already exist. Instead, jobs are now stored durably and we check to see if a trigger already exists, rather than a job.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6200)
<!-- Reviewable:end -->
