### PR TITLE
Reorder tenant services initialization for proper execution.

### DIFF
--- a/src/modules/Elsa.Common/Features/MultitenancyFeature.cs
+++ b/src/modules/Elsa.Common/Features/MultitenancyFeature.cs
@@ -40,6 +40,9 @@ public class MultitenancyFeature(IModule module) : FeatureBase(module)
             .AddSingleton<ITenantFinder, DefaultTenantFinder>()
             .AddSingleton<ITenantService, DefaultTenantService>()
             
+            // Order is important: Startup task first, then background and recurring tasks.
+            .AddSingleton<ITenantActivatedEvent, RunStartupTasks>()
+            
             .AddSingleton<RunBackgroundTasks>()
             .AddSingleton<ITenantActivatedEvent>(sp => sp.GetRequiredService<RunBackgroundTasks>())
             .AddSingleton<ITenantDeactivatedEvent>(sp => sp.GetRequiredService<RunBackgroundTasks>())
@@ -48,7 +51,6 @@ public class MultitenancyFeature(IModule module) : FeatureBase(module)
             .AddSingleton<ITenantActivatedEvent>(sp => sp.GetRequiredService<StartRecurringTasks>())
             .AddSingleton<ITenantDeactivatedEvent>(sp => sp.GetRequiredService<StartRecurringTasks>())
             
-            .AddSingleton<ITenantActivatedEvent, RunStartupTasks>()
             .AddSingleton<RecurringTaskScheduleManager>()
             .AddSingleton<TenantEventsManager>()
             .AddScoped<DefaultTenantsProvider>()


### PR DESCRIPTION
Ensure `RunStartupTasks` is added before background and recurring tasks as order is critical for correct startup and tenant activation behavior. This prevents potential misalignment in task execution during tenant lifecycle events.

Fixes #6269

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6303)
<!-- Reviewable:end -->
