### PR TITLE
Add AddManyAsync method to activity execution stores

### DIFF
--- a/src/modules/Elsa.Dapper/Modules/Runtime/Stores/DapperActivityExecutionRecordStore.cs
+++ b/src/modules/Elsa.Dapper/Modules/Runtime/Stores/DapperActivityExecutionRecordStore.cs
@@ -35,6 +35,13 @@ internal class DapperActivityExecutionRecordStore(Store<ActivityExecutionRecordR
     }
 
     /// <inheritdoc />
+    public async Task AddManyAsync(IEnumerable<ActivityExecutionRecord> records, CancellationToken cancellationToken = default)
+    {
+        var mappedRecords = records.Select(Map).ToList();
+        await store.AddManyAsync(mappedRecords, cancellationToken);
+    }
+
+    /// <inheritdoc />
     public async Task<ActivityExecutionRecord?> FindAsync(ActivityExecutionRecordFilter filter, CancellationToken cancellationToken = default)
     {
         var record = await store.FindAsync(q => ApplyFilter(q, filter), cancellationToken);

--- a/src/modules/Elsa.EntityFrameworkCore/Modules/Runtime/ActivityExecutionLogStore.cs
+++ b/src/modules/Elsa.EntityFrameworkCore/Modules/Runtime/ActivityExecutionLogStore.cs
@@ -35,6 +35,9 @@ public class EFCoreActivityExecutionStore(
     public async Task SaveManyAsync(IEnumerable<ActivityExecutionRecord> records, CancellationToken cancellationToken = default) => await store.SaveManyAsync(records, OnSaveAsync, cancellationToken);
 
     /// <inheritdoc />
+    public async Task AddManyAsync(IEnumerable<ActivityExecutionRecord> records, CancellationToken cancellationToken = default) => await store.AddManyAsync(records, OnSaveAsync, cancellationToken);
+
+    /// <inheritdoc />
     [RequiresUnreferencedCode("Calls Elsa.EntityFrameworkCore.Modules.Runtime.EFCoreActivityExecutionStore.DeserializeActivityState(RuntimeElsaDbContext, ActivityExecutionRecord, CancellationToken)")]
     public async Task<ActivityExecutionRecord?> FindAsync(ActivityExecutionRecordFilter filter, CancellationToken cancellationToken = default)
     {

--- a/src/modules/Elsa.MongoDb/Modules/Runtime/ActivityExecutionLogStore.cs
+++ b/src/modules/Elsa.MongoDb/Modules/Runtime/ActivityExecutionLogStore.cs
@@ -28,6 +28,12 @@ public class MongoActivityExecutionLogStore(MongoDbStore<ActivityExecutionRecord
     }
 
     /// <inheritdoc />
+    public Task AddManyAsync(IEnumerable<ActivityExecutionRecord> records, CancellationToken cancellationToken = default)
+    {
+        return mongoDbStore.AddManyAsync(records, cancellationToken);
+    }
+
+    /// <inheritdoc />
     public Task<ActivityExecutionRecord?> FindAsync(ActivityExecutionRecordFilter filter, CancellationToken cancellationToken = default)
     {
         return mongoDbStore.FindAsync(queryable => Filter(queryable, filter), cancellationToken);

--- a/src/modules/Elsa.Workflows.Runtime/Contracts/ILogRecordStore.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Contracts/ILogRecordStore.cs
@@ -14,4 +14,9 @@ public interface ILogRecordStore<in T> where T : ILogRecord
     /// If a record does not already exist, it is added to the store; if it does exist, its existing entry is updated.
     /// </remarks>
     Task SaveManyAsync(IEnumerable<T> records, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Adds a collection of log records to the store.
+    /// </summary>
+    Task AddManyAsync(IEnumerable<T> records, CancellationToken cancellationToken = default);
 }

--- a/src/modules/Elsa.Workflows.Runtime/Stores/MemoryActivityExecutionStore.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Stores/MemoryActivityExecutionStore.cs
@@ -36,6 +36,13 @@ public class MemoryActivityExecutionStore : IActivityExecutionStore
     }
 
     /// <inheritdoc />
+    public Task AddManyAsync(IEnumerable<ActivityExecutionRecord> records, CancellationToken cancellationToken = default)
+    {
+        _store.AddMany(records, x => x.Id);
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
     public Task<ActivityExecutionRecord?> FindAsync(ActivityExecutionRecordFilter filter, CancellationToken cancellationToken = default)
     {
         var result = _store.Query(query => Filter(query, filter)).FirstOrDefault();

--- a/src/modules/Elsa.Workflows.Runtime/Stores/NoopActivityExecutionStore.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Stores/NoopActivityExecutionStore.cs
@@ -16,6 +16,11 @@ public class NoopActivityExecutionStore : IActivityExecutionStore
         return Task.CompletedTask;
     }
 
+    public Task AddManyAsync(IEnumerable<ActivityExecutionRecord> records, CancellationToken cancellationToken = default)
+    {
+        return Task.CompletedTask;
+    }
+
     public Task<ActivityExecutionRecord?> FindAsync(ActivityExecutionRecordFilter filter, CancellationToken cancellationToken = default)
     {
         return Task.FromResult<ActivityExecutionRecord?>(null);


### PR DESCRIPTION
Introduced a new AddManyAsync method across multiple activity execution stores to add collections of log records. This enhancement ensures consistency in handling bulk additions and aligns with existing store interfaces.
