### PR TITLE
Refactor array type handling in variable and JSON converters

### DIFF
--- a/src/modules/Elsa.Workflows.Core/Serialization/Converters/TypeJsonConverter.cs
+++ b/src/modules/Elsa.Workflows.Core/Serialization/Converters/TypeJsonConverter.cs
@@ -36,7 +36,7 @@ public class TypeJsonConverter : JsonConverter<Type>
         {
             var elementTypeAlias = typeAlias[..^"[]".Length];
             var elementType = _wellKnownTypeRegistry.TryGetType(elementTypeAlias, out var t) ? t : Type.GetType(elementTypeAlias)!;
-            return typeof(List<>).MakeGenericType(elementType);
+            return elementType.MakeArrayType();
         }
 
         return _wellKnownTypeRegistry.TryGetType(typeAlias, out var type) ? type : Type.GetType(typeAlias);

--- a/src/modules/Elsa.Workflows.Management/Mappers/VariableDefinitionMapper.cs
+++ b/src/modules/Elsa.Workflows.Management/Mappers/VariableDefinitionMapper.cs
@@ -30,7 +30,7 @@ public class VariableDefinitionMapper
         if (!_wellKnownTypeRegistry.TryGetTypeOrDefault(source.TypeName, out var type))
             return null;
 
-        var valueType = source.IsArray ? typeof(ICollection<>).MakeGenericType(type) : type;
+        var valueType = source.IsArray ? type.MakeArrayType() : type;
         var variableGenericType = typeof(Variable<>).MakeGenericType(valueType);
         var variable = (Variable)Activator.CreateInstance(variableGenericType)!;
 


### PR DESCRIPTION
Updated the logic to use `MakeArrayType` for array handling instead of generic collection types, ensuring consistency and better alignment with expected type structures. Adjustments were made in both the `VariableDefinitionMapper` and the `TypeJsonConverter`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6283)
<!-- Reviewable:end -->
