### PR TITLE
Add CorrelationId to NewBookmarkQueueItem

### DIFF
--- a/src/modules/Elsa.Workflows.Runtime/Models/NewBookmarkQueueItem.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Models/NewBookmarkQueueItem.cs
@@ -25,7 +25,7 @@ public class NewBookmarkQueueItem
     public string? ActivityInstanceId { get; set; }
 
     /// <summary>
-    /// The ID of the correlation an instance is associated with the bookmark.
+    /// The correlation ID that is associated with the bookmark if any.
     /// </summary>
     public string? CorrelationId { get; set; }
 

--- a/src/modules/Elsa.Workflows.Runtime/Models/NewBookmarkQueueItem.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Models/NewBookmarkQueueItem.cs
@@ -25,6 +25,11 @@ public class NewBookmarkQueueItem
     public string? ActivityInstanceId { get; set; }
 
     /// <summary>
+    /// The ID of the correlation an instance is associated with the bookmark.
+    /// </summary>
+    public string? CorrelationId { get; set; }
+
+    /// <summary>
     /// The type name of the activity associated with the bookmark.
     /// </summary>
     public string? ActivityTypeName { get; set; }

--- a/src/modules/Elsa.Workflows.Runtime/Services/StimulusSender.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Services/StimulusSender.cs
@@ -127,6 +127,7 @@ public class StimulusSender(
             {
                 WorkflowInstanceId = workflowInstanceId,
                 BookmarkId = metadata?.BookmarkId,
+                CorrelationId = metadata?.CorrelationId,
                 StimulusHash = stimulusHash,
                 Options = new()
                 {

--- a/src/modules/Elsa.Workflows.Runtime/Services/StoreBookmarkQueue.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Services/StoreBookmarkQueue.cs
@@ -18,6 +18,7 @@ public class StoreBookmarkQueue(
         var filter = new BookmarkFilter
         {
             BookmarkId = item.BookmarkId,
+            CorrelationId = item.CorrelationId,
             Hash = item.StimulusHash,
             WorkflowInstanceId = item.WorkflowInstanceId,
             ActivityTypeName = item.ActivityTypeName
@@ -39,6 +40,7 @@ public class StoreBookmarkQueue(
             Id = identityGenerator.GenerateId(),
             WorkflowInstanceId = item.WorkflowInstanceId,
             BookmarkId = item.BookmarkId,
+            CorrelationId = item.CorrelationId,
             StimulusHash = item.StimulusHash,
             ActivityInstanceId = item.ActivityInstanceId,
             ActivityTypeName = item.ActivityTypeName,


### PR DESCRIPTION
Added CorrelationId for the NewBookmarkQueueItems.cs class. This makes sure that unrelated workflows are not randomly executing when working in a correlated environment.

For a better description of the issue see #6409 

I didn't see any tests associated to this so I didn't write any, not sure if there is a policy to create those

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6412)
<!-- Reviewable:end -->
