### PR TITLE
Add option to disable variable copying in Jint engine

### DIFF
--- a/src/apps/Elsa.Server.Web/Program.cs
+++ b/src/apps/Elsa.Server.Web/Program.cs
@@ -89,6 +89,7 @@ const bool useTenantsFromConfiguration = true;
 const bool useAgents = false;
 const bool useSecrets = false;
 const bool disableVariableWrappers = false;
+const bool disableVariableCopying = true;
 
 var builder = WebApplication.CreateBuilder(args);
 var services = builder.Services;
@@ -355,6 +356,7 @@ services
             {
                 options.AllowClrAccess = true;
                 options.DisableWrappers = disableVariableWrappers;
+                options.DisableVariableCopying = disableVariableCopying;
                 options.RegisterType<OrderReceived>();
                 options.ConfigureEngine(engine =>
                 {

--- a/src/apps/Elsa.Server.Web/Program.cs
+++ b/src/apps/Elsa.Server.Web/Program.cs
@@ -89,7 +89,7 @@ const bool useTenantsFromConfiguration = true;
 const bool useAgents = false;
 const bool useSecrets = false;
 const bool disableVariableWrappers = false;
-const bool disableVariableCopying = true;
+const bool disableVariableCopying = false;
 
 var builder = WebApplication.CreateBuilder(args);
 var services = builder.Services;

--- a/src/modules/Elsa.JavaScript/Extensions/EngineExtensions.cs
+++ b/src/modules/Elsa.JavaScript/Extensions/EngineExtensions.cs
@@ -24,12 +24,12 @@ public static class EngineExtensions
 
     internal static void SyncVariablesContainer(this Engine engine, IOptions<JintOptions> options, string name, object? value)
     {
-        if (!options.Value.DisableWrappers)
-        {
-            // To ensure both variable accessor syntaxes work, we need to update the variables container in the engine as well as the context to keep them in sync.
-            var variablesContainer = (IDictionary<string, object?>)engine.GetValue("variables").ToObject()!;
-            variablesContainer[name] = ObjectConverterHelper.ProcessVariableValue(engine, value);
-            engine.SetValue("variables", variablesContainer);
-        }
+        if (options.Value.DisableWrappers || options.Value.DisableVariableCopying)
+            return;
+
+        // To ensure both variable accessor syntaxes work, we need to update the variables container in the engine as well as the context to keep them in sync.
+        var variablesContainer = (IDictionary<string, object?>)engine.GetValue("variables").ToObject()!;
+        variablesContainer[name] = ObjectConverterHelper.ProcessVariableValue(engine, value);
+        engine.SetValue("variables", variablesContainer);
     }
 }

--- a/src/modules/Elsa.JavaScript/Options/JintOptions.cs
+++ b/src/modules/Elsa.JavaScript/Options/JintOptions.cs
@@ -48,6 +48,12 @@ public class JintOptions
     public bool DisableWrappers { get; set; }
     
     /// <summary>
+    /// Disables copying workflow variables into the Jint engine and copying them back into the workflow execution context.
+    /// Disabling this option will increase performance but will also prevent you from accessing workflow variables from within JavaScript expressions using the <c>variables.MyVariable</c> syntax.
+    /// </summary>
+    public bool DisableVariableCopying { get; set; }
+    
+    /// <summary>
     /// Configures the Jint engine options.
     /// </summary>
     /// <param name="configurator">A callback that is invoked when the Jint engine options are created. Use this to configure the options.</param>

--- a/src/modules/Elsa.Workflows.Core/Extensions/ExpressionExecutionContextExtensions.cs
+++ b/src/modules/Elsa.Workflows.Core/Extensions/ExpressionExecutionContextExtensions.cs
@@ -119,7 +119,7 @@ public static class ExpressionExecutionContextExtensions
     public static Variable? GetVariable(this ExpressionExecutionContext context, string name, bool localScopeOnly = false)
     {
         var block = context.GetVariableBlock(name, localScopeOnly);
-        return block?.Metadata is VariableBlockMetadata metadata ? metadata.Variable : default;
+        return block?.Metadata is VariableBlockMetadata metadata ? metadata.Variable : null;
     }
 
     private static MemoryBlock? GetVariableBlock(this ExpressionExecutionContext context, string name, bool localScopeOnly = false)
@@ -138,7 +138,7 @@ public static class ExpressionExecutionContextExtensions
     /// Creates a named variable in the context.
     /// </summary>
     public static Variable CreateVariable<T>(this ExpressionExecutionContext context, string name, T? value, Type? storageDriverType = null,
-        Action<MemoryBlock>? configure = default)
+        Action<MemoryBlock>? configure = null)
     {
         var existingVariable = context.GetVariable(name, localScopeOnly: true);
 
@@ -173,7 +173,7 @@ public static class ExpressionExecutionContextExtensions
     /// <summary>
     /// Sets the value of a named variable in the context.
     /// </summary>
-    public static Variable SetVariable<T>(this ExpressionExecutionContext context, string name, T? value, Action<MemoryBlock>? configure = default)
+    public static Variable SetVariable<T>(this ExpressionExecutionContext context, string name, T? value, Action<MemoryBlock>? configure = null)
     {
         var variable = context.GetVariable(name);
 
@@ -193,7 +193,7 @@ public static class ExpressionExecutionContextExtensions
     /// <summary>
     /// Sets the output to the specified value.
     /// </summary>
-    public static void Set(this ExpressionExecutionContext context, Output? output, object? value, Action<MemoryBlock>? configure = default)
+    public static void Set(this ExpressionExecutionContext context, Output? output, object? value, Action<MemoryBlock>? configure = null)
     {
         if (output != null)
         {
@@ -412,11 +412,11 @@ public static class ExpressionExecutionContextExtensions
         // Otherwise, return the input.
         var workflowExecutionContext = context.GetWorkflowExecutionContext();
         var input = workflowExecutionContext.Input;
-        return input.TryGetValue(name, out var value) ? value : default;
+        return input.TryGetValue(name, out var value) ? value : null;
     }
 
     /// <summary>
-    /// Returns the value of the specified input.
+    /// Returns the value of the specified output.
     /// </summary>
     /// <param name="context"></param>
     /// <param name="activityIdOrName">The ID or name of the activity.</param>
@@ -433,9 +433,9 @@ public static class ExpressionExecutionContextExtensions
             throw new InvalidOperationException("Activity not found.");
 
         var outputRegister = workflowExecutionContext.GetActivityOutputRegister();
-        var outputRecordCandidates = outputRegister.FindMany(x => x.ActivityId == activity.Id && x.OutputName == outputName).ToList();
+        var outputRecordCandidates = outputRegister.FindMany(activity.Id, outputName);
         var containerIds = activityExecutionContext.GetAncestors().Select(x => x.Id).ToList();
-        var filteredOutputRecordCandidates = outputRecordCandidates.Where(x => containerIds.Contains(x.ContainerId)).ToList();
+        var filteredOutputRecordCandidates = outputRecordCandidates.Where(x => containerIds.Contains(x.ContainerId));
         var outputRecord = filteredOutputRecordCandidates.FirstOrDefault();
         return outputRecord?.Value;
     }

--- a/src/modules/Elsa.Workflows.Core/Extensions/ExpressionExecutionContextExtensions.cs
+++ b/src/modules/Elsa.Workflows.Core/Extensions/ExpressionExecutionContextExtensions.cs
@@ -143,7 +143,7 @@ public static class ExpressionExecutionContextExtensions
         var existingVariable = context.GetVariable(name, localScopeOnly: true);
 
         if (existingVariable != null)
-            throw new Exception($"Variable {name} already exists in the context.");
+            throw new($"Variable {name} already exists in the context.");
 
         var variable = new Variable(name, value)
         {
@@ -464,7 +464,7 @@ public static class ExpressionExecutionContextExtensions
             foreach (var output in activityDescriptor.Outputs)
             {
                 var outputPascalName = output.Name.Pascalize();
-                yield return new ActivityOutputs(activity.Id, activityIdPascalName, [
+                yield return new(activity.Id, activityIdPascalName, [
                     outputPascalName
                 ]);
             }
@@ -508,7 +508,7 @@ public static class ExpressionExecutionContextExtensions
             {
                 var inputPascalName = inputEntry.Key.Pascalize();
                 var inputValue = inputEntry.Value;
-                yield return new WorkflowInput(inputPascalName, inputValue);
+                yield return new(inputPascalName, inputValue);
             }
         }
         else
@@ -522,7 +522,7 @@ public static class ExpressionExecutionContextExtensions
 
                 var variable = variableBlockMetadata.Variable;
                 var variablePascalName = variable.Name.Pascalize();
-                yield return new WorkflowInput(variablePascalName, block.Value);
+                yield return new(variablePascalName, block.Value);
             }
         }
     }

--- a/src/modules/Elsa.Workflows.Core/Models/ActivityOutputRegister.cs
+++ b/src/modules/Elsa.Workflows.Core/Models/ActivityOutputRegister.cs
@@ -45,17 +45,17 @@ public class ActivityOutputRegister
             outputName = outputDescriptor.Name;
 
         var record = new ActivityOutputRecord(containerId, activityId, activityInstanceId, outputName, outputValue);
-        
+
         _recordsByActivityInstanceIdAndOutputName[CreateActivityInstanceIdLookupKey(activityInstanceId, outputName)] = record;
-        
+
         var scopedRecordsKey = CreateActivityIdLookupKey(activityId, outputName);
 
-        if(!_recordsByActivityIdAndOutputName.TryGetValue(scopedRecordsKey, out var scopedRecords))
+        if (!_recordsByActivityIdAndOutputName.TryGetValue(scopedRecordsKey, out var scopedRecords))
         {
             scopedRecords = new();
             _recordsByActivityIdAndOutputName[scopedRecordsKey] = scopedRecords;
         }
-        
+
         scopedRecords.Add(record);
     }
 
@@ -77,8 +77,8 @@ public class ActivityOutputRegister
     public object? FindOutputByActivityId(string activityId, string? outputName = null)
     {
         var key = CreateActivityIdLookupKey(activityId, outputName);
-        return !_recordsByActivityIdAndOutputName.TryGetValue(key, out var records) 
-            ? null 
+        return !_recordsByActivityIdAndOutputName.TryGetValue(key, out var records)
+            ? null
             : records.FirstOrDefault()?.Value;
     }
 
@@ -91,11 +91,11 @@ public class ActivityOutputRegister
     public object? FindOutputByActivityInstanceId(string activityInstanceId, string? outputName = null)
     {
         var key = CreateActivityInstanceIdLookupKey(activityInstanceId, outputName);
-        return !_recordsByActivityInstanceIdAndOutputName.TryGetValue(key, out var record) 
-            ? null 
+        return !_recordsByActivityInstanceIdAndOutputName.TryGetValue(key, out var record)
+            ? null
             : record.Value;
     }
-    
+
     private string CreateActivityIdLookupKey(string activityId, string? outputName) => $"{activityId}:{outputName ?? DefaultOutputName}";
     private string CreateActivityInstanceIdLookupKey(string activityInstanceId, string? outputName) => $"{activityInstanceId}:{outputName ?? DefaultOutputName}";
 }

--- a/src/modules/Elsa.Workflows.Core/Models/ActivityOutputRegister.cs
+++ b/src/modules/Elsa.Workflows.Core/Models/ActivityOutputRegister.cs
@@ -79,7 +79,7 @@ public class ActivityOutputRegister
         var key = CreateActivityIdLookupKey(activityId, outputName);
         return !_recordsByActivityIdAndOutputName.TryGetValue(key, out var records) 
             ? null 
-            : records.FirstOrDefault();
+            : records.FirstOrDefault()?.Value;
     }
 
     /// <summary>

--- a/src/modules/Elsa.Workflows.Core/Models/PropertyDescriptor.cs
+++ b/src/modules/Elsa.Workflows.Core/Models/PropertyDescriptor.cs
@@ -11,13 +11,13 @@ public abstract class PropertyDescriptor
     /// <summary>
     /// The name.
     /// </summary>
-    public string Name { get; set; } = default!;
+    public string Name { get; set; } = null!;
 
     /// <summary>
     /// The .NET type.
     /// </summary>
     [JsonPropertyName("typeName")]
-    public Type Type { get; set; } = default!;
+    public Type Type { get; set; } = null!;
 
     /// <summary>
     /// The user friendly name of the input. Used by UI tools.
@@ -53,13 +53,13 @@ public abstract class PropertyDescriptor
     /// Returns the value of the input property for the specified activity.
     /// </summary>
     [JsonIgnore]
-    public Func<IActivity, object?> ValueGetter { get; set; } = default!;
+    public Func<IActivity, object?> ValueGetter { get; set; } = null!;
     
     /// <summary>
     /// Sets the value of the input property for the specified activity.
     /// </summary>
     [JsonIgnore]
-    public Action<IActivity, object?> ValueSetter { get; set; } = default!;
+    public Action<IActivity, object?> ValueSetter { get; set; } = null!;
     
     /// <summary>
     /// The source of the property, if any.


### PR DESCRIPTION
Introduce a `DisableVariableCopying` option to improve performance by preventing workflow variables from being copied into the Jint engine or back into the workflow context. Updated related logic to honor this setting and ensure compatibility with existing behavior.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6320)
<!-- Reviewable:end -->
