### PR TITLE
Add support for waiting for child workflows in ExecuteWorkflow

### DIFF
--- a/src/modules/Elsa.Workflows.Core/Contexts/StorageDriverContext.cs
+++ b/src/modules/Elsa.Workflows.Core/Contexts/StorageDriverContext.cs
@@ -1,8 +1,9 @@
 using Elsa.Workflows.Contracts;
+using Elsa.Workflows.Memory;
 
 namespace Elsa.Workflows;
 
 /// <summary>
 /// Provides context for storage drivers.
 /// </summary>
-public record StorageDriverContext(IExecutionContext ExecutionContext, CancellationToken CancellationToken);
+public record StorageDriverContext(IExecutionContext ExecutionContext, Variable Variable, CancellationToken CancellationToken);

--- a/src/modules/Elsa.Workflows.Core/Services/VariablePersistenceManager.cs
+++ b/src/modules/Elsa.Workflows.Core/Services/VariablePersistenceManager.cs
@@ -31,7 +31,7 @@ public class VariablePersistenceManager : IVariablePersistenceManager
             foreach (var variable in variables)
             {
                 context.ExpressionExecutionContext.Memory.Declare(variable);
-                var storageDriverContext = new StorageDriverContext(context, cancellationToken);
+                var storageDriverContext = new StorageDriverContext(context, variable, cancellationToken);
                 var register = context.ExpressionExecutionContext.Memory;
                 var block = EnsureBlock(register, variable);
                 var metadata = (VariableBlockMetadata)block.Metadata!;
@@ -62,7 +62,6 @@ public class VariablePersistenceManager : IVariablePersistenceManager
         foreach (var context in contexts)
         {
             var variables = GetLocalVariables(context).ToList();
-            var storageDriverContext = new StorageDriverContext(context, cancellationToken);
 
             foreach (var variable in variables)
             {
@@ -75,6 +74,7 @@ public class VariablePersistenceManager : IVariablePersistenceManager
                 
                 var id = GetStateId(variable);
                 var value = block.Value;
+                var storageDriverContext = new StorageDriverContext(context, variable, cancellationToken);
 
                 if (value == null)
                     await driver.DeleteAsync(id, storageDriverContext);
@@ -91,7 +91,6 @@ public class VariablePersistenceManager : IVariablePersistenceManager
         var register = context.ExpressionExecutionContext.Memory;
         var variableList = GetLocalVariables(context).ToList();
         var cancellationToken = context.CancellationToken;
-        var storageDriverContext = new StorageDriverContext(context, cancellationToken);
 
         foreach (var variable in variableList)
         {
@@ -105,6 +104,7 @@ public class VariablePersistenceManager : IVariablePersistenceManager
                 continue;
 
             var id = GetStateId(variable);
+            var storageDriverContext = new StorageDriverContext(context, variable, cancellationToken);
             await driver.DeleteAsync(id, storageDriverContext);
             register.Blocks.Remove(variable.Id);
         }

--- a/src/modules/Elsa.Workflows.Runtime/Bookmarks/ExecuteWorkflowPayload.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Bookmarks/ExecuteWorkflowPayload.cs
@@ -1,0 +1,9 @@
+using Elsa.Workflows.Runtime.Activities;
+
+namespace Elsa.Workflows.Runtime.Bookmarks;
+
+/// <summary>
+/// Bookmark payload for the <see cref="ExecuteWorkflow"/> activity.
+/// </summary>
+/// <param name="ChildInstanceId">The instance ID of the child workflow that was created by the <see cref="ExecuteWorkflow"/> activity.</param>
+public record ExecuteWorkflowPayload(string ChildInstanceId);

--- a/src/modules/Elsa.Workflows.Runtime/Features/WorkflowRuntimeFeature.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Features/WorkflowRuntimeFeature.cs
@@ -275,6 +275,7 @@ public class WorkflowRuntimeFeature : FeatureBase
             .AddCommandHandler<CancelWorkflowsCommandHandler>()
             .AddNotificationHandler<ResumeDispatchWorkflowActivity>()
             .AddNotificationHandler<ResumeBulkDispatchWorkflowActivity>()
+            .AddNotificationHandler<ResumeExecuteWorkflowActivity>()
             .AddNotificationHandler<IndexTriggers>()
             .AddNotificationHandler<CancelBackgroundActivities>()
             .AddNotificationHandler<DeleteBookmarks>()

--- a/src/modules/Elsa.Workflows.Runtime/Handlers/ResumeExecuteWorkflowActivity.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Handlers/ResumeExecuteWorkflowActivity.cs
@@ -1,0 +1,40 @@
+using Elsa.Mediator.Contracts;
+using Elsa.Workflows.Helpers;
+using Elsa.Workflows.Notifications;
+using Elsa.Workflows.Runtime.Activities;
+using Elsa.Workflows.Runtime.Bookmarks;
+using Elsa.Workflows.Runtime.Contracts;
+using Elsa.Workflows.Runtime.Models;
+using JetBrains.Annotations;
+
+namespace Elsa.Workflows.Runtime.Handlers;
+
+/// <summary>
+/// Resumes any blocking <see cref="ExecuteWorkflow"/> activities when its child workflow completes.
+/// </summary>
+[PublicAPI]
+internal class ResumeExecuteWorkflowActivity(IWorkflowInbox bookmarkQueue) : INotificationHandler<WorkflowExecuted>
+{
+    private static readonly string ActivityTypeName = ActivityTypeNameHelper.GenerateTypeName<ExecuteWorkflow>();
+
+    public async Task HandleAsync(WorkflowExecuted notification, CancellationToken cancellationToken)
+    {
+        var workflowState = notification.WorkflowState;
+
+        if (workflowState.Status != WorkflowStatus.Finished)
+            return;
+
+        var workflowInstanceId = notification.WorkflowState.Id;
+        var payload = new ExecuteWorkflowPayload(workflowInstanceId);
+        var input = workflowState.Output;
+
+        var message = new NewWorkflowInboxMessage
+        {
+            ActivityTypeName = ActivityTypeName,
+            BookmarkPayload = payload,
+            Input = input,
+        };
+
+        await bookmarkQueue.SubmitAsync(message, cancellationToken);
+    }
+}


### PR DESCRIPTION
This update introduces the ability to optionally wait for child workflows to complete before finishing the ExecuteWorkflow activity. A bookmark mechanism is used to resume the activity when the child workflow completes. Additionally, a new handler was added to manage the resumption of these workflows upon completion events.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6226)
<!-- Reviewable:end -->
