### PR TITLE
Refactor JsonWorkflowStateSerializer to improve performance

### DIFF
--- a/src/apps/Directory.Build.props
+++ b/src/apps/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/ImportFiles/Endpoint.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/ImportFiles/Endpoint.cs
@@ -108,7 +108,7 @@ internal class ImportFiles : ElsaEndpoint<WorkflowDefinitionModel>
 
     private async Task ImportJsonStreamAsync(Stream jsonStream, CancellationToken cancellationToken)
     {
-        var json = await new StreamReader(jsonStream).ReadToEndAsync();
+        var json = await new StreamReader(jsonStream).ReadToEndAsync(cancellationToken);
         var model = _apiSerializer.Deserialize<WorkflowDefinitionModel>(json);
         await ImportSingleWorkflowDefinitionAsync(model, cancellationToken);
     }

--- a/src/modules/Elsa.Workflows.Core/Serialization/ReferenceHandlers/CrossScopedReferenceHandler.cs
+++ b/src/modules/Elsa.Workflows.Core/Serialization/ReferenceHandlers/CrossScopedReferenceHandler.cs
@@ -7,29 +7,23 @@ namespace Elsa.Workflows.Serialization.ReferenceHandlers;
 /// </summary>
 public class CrossScopedReferenceHandler : ReferenceHandler
 {
-    /// <inheritdoc />
-    public CrossScopedReferenceHandler() => Reset();
-    private ReferenceResolver? _rootedResolver;
+    private static readonly AsyncLocal<CustomPreserveReferenceResolver> RootedResolverState = new();
+
+    private CustomPreserveReferenceResolver RootedResolver
+    {
+        get
+        {
+            RootedResolverState.Value ??= new CustomPreserveReferenceResolver();
+            return RootedResolverState.Value!;
+        }
+    }
 
     /// <inheritdoc />
-    public override ReferenceResolver CreateResolver() => _rootedResolver!;
-    
-    /// <summary>
-    /// Resets the reference resolver.
-    /// </summary>
-    public void Reset() => _rootedResolver = new CustomPreserveReferenceResolver();
-    
+    public override ReferenceResolver CreateResolver() => RootedResolver;
+
     /// <summary>
     /// Gets the reference resolver.
     /// </summary>
     /// <returns>The reference resolver.</returns>
-    public ReferenceResolver GetResolver() => _rootedResolver!;
-}
-
-public class PerCallReferenceHandlerWrapper : ReferenceHandler
-{
-    public override ReferenceResolver CreateResolver()
-    {
-        return new CrossScopedReferenceHandler().CreateResolver();
-    }
+    public ReferenceResolver GetResolver() => RootedResolver;
 }

--- a/src/modules/Elsa.Workflows.Core/Serialization/ReferenceHandlers/CrossScopedReferenceHandler.cs
+++ b/src/modules/Elsa.Workflows.Core/Serialization/ReferenceHandlers/CrossScopedReferenceHandler.cs
@@ -7,23 +7,21 @@ namespace Elsa.Workflows.Serialization.ReferenceHandlers;
 /// </summary>
 public class CrossScopedReferenceHandler : ReferenceHandler
 {
-    private static readonly AsyncLocal<CustomPreserveReferenceResolver> RootedResolverState = new();
-
-    private CustomPreserveReferenceResolver RootedResolver
-    {
-        get
-        {
-            RootedResolverState.Value ??= new CustomPreserveReferenceResolver();
-            return RootedResolverState.Value!;
-        }
-    }
+    /// <inheritdoc />
+    public CrossScopedReferenceHandler() => Reset();
+    private ReferenceResolver? _rootedResolver;
 
     /// <inheritdoc />
-    public override ReferenceResolver CreateResolver() => RootedResolver;
-
+    public override ReferenceResolver CreateResolver() => _rootedResolver!;
+    
+    /// <summary>
+    /// Resets the reference resolver.
+    /// </summary>
+    public void Reset() => _rootedResolver = new CustomPreserveReferenceResolver();
+    
     /// <summary>
     /// Gets the reference resolver.
     /// </summary>
     /// <returns>The reference resolver.</returns>
-    public ReferenceResolver GetResolver() => RootedResolver;
+    public ReferenceResolver GetResolver() => _rootedResolver!;
 }

--- a/src/modules/Elsa.Workflows.Core/Serialization/ReferenceHandlers/CrossScopedReferenceHandler.cs
+++ b/src/modules/Elsa.Workflows.Core/Serialization/ReferenceHandlers/CrossScopedReferenceHandler.cs
@@ -25,3 +25,11 @@ public class CrossScopedReferenceHandler : ReferenceHandler
     /// <returns>The reference resolver.</returns>
     public ReferenceResolver GetResolver() => _rootedResolver!;
 }
+
+public class PerCallReferenceHandlerWrapper : ReferenceHandler
+{
+    public override ReferenceResolver CreateResolver()
+    {
+        return new CrossScopedReferenceHandler().CreateResolver();
+    }
+}

--- a/src/modules/Elsa.Workflows.Core/Serialization/Serializers/JsonWorkflowStateSerializer.cs
+++ b/src/modules/Elsa.Workflows.Core/Serialization/Serializers/JsonWorkflowStateSerializer.cs
@@ -138,6 +138,7 @@ public class JsonWorkflowStateSerializer : ConfigurableSerializer, IWorkflowStat
 
     public override void ApplyOptions(JsonSerializerOptions options)
     {
+        base.ApplyOptions(options);
         options.ReferenceHandler = new PerCallReferenceHandlerWrapper();
     }
 

--- a/src/modules/Elsa.Workflows.Core/Serialization/Serializers/JsonWorkflowStateSerializer.cs
+++ b/src/modules/Elsa.Workflows.Core/Serialization/Serializers/JsonWorkflowStateSerializer.cs
@@ -129,29 +129,18 @@ public class JsonWorkflowStateSerializer : ConfigurableSerializer, IWorkflowStat
     /// <inheritdoc />
     public override JsonSerializerOptions GetOptions()
     {
-        // Bypass cached options to ensure that the reference handler is always fresh.
-        return GetOptionsInternal();
-    }
-
-    /// <inheritdoc />
-    protected override void Configure(JsonSerializerOptions options)
-    {
-        var referenceHandler = new CrossScopedReferenceHandler();
-
-        options.ReferenceHandler = referenceHandler;
-        options.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
-        options.PropertyNameCaseInsensitive = true;
-        options.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
+        var options = base.GetOptions();
+        return new JsonSerializerOptions(options)
+        {
+            ReferenceHandler = new CrossScopedReferenceHandler()
+        };
     }
 
     /// <inheritdoc />
     protected override void AddConverters(JsonSerializerOptions options)
     {
-        options.Converters.Add(new JsonStringEnumConverter());
         options.Converters.Add(new TypeJsonConverter(_wellKnownTypeRegistry));
-        options.Converters.Add(JsonMetadataServices.TimeSpanConverter);
         options.Converters.Add(new PolymorphicObjectConverterFactory(_wellKnownTypeRegistry));
-        options.Converters.Add(new TypeJsonConverter(_wellKnownTypeRegistry));
         options.Converters.Add(new VariableConverterFactory(_wellKnownTypeRegistry, _loggerFactory));
     }
 }

--- a/src/modules/Elsa.Workflows.Core/Serialization/Serializers/JsonWorkflowStateSerializer.cs
+++ b/src/modules/Elsa.Workflows.Core/Serialization/Serializers/JsonWorkflowStateSerializer.cs
@@ -124,10 +124,14 @@ public class JsonWorkflowStateSerializer : ConfigurableSerializer, IWorkflowStat
         return JsonSerializer.Deserialize<T>(serializedState, options)!;
     }
 
-    public override void ApplyOptions(JsonSerializerOptions options)
+    /// <inheritdoc />
+    public override JsonSerializerOptions GetOptions()
     {
-        base.ApplyOptions(options);
-        options.ReferenceHandler = new CrossScopedReferenceHandler();
+        var options = base.GetOptions();
+        return new JsonSerializerOptions(options)
+        {
+            ReferenceHandler = new CrossScopedReferenceHandler()
+        };
     }
 
     /// <inheritdoc />

--- a/src/modules/Elsa.Workflows.Core/Serialization/Serializers/JsonWorkflowStateSerializer.cs
+++ b/src/modules/Elsa.Workflows.Core/Serialization/Serializers/JsonWorkflowStateSerializer.cs
@@ -126,14 +126,19 @@ public class JsonWorkflowStateSerializer : ConfigurableSerializer, IWorkflowStat
         return JsonSerializer.Deserialize<T>(serializedState, options)!;
     }
 
-    /// <inheritdoc />
-    public override JsonSerializerOptions GetOptions()
+    // /// <inheritdoc />
+    // public override JsonSerializerOptions GetOptions()
+    // {
+    //     var options = base.GetOptions();
+    //     return new JsonSerializerOptions(options)
+    //     {
+    //         ReferenceHandler = new CrossScopedReferenceHandler()
+    //     };
+    // }
+
+    public override void ApplyOptions(JsonSerializerOptions options)
     {
-        var options = base.GetOptions();
-        return new JsonSerializerOptions(options)
-        {
-            ReferenceHandler = new CrossScopedReferenceHandler()
-        };
+        options.ReferenceHandler = new PerCallReferenceHandlerWrapper();
     }
 
     /// <inheritdoc />

--- a/src/modules/Elsa.Workflows.Core/Serialization/Serializers/JsonWorkflowStateSerializer.cs
+++ b/src/modules/Elsa.Workflows.Core/Serialization/Serializers/JsonWorkflowStateSerializer.cs
@@ -1,7 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
-using System.Text.Json.Serialization;
-using System.Text.Json.Serialization.Metadata;
 using Elsa.Common.Serialization;
 using Elsa.Expressions.Contracts;
 using Elsa.Workflows.Serialization.Converters;
@@ -126,20 +124,10 @@ public class JsonWorkflowStateSerializer : ConfigurableSerializer, IWorkflowStat
         return JsonSerializer.Deserialize<T>(serializedState, options)!;
     }
 
-    // /// <inheritdoc />
-    // public override JsonSerializerOptions GetOptions()
-    // {
-    //     var options = base.GetOptions();
-    //     return new JsonSerializerOptions(options)
-    //     {
-    //         ReferenceHandler = new CrossScopedReferenceHandler()
-    //     };
-    // }
-
     public override void ApplyOptions(JsonSerializerOptions options)
     {
         base.ApplyOptions(options);
-        options.ReferenceHandler = new PerCallReferenceHandlerWrapper();
+        options.ReferenceHandler = new CrossScopedReferenceHandler();
     }
 
     /// <inheritdoc />

--- a/src/modules/Elsa.Workflows.Management/Services/WorkflowDefinitionImporter.cs
+++ b/src/modules/Elsa.Workflows.Management/Services/WorkflowDefinitionImporter.cs
@@ -36,7 +36,7 @@ namespace Elsa.Workflows.Management.Services
             // Get a workflow draft version.
             var draft = !string.IsNullOrWhiteSpace(definitionId)
                 ? await _workflowDefinitionPublisher.GetDraftAsync(definitionId, VersionOptions.Latest, cancellationToken)
-                : default;
+                : null;
 
             var isNew = draft == null;
 


### PR DESCRIPTION
- **Improves performance:** The converters and static properties are pre-configured when the class is initialized. Only the `ReferenceHandler` is refreshed per call, avoiding repeated configuration of common options like converters.
- **Thread-safe:** Since `_cachedOptions` is immutable, it can safely be reused across threads.

**Tradeoffs:** Still a performance cost during cloning, but much faster than fully recreating options each time as was done before the PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6272)
<!-- Reviewable:end -->
