### PR TITLE
Disable activity state filtering temporarily.

### DIFF
--- a/src/modules/Elsa.Workflows.Core/Extensions/ActivityExecutionContextExtensions.InputEvaluation.cs
+++ b/src/modules/Elsa.Workflows.Core/Extensions/ActivityExecutionContextExtensions.InputEvaluation.cs
@@ -121,11 +121,12 @@ public static partial class ActivityExecutionContextExtensions
         // Serializing the value ensures we store a copy of the value and not a reference to the input, which may change over time.
         if (inputDescriptor.IsSerializable != false)
         {
-            var serializedValue = await context.GetRequiredService<ISafeSerializer>().SerializeToElementAsync(value);
-            var manager = context.GetRequiredService<IActivityStateFilterManager>();
-            var filterContext = new ActivityStateFilterContext(context, inputDescriptor, serializedValue, context.CancellationToken);
-            var filterResult = await manager.RunFiltersAsync(filterContext);
-            context.ActivityState[inputDescriptor.Name] = filterResult;
+            // TODO: Disable filtering for now until we redesign log sanitization.
+            // var serializedValue = await context.GetRequiredService<ISafeSerializer>().SerializeToElementAsync(value);
+            // var manager = context.GetRequiredService<IActivityStateFilterManager>();
+            // var filterContext = new ActivityStateFilterContext(context, inputDescriptor, serializedValue, context.CancellationToken);
+            // var filterResult = await manager.RunFiltersAsync(filterContext);
+            context.ActivityState[inputDescriptor.Name] = value;
         }
     }
 }


### PR DESCRIPTION
Commented out state filtering logic to address issues with log sanitization. The raw value is now directly stored in the activity state until a redesigned solution is implemented.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6202)
<!-- Reviewable:end -->
