### PR TITLE
Upgrade MediatR to v12.4.1 to support updated AddMediatRClasses signature

### DIFF
--- a/src/core/Elsa.Abstractions/Elsa.Abstractions.csproj
+++ b/src/core/Elsa.Abstractions/Elsa.Abstractions.csproj
@@ -16,7 +16,7 @@
     <ItemGroup>
         <PackageReference Include="DistributedLock.Core" Version="1.0.4" />
         <PackageReference Include="LinqKit.Core" Version="1.2.5" />
-        <PackageReference Include="MediatR" Version="12.0.1" />
+        <PackageReference Include="MediatR" Version="12.4.1" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.1" />

--- a/src/core/Elsa.Core/Elsa.Core.csproj
+++ b/src/core/Elsa.Core/Elsa.Core.csproj
@@ -20,7 +20,7 @@
         <PackageReference Include="DistributedLock.FileSystem" Version="1.0.1" />
         <PackageReference Include="FluentStorage" Version="5.6.0" />
         <PackageReference Include="Humanizer.Core" Version="2.13.14" />
-        <PackageReference Include="MediatR" Version="12.0.1" />
+        <PackageReference Include="MediatR" Version="12.4.1" />
         <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="9.0.1" />
         <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
         <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.1" />

--- a/src/samples/aspnet/Elsa.Samples.InProcessBackgroundMediator/Elsa.Samples.InProcessBackgroundMediator.csproj
+++ b/src/samples/aspnet/Elsa.Samples.InProcessBackgroundMediator/Elsa.Samples.InProcessBackgroundMediator.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="MediatR" Version="12.0.1" />
+      <PackageReference Include="MediatR" Version="12.4.1" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
### Summary
This PR upgrades the MediatR package from v12.0.1 to v12.4.1. The update was required because the
`AddMediatRClasses` method in `MediatR.Registration.ServiceRegistrar` now includes an optional
`CancellationToken` parameter. Without this upgrade, solutions using the latest MediatR version would
encounter a `MissingMethodException` due to the absence of the old method signature.

### Changes
- Updated the MediatR package reference to v12.4.1.
- Ensured compatibility across the project.

### Rationale
The introduction of the CancellationToken parameter in the AddMediatRClasses method by MediatR means
that maintaining compatibility with the latest version is crucial. This change prevents runtime errors
and ensures that the project remains up-to-date with its dependencies.

### Testing
All unit tests have been executed and passed successfully.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6403)
<!-- Reviewable:end -->
