### PR TITLE
#6161 ComputeBookmarkHash in HttpWorkflowsMiddleware

### DIFF
--- a/src/modules/Elsa.Http/Middleware/HttpWorkflowsMiddleware.cs
+++ b/src/modules/Elsa.Http/Middleware/HttpWorkflowsMiddleware.cs
@@ -1,26 +1,26 @@
-using Elsa.Extensions;
-using Elsa.Http.Bookmarks;
-using Elsa.Http.Options;
-using Elsa.Workflows.Runtime.Filters;
-using JetBrains.Annotations;
-using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
+using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Net.Mime;
 using System.Text.Json;
+using Elsa.Common.Multitenancy;
+using Elsa.Extensions;
+using Elsa.Http.Bookmarks;
+using Elsa.Http.Options;
+using Elsa.Workflows;
 using Elsa.Workflows.Activities;
 using Elsa.Workflows.Helpers;
-using Elsa.Workflows.Runtime.Entities;
-using FastEndpoints;
-using System.Diagnostics.CodeAnalysis;
-using Elsa.Common.Multitenancy;
-using Elsa.Workflows;
 using Elsa.Workflows.Management;
 using Elsa.Workflows.Management.Entities;
 using Elsa.Workflows.Models;
 using Elsa.Workflows.Options;
 using Elsa.Workflows.Runtime;
+using Elsa.Workflows.Runtime.Entities;
+using Elsa.Workflows.Runtime.Filters;
+using FastEndpoints;
+using JetBrains.Annotations;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Open.Linq.AsyncExtensions;
 
 namespace Elsa.Http.Middleware;
@@ -57,7 +57,7 @@ public class HttpWorkflowsMiddleware(RequestDelegate next, ITenantAccessor tenan
         }
 
         matchingPath = matchingPath.NormalizeRoute();
-        
+
         var input = new Dictionary<string, object>
         {
             [HttpEndpoint.HttpContextInputKey] = true,
@@ -372,7 +372,6 @@ public class HttpWorkflowsMiddleware(RequestDelegate next, ITenantAccessor tenan
     {
         var bookmarkPayload = new HttpEndpointBookmarkPayload(path, method);
         var bookmarkHasher = serviceProvider.GetRequiredService<IStimulusHasher>();
-        var activityTypeName = ActivityTypeNameHelper.GenerateTypeName<HttpEndpoint>();
-        return bookmarkHasher.Hash(activityTypeName, bookmarkPayload);
+        return bookmarkHasher.Hash(activityTypeName: null, bookmarkPayload);
     }
 }

--- a/src/modules/Elsa.Workflows.Core/Contracts/IStimulusHasher.cs
+++ b/src/modules/Elsa.Workflows.Core/Contracts/IStimulusHasher.cs
@@ -8,5 +8,5 @@ public interface IStimulusHasher
     /// <summary>
     /// Produces a hash from the specified activity type name, payload and activity instance ID.
     /// </summary>
-    string Hash(string activityTypeName, object? payload = null, string? activityInstanceId = null);
+    string Hash(string? activityTypeName, object? payload = null, string? activityInstanceId = null);
 }

--- a/src/modules/Elsa.Workflows.Core/Services/StimulusHasher.cs
+++ b/src/modules/Elsa.Workflows.Core/Services/StimulusHasher.cs
@@ -4,7 +4,7 @@ namespace Elsa.Workflows;
 public class StimulusHasher(IHasher hasher) : IStimulusHasher
 {
     /// <inheritdoc />
-    public string Hash(string activityTypeName, object? payload = null, string? activityInstanceId = null)
+    public string Hash(string? activityTypeName, object? payload = null, string? activityInstanceId = null)
     {
         return hasher.Hash(activityTypeName, payload, activityInstanceId);
     }

--- a/src/modules/Elsa.Workflows.Runtime/Services/TriggerIndexer.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Services/TriggerIndexer.cs
@@ -68,7 +68,7 @@ public class TriggerIndexer : ITriggerIndexer
 
             if (workflowGraph == null)
                 continue;
-            
+
             await DeleteTriggersAsync(workflowGraph.Workflow, cancellationToken);
         }
     }
@@ -109,7 +109,7 @@ public class TriggerIndexer : ITriggerIndexer
     {
         return await GetTriggersInternalAsync(workflow, cancellationToken).ToListAsync(cancellationToken);
     }
-    
+
     private async Task DeleteTriggersAsync(Workflow workflow, CancellationToken cancellationToken = default)
     {
         var emptyTriggerList = new List<StoredTrigger>(0);
@@ -158,13 +158,13 @@ public class TriggerIndexer : ITriggerIndexer
         var cancellationToken = context.CancellationToken;
         var triggerTypeName = trigger.Type;
         var triggerDescriptor = _activityRegistry.Find(triggerTypeName, trigger.Version);
-        
+
         if (triggerDescriptor == null)
         {
             _logger.LogWarning("Could not find activity descriptor for activity type {ActivityType}", triggerTypeName);
             return new List<StoredTrigger>(0);
         }
-        
+
         var expressionExecutionContext = await trigger.CreateExpressionExecutionContextAsync(triggerDescriptor, _serviceProvider, context, _expressionEvaluator, _logger);
         var triggerIndexingContext = new TriggerIndexingContext(context, expressionExecutionContext, trigger, cancellationToken);
         var triggerData = await TryGetTriggerDataAsync(trigger, triggerIndexingContext);
@@ -179,7 +179,7 @@ public class TriggerIndexer : ITriggerIndexer
             WorkflowDefinitionVersionId = workflow.Identity.Id,
             Name = triggerTypeName,
             ActivityId = trigger.Id,
-            Hash = _hasher.Hash(triggerTypeName, payload),
+            Hash = _hasher.Hash(activityTypeName: null, payload),
             Payload = payload
         });
 

--- a/src/modules/Elsa.Workflows.Runtime/Services/TriggerIndexer.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Services/TriggerIndexer.cs
@@ -1,4 +1,4 @@
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using Elsa.Expressions.Contracts;
 using Elsa.Extensions;
 using Elsa.Mediator.Contracts;
@@ -179,7 +179,7 @@ public class TriggerIndexer : ITriggerIndexer
             WorkflowDefinitionVersionId = workflow.Identity.Id,
             Name = triggerTypeName,
             ActivityId = trigger.Id,
-            Hash = _hasher.Hash(activityTypeName: null, payload),
+            Hash = _hasher.Hash(triggerTypeName.StartsWith("Elsa.") ? triggerTypeName : null, payload),
             Payload = payload
         });
 


### PR DESCRIPTION
When creating custom triggers, the system uses activityTypeName to generate a hash. However, when the trigger is invoked, it searches through all the hashes in the database but does not use the activityTypeName of the trigger itself (for good reason, as it does not have access to it). Instead, it defaults to using the activityTypeName of HttpEndpoint.

As a result, it's not possible to create custom triggers with an activityTypeName different from HttpEndpoint, which leads to issues.


It is also mentioned here: #6161

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6407)
<!-- Reviewable:end -->
