### PR TITLE
Add obsolete ExecuteAsync overloads for job classes

### DIFF
--- a/src/modules/Elsa.Hangfire/Jobs/ExecuteBackgroundActivityJob.cs
+++ b/src/modules/Elsa.Hangfire/Jobs/ExecuteBackgroundActivityJob.cs
@@ -19,4 +19,14 @@ public class ExecuteBackgroundActivityJob(IBackgroundActivityInvoker backgroundA
         using var scope = tenantAccessor.PushContext(tenant);
         await backgroundActivityInvoker.ExecuteAsync(scheduledBackgroundActivity, cancellationToken);
     }
+    
+    /// <summary>
+    /// Executes the job.
+    /// </summary>
+    [Obsolete("Use the other overload.")]
+    [UsedImplicitly]
+    public async Task ExecuteAsync(ScheduledBackgroundActivity scheduledBackgroundActivity, CancellationToken cancellationToken = default)
+    {
+        await backgroundActivityInvoker.ExecuteAsync(scheduledBackgroundActivity, cancellationToken);
+    }
 }


### PR DESCRIPTION
Introduce `[Obsolete]` ExecuteAsync overloads in job classes to support legacy calls while encouraging migration to preferred methods. `[UsedImplicitly]` annotations ensure these methods are retained for compatibility.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6388)
<!-- Reviewable:end -->
