### PR TITLE
Add concurrency locks to DefaultTenantService operations

### DIFF
--- a/src/modules/Elsa.Tenants.AspNetCore/Extensions/ModuleExtensions.cs
+++ b/src/modules/Elsa.Tenants.AspNetCore/Extensions/ModuleExtensions.cs
@@ -13,7 +13,7 @@ public static class ModuleExtensions
     /// <summary>
     /// Installs and configures the <see cref="TenantsFeature"/> feature.
     /// </summary>
-    public static IModule UseTenantHttpRouting(this IModule module, Action<MultitenantHttpRoutingFeature>? configure = default)
+    public static IModule UseTenantHttpRouting(this IModule module, Action<MultitenantHttpRoutingFeature>? configure = null)
     {
         module.Configure(configure);
         return module;


### PR DESCRIPTION
- Introduced `SemaphoreSlim` to ensure thread safety for initialization and refresh operations in `DefaultTenantService`.  
- These changes address race conditions and enhance reliability during tenant operations.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6205)
<!-- Reviewable:end -->
