### PR TITLE
Simplify DbContext creation with ActivatorUtilities.

### DIFF
--- a/src/apps/Elsa.Server.Web/Elsa.Server.Web.csproj
+++ b/src/apps/Elsa.Server.Web/Elsa.Server.Web.csproj
@@ -14,6 +14,7 @@
         <ProjectReference Include="..\..\modules\Elsa.MassTransit.AzureServiceBus\Elsa.MassTransit.AzureServiceBus.csproj"/>
         <ProjectReference Include="..\..\modules\Elsa.OpenTelemetry\Elsa.OpenTelemetry.csproj" />
         <ProjectReference Include="..\..\modules\Elsa.Quartz.EntityFrameworkCore.MySql\Elsa.Quartz.EntityFrameworkCore.MySql.csproj" Condition=" '$(TargetFramework)' != 'net9.0' " />
+        <ProjectReference Include="..\..\modules\Elsa.Quartz.EntityFrameworkCore.PostgreSql\Elsa.Quartz.EntityFrameworkCore.PostgreSql.csproj" />
         <ProjectReference Include="..\..\modules\Elsa.Retention\Elsa.Retention.csproj" />
         <ProjectReference Include="..\..\modules\Elsa.Secrets.Api\Elsa.Secrets.Api.csproj" />
         <ProjectReference Include="..\..\modules\Elsa.Secrets.Persistence.EntityFrameworkCore.PostgreSql\Elsa.Secrets.Persistence.EntityFrameworkCore.PostgreSql.csproj" />

--- a/src/apps/Elsa.Server.Web/Program.cs
+++ b/src/apps/Elsa.Server.Web/Program.cs
@@ -167,7 +167,7 @@ services
             {
                 jobStorage = new MemoryStorage();
             }
-            
+
             elsa.UseHangfire(hangfire => hangfire.UseJobStorage(jobStorage));
         }
 
@@ -371,7 +371,7 @@ services
                     // Make sure to configure the path to the python DLL. E.g. /opt/homebrew/Cellar/python@3.11/3.11.6_1/Frameworks/Python.framework/Versions/3.11/bin/python3.11
                     // alternatively, you can set the PYTHONNET_PYDLL environment variable.
                     configuration.GetSection("Scripting:Python").Bind(options);
-                    
+
                     options.AddScript(sb =>
                     {
                         sb.AppendLine("def greet():");
@@ -428,7 +428,13 @@ services
 
         if (useQuartz)
         {
-            elsa.UseQuartz(quartz => { quartz.UseSqlite(sqliteConnectionString); });
+            elsa.UseQuartz(quartz =>
+            {
+                if (sqlDatabaseProvider == SqlDatabaseProvider.Sqlite)
+                    quartz.UseSqlite(sqliteConnectionString);
+                else if (sqlDatabaseProvider == SqlDatabaseProvider.PostgreSql)
+                    quartz.UsePostgreSql(postgresConnectionString);
+            });
         }
 
         if (useSignalR)
@@ -560,7 +566,7 @@ services
                 .UseSecretsScripting()
                 ;
         }
-        
+
         elsa.UseRetention(r =>
         {
             r.SweepInterval = TimeSpan.FromHours(5);

--- a/src/modules/Elsa.EntityFrameworkCore.Common/Abstractions/DesignTimeDbContextFactoryBase.cs
+++ b/src/modules/Elsa.EntityFrameworkCore.Common/Abstractions/DesignTimeDbContextFactoryBase.cs
@@ -27,7 +27,7 @@ public abstract class DesignTimeDbContextFactoryBase<TDbContext> : IDesignTimeDb
 
         ConfigureBuilder(builder, connectionString);
 
-        return (TDbContext)Activator.CreateInstance(typeof(TDbContext), builder.Options, serviceProvider)!;
+        return (TDbContext)ActivatorUtilities.CreateInstance(serviceProvider, typeof(TDbContext), builder.Options);
     }
 
     /// <summary>


### PR DESCRIPTION
Replaced Activator.CreateInstance with ActivatorUtilities.CreateInstance to streamline the DbContext instantiation. This improves dependency injection support and ensures better compatibility with service provider configurations.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6354)
<!-- Reviewable:end -->
