### PR TITLE
Retention: Add sweep interval to feature configuration

### DIFF
--- a/src/modules/Elsa.Retention/Feature/RetentionFeature.cs
+++ b/src/modules/Elsa.Retention/Feature/RetentionFeature.cs
@@ -30,6 +30,11 @@ public class RetentionFeature : FeatureBase
     /// </summary>
     public Action<CleanupOptions> ConfigureCleanupOptions { get; set; } = _ => { };
 
+    /// <summary>
+    ///     Defines the run interval of the cleanup job
+    /// </summary>
+    public TimeSpan SweepInterval { get; set; } = TimeSpan.FromHours(4);
+
     /// <inheritdoc cref="FeatureBase" />
     public override void Apply()
     {
@@ -44,7 +49,7 @@ public class RetentionFeature : FeatureBase
         Services.AddScoped<IRelatedEntityCollector, ActivityExecutionRecordCollector>();
         Services.AddScoped<IRelatedEntityCollector, WorkflowExecutionLogRecordCollector>();
 
-        Services.AddRecurringTask<CleanupRecurringTask>(TimeSpan.FromHours(4));
+        Services.AddRecurringTask<CleanupRecurringTask>(SweepInterval);
 
         foreach (var policy in this.GetPolicies())
         {


### PR DESCRIPTION
Allow users to define their own sweep interval of the cleanup job in the Retention module

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6208)
<!-- Reviewable:end -->
