### PR TITLE
Fix activity output

### DIFF
--- a/src/modules/Elsa.Workflows.Core/Models/ActivityOutputRegister.cs
+++ b/src/modules/Elsa.Workflows.Core/Models/ActivityOutputRegister.cs
@@ -79,7 +79,7 @@ public class ActivityOutputRegister
         var key = CreateActivityIdLookupKey(activityId, outputName);
         return !_recordsByActivityIdAndOutputName.TryGetValue(key, out var records)
             ? null
-            : records.FirstOrDefault()?.Value;
+            : records.LastOrDefault()?.Value; // Always return the last value.
     }
 
     /// <summary>

--- a/test/integration/Elsa.Workflows.IntegrationTests/Scenarios/ActivityOutputs/LoopingWorkflow.cs
+++ b/test/integration/Elsa.Workflows.IntegrationTests/Scenarios/ActivityOutputs/LoopingWorkflow.cs
@@ -1,0 +1,33 @@
+using Elsa.Extensions;
+using Elsa.Workflows.Activities;
+
+namespace Elsa.Workflows.IntegrationTests.Scenarios.ActivityOutputs;
+
+public class LoopingWorkflow : WorkflowBase
+{
+    protected override void Build(IWorkflowBuilder builder)
+    {
+        var readCurrentValue = new Inline<string>(context => context.GetVariable<string>("CurrentValue")!);
+
+        builder.Root = new ForEach<string>(
+        [
+            "Item 1",
+            "Item 2"
+        ])
+        {
+            Body = new Sequence
+            {
+                Activities =
+                [
+                    readCurrentValue,
+                    new WriteLine(context =>
+                    {
+                        var currentValue = context.GetVariable<string>("CurrentValue");
+                        var activityResult = context.GetActivityExecutionContext().GetResult(readCurrentValue);
+                        return $"Current value: {currentValue}, Activity result: {activityResult}";
+                    })
+                ]
+            }
+        };
+    }
+}

--- a/test/integration/Elsa.Workflows.IntegrationTests/Scenarios/ActivityOutputs/LoopingWorkflow.cs
+++ b/test/integration/Elsa.Workflows.IntegrationTests/Scenarios/ActivityOutputs/LoopingWorkflow.cs
@@ -12,7 +12,8 @@ public class LoopingWorkflow : WorkflowBase
         builder.Root = new ForEach<string>(
         [
             "Item 1",
-            "Item 2"
+            "Item 2",
+            "Item 3"
         ])
         {
             Body = new Sequence

--- a/test/integration/Elsa.Workflows.IntegrationTests/Scenarios/ActivityOutputs/Tests.cs
+++ b/test/integration/Elsa.Workflows.IntegrationTests/Scenarios/ActivityOutputs/Tests.cs
@@ -37,7 +37,8 @@ public class Tests
         Assert.Equal(new[]
         {
             "Current value: Item 1, Activity result: Item 1",
-            "Current value: Item 2, Activity result: Item 2"
+            "Current value: Item 2, Activity result: Item 2",
+            "Current value: Item 3, Activity result: Item 3"
         }, lines);
     }
 }

--- a/test/integration/Elsa.Workflows.IntegrationTests/Scenarios/ActivityOutputs/Tests.cs
+++ b/test/integration/Elsa.Workflows.IntegrationTests/Scenarios/ActivityOutputs/Tests.cs
@@ -24,8 +24,20 @@ public class Tests
         var lines = _capturingTextWriter.Lines.ToList();
         Assert.Equal(new[]
         {
-            "The result of 4 and 6 is 10.",
-            "The last result is 10."
+            "The result of 4 and 6 is 10.", "The last result is 10."
+        }, lines);
+    }
+
+    [Fact(DisplayName = "The last activity output is returned.")]
+    public async Task Test2()
+    {
+        await _services.PopulateRegistriesAsync();
+        await _workflowRunner.RunAsync<LoopingWorkflow>();
+        var lines = _capturingTextWriter.Lines.ToList();
+        Assert.Equal(new[]
+        {
+            "Current value: Item 1, Activity result: Item 1",
+            "Current value: Item 2, Activity result: Item 2"
         }, lines);
     }
 }


### PR DESCRIPTION
 Updated `ActivityOutputRegister` to always return the last output value. Added new integration test to validate the functionality.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6358)
<!-- Reviewable:end -->
