### PR TITLE
Add IBusRegistrationContext to Transport Configuration Actions

### DIFF
--- a/src/apps/Elsa.Server.Web/Program.cs
+++ b/src/apps/Elsa.Server.Web/Program.cs
@@ -481,7 +481,7 @@ services
 
                 if (massTransitBroker == MassTransitBroker.AzureServiceBus)
                 {
-                    massTransit.UseAzureServiceBus(azureServiceBusConnectionString, serviceBusFeature => serviceBusFeature.ConfigureServiceBus = bus =>
+                    massTransit.UseAzureServiceBus(azureServiceBusConnectionString, serviceBusFeature => serviceBusFeature.ConfigureTransportBus = (context, bus) =>
                     {
                         bus.PrefetchCount = 50;
                         bus.LockDuration = TimeSpan.FromMinutes(5);
@@ -493,7 +493,7 @@ services
 
                 if (massTransitBroker == MassTransitBroker.RabbitMq)
                 {
-                    massTransit.UseRabbitMq(rabbitMqConnectionString, rabbit => rabbit.ConfigureServiceBus = bus =>
+                    massTransit.UseRabbitMq(rabbitMqConnectionString, rabbit => rabbit.ConfigureTransportBus = (context, bus) =>
                     {
                         bus.PrefetchCount = 50;
                         bus.Durable = true;

--- a/src/modules/Elsa.MassTransit.AzureServiceBus/Features/AzureServiceBusFeature.cs
+++ b/src/modules/Elsa.MassTransit.AzureServiceBus/Features/AzureServiceBusFeature.cs
@@ -53,7 +53,19 @@ public class AzureServiceBusFeature : FeatureBase
     /// <summary>
     /// A delegate that configures the Azure Service Bus transport options.
     /// </summary>
+    /// <remarks>This method is being marked as obsolete in favor of the ConfigureTransportBus which will provide additional access to the <see cref="IBusRegistrationContext"/></remarks>
+    [Obsolete("Use ConfigureTransportBus instead which provides a reference to IBusRegistrationContext.")]
     public Action<IServiceBusBusFactoryConfigurator>? ConfigureServiceBus { get; set; }
+
+    /// <summary>
+    /// Configures the Azure Service Bus within MassTransit for additional transport level components or features.
+    /// This action provides access to the <see cref="IBusRegistrationContext"/> and <see cref="IServiceBusBusFactoryConfigurator"/>.
+    /// </summary>
+    /// <remarks>
+    /// Use this action to configure advanced settings and features for the Azure Service Bus, such as middleware 
+    /// or additional endpoints. This action will run in addition to the Elsa required configuration.
+    /// </remarks>
+    public Action<IBusRegistrationContext, IServiceBusBusFactoryConfigurator> ConfigureTransportBus { get; set; }
 
     /// <summary>
     /// A delegate to configure <see cref="AzureServiceBusOptions"/>.
@@ -104,6 +116,7 @@ public class AzureServiceBusFeature : FeatureBase
 
                     configurator.UseServiceBusMessageScheduler();
                     ConfigureServiceBus?.Invoke(configurator);
+                    ConfigureTransportBus?.Invoke(context, configurator);
                     var instanceNameProvider = context.GetRequiredService<IApplicationInstanceNameProvider>();
 
                     foreach (var consumer in temporaryConsumers)

--- a/src/modules/Elsa.MassTransit.RabbitMq/Features/RabbitMqServiceBusFeature.cs
+++ b/src/modules/Elsa.MassTransit.RabbitMq/Features/RabbitMqServiceBusFeature.cs
@@ -39,7 +39,19 @@ public class RabbitMqServiceBusFeature : FeatureBase
     /// <summary>
     /// Configures the RabbitMQ bus.
     /// </summary>
+    /// <remarks>This method is being marked as obsolete in favor of the ConfigureTransportBus which will provide additional access to the <see cref="IBusRegistrationContext"/></remarks>
+    [Obsolete("Use ConfigureTransportBus instead which provides a reference to IBusRegistrationContext.")]
     public Action<IRabbitMqBusFactoryConfigurator>? ConfigureServiceBus { get; set; }
+
+    /// <summary>
+    /// Configures the RabbitMQ bus within MassTransit for additional transport level components or features.
+    /// This action provides access to the <see cref="IBusRegistrationContext"/> and <see cref="IRabbitMqBusFactoryConfigurator"/>.
+    /// </summary>
+    /// <remarks>
+    /// Use this action to configure advanced settings and features for the RabbitMQ bus, such as middleware 
+    /// or additional endpoints. This action will run in addition to the Elsa required configuration.
+    /// </remarks>
+    public Action<IBusRegistrationContext, IRabbitMqBusFactoryConfigurator> ConfigureTransportBus { get; set; }
 
     /// <inheritdoc />
     public override void Configure()
@@ -69,6 +81,7 @@ public class RabbitMqServiceBusFeature : FeatureBase
                     configurator.ConcurrentMessageLimit = options.ConcurrentMessageLimit;
 
                     ConfigureServiceBus?.Invoke(configurator);
+                    ConfigureTransportBus?.Invoke(context, configurator);
 
                     foreach (var consumer in temporaryConsumers)
                     {

--- a/src/modules/Elsa.MassTransit/Features/MassTransitFeature.cs
+++ b/src/modules/Elsa.MassTransit/Features/MassTransitFeature.cs
@@ -89,6 +89,7 @@ public class MassTransitFeature : FeatureBase
     /// <summary>
     /// Adds MassTransit to the service container and registers all collected assemblies for discovery of consumers.
     /// </summary>
+    /// <param name="busConfigurator">The bus configurator used to configure the MassTransit Bus.</param>
     private void AddMassTransit(Action<IBusRegistrationConfigurator> busConfigurator)
     {
         // For each message type, create a concrete WorkflowMessageConsumer<T>.
@@ -119,6 +120,10 @@ public class MassTransitFeature : FeatureBase
         });
     }
 
+    /// <summary>
+    /// Configures MassTransit to use the in-memory transport when no other transport has been configured.
+    /// </summary>
+    /// <param name="configure"><see cref="IBusRegistrationConfigurator"/> reference to the MassTransit bus to configure for and in-memory transport</param>
     private void ConfigureInMemoryTransport(IBusRegistrationConfigurator configure)
     {
         var consumers = this.GetConsumers().ToList();
@@ -131,6 +136,7 @@ public class MassTransitFeature : FeatureBase
         configure.UsingInMemory((context, bus) =>
         {
             var options = context.GetRequiredService<IOptions<MassTransitWorkflowDispatcherOptions>>().Value;
+            var busOptions = context.GetRequiredService<IOptions<MassTransitOptions>>().Value;
 
             foreach (var consumer in temporaryConsumers)
             {
@@ -156,7 +162,7 @@ public class MassTransitFeature : FeatureBase
                 return serializerOptions;
             });
 
-            if (PrefetchCount != null) bus.PrefetchCount = PrefetchCount.Value;
+            if (busOptions.PrefetchCount.HasValue) bus.PrefetchCount = busOptions.PrefetchCount.Value;
 
             bus.ConfigureTenantMiddleware(context);
         });


### PR DESCRIPTION
This PR updates MassTransit configuration for Azure Service Bus and RabbitMQ. Previously, the IBusRegistrationContext was not included in the configuration action and prevents configuration of additional MassTransit components that require the context being passed in.

- `Program.cs`: Replaces `ConfigureServiceBus` with `ConfigureTransportBus` as the old action is now obsolete.
- `AzureServiceBusFeature.cs` and `RabbitMqServiceBusFeature.cs`: Marks `ConfigureServiceBus` as obsolete, introduces `ConfigureTransportBus`. Added XML documentation to bring awareness to the alternative action and some clarification that this action runs in addition to Elsa's standard configuration.
- `MassTransitFeature.cs`: Updates `ConfigureInMemoryTransport` method documentation and updates `AddMassTransit` method within to include `MassTransitOptions` configuration for prefetch count. While not directly part of the change, it was made because `PrefetchCount` was marked as obsolete in the feature class.

_**NOTE:** A name of ConfigureTransportBus was chosen for the new action to avoid conflicts with the old ConfigureServiceBus. Given that both ASB and RMQ are both transports in the eyes of MassTransit, it made the most sense to go this route without doing something like ConfigureServiceBusWithContext or similar._

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6413)
<!-- Reviewable:end -->
