### PR TITLE
Fix output and input definition typing

### DIFF
--- a/src/modules/Elsa.Workflows.Api/Serialization/ArgumentJsonConverter.cs
+++ b/src/modules/Elsa.Workflows.Api/Serialization/ArgumentJsonConverter.cs
@@ -28,10 +28,18 @@ public class ArgumentJsonConverter : JsonConverter<ArgumentDefinition>
         newOptions.Converters.RemoveWhere(x => x is ArgumentJsonConverterFactory);
         
         var jsonObject = (JsonObject)JsonSerializer.SerializeToNode(value, value.GetType(), newOptions)!;
-        var isArray = value.Type.IsCollectionType();
-        jsonObject["isArray"] = isArray;
-        jsonObject["type"] = _wellKnownTypeRegistry.GetAliasOrDefault(isArray ? value.Type.GetCollectionElementType() : value.Type);
-
+        var typeName = value.Type;
+        var typeAlias = _wellKnownTypeRegistry.TryGetAlias(typeName, out var alias) ? alias : null;
+        var isArray = typeName.IsArray;
+        var isCollection = typeName.IsCollectionType();
+        var elementTypeName = isArray ? typeName.GetElementType() : isCollection ? typeName.GenericTypeArguments[0] : typeName;
+        var elementTypeAlias = _wellKnownTypeRegistry.GetAliasOrDefault(elementTypeName);
+        var finalTypeAlias = isArray || isCollection ? elementTypeAlias : typeAlias;
+        
+        if(isArray) jsonObject["isArray"] = isArray;
+        if(isCollection) jsonObject["isCollection"] = isCollection;
+        
+        jsonObject["type"] = finalTypeAlias;
         JsonSerializer.Serialize(writer, jsonObject, newOptions);
     }
 
@@ -40,11 +48,12 @@ public class ArgumentJsonConverter : JsonConverter<ArgumentDefinition>
     {
         var jsonObject = (JsonObject)JsonNode.Parse(ref reader)!;
         var isArray = jsonObject["isArray"]?.GetValue<bool>() ?? false;
-        var typeName = jsonObject["type"]!.GetValue<string>();
-        var type = _wellKnownTypeRegistry.GetTypeOrDefault(typeName);
+        var isCollection = jsonObject["isCollection"]?.GetValue<bool>() ?? false;
+        var typeAlias = jsonObject["type"]!.GetValue<string>();
+        var type = _wellKnownTypeRegistry.GetTypeOrDefault(typeAlias);
 
-        if (isArray)
-            type = type.MakeArrayType();
+        if (isArray) type = type.MakeArrayType();
+        if (isCollection) type = type.MakeGenericType(type.GenericTypeArguments[0]);
 
         var newOptions = new JsonSerializerOptions(options);
         newOptions.Converters.RemoveWhere(x => x is ArgumentJsonConverterFactory);


### PR DESCRIPTION
This PR fixes a parsing issue of input and output definitions at the workflow definition level.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6373)
<!-- Reviewable:end -->
