### PR TITLE
Controlled Commit States Feature Implementation

### DIFF
--- a/src/clients/Elsa.Api.Client/Extensions/ActivityExtensions.cs
+++ b/src/clients/Elsa.Api.Client/Extensions/ActivityExtensions.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Nodes;
+using Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
 using Elsa.Api.Client.Shared.Models;
 
 namespace Elsa.Api.Client.Extensions;
@@ -182,4 +183,14 @@ public static class ActivityExtensions
     /// Sets a value indicating whether the specified activity can trigger the workflow.
     /// </summary>
     public static void SetRunAsynchronously(this JsonObject activity, bool value) => activity.SetProperty(JsonValue.Create(value), "customProperties", "runAsynchronously");
+    
+    /// <summary>
+    /// Gets the commit state behavior for the specified activity.
+    /// </summary>
+    public static ActivityCommitStateBehavior GetCommitStateBehavior(this JsonObject activity) => activity.TryGetProperty<ActivityCommitStateBehavior?>("customProperties", "commitStateBehavior") ?? ActivityCommitStateBehavior.Default;
+
+    /// <summary>
+    /// Sets the commit state behavior for the specified activity.
+    /// </summary>
+    public static void SetCommitStateBehavior(this JsonObject activity, ActivityCommitStateBehavior value) => activity.SetProperty(JsonValue.Create(value.ToString()), "customProperties", "commitStateBehavior");
 }

--- a/src/clients/Elsa.Api.Client/Resources/WorkflowDefinitions/Models/ActivityCommitStateBehavior.cs
+++ b/src/clients/Elsa.Api.Client/Resources/WorkflowDefinitions/Models/ActivityCommitStateBehavior.cs
@@ -1,0 +1,29 @@
+namespace Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
+
+public enum ActivityCommitStateBehavior
+{
+    /// <summary>
+    /// Never commit state, regardless of the workflow commit state options.
+    /// </summary>
+    Never,
+    
+    /// <summary>
+    /// Look at the workflow commit state options to determine if state should be committed.
+    /// </summary>
+    Default,
+    
+    /// <summary>
+    /// Commit state before the activity starts.
+    /// </summary>
+    Executing,
+    
+    /// <summary>
+    /// Commit state after the activity executes.
+    /// </summary>
+    Executed,
+    
+    /// <summary>
+    /// Commit state before the activity starts and after the activity executes.
+    /// </summary>
+    BeforeAndAfterExecution
+}

--- a/src/clients/Elsa.Api.Client/Resources/WorkflowDefinitions/Models/WorkflowCommitStateOptions.cs
+++ b/src/clients/Elsa.Api.Client/Resources/WorkflowDefinitions/Models/WorkflowCommitStateOptions.cs
@@ -1,0 +1,19 @@
+namespace Elsa.Api.Client.Resources.WorkflowDefinitions.Models;
+
+public class WorkflowCommitStateOptions
+{
+    /// <summary>
+    /// Commit workflow state before the workflow starts.
+    /// </summary>
+    public bool Starting { get; set; }
+
+    /// <summary>
+    /// Commit workflow state before an activity executes, unless the activity is configured to not commit state.
+    /// </summary>
+    public bool ActivityExecuting { get; set; }
+    
+    /// <summary>
+    /// Commit workflow state after an activity executes, unless the activity is configured to not commit state.
+    /// </summary>
+    public bool ActivityExecuted { get; set; }
+}

--- a/src/clients/Elsa.Api.Client/Resources/WorkflowDefinitions/Models/WorkflowOptions.cs
+++ b/src/clients/Elsa.Api.Client/Resources/WorkflowDefinitions/Models/WorkflowOptions.cs
@@ -29,4 +29,9 @@ public class WorkflowOptions
     /// The type of <c>IIncidentStrategy</c> to use when a fault occurs in the workflow.
     /// </summary>
     public string? IncidentStrategyType { get; set; }
+    
+    /// <summary>
+    /// The options for committing workflow state.
+    /// </summary>
+    public WorkflowCommitStateOptions CommitStateOptions { get; set; } = new();
 }

--- a/src/modules/Elsa.EntityFrameworkCore.Common/Store.cs
+++ b/src/modules/Elsa.EntityFrameworkCore.Common/Store.cs
@@ -79,8 +79,12 @@ public class Store<TDbContext, TEntity>(IDbContextFactory<TDbContext> dbContextF
         Func<TDbContext, TEntity, CancellationToken, ValueTask>? onSaving = default,
         CancellationToken cancellationToken = default)
     {
-        await using var dbContext = await CreateDbContextAsync(cancellationToken);
         var entityList = entities.ToList();
+
+        if (entityList.Count == 0)
+            return;
+
+        await using var dbContext = await CreateDbContextAsync(cancellationToken);
 
         if (onSaving != null)
         {
@@ -162,8 +166,12 @@ public class Store<TDbContext, TEntity>(IDbContextFactory<TDbContext> dbContextF
         Func<TDbContext, TEntity, CancellationToken, ValueTask>? onSaving = default,
         CancellationToken cancellationToken = default)
     {
-        await using var dbContext = await CreateDbContextAsync(cancellationToken);
         var entityList = entities.ToList();
+
+        if (entityList.Count == 0)
+            return;
+
+        await using var dbContext = await CreateDbContextAsync(cancellationToken);
 
         if (onSaving != null)
         {

--- a/src/modules/Elsa.Workflows.Core/Contracts/ICommitStateHandler.cs
+++ b/src/modules/Elsa.Workflows.Core/Contracts/ICommitStateHandler.cs
@@ -4,5 +4,6 @@ namespace Elsa.Workflows;
 
 public interface ICommitStateHandler
 {
+    Task CommitAsync(WorkflowExecutionContext workflowExecutionContext, CancellationToken cancellationToken = default);
     Task CommitAsync(WorkflowExecutionContext workflowExecutionContext, WorkflowState workflowState, CancellationToken cancellationToken = default);
 }

--- a/src/modules/Elsa.Workflows.Core/Elsa.Workflows.Core.csproj.DotSettings
+++ b/src/modules/Elsa.Workflows.Core/Elsa.Workflows.Core.csproj.DotSettings
@@ -7,6 +7,8 @@
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=activities_005Cprimitives_005Csetname/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=activities_005Csignaling_005Cactivities_005Csignalreceived/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=activities_005Cworkflows_005Cfreeflowchart/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=commitstates_005Ccontracts/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=commitstates_005Cmodels/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=constants/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=contexts/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=contracts/@EntryIndexedValue">True</s:Boolean>

--- a/src/modules/Elsa.Workflows.Core/Enums/ActivityCommitStateBehavior.cs
+++ b/src/modules/Elsa.Workflows.Core/Enums/ActivityCommitStateBehavior.cs
@@ -1,0 +1,29 @@
+namespace Elsa.Workflows;
+
+public enum ActivityCommitStateBehavior
+{
+    /// <summary>
+    /// Never commit state, regardless of the workflow commit state options.
+    /// </summary>
+    Never,
+    
+    /// <summary>
+    /// Look at the workflow commit state options to determine if state should be committed.
+    /// </summary>
+    Default,
+    
+    /// <summary>
+    /// Commit state before the activity starts.
+    /// </summary>
+    Executing,
+    
+    /// <summary>
+    /// Commit state after the activity executes.
+    /// </summary>
+    Executed,
+    
+    /// <summary>
+    /// Commit state before the activity starts and after the activity executes.
+    /// </summary>
+    BeforeAndAfterExecution
+}

--- a/src/modules/Elsa.Workflows.Core/Extensions/ActivityPropertyExtensions.cs
+++ b/src/modules/Elsa.Workflows.Core/Extensions/ActivityPropertyExtensions.cs
@@ -11,6 +11,7 @@ public static class ActivityPropertyExtensions
     private static readonly string[] CanStartWorkflowPropertyName = ["canStartWorkflow", "CanStartWorkflow"];
     private static readonly string[] RunAsynchronouslyPropertyName = ["runAsynchronously", "RunAsynchronously"];
     private static readonly string[] SourcePropertyName = ["source", "Source"];
+    private static readonly string[] CommitStateBehaviorName = ["commitStateBehavior", "CommitStateBehavior"];
 
     /// <summary>
     /// Gets a flag indicating whether this activity can be used for starting a workflow.
@@ -46,6 +47,16 @@ public static class ActivityPropertyExtensions
     /// Sets the source file and line number where this activity was instantiated, if any.
     /// </summary>
     public static void SetSource(this IActivity activity, string value) => activity.CustomProperties[SourcePropertyName[0]] = value;
+    
+    /// <summary>
+    /// Gets the commit state behavior for the specified activity.
+    /// </summary>
+    public static ActivityCommitStateBehavior GetCommitStateBehavior(this IActivity activity) => activity.CustomProperties.GetValueOrDefault(CommitStateBehaviorName, () => ActivityCommitStateBehavior.Default);
+    
+    /// <summary>
+    /// Sets the commit state behavior for the specified activity.
+    /// </summary>
+    public static void SetCommitStateBehavior(this IActivity activity, ActivityCommitStateBehavior value) => activity.CustomProperties[CommitStateBehaviorName[0]] = value;
 
     /// <summary>
     /// Sets the source file and line number where this activity was instantiated, if any.
@@ -62,7 +73,7 @@ public static class ActivityPropertyExtensions
     /// <summary>
     /// Gets the display text for the specified activity.
     /// </summary>
-    public static string? GetDisplayText(this IActivity activity) => activity.Metadata.TryGetValue("displayText", out var value) ? value.ToString() : default;
+    public static string? GetDisplayText(this IActivity activity) => activity.Metadata.TryGetValue("displayText", out var value) ? value.ToString() : null;
     
     /// <summary>
     /// Sets the display text for the specified activity.
@@ -72,7 +83,7 @@ public static class ActivityPropertyExtensions
     /// <summary>
     /// Gets the description for the specified activity.
     /// </summary>
-    public static string? GetDescription(this IActivity activity) => activity.Metadata.TryGetValue("description", out var value) ? value.ToString() : default;
+    public static string? GetDescription(this IActivity activity) => activity.Metadata.TryGetValue("description", out var value) ? value.ToString() : null;
     
     /// <summary>
     /// Sets the description for the specified activity.

--- a/src/modules/Elsa.Workflows.Core/Middleware/Activities/DefaultActivityInvokerMiddleware.cs
+++ b/src/modules/Elsa.Workflows.Core/Middleware/Activities/DefaultActivityInvokerMiddleware.cs
@@ -49,7 +49,7 @@ public class DefaultActivityInvokerMiddleware(ActivityMiddlewareDelegate next, I
         }
         
         // Conditionally commit the workflow state.
-        if(ShouldCommitWhenStarting(context))
+        if(ShouldCommitWhenExecuting(context))
             await context.WorkflowExecutionContext.CommitAsync();
 
         context.TransitionTo(ActivityStatus.Running);
@@ -120,7 +120,7 @@ public class DefaultActivityInvokerMiddleware(ActivityMiddlewareDelegate next, I
         await context.EvaluateInputPropertiesAsync();
     }
     
-    private bool ShouldCommitWhenStarting(ActivityExecutionContext context)
+    private bool ShouldCommitWhenExecuting(ActivityExecutionContext context)
     {
         var behavior = context.Activity.GetCommitStateBehavior();
         

--- a/src/modules/Elsa.Workflows.Core/Middleware/Workflows/DefaultActivitySchedulerMiddleware.cs
+++ b/src/modules/Elsa.Workflows.Core/Middleware/Workflows/DefaultActivitySchedulerMiddleware.cs
@@ -36,6 +36,8 @@ public class DefaultActivitySchedulerMiddleware : WorkflowExecutionMiddleware
 
         context.TransitionTo(WorkflowSubStatus.Executing);
         
+        await ConditionallyCommitStateAsync(context);
+        
         while (scheduler.HasAny)
         {
             // Do not start a workflow if cancellation has been requested.
@@ -64,5 +66,13 @@ public class DefaultActivitySchedulerMiddleware : WorkflowExecutionMiddleware
         };
 
         await _activityInvoker.InvokeAsync(context, workItem.Activity, options);
+    }
+    
+    private async Task ConditionallyCommitStateAsync(WorkflowExecutionContext context)
+    {
+        var shouldCommit = context.Workflow.Options.CommitStateOptions.Starting;
+        
+        if (shouldCommit)
+            await context.CommitAsync();
     }
 }

--- a/src/modules/Elsa.Workflows.Core/Models/WorkflowCommitStateOptions.cs
+++ b/src/modules/Elsa.Workflows.Core/Models/WorkflowCommitStateOptions.cs
@@ -1,0 +1,19 @@
+namespace Elsa.Workflows.Models;
+
+public class WorkflowCommitStateOptions
+{
+    /// <summary>
+    /// Commit workflow state before the workflow starts.
+    /// </summary>
+    public bool Starting { get; set; }
+
+    /// <summary>
+    /// Commit workflow state before an activity executes, unless the activity is configured to not commit state.
+    /// </summary>
+    public bool ActivityExecuting { get; set; }
+    
+    /// <summary>
+    /// Commit workflow state after an activity executes, unless the activity is configured to not commit state.
+    /// </summary>
+    public bool ActivityExecuted { get; set; }
+}

--- a/src/modules/Elsa.Workflows.Core/Models/WorkflowOptions.cs
+++ b/src/modules/Elsa.Workflows.Core/Models/WorkflowOptions.cs
@@ -29,4 +29,9 @@ public class WorkflowOptions
     /// The type of <see cref="IIncidentStrategy"/> to use when a fault occurs in the workflow.
     /// </summary>
     public Type? IncidentStrategyType { get; set; }
+  
+    /// <summary>
+    /// The options for committing workflow state.
+    /// </summary>
+    public WorkflowCommitStateOptions CommitStateOptions { get; set; } = new();
 }

--- a/src/modules/Elsa.Workflows.Core/Services/NoopCommitStateHandler.cs
+++ b/src/modules/Elsa.Workflows.Core/Services/NoopCommitStateHandler.cs
@@ -4,6 +4,11 @@ namespace Elsa.Workflows;
 
 public class NoopCommitStateHandler : ICommitStateHandler
 {
+    public Task CommitAsync(WorkflowExecutionContext workflowExecutionContext, CancellationToken cancellationToken = default)
+    {
+        return Task.CompletedTask;
+    }
+
     public Task CommitAsync(WorkflowExecutionContext workflowExecutionContext, WorkflowState workflowState, CancellationToken cancellationToken = default)
     {
         return Task.CompletedTask;

--- a/src/modules/Elsa.Workflows.Runtime/Extensions/WorkflowExecutionPipelineBuilderExtensions.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Extensions/WorkflowExecutionPipelineBuilderExtensions.cs
@@ -18,9 +18,6 @@ public static class WorkflowExecutionPipelineBuilderExtensions
         pipelineBuilder
             .Reset()
             .UseEngineExceptionHandling()
-            .UseBookmarkPersistence()
-            .UseActivityExecutionLogPersistence()
-            .UseWorkflowExecutionLogPersistence()
             .UsePersistentVariables()
             .UseExceptionHandling()
             .UseDefaultActivityScheduler();
@@ -33,15 +30,18 @@ public static class WorkflowExecutionPipelineBuilderExtensions
     /// <summary>
     /// Installs middleware that persists bookmarks after workflow execution.
     /// </summary>
+    [Obsolete("This middleware is no longer used and will be removed in a future version. Bookmarks are now persisted through the commit state handler.")]
     public static IWorkflowExecutionPipelineBuilder UseBookmarkPersistence(this IWorkflowExecutionPipelineBuilder pipelineBuilder) => pipelineBuilder.UseMiddleware<PersistBookmarkMiddleware>();
 
     /// <summary>
     /// Installs middleware that persists the workflow execution journal.
     /// </summary>
+    [Obsolete("This middleware is no longer used and will be removed in a future version. Execution logs are now persisted through the commit state handler.")]
     public static IWorkflowExecutionPipelineBuilder UseWorkflowExecutionLogPersistence(this IWorkflowExecutionPipelineBuilder pipelineBuilder) => pipelineBuilder.UseMiddleware<PersistWorkflowExecutionLogMiddleware>();
 
     /// <summary>
     /// Installs middleware that persists activity execution records.
     /// </summary>
+    [Obsolete("This middleware is no longer used and will be removed in a future version. Activity state is now persisted through the commit state handler.")]
     public static IWorkflowExecutionPipelineBuilder UseActivityExecutionLogPersistence(this IWorkflowExecutionPipelineBuilder pipelineBuilder) => pipelineBuilder.UseMiddleware<PersistActivityExecutionLogMiddleware>();
 }

--- a/src/modules/Elsa.Workflows.Runtime/Middleware/Workflows/PersistActivityExecutionLogMiddleware.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Middleware/Workflows/PersistActivityExecutionLogMiddleware.cs
@@ -1,17 +1,19 @@
 using Elsa.Workflows.Pipelines.WorkflowExecution;
-using Elsa.Workflows.Runtime.Entities;
 
 namespace Elsa.Workflows.Runtime.Middleware.Workflows;
 
 /// <summary>
 /// Creates and updates activity execution records from activity execution contexts.
 /// </summary>
-public class PersistActivityExecutionLogMiddleware(WorkflowMiddlewareDelegate next, ILogRecordSink<ActivityExecutionRecord> sink) : WorkflowExecutionMiddleware(next)
+[Obsolete("This middleware is no longer used and will be removed in a future version. Activity state is now persisted through the commit state handler")]
+public class PersistActivityExecutionLogMiddleware(WorkflowMiddlewareDelegate next) : WorkflowExecutionMiddleware(next)
 {
     /// <inheritdoc />
     public override async ValueTask InvokeAsync(WorkflowExecutionContext context)
     {
         await Next(context);
-        await sink.PersistExecutionLogsAsync(context);
+        
+        // Not used anymore.
+        //await sink.PersistExecutionLogsAsync(context);
     }
 }

--- a/src/modules/Elsa.Workflows.Runtime/Middleware/Workflows/PersistBookmarkMiddleware.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Middleware/Workflows/PersistBookmarkMiddleware.cs
@@ -1,26 +1,20 @@
 using Elsa.Workflows.Pipelines.WorkflowExecution;
-using Elsa.Workflows.Runtime.Requests;
 
 namespace Elsa.Workflows.Runtime.Middleware.Workflows;
 
 /// <summary>
 /// Takes care of loading and persisting bookmarks.
 /// </summary>
-public class PersistBookmarkMiddleware : WorkflowExecutionMiddleware
+[Obsolete("This middleware is no longer used and will be removed in a future version. Bookmarks are now persisted through the commit state handler")]
+public class PersistBookmarkMiddleware(WorkflowMiddlewareDelegate next) : WorkflowExecutionMiddleware(next)
 {
-    private readonly IBookmarksPersister _bookmarksPersister;
-
-    /// <inheritdoc />
-    public PersistBookmarkMiddleware(WorkflowMiddlewareDelegate next, IBookmarksPersister bookmarksPersister) : base(next)
-    {
-        _bookmarksPersister = bookmarksPersister;
-    }
-
     /// <inheritdoc />
     public override async ValueTask InvokeAsync(WorkflowExecutionContext context)
     {
         await Next(context);
-        var bookmarkRequest = new UpdateBookmarksRequest(context, context.BookmarksDiff, context.CorrelationId);
-        await _bookmarksPersister.PersistBookmarksAsync(bookmarkRequest);
+        
+        // Not used anymore.
+        // var bookmarkRequest = new UpdateBookmarksRequest(context, context.BookmarksDiff, context.CorrelationId);
+        // await _bookmarksPersister.PersistBookmarksAsync(bookmarkRequest);
     }
 }

--- a/src/modules/Elsa.Workflows.Runtime/Middleware/Workflows/PersistWorkflowExecutionLogMiddleware.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Middleware/Workflows/PersistWorkflowExecutionLogMiddleware.cs
@@ -1,12 +1,12 @@
 using Elsa.Workflows.Pipelines.WorkflowExecution;
-using Elsa.Workflows.Runtime.Entities;
 
 namespace Elsa.Workflows.Runtime.Middleware.Workflows;
 
 /// <summary>
 /// Takes care of persisting workflow execution log entries.
 /// </summary>
-public class PersistWorkflowExecutionLogMiddleware(WorkflowMiddlewareDelegate next, ILogRecordSink<WorkflowExecutionLogRecord> sink) : WorkflowExecutionMiddleware(next)
+[Obsolete("This middleware is no longer used and will be removed in a future version. Execution logs are now persisted through the commit state handler.")]
+public class PersistWorkflowExecutionLogMiddleware(WorkflowMiddlewareDelegate next) : WorkflowExecutionMiddleware(next)
 {
     /// <inheritdoc />
     public override async ValueTask InvokeAsync(WorkflowExecutionContext context)
@@ -14,6 +14,7 @@ public class PersistWorkflowExecutionLogMiddleware(WorkflowMiddlewareDelegate ne
         // Invoke next middleware.
         await Next(context);
 
-        await sink.PersistExecutionLogsAsync(context);
+        // Not used anymore.
+        //await sink.PersistExecutionLogsAsync(context);
     }
 }

--- a/src/modules/Elsa.Workflows.Runtime/Middleware/Workflows/PersistentVariablesMiddleware.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Middleware/Workflows/PersistentVariablesMiddleware.cs
@@ -5,28 +5,17 @@ namespace Elsa.Workflows.Runtime.Middleware.Workflows;
 /// <summary>
 /// Takes care of loading and persisting workflow variables.
 /// </summary>
-public class PersistentVariablesMiddleware : WorkflowExecutionMiddleware
+public class PersistentVariablesMiddleware(WorkflowMiddlewareDelegate next, IVariablePersistenceManager variablePersistenceManager) : WorkflowExecutionMiddleware(next)
 {
-    private readonly IVariablePersistenceManager _variablePersistenceManager;
-
-    /// <summary>
-    /// Constructor.
-    /// </summary>
-    public PersistentVariablesMiddleware(WorkflowMiddlewareDelegate next, IVariablePersistenceManager variablePersistenceManager) : base(next)
-    {
-        _variablePersistenceManager = variablePersistenceManager;
-    }
-
     /// <inheritdoc />
     public override async ValueTask InvokeAsync(WorkflowExecutionContext context)
     {
         // Load variables into the workflow execution context.
-        await _variablePersistenceManager.LoadVariablesAsync(context);
+        await variablePersistenceManager.LoadVariablesAsync(context);
         
         // Invoke next middleware.
         await Next(context);
         
-        // Persist variables.
-        await _variablePersistenceManager.SaveVariablesAsync(context);
+        // Variables are persisted through the commit state handler.
     }
 }

--- a/src/modules/Elsa.Workflows.Runtime/Services/StoreActivityExecutionLogSink.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Services/StoreActivityExecutionLogSink.cs
@@ -15,6 +15,10 @@ public class StoreActivityExecutionLogSink(IActivityExecutionStore activityExecu
     public async Task PersistExecutionLogsAsync(WorkflowExecutionContext context, CancellationToken cancellationToken = default)
     {
         var records = await extractor.ExtractLogRecordsAsync(context).ToList();
+        
+        if(records.Count == 0)
+            return;
+        
         await activityExecutionStore.SaveManyAsync(records, cancellationToken);
         await notificationSender.SendAsync(new ActivityExecutionLogUpdated(context, records), cancellationToken);
     }

--- a/src/modules/Elsa.Workflows.Runtime/Services/StoreCommitStateHandler.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Services/StoreCommitStateHandler.cs
@@ -5,6 +5,12 @@ namespace Elsa.Workflows.Runtime;
 
 public class StoreCommitStateHandler(IWorkflowInstanceManager workflowInstanceManager) : ICommitStateHandler
 {
+    public async Task CommitAsync(WorkflowExecutionContext workflowExecutionContext, CancellationToken cancellationToken = default)
+    {
+        var workflowState = workflowInstanceManager.ExtractWorkflowState(workflowExecutionContext);
+        await CommitAsync(workflowExecutionContext, workflowState, cancellationToken);
+    }
+
     public async Task CommitAsync(WorkflowExecutionContext workflowExecutionContext, WorkflowState workflowState, CancellationToken cancellationToken = default)
     {
         await workflowInstanceManager.SaveAsync(workflowState, cancellationToken);

--- a/src/modules/Elsa.Workflows.Runtime/Services/StoreWorkflowExecutionLogSink.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Services/StoreWorkflowExecutionLogSink.cs
@@ -14,6 +14,10 @@ public class StoreWorkflowExecutionLogSink(IWorkflowExecutionLogStore store, ILo
     public async Task PersistExecutionLogsAsync(WorkflowExecutionContext context, CancellationToken cancellationToken)
     {
         var records = await extractor.ExtractLogRecordsAsync(context).ToList();
+        
+        if(records.Count == 0)
+            return;
+        
         await store.AddManyAsync(records, context.CancellationToken);
         await notificationSender.SendAsync(new WorkflowExecutionLogUpdated(context), context.CancellationToken);
     }


### PR DESCRIPTION
This pull request implements the "Controlled Commit States" feature as described in issue #4835. This feature introduces fine-grained control over when a workflow commits its state to the underlying database, providing developers greater flexibility and configurability.

### Feature Overview

#### Workflow-Level Options
- **Commit workflow state before it starts executing.**
- **Commit workflow state before an activity starts executing.**
- **Commit workflow state after an activity has executed.**

These options can be enabled simultaneously to suit various use cases.

#### Activity-Level Options
- **Commit workflow state before it starts executing.**
- **Commit workflow state after it has executed.**
- **Commit workflow state before it starts executing and after it has executed.**
- **Commit workflow state based on the setting at the workflow level.**
- **Never commit workflow state when this activity starts executing or has executed, regardless of the workflow-level setting.**

Only one of the above activity-level options can be selected per activity.

### Example Usage
The following demonstrates how to configure these options in code:

```csharp
public class SampleWorkflow : WorkflowBase
{
    protected override void Build(IWorkflowBuilder builder)
    {
        builder.WorkflowOptions.CommitStateOptions = new()
        {
            // Commit state before workflow starts executing.
            Starting = true,
            
            // Commit state before every activity that is about to execute.
            ActivityExecuting = true,
            
            // Commit state after every activity that executed.
            ActivityExecuted = true,
        };
        builder.Root = new Sequence
        {
            Activities =
            {
                new WriteLine("Commit before executing").WithCommitStateBehavior(ActivityCommitStateBehavior.Executing),
                new WriteLine("Commit after executing").WithCommitStateBehavior(ActivityCommitStateBehavior.Executed),
                new WriteLine("Commit only based on the workflow commit options").WithCommitStateBehavior(ActivityCommitStateBehavior.Default),
                new WriteLine("Never commit the workflow when this activity is about to execute or has executed").WithCommitStateBehavior(ActivityCommitStateBehavior.Never),
            }
        };
    }
}
```

### Elsa Studio UI Support
Elsa Studio has been updated to include UI support for configuring these commit state behaviors. This enhancement ensures users can conveniently manage these options via the graphical interface.

TODO: Attach screenshot

### Documentation
Documentation updates will be provided to explain the new configuration options at both the workflow and activity levels.

### Notes
This PR significantly improves the configurability of workflows in Elsa, addressing scenarios where precise control over state persistence is required.