### PR TITLE
Retention: Allow to define cleanup strategy for workflow instances

### DIFF
--- a/src/modules/Elsa.Retention/CleanupStrategies/DeleteWorkflowInstanceStrategy.cs
+++ b/src/modules/Elsa.Retention/CleanupStrategies/DeleteWorkflowInstanceStrategy.cs
@@ -1,0 +1,20 @@
+using Elsa.Retention.Contracts;
+using Elsa.Workflows.Management;
+using Elsa.Workflows.Management.Entities;
+using Elsa.Workflows.Management.Filters;
+
+namespace Elsa.Retention.CleanupStrategies;
+
+/// <summary>
+///     Deletes the workflow instance.
+/// </summary>
+public class DeleteWorkflowInstanceStrategy(IWorkflowInstanceStore store) : IDeletionCleanupStrategy<WorkflowInstance>
+{
+    public async Task Cleanup(ICollection<WorkflowInstance> collection)
+    {
+        await store.DeleteAsync(new WorkflowInstanceFilter
+        {
+            Ids = collection.Select(x => x.Id).ToArray()
+        });
+    }
+}

--- a/src/modules/Elsa.Retention/Feature/RetentionFeature.cs
+++ b/src/modules/Elsa.Retention/Feature/RetentionFeature.cs
@@ -7,6 +7,7 @@ using Elsa.Retention.Contracts;
 using Elsa.Retention.Extensions;
 using Elsa.Retention.Jobs;
 using Elsa.Retention.Options;
+using Elsa.Workflows.Management.Entities;
 using Elsa.Workflows.Runtime.Entities;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -44,6 +45,7 @@ public class RetentionFeature : FeatureBase
         Services.AddScoped<IDeletionCleanupStrategy<StoredBookmark>, DeleteBookmarkStrategy>();
         Services.AddScoped<IDeletionCleanupStrategy<ActivityExecutionRecord>, DeleteActivityExecutionRecordStrategy>();
         Services.AddScoped<IDeletionCleanupStrategy<WorkflowExecutionLogRecord>, DeleteWorkflowExecutionRecordStrategy>();
+        Services.AddScoped<IDeletionCleanupStrategy<WorkflowInstance>, DeleteWorkflowInstanceStrategy>();
 
         Services.AddScoped<IRelatedEntityCollector, BookmarkCollector>();
         Services.AddScoped<IRelatedEntityCollector, ActivityExecutionRecordCollector>();


### PR DESCRIPTION
Currently, we always delete `WorkflowInstance` entities after executing the `CleanupStrategy` of the related entities. 
https://github.com/elsa-workflows/elsa-core/blob/08f7c2bf782e867c327cc91863b63befceb804a2/src/modules/Elsa.Retention/Jobs/CleanupJob.cs#L75-L78

This might not be wanted if a stategy is implemented that archives the workflows while still retaining them in the orginal database. The introduced change allows us to define `CleanupStrategy` for the `WorkflowInstance` just like any other related entity.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6211)
<!-- Reviewable:end -->
