### PR TITLE
Drop .NET 6 Support

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,35 +16,35 @@
     <PackageVersion Include="Azure.ResourceManager" Version="1.13.0" />
     <PackageVersion Include="Azure.ResourceManager.AppContainers" Version="1.3.0" />
     <PackageVersion Include="Azure.ResourceManager.Resources" Version="1.9.0" />
-    <PackageVersion Include="Azure.ResourceManager.ServiceBus" Version="1.0.1" />
+    <PackageVersion Include="Azure.ResourceManager.ServiceBus" Version="1.1.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
     <PackageVersion Include="Bogus" Version="35.6.1" />
     <PackageVersion Include="ConfigureAwait.Fody" Version="3.3.2" PrivateAssets="All" />
     <PackageVersion Include="Confluent.Kafka" Version="2.6.1" />
-    <PackageVersion Include="Confluent.SchemaRegistry.Serdes.Avro" Version="2.4.0" />
+    <PackageVersion Include="Confluent.SchemaRegistry.Serdes.Avro" Version="2.6.1" />
     <PackageVersion Include="coverlet.collector" Version="6.0.2" PrivateAssets="All" />
-    <PackageVersion Include="Cronos" Version="0.8.4" />
+    <PackageVersion Include="Cronos" Version="0.9.0" />
     <PackageVersion Include="Dapper" Version="2.1.35" />
-    <PackageVersion Include="DistributedLock.Core" Version="1.0.7" />
-    <PackageVersion Include="DistributedLock.FileSystem" Version="1.0.2" />
-    <PackageVersion Include="DistributedLock.Postgres" Version="1.2.0" />
+    <PackageVersion Include="DistributedLock.Core" Version="1.0.8" />
+    <PackageVersion Include="DistributedLock.FileSystem" Version="1.0.3" />
+    <PackageVersion Include="DistributedLock.Postgres" Version="1.2.1" />
     <PackageVersion Include="DistributedLock.Redis" Version="1.0.3" />
-    <PackageVersion Include="Elastic.Clients.Elasticsearch" Version="8.15.10" />
-    <PackageVersion Include="Elsa.Studio" Version="3.3.0-preview.630" />
-    <PackageVersion Include="Elsa.Studio.Agents" Version="3.3.0-preview.630" />
-    <PackageVersion Include="Elsa.Studio.Core.BlazorWasm" Version="3.3.0-preview.630" />
-    <PackageVersion Include="Elsa.Studio.Login.BlazorWasm" Version="3.3.0-preview.630" />
-    <PackageVersion Include="FastEndpoints" Version="5.31.0" />
-    <PackageVersion Include="FastEndpoints.Security" Version="5.31.0" />
-    <PackageVersion Include="FastEndpoints.Swagger" Version="5.31.0" />
+    <PackageVersion Include="Elastic.Clients.Elasticsearch" Version="8.16.3" />
+    <PackageVersion Include="Elsa.Studio" Version="3.3.0-rc4" />
+    <PackageVersion Include="Elsa.Studio.Agents" Version="3.3.0-rc4" />
+    <PackageVersion Include="Elsa.Studio.Core.BlazorWasm" Version="3.3.0-rc4" />
+    <PackageVersion Include="Elsa.Studio.Login.BlazorWasm" Version="3.3.0-rc4" />
+    <PackageVersion Include="FastEndpoints" Version="5.32.0" />
+    <PackageVersion Include="FastEndpoints.Security" Version="5.32.0" />
+    <PackageVersion Include="FastEndpoints.Swagger" Version="5.32.0" />
     <PackageVersion Include="FluentMigrator" Version="6.2.0" />
     <PackageVersion Include="FluentMigrator.Runner" Version="6.2.0" />
     <PackageVersion Include="FluentStorage" Version="5.6.0" />
     <PackageVersion Include="FluentStorage.Azure.Blobs" Version="5.3.0" />
-    <PackageVersion Include="Fluid.Core" Version="2.14.0" />
+    <PackageVersion Include="Fluid.Core" Version="2.16.0" />
     <PackageVersion Include="Fody" Version="6.9.1" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
-    <PackageVersion Include="Google.Protobuf" Version="3.29.1" />
+    <PackageVersion Include="Google.Protobuf" Version="3.29.2" />
     <PackageVersion Include="Grpc.Net.Client" Version="2.67.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.68.1" />
     <PackageVersion Include="Hangfire" Version="1.8.17" />
@@ -55,17 +55,17 @@
     <PackageVersion Include="JetBrains.Annotations" Version="2024.3.0" />
     <PackageVersion Include="Jint" Version="4.1.0" />
     <PackageVersion Include="LinqKit.Core" Version="1.2.7" />
-    <PackageVersion Include="MailKit" Version="4.8.0" />
-    <PackageVersion Include="MassTransit" Version="8.3.0" />
-    <PackageVersion Include="MassTransit.Azure.ServiceBus.Core" Version="8.3.0" />
-    <PackageVersion Include="MassTransit.RabbitMQ" Version="8.3.0" />
+    <PackageVersion Include="MailKit" Version="4.9.0" />
+    <PackageVersion Include="MassTransit" Version="8.3.4" />
+    <PackageVersion Include="MassTransit.Azure.ServiceBus.Core" Version="8.3.4" />
+    <PackageVersion Include="MassTransit.RabbitMQ" Version="8.3.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.12.0" />
     <PackageVersion Include="Microsoft.Identity.Client" Version="4.66.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageVersion Include="Microsoft.SemanticKernel" Version="1.25.0" />
+    <PackageVersion Include="Microsoft.SemanticKernel" Version="1.32.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="MongoDB.Driver" Version="3.1.0" />
-    <PackageVersion Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="1.5.0" />
+    <PackageVersion Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="2.0.0" />
     <PackageVersion Include="MongoDB.Driver.Extensions" Version="2.0.2" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
@@ -86,84 +86,45 @@
     <PackageVersion Include="Proto.Persistence.Sqlite" Version="1.7.0" />
     <PackageVersion Include="Proto.Persistence.SqlServer" Version="1.7.0" />
     <PackageVersion Include="Proto.Remote" Version="1.7.0" />
-    <PackageVersion Include="pythonnet" Version="3.0.4" />
+    <PackageVersion Include="pythonnet" Version="3.0.5" />
     <PackageVersion Include="Quartz.Extensions.Hosting" Version="3.13.1" />
     <PackageVersion Include="Quartz.Serialization.Json" Version="3.13.1" />
     <PackageVersion Include="Scrutor" Version="5.0.2" />
     <PackageVersion Include="ShortGuid" Version="2.0.1" />
-    <PackageVersion Include="StackExchange.Redis" Version="2.8.16" />
+    <PackageVersion Include="StackExchange.Redis" Version="2.8.24" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
-    <PackageVersion Include="System.Data.SqlClient" Version="4.8.6" />
+    <PackageVersion Include="System.Data.SqlClient" Version="4.9.0" />
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
-    <PackageVersion Include="System.Linq.Dynamic.Core" Version="1.4.9" />
+    <PackageVersion Include="System.Linq.Dynamic.Core" Version="1.5.1" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageVersion Include="Testcontainers" Version="3.10.0" />
-    <PackageVersion Include="Testcontainers.PostgreSql" Version="3.10.0" />
-    <PackageVersion Include="Testcontainers.RabbitMq" Version="3.10.0" />
-    <PackageVersion Include="Testcontainers.Redis" Version="3.10.0" />
+    <PackageVersion Include="Testcontainers" Version="4.1.0" />
+    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.1.0" />
+    <PackageVersion Include="Testcontainers.RabbitMq" Version="4.1.0" />
+    <PackageVersion Include="Testcontainers.Redis" Version="4.1.0" />
     <PackageVersion Include="ThrottleDebounce" Version="2.0.0" />
     <PackageVersion Include="WebhooksCore" Version="0.0.1" />
     <PackageVersion Include="xunit" Version="2.9.2" />
     <PackageVersion Include="xunit.abstractions" Version="2.0.3" />
     <PackageVersion Include="xunit.extensibility.core" Version="2.9.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0" />
     <PackageVersion Include="Yarp.ReverseProxy" Version="2.2.0" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageVersion Include="AspNetCore.Authentication.ApiKey" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="7.0.20" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.20" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.0.20" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="7.0.20" />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="7.0.20" />
-    <PackageVersion Include="Microsoft.Data.Sqlite" Version="7.0.20" />
-    <PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="7.0.20" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="7.0.20" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.20" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.20" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.20" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.20" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="7.0.20" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
-    <PackageVersion Include="Npgsql" Version="7.0.8" />
-    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.18" />
-    <PackageVersion Include="Oracle.EntityFrameworkCore" Version="7.21.13" />
-    <PackageVersion Include="Polly" Version="7.2.4" />
-    <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="7.0.0" />
-    <PackageVersion Include="Refit" Version="7.2.22" />
-    <PackageVersion Include="Refit.HttpClientFactory" Version="7.0.0" />
-    <PackageVersion Include="System.Formats.Asn1" Version="8.0.1" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageVersion Include="AspNetCore.Authentication.ApiKey" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="8.0.10" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.10" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.10" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.10" />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="8.0.10" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.10" />
-    <PackageVersion Include="Microsoft.Data.Sqlite" Version="8.0.10" />
-    <PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="8.0.10" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.10" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.10" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.10" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.10" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.10" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="8.0.11" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.11" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.11" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.11" />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="8.0.11" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.11" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="8.0.11" />
+    <PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="8.0.11" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.11" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.11" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.11" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
@@ -174,16 +135,16 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="8.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="8.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="8.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
-    <PackageVersion Include="Npgsql" Version="8.0.5" />
-    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.10" />
+    <PackageVersion Include="Npgsql" Version="8.0.6" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
     <PackageVersion Include="Oracle.EntityFrameworkCore" Version="8.23.60" />
-    <PackageVersion Include="Polly" Version="8.4.2" />
+    <PackageVersion Include="Polly" Version="8.5.0" />
     <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.2" />
     <PackageVersion Include="Refit" Version="8.0.0" />
     <PackageVersion Include="Refit.HttpClientFactory" Version="8.0.0" />
@@ -221,11 +182,11 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.0" />
-    <PackageVersion Include="Npgsql" Version="9.0.1" />
-    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.1" />
+    <PackageVersion Include="Npgsql" Version="9.0.2" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.2" />
     <PackageVersion Include="Oracle.EntityFrameworkCore" Version="9.23.60" />
     <PackageVersion Include="Polly" Version="8.5.0" />
-    <!-- <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.2" /> -->
+    <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="9.0.0-preview.2.efcore.9.0.0" /> 
     <PackageVersion Include="Refit" Version="8.0.0" />
     <PackageVersion Include="Refit.HttpClientFactory" Version="8.0.0" />
     <PackageVersion Include="System.Formats.Asn1" Version="9.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,195 +1,152 @@
 <Project>
-  <PropertyGroup>
-    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageVersion Include="Antlr4.Runtime.Standard" Version="4.13.1" />
-    <PackageVersion Include="AppAny.Quartz.EntityFrameworkCore.Migrations" Version="0.5.1" />
-    <PackageVersion Include="AppAny.Quartz.EntityFrameworkCore.Migrations.MySql" Version="0.5.1" />
-    <PackageVersion Include="AppAny.Quartz.EntityFrameworkCore.Migrations.PostgreSQL" Version="0.5.1" />
-    <PackageVersion Include="AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite" Version="0.5.1" />
-    <PackageVersion Include="AppAny.Quartz.EntityFrameworkCore.Migrations.SqlServer" Version="0.5.1" />
-    <PackageVersion Include="AutoMapper" Version="13.0.1" PrivateAssets="All" />
-    <PackageVersion Include="Azure.Identity" Version="1.13.1" />
-    <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.18.2" />
-    <PackageVersion Include="Azure.ResourceManager" Version="1.13.0" />
-    <PackageVersion Include="Azure.ResourceManager.AppContainers" Version="1.3.0" />
-    <PackageVersion Include="Azure.ResourceManager.Resources" Version="1.9.0" />
-    <PackageVersion Include="Azure.ResourceManager.ServiceBus" Version="1.1.0" />
-    <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
-    <PackageVersion Include="Bogus" Version="35.6.1" />
-    <PackageVersion Include="ConfigureAwait.Fody" Version="3.3.2" PrivateAssets="All" />
-    <PackageVersion Include="Confluent.Kafka" Version="2.6.1" />
-    <PackageVersion Include="Confluent.SchemaRegistry.Serdes.Avro" Version="2.6.1" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.2" PrivateAssets="All" />
-    <PackageVersion Include="Cronos" Version="0.9.0" />
-    <PackageVersion Include="Dapper" Version="2.1.35" />
-    <PackageVersion Include="DistributedLock.Core" Version="1.0.8" />
-    <PackageVersion Include="DistributedLock.FileSystem" Version="1.0.3" />
-    <PackageVersion Include="DistributedLock.Postgres" Version="1.2.1" />
-    <PackageVersion Include="DistributedLock.Redis" Version="1.0.3" />
-    <PackageVersion Include="Elastic.Clients.Elasticsearch" Version="8.16.3" />
-    <PackageVersion Include="Elsa.Studio" Version="3.3.0-rc4" />
-    <PackageVersion Include="Elsa.Studio.Agents" Version="3.3.0-rc4" />
-    <PackageVersion Include="Elsa.Studio.Core.BlazorWasm" Version="3.3.0-rc4" />
-    <PackageVersion Include="Elsa.Studio.Login.BlazorWasm" Version="3.3.0-rc4" />
-    <PackageVersion Include="FastEndpoints" Version="5.32.0" />
-    <PackageVersion Include="FastEndpoints.Security" Version="5.32.0" />
-    <PackageVersion Include="FastEndpoints.Swagger" Version="5.32.0" />
-    <PackageVersion Include="FluentMigrator" Version="6.2.0" />
-    <PackageVersion Include="FluentMigrator.Runner" Version="6.2.0" />
-    <PackageVersion Include="FluentStorage" Version="5.6.0" />
-    <PackageVersion Include="FluentStorage.Azure.Blobs" Version="5.3.0" />
-    <PackageVersion Include="Fluid.Core" Version="2.16.0" />
-    <PackageVersion Include="Fody" Version="6.9.1" />
-    <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
-    <PackageVersion Include="Google.Protobuf" Version="3.29.2" />
-    <PackageVersion Include="Grpc.Net.Client" Version="2.67.0" />
-    <PackageVersion Include="Grpc.Tools" Version="2.68.1" />
-    <PackageVersion Include="Hangfire" Version="1.8.17" />
-    <PackageVersion Include="Hangfire.MemoryStorage" Version="1.8.1.1" />
-    <PackageVersion Include="Hangfire.Storage.SQLite" Version="0.4.2" />
-    <PackageVersion Include="Humanizer.Core" Version="2.14.1" />
-    <PackageVersion Include="IronCompress" Version="1.6.3" />
-    <PackageVersion Include="JetBrains.Annotations" Version="2024.3.0" />
-    <PackageVersion Include="Jint" Version="4.1.0" />
-    <PackageVersion Include="LinqKit.Core" Version="1.2.7" />
-    <PackageVersion Include="MailKit" Version="4.9.0" />
-    <PackageVersion Include="MassTransit" Version="8.3.4" />
-    <PackageVersion Include="MassTransit.Azure.ServiceBus.Core" Version="8.3.4" />
-    <PackageVersion Include="MassTransit.RabbitMQ" Version="8.3.4" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.12.0" />
-    <PackageVersion Include="Microsoft.Identity.Client" Version="4.66.2" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageVersion Include="Microsoft.SemanticKernel" Version="1.32.0" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
-    <PackageVersion Include="MongoDB.Driver" Version="3.1.0" />
-    <PackageVersion Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="2.0.0" />
-    <PackageVersion Include="MongoDB.Driver.Extensions" Version="2.0.2" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageVersion Include="NSubstitute" Version="5.3.0" />
-    <PackageVersion Include="NuGet.Packaging" Version="6.12.1" />
-    <PackageVersion Include="NuGet.Protocol" Version="6.12.1" />
-    <PackageVersion Include="Nuke.Components" Version="9.0.3" />
-    <PackageVersion Include="Open.Linq.AsyncExtensions" Version="1.2.0" />
-    <PackageVersion Include="Polly.Extensions.Http" Version="3.0.0" />
-    <PackageVersion Include="PolySharp" Version="1.15.0" />
-    <PackageVersion Include="Proto.Actor" Version="1.7.0" />
-    <PackageVersion Include="Proto.Cluster" Version="1.7.0" />
-    <PackageVersion Include="Proto.Cluster.AzureContainerApps" Version="1.7.0" />
-    <PackageVersion Include="Proto.Cluster.CodeGen" Version="1.7.0" />
-    <PackageVersion Include="Proto.Cluster.Kubernetes" Version="1.7.0" />
-    <PackageVersion Include="Proto.Cluster.TestProvider" Version="1.7.0" />
-    <PackageVersion Include="Proto.OpenTelemetry" Version="1.7.0" />
-    <PackageVersion Include="Proto.Persistence" Version="1.7.0" />
-    <PackageVersion Include="Proto.Persistence.Sqlite" Version="1.7.0" />
-    <PackageVersion Include="Proto.Persistence.SqlServer" Version="1.7.0" />
-    <PackageVersion Include="Proto.Remote" Version="1.7.0" />
-    <PackageVersion Include="pythonnet" Version="3.0.5" />
-    <PackageVersion Include="Quartz.Extensions.Hosting" Version="3.13.1" />
-    <PackageVersion Include="Quartz.Serialization.Json" Version="3.13.1" />
-    <PackageVersion Include="Scrutor" Version="5.0.2" />
-    <PackageVersion Include="ShortGuid" Version="2.0.1" />
-    <PackageVersion Include="StackExchange.Redis" Version="2.8.24" />
-    <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
-    <PackageVersion Include="System.Data.SqlClient" Version="4.9.0" />
-    <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
-    <PackageVersion Include="System.Linq.Dynamic.Core" Version="1.5.1" />
-    <PackageVersion Include="System.Net.Http" Version="4.3.4" />
-    <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageVersion Include="Testcontainers" Version="4.1.0" />
-    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.1.0" />
-    <PackageVersion Include="Testcontainers.RabbitMq" Version="4.1.0" />
-    <PackageVersion Include="Testcontainers.Redis" Version="4.1.0" />
-    <PackageVersion Include="ThrottleDebounce" Version="2.0.0" />
-    <PackageVersion Include="WebhooksCore" Version="0.0.1" />
-    <PackageVersion Include="xunit" Version="2.9.2" />
-    <PackageVersion Include="xunit.abstractions" Version="2.0.3" />
-    <PackageVersion Include="xunit.extensibility.core" Version="2.9.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0" />
-    <PackageVersion Include="Yarp.ReverseProxy" Version="2.2.0" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageVersion Include="AspNetCore.Authentication.ApiKey" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="8.0.11" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.11" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.11" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.11" />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="8.0.11" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.11" />
-    <PackageVersion Include="Microsoft.Data.Sqlite" Version="8.0.11" />
-    <PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="8.0.11" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.11" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.11" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.11" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="8.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="8.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
-    <PackageVersion Include="Npgsql" Version="8.0.6" />
-    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
-    <PackageVersion Include="Oracle.EntityFrameworkCore" Version="8.23.60" />
-    <PackageVersion Include="Polly" Version="8.5.0" />
-    <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.2" />
-    <PackageVersion Include="Refit" Version="8.0.0" />
-    <PackageVersion Include="Refit.HttpClientFactory" Version="8.0.0" />
-    <PackageVersion Include="System.Formats.Asn1" Version="8.0.1" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageVersion Include="AspNetCore.Authentication.ApiKey" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Data.Sqlite" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.0" />
-    <PackageVersion Include="Npgsql" Version="9.0.2" />
-    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.2" />
-    <PackageVersion Include="Oracle.EntityFrameworkCore" Version="9.23.60" />
-    <PackageVersion Include="Polly" Version="8.5.0" />
-    <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="9.0.0-preview.2.efcore.9.0.0" /> 
-    <PackageVersion Include="Refit" Version="8.0.0" />
-    <PackageVersion Include="Refit.HttpClientFactory" Version="8.0.0" />
-    <PackageVersion Include="System.Formats.Asn1" Version="9.0.0" />
-    <PackageVersion Include="System.Text.Json" Version="9.0.0" />
-  </ItemGroup>
+    <PropertyGroup>
+        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+        <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageVersion Include="Antlr4.Runtime.Standard" Version="4.13.1"/>
+        <PackageVersion Include="AppAny.Quartz.EntityFrameworkCore.Migrations" Version="0.5.1"/>
+        <PackageVersion Include="AppAny.Quartz.EntityFrameworkCore.Migrations.MySql" Version="0.5.1"/>
+        <PackageVersion Include="AppAny.Quartz.EntityFrameworkCore.Migrations.PostgreSQL" Version="0.5.1"/>
+        <PackageVersion Include="AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite" Version="0.5.1"/>
+        <PackageVersion Include="AppAny.Quartz.EntityFrameworkCore.Migrations.SqlServer" Version="0.5.1"/>
+        <PackageVersion Include="AutoMapper" Version="13.0.1" PrivateAssets="All"/>
+        <PackageVersion Include="Azure.Identity" Version="1.13.1"/>
+        <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.18.2"/>
+        <PackageVersion Include="Azure.ResourceManager" Version="1.13.0"/>
+        <PackageVersion Include="Azure.ResourceManager.AppContainers" Version="1.3.0"/>
+        <PackageVersion Include="Azure.ResourceManager.Resources" Version="1.9.0"/>
+        <PackageVersion Include="Azure.ResourceManager.ServiceBus" Version="1.1.0"/>
+        <PackageVersion Include="BenchmarkDotNet" Version="0.14.0"/>
+        <PackageVersion Include="Bogus" Version="35.6.1"/>
+        <PackageVersion Include="ConfigureAwait.Fody" Version="3.3.2" PrivateAssets="All"/>
+        <PackageVersion Include="Confluent.Kafka" Version="2.6.1"/>
+        <PackageVersion Include="Confluent.SchemaRegistry.Serdes.Avro" Version="2.6.1"/>
+        <PackageVersion Include="coverlet.collector" Version="6.0.2" PrivateAssets="All"/>
+        <PackageVersion Include="Cronos" Version="0.9.0"/>
+        <PackageVersion Include="Dapper" Version="2.1.35"/>
+        <PackageVersion Include="DistributedLock.Core" Version="1.0.8"/>
+        <PackageVersion Include="DistributedLock.FileSystem" Version="1.0.3"/>
+        <PackageVersion Include="DistributedLock.Postgres" Version="1.2.1"/>
+        <PackageVersion Include="DistributedLock.Redis" Version="1.0.3"/>
+        <PackageVersion Include="Elastic.Clients.Elasticsearch" Version="8.16.3"/>
+        <PackageVersion Include="Elsa.Studio" Version="3.3.0-rc4"/>
+        <PackageVersion Include="Elsa.Studio.Agents" Version="3.3.0-rc4"/>
+        <PackageVersion Include="Elsa.Studio.Core.BlazorWasm" Version="3.3.0-rc4"/>
+        <PackageVersion Include="Elsa.Studio.Login.BlazorWasm" Version="3.3.0-rc4"/>
+        <PackageVersion Include="FastEndpoints" Version="5.32.0"/>
+        <PackageVersion Include="FastEndpoints.Security" Version="5.32.0"/>
+        <PackageVersion Include="FastEndpoints.Swagger" Version="5.32.0"/>
+        <PackageVersion Include="FluentMigrator" Version="6.2.0"/>
+        <PackageVersion Include="FluentMigrator.Runner" Version="6.2.0"/>
+        <PackageVersion Include="FluentStorage" Version="5.6.0"/>
+        <PackageVersion Include="FluentStorage.Azure.Blobs" Version="5.3.0"/>
+        <PackageVersion Include="Fluid.Core" Version="2.16.0"/>
+        <PackageVersion Include="Fody" Version="6.9.1"/>
+        <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1"/>
+        <PackageVersion Include="Google.Protobuf" Version="3.29.2"/>
+        <PackageVersion Include="Grpc.Net.Client" Version="2.67.0"/>
+        <PackageVersion Include="Grpc.Tools" Version="2.68.1"/>
+        <PackageVersion Include="Hangfire" Version="1.8.17"/>
+        <PackageVersion Include="Hangfire.MemoryStorage" Version="1.8.1.1"/>
+        <PackageVersion Include="Hangfire.Storage.SQLite" Version="0.4.2"/>
+        <PackageVersion Include="Humanizer.Core" Version="2.14.1"/>
+        <PackageVersion Include="IronCompress" Version="1.6.3"/>
+        <PackageVersion Include="JetBrains.Annotations" Version="2024.3.0"/>
+        <PackageVersion Include="Jint" Version="4.1.0"/>
+        <PackageVersion Include="LinqKit.Core" Version="1.2.7"/>
+        <PackageVersion Include="MailKit" Version="4.9.0"/>
+        <PackageVersion Include="MassTransit" Version="8.3.4"/>
+        <PackageVersion Include="MassTransit.Azure.ServiceBus.Core" Version="8.3.4"/>
+        <PackageVersion Include="MassTransit.RabbitMQ" Version="8.3.4"/>
+        <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.12.0"/>
+        <PackageVersion Include="Microsoft.Identity.Client" Version="4.66.2"/>
+        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
+        <PackageVersion Include="Microsoft.SemanticKernel" Version="1.32.0"/>
+        <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0"/>
+        <PackageVersion Include="MongoDB.Driver" Version="3.1.0"/>
+        <PackageVersion Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="2.0.0"/>
+        <PackageVersion Include="MongoDB.Driver.Extensions" Version="2.0.2"/>
+        <PackageVersion Include="Newtonsoft.Json" Version="13.0.3"/>
+        <PackageVersion Include="NSubstitute" Version="5.3.0"/>
+        <PackageVersion Include="NuGet.Packaging" Version="6.12.1"/>
+        <PackageVersion Include="NuGet.Protocol" Version="6.12.1"/>
+        <PackageVersion Include="Nuke.Components" Version="9.0.3"/>
+        <PackageVersion Include="Open.Linq.AsyncExtensions" Version="1.2.0"/>
+        <PackageVersion Include="Polly.Extensions.Http" Version="3.0.0"/>
+        <PackageVersion Include="PolySharp" Version="1.15.0"/>
+        <PackageVersion Include="Proto.Actor" Version="1.7.0"/>
+        <PackageVersion Include="Proto.Cluster" Version="1.7.0"/>
+        <PackageVersion Include="Proto.Cluster.AzureContainerApps" Version="1.7.0"/>
+        <PackageVersion Include="Proto.Cluster.CodeGen" Version="1.7.0"/>
+        <PackageVersion Include="Proto.Cluster.Kubernetes" Version="1.7.0"/>
+        <PackageVersion Include="Proto.Cluster.TestProvider" Version="1.7.0"/>
+        <PackageVersion Include="Proto.OpenTelemetry" Version="1.7.0"/>
+        <PackageVersion Include="Proto.Persistence" Version="1.7.0"/>
+        <PackageVersion Include="Proto.Persistence.Sqlite" Version="1.7.0"/>
+        <PackageVersion Include="Proto.Persistence.SqlServer" Version="1.7.0"/>
+        <PackageVersion Include="Proto.Remote" Version="1.7.0"/>
+        <PackageVersion Include="pythonnet" Version="3.0.5"/>
+        <PackageVersion Include="Quartz.Extensions.Hosting" Version="3.13.1"/>
+        <PackageVersion Include="Quartz.Serialization.Json" Version="3.13.1"/>
+        <PackageVersion Include="Scrutor" Version="5.0.2"/>
+        <PackageVersion Include="ShortGuid" Version="2.0.1"/>
+        <PackageVersion Include="StackExchange.Redis" Version="2.8.24"/>
+        <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1"/>
+        <PackageVersion Include="System.Data.SqlClient" Version="4.9.0"/>
+        <PackageVersion Include="System.Linq.Async" Version="6.0.1"/>
+        <PackageVersion Include="System.Linq.Dynamic.Core" Version="1.5.1"/>
+        <PackageVersion Include="System.Net.Http" Version="4.3.4"/>
+        <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1"/>
+        <PackageVersion Include="Testcontainers" Version="4.1.0"/>
+        <PackageVersion Include="Testcontainers.PostgreSql" Version="4.1.0"/>
+        <PackageVersion Include="Testcontainers.RabbitMq" Version="4.1.0"/>
+        <PackageVersion Include="Testcontainers.Redis" Version="4.1.0"/>
+        <PackageVersion Include="ThrottleDebounce" Version="2.0.0"/>
+        <PackageVersion Include="WebhooksCore" Version="0.0.1"/>
+        <PackageVersion Include="xunit" Version="2.9.2"/>
+        <PackageVersion Include="xunit.abstractions" Version="2.0.3"/>
+        <PackageVersion Include="xunit.extensibility.core" Version="2.9.2"/>
+        <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0"/>
+        <PackageVersion Include="Yarp.ReverseProxy" Version="2.2.0"/>
+        <PackageVersion Include="AspNetCore.Authentication.ApiKey" Version="8.0.1"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="9.0.0"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.0"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.0"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="9.0.0"/>
+        <PackageVersion Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="9.0.0"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0"/>
+        <PackageVersion Include="Microsoft.Data.Sqlite" Version="9.0.0"/>
+        <PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="9.0.0"/>
+        <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.0"/>
+        <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0"/>
+        <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.0"/>
+        <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.0"/>
+        <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0"/>
+        <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.0"/>
+        <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="9.0.0"/>
+        <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.0"/>
+        <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.0"/>
+        <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0"/>
+        <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0"/>
+        <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0"/>
+        <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="9.0.0"/>
+        <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.0"/>
+        <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.0"/>
+        <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="9.0.0"/>
+        <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.0"/>
+        <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0"/>
+        <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.0"/>
+        <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.0"/>
+        <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.0"/>
+        <PackageVersion Include="Npgsql" Version="9.0.2"/>
+        <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.2"/>
+        <PackageVersion Include="Oracle.EntityFrameworkCore" Version="9.23.60"/>
+        <PackageVersion Include="Polly" Version="8.5.0"/>
+        <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="9.0.0-preview.2.efcore.9.0.0"/>
+        <PackageVersion Include="Refit" Version="8.0.0"/>
+        <PackageVersion Include="Refit.HttpClientFactory" Version="8.0.0"/>
+        <PackageVersion Include="System.Formats.Asn1" Version="9.0.0"/>
+        <PackageVersion Include="System.Text.Json" Version="9.0.0"/>
+    </ItemGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
   <PropertyGroup Label="TargetFrameworks">
-    <TargetFrameworks>net6.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup Label="Files">

--- a/src/modules/Elsa.Agents.Persistence.EntityFrameworkCore.MySql/Elsa.Agents.Persistence.EntityFrameworkCore.MySql.csproj
+++ b/src/modules/Elsa.Agents.Persistence.EntityFrameworkCore.MySql/Elsa.Agents.Persistence.EntityFrameworkCore.MySql.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
         <Description>Provides an EF Core migrations for MySQL for the Agents Persistence module.</Description>
         <PackageTags>elsa module agents semantic kernel llm ai persistence efcore entity framework core mysql</PackageTags>
     </PropertyGroup>

--- a/src/modules/Elsa.Common/Elsa.Common.csproj
+++ b/src/modules/Elsa.Common/Elsa.Common.csproj
@@ -21,8 +21,4 @@
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-        <PackageReference Include="System.Text.Json" />
-    </ItemGroup>
-
 </Project>

--- a/src/modules/Elsa.EntityFrameworkCore.MySql/Elsa.EntityFrameworkCore.MySql.csproj
+++ b/src/modules/Elsa.EntityFrameworkCore.MySql/Elsa.EntityFrameworkCore.MySql.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
         <Description>
             Provides MySQL EF Core migrations for various modules.
         </Description>

--- a/src/modules/Elsa.Quartz.EntityFrameworkCore.MySql/Elsa.Quartz.EntityFrameworkCore.MySql.csproj
+++ b/src/modules/Elsa.Quartz.EntityFrameworkCore.MySql/Elsa.Quartz.EntityFrameworkCore.MySql.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
         <Description>
             Provides EF Core migrations for Quartz.NET.
         </Description>

--- a/src/modules/Elsa.Quartz/Elsa.Quartz.csproj
+++ b/src/modules/Elsa.Quartz/Elsa.Quartz.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
         <Description>
             Provides integration with the Quartz.NET library and provide am implementation of Elsa's IJobScheduler using Quartz.NET.
         </Description>


### PR DESCRIPTION
This PR removes support for .NET 6.0 from the project. Updates include:  
- Adjusted project files to target only supported .NET versions.  
- Updated documentation and CI/CD pipelines to reflect the removal of .NET 6.0.  
- Removed any .NET 6.0-specific code or dependencies.  

This change simplifies maintenance and focuses development on currently supported .NET versions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6233)
<!-- Reviewable:end -->
