### PR TITLE
Add customizable tenant header support for HTTP routing

### DIFF
--- a/Elsa.sln
+++ b/Elsa.sln
@@ -84,14 +84,12 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docker", "docker", "{986E54
 	ProjectSection(SolutionItems) = preProject
 		docker\.dockerignore = docker\.dockerignore
 		docker\docker-compose-datadog.yml = docker\docker-compose-datadog.yml
-		docker\docker-compose-kafka.yml = docker\docker-compose-kafka.yml
 		docker\docker-compose.yml = docker\docker-compose.yml
 		docker\ElsaServer-Datadog.Dockerfile = docker\ElsaServer-Datadog.Dockerfile
 		docker\ElsaServer.Dockerfile = docker\ElsaServer.Dockerfile
 		docker\ElsaServerAndStudio.Dockerfile = docker\ElsaServerAndStudio.Dockerfile
 		docker\ElsaStudio.Dockerfile = docker\ElsaStudio.Dockerfile
 		docker\otel-collector-config.yaml = docker\otel-collector-config.yaml
-		docker\docker-compose-kafka.yml = docker\docker-compose-kafka.yml
 		docker\init-db-postgres.sh = docker\init-db-postgres.sh
 	EndProjectSection
 EndProject
@@ -399,6 +397,7 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Sql.Sqlite", "src\modules\Elsa.Sql.Sqlite\Elsa.Sql.Sqlite.csproj", "{FA5E857F-B173-4B5D-8049-B817A210DEF5}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Sql.SqlServer", "src\modules\Elsa.Sql.SqlServer\Elsa.Sql.SqlServer.csproj", "{A51F9683-DA9F-45E7-82DE-1E261ACD6D68}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "oracle-setup", "oracle-setup", "{66E2E2CF-967F-4564-89E8-F46FA973C99B}"
 	ProjectSection(SolutionItems) = preProject
 		docker\oracle-setup\setup.sql = docker\oracle-setup\setup.sql

--- a/src/apps/Elsa.Server.Web/Program.cs
+++ b/src/apps/Elsa.Server.Web/Program.cs
@@ -659,7 +659,11 @@ services
                 }
             });
 
-            elsa.UseTenantHttpRouting();
+            elsa.UseTenantHttpRouting(tenantHttpRouting =>
+            {
+                // Override the tenant header name with a custom one.
+                tenantHttpRouting.WithTenantHeader("X-Company-Id");
+            });
         }
 
         elsa.InstallDropIns(options => options.DropInRootDirectory = Path.Combine(Directory.GetCurrentDirectory(), "App_Data", "DropIns"));

--- a/src/modules/Elsa.Tenants.AspNetCore/Features/MultitenantHttpRoutingFeature.cs
+++ b/src/modules/Elsa.Tenants.AspNetCore/Features/MultitenantHttpRoutingFeature.cs
@@ -3,6 +3,7 @@ using Elsa.Features.Abstractions;
 using Elsa.Features.Attributes;
 using Elsa.Features.Services;
 using Elsa.Http.Features;
+using Elsa.Tenants.AspNetCore.Options;
 using Elsa.Tenants.AspNetCore.Services;
 using Elsa.Tenants.Features;
 using Microsoft.Extensions.DependencyInjection;
@@ -13,6 +14,26 @@ namespace Elsa.Tenants.AspNetCore.Features;
 [DependencyOf(typeof(TenantsFeature))]
 public class MultitenantHttpRoutingFeature(IModule module) : FeatureBase(module)
 {
+    private Action<MultitenancyHttpOptions> _configureMultitenancyHttpOptions = _ => { };
+
+    /// <summary>
+    /// Configures the MultitenantHttpRoutingFeature to use a specific tenant header name.
+    /// </summary>
+    /// <param name="headerName">The name of the HTTP header used to identify the tenant.</param>
+    /// <returns>The current instance of <see cref="MultitenantHttpRoutingFeature"/> for fluent configuration.</returns>
+    public MultitenantHttpRoutingFeature WithTenantHeader(string headerName) => WithMultitenancyHttpOptions(options => options.TenantHeaderName = headerName);
+
+    /// <summary>
+    /// Configures the MultitenantHttpRoutingFeature with custom multitenancy HTTP options.
+    /// </summary>
+    /// <param name="configure">The action to configure <see cref="MultitenancyHttpOptions"/>.</param>
+    /// <returns>The current instance of <see cref="MultitenantHttpRoutingFeature"/> for fluent configuration.</returns>
+    public MultitenantHttpRoutingFeature WithMultitenancyHttpOptions(Action<MultitenancyHttpOptions> configure)
+    {
+        _configureMultitenancyHttpOptions = configure;
+        return this;
+    }
+    
     public override void Configure()
     {
         Module.Configure<HttpFeature>(feature =>
@@ -24,6 +45,9 @@ public class MultitenantHttpRoutingFeature(IModule module) : FeatureBase(module)
 
     public override void Apply()
     {
+        // Multitenancy HTTP options.
+        Services.Configure(_configureMultitenancyHttpOptions);
+        
         // Tenant resolvers.
         Services
             .AddScoped<ITenantResolver, RoutePrefixTenantResolver>()

--- a/src/modules/Elsa.Tenants.AspNetCore/Options/MultitenancyHttpOptions.cs
+++ b/src/modules/Elsa.Tenants.AspNetCore/Options/MultitenancyHttpOptions.cs
@@ -1,0 +1,6 @@
+namespace Elsa.Tenants.AspNetCore.Options;
+
+public class MultitenancyHttpOptions
+{
+    public string TenantHeaderName { get; set; } = "X-Tenant-Id";
+}

--- a/src/modules/Elsa.Tenants.AspNetCore/Resolvers/HeaderTenantResolver.cs
+++ b/src/modules/Elsa.Tenants.AspNetCore/Resolvers/HeaderTenantResolver.cs
@@ -1,12 +1,14 @@
 using Elsa.Common.Multitenancy;
+using Elsa.Tenants.AspNetCore.Options;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
 
 namespace Elsa.Tenants.AspNetCore;
 
 /// <summary>
 /// Resolves the tenant based on the header in the request.
 /// </summary>
-public class HeaderTenantResolver(IHttpContextAccessor httpContextAccessor) : TenantResolverBase
+public class HeaderTenantResolver(IHttpContextAccessor httpContextAccessor, IOptions<MultitenancyHttpOptions> options) : TenantResolverBase
 {
     protected override TenantResolverResult Resolve(TenantResolverContext context)
     {
@@ -15,7 +17,8 @@ public class HeaderTenantResolver(IHttpContextAccessor httpContextAccessor) : Te
         if (httpContext == null)
             return Unresolved();
 
-        var tenantId = httpContext.Request.Headers["X-Tenant-Id"].FirstOrDefault();
+        var headerName = options.Value.TenantHeaderName;
+        var tenantId = httpContext.Request.Headers[headerName].FirstOrDefault();
 
         return AutoResolve(tenantId);
     }


### PR DESCRIPTION
Introduced `MultitenancyHttpOptions` to configure the tenant header name used for HTTP routing. Updated `HeaderTenantResolver` to utilize this option and modified the server setup to allow overriding the default header name. This enables more flexible multitenancy configurations.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6395)
<!-- Reviewable:end -->
