### PR TITLE
Add AddManyAsync method to activity execution stores

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - 'blueberry'
       - 'feature/*'
+      - 'enh/*'
   release:
     types: [ prereleased, published ]
 env:

--- a/src/modules/Elsa.Dapper/Modules/Runtime/Stores/DapperActivityExecutionRecordStore.cs
+++ b/src/modules/Elsa.Dapper/Modules/Runtime/Stores/DapperActivityExecutionRecordStore.cs
@@ -52,8 +52,8 @@ public class DapperActivityExecutionRecordStore : IActivityExecutionStore
     /// <inheritdoc />
     public async Task AddManyAsync(IEnumerable<ActivityExecutionRecord> records, CancellationToken cancellationToken = default)
     {
-        var mappedRecords = records.Select(Map).ToList();
-        await store.AddManyAsync(mappedRecords, cancellationToken);
+        var mappedRecords = records.Select(x => Map(x, cancellationToken));
+        await _store.AddManyAsync(mappedRecords, cancellationToken);
     }
 
     /// <inheritdoc />

--- a/src/modules/Elsa.Dapper/Modules/Runtime/Stores/DapperActivityExecutionRecordStore.cs
+++ b/src/modules/Elsa.Dapper/Modules/Runtime/Stores/DapperActivityExecutionRecordStore.cs
@@ -50,6 +50,13 @@ public class DapperActivityExecutionRecordStore : IActivityExecutionStore
     }
 
     /// <inheritdoc />
+    public async Task AddManyAsync(IEnumerable<ActivityExecutionRecord> records, CancellationToken cancellationToken = default)
+    {
+        var mappedRecords = records.Select(Map).ToList();
+        await store.AddManyAsync(mappedRecords, cancellationToken);
+    }
+
+    /// <inheritdoc />
     public async Task<ActivityExecutionRecord?> FindAsync(ActivityExecutionRecordFilter filter, CancellationToken cancellationToken = default)
     {
         var record = await _store.FindAsync(q => ApplyFilter(q, filter), cancellationToken);

--- a/src/modules/Elsa.EntityFrameworkCore.Common/Extensions/BulkUpsertExtensions.cs
+++ b/src/modules/Elsa.EntityFrameworkCore.Common/Extensions/BulkUpsertExtensions.cs
@@ -106,15 +106,16 @@ public static class BulkUpsertExtensions
         mergeSql.AppendLine("USING (VALUES");
 
         var parameters = new List<object>();
+        var parameterCount = 0;
+        
         for (var i = 0; i < entities.Count; i++)
         {
             var entity = entities[i];
             var values = new List<string>();
 
-            for (var j = 0; j < props.Count; j++)
+            foreach (var property in props)
             {
-                var property = props[j];
-                var paramName = $"@p{i}_{j}";
+                var paramName = $"{{{parameterCount++}}}";
 
                 // If it's a shadow property, retrieve value via Entry(..).Property(..)
                 object? value = property.IsShadowProperty()
@@ -160,6 +161,7 @@ public static class BulkUpsertExtensions
 
         var sb = new StringBuilder();
         var parameters = new List<object>();
+        var parameterCount = 0;
 
         sb.Append($"INSERT INTO \"{tableName}\" ({string.Join(", ", columnNames.Select(c => $"\"{c}\""))}) VALUES ");
 
@@ -168,10 +170,9 @@ public static class BulkUpsertExtensions
             var entity = entities[i];
             var placeholders = new List<string>();
 
-            for (var j = 0; j < props.Count; j++)
+            foreach (var property in props)
             {
-                var property = props[j];
-                var paramName = $"@p{i}_{j}";
+                var paramName = $"{{{parameterCount++}}}";
 
                 object? value = property.IsShadowProperty()
                     ? dbContext.Entry(entity).Property(property.Name).CurrentValue
@@ -276,6 +277,7 @@ public static class BulkUpsertExtensions
 
         var sb = new StringBuilder();
         var parameters = new List<object>();
+        var parameterCount = 0;
 
         sb.Append($"INSERT INTO `{tableName}` ({string.Join(", ", columnNames.Select(c => $"`{c}`"))}) VALUES ");
 
@@ -284,10 +286,9 @@ public static class BulkUpsertExtensions
             var entity = entities[i];
             var placeholders = new List<string>();
 
-            for (var j = 0; j < props.Count; j++)
+            foreach (var property in props)
             {
-                var property = props[j];
-                var paramName = $"@p{i}_{j}";
+                var paramName = $"{{{parameterCount++}}}";
 
                 object? value = property.IsShadowProperty()
                     ? dbContext.Entry(entity).Property(property.Name).CurrentValue
@@ -337,6 +338,7 @@ public static class BulkUpsertExtensions
 
         var sb = new StringBuilder();
         var parameters = new List<object>();
+        var parameterCount = 0;
 
         sb.AppendLine($"MERGE INTO {fullName} Target");
         sb.AppendLine("USING (SELECT");
@@ -346,10 +348,9 @@ public static class BulkUpsertExtensions
             var entity = entities[i];
             var lineParts = new List<string>();
 
-            for (var j = 0; j < props.Count; j++)
+            foreach (var property in props)
             {
-                var property = props[j];
-                var paramName = $":p{i}_{j}";
+                var paramName = $"{{{parameterCount++}}}";
 
                 object? value = property.IsShadowProperty()
                     ? dbContext.Entry(entity).Property(property.Name).CurrentValue

--- a/src/modules/Elsa.EntityFrameworkCore.Common/Extensions/BulkUpsertExtensions.cs
+++ b/src/modules/Elsa.EntityFrameworkCore.Common/Extensions/BulkUpsertExtensions.cs
@@ -119,6 +119,10 @@ public static class BulkUpsertExtensions
                 object? value = property.IsShadowProperty()
                     ? dbContext.Entry(entity).Property(property.Name).CurrentValue
                     : property.PropertyInfo?.GetValue(entity);
+                
+                var converter = property.GetTypeMapping().Converter;
+                if (converter != null) 
+                    value = converter.ConvertToProvider(value);
 
                 values.Add(paramName);
                 parameters.Add(value);
@@ -175,6 +179,10 @@ public static class BulkUpsertExtensions
                 object? value = property.IsShadowProperty()
                     ? dbContext.Entry(entity).Property(property.Name).CurrentValue
                     : property.PropertyInfo?.GetValue(entity);
+                
+                var converter = property.GetTypeMapping().Converter;
+                if (converter != null) 
+                    value = converter.ConvertToProvider(value);
 
                 placeholders.Add(paramName);
                 parameters.Add(value);
@@ -233,6 +241,10 @@ public static class BulkUpsertExtensions
                 object? value = property.IsShadowProperty()
                     ? dbContext.Entry(entity).Property(property.Name).CurrentValue
                     : property.PropertyInfo?.GetValue(entity);
+                
+                var converter = property.GetTypeMapping().Converter;
+                if (converter != null) 
+                    value = converter.ConvertToProvider(value);
 
                 placeholders.Add(paramName);
                 parameters.Add(value);
@@ -291,6 +303,10 @@ public static class BulkUpsertExtensions
                 object? value = property.IsShadowProperty()
                     ? dbContext.Entry(entity).Property(property.Name).CurrentValue
                     : property.PropertyInfo?.GetValue(entity);
+                
+                var converter = property.GetTypeMapping().Converter;
+                if (converter != null) 
+                    value = converter.ConvertToProvider(value);
 
                 placeholders.Add(paramName);
                 parameters.Add(value);
@@ -353,6 +369,10 @@ public static class BulkUpsertExtensions
                 object? value = property.IsShadowProperty()
                     ? dbContext.Entry(entity).Property(property.Name).CurrentValue
                     : property.PropertyInfo?.GetValue(entity);
+                
+                var converter = property.GetTypeMapping().Converter;
+                if (converter != null) 
+                    value = converter.ConvertToProvider(value);
 
                 parameters.Add(value);
 

--- a/src/modules/Elsa.EntityFrameworkCore.Common/Extensions/BulkUpsertExtensions.cs
+++ b/src/modules/Elsa.EntityFrameworkCore.Common/Extensions/BulkUpsertExtensions.cs
@@ -1,5 +1,3 @@
-
-
 using System.Text;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -81,7 +79,7 @@ public static class BulkUpsertExtensions
             await dbContext.Database.ExecuteSqlRawAsync(sql, parameters, cancellationToken);
         }
     }
-    
+
     private static (string, object[]) GenerateSqlServerUpsert<TEntity>(
         DbContext dbContext,
         IList<TEntity> entities,
@@ -107,7 +105,7 @@ public static class BulkUpsertExtensions
 
         var parameters = new List<object>();
         var parameterCount = 0;
-        
+
         for (var i = 0; i < entities.Count; i++)
         {
             var entity = entities[i];

--- a/src/modules/Elsa.EntityFrameworkCore.Common/Extensions/BulkUpsertExtensions.cs
+++ b/src/modules/Elsa.EntityFrameworkCore.Common/Extensions/BulkUpsertExtensions.cs
@@ -1,0 +1,384 @@
+
+
+using System.Text;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using System.Linq.Expressions;
+
+// ReSharper disable once CheckNamespace
+namespace Elsa.EntityFrameworkCore.Extensions;
+
+/// <summary>
+/// Provides extension methods to perform bulk upsert operations for entities
+/// in an Entity Framework Core context, supporting multiple database providers.
+/// </summary>
+public static class BulkUpsertExtensions
+{
+    /// <summary>
+    /// Performs a bulk upsert operation on a list of entities in the specified database context using a key selector.
+    /// </summary>
+    /// <typeparam name="TDbContext">The type of the database context.</typeparam>
+    /// <typeparam name="TEntity">The type of the entity being upserted.</typeparam>
+    /// <param name="dbContext">The database context where the bulk upsert operation will be executed.</param>
+    /// <param name="entities">The list of entities to be upserted.</param>
+    /// <param name="keySelector">An expression used to determine the key for upsert operations.</param>
+    /// <param name="cancellationToken">A token to observe while waiting for the operation to complete.</param>
+    public static async Task BulkUpsertAsync<TDbContext, TEntity>(
+        this TDbContext dbContext,
+        IList<TEntity> entities,
+        Expression<Func<TEntity, string>> keySelector,
+        CancellationToken cancellationToken = default)
+        where TDbContext : DbContext
+        where TEntity : class, new()
+    {
+        await BulkUpsertAsync(dbContext, entities, keySelector, 50, cancellationToken);
+    }
+
+    /// <summary>
+    /// Performs a bulk upsert operation on a list of entities in the specified database context using a key selector and optional batch size.
+    /// </summary>
+    /// <typeparam name="TDbContext">The type of the database context.</typeparam>
+    /// <typeparam name="TEntity">The type of the entity being upserted.</typeparam>
+    /// <param name="dbContext">The database context where the bulk upsert operation will be executed.</param>
+    /// <param name="entities">The list of entities to be upserted.</param>
+    /// <param name="keySelector">An expression used to determine the key for upsert operations.</param>
+    /// <param name="batchSize">The size of each batch for processing the upsert operation. Defaults to 50.</param>
+    /// <param name="cancellationToken">A token to observe while waiting for the operation to complete.</param>
+    /// <exception cref="NotSupportedException">Thrown if the database provider for the context is not supported.</exception>
+    public static async Task BulkUpsertAsync<TDbContext, TEntity>(
+        this TDbContext dbContext,
+        IList<TEntity> entities,
+        Expression<Func<TEntity, string>> keySelector,
+        int batchSize = 50,
+        CancellationToken cancellationToken = default)
+        where TDbContext : DbContext
+        where TEntity : class, new()
+    {
+        if (entities.Count == 0)
+            return;
+
+        // Identify the current provider (e.g., "Microsoft.EntityFrameworkCore.SqlServer")
+        var providerName = dbContext.Database.ProviderName?.ToLowerInvariant() ?? string.Empty;
+
+        // Determine the method for generating SQL based on the provider
+        Func<DbContext, IList<TEntity>, Expression<Func<TEntity, string>>, (string, object[])> generateSql = providerName switch
+        {
+            var pn when pn.Contains("sqlserver") => GenerateSqlServerUpsert,
+            var pn when pn.Contains("sqlite") => GenerateSqliteUpsert,
+            var pn when pn.Contains("postgres") => GeneratePostgresUpsert,
+            var pn when pn.Contains("mysql") => GenerateMySqlUpsert,
+            var pn when pn.Contains("oracle") => GenerateOracleUpsert,
+            _ => throw new NotSupportedException($"Provider '{providerName}' is not supported.")
+        };
+
+        // Loop through batched entities
+        foreach (var batch in entities.Chunk(batchSize))
+        {
+            // Generate SQL and parameters
+            var (sql, parameters) = generateSql(dbContext, batch, keySelector);
+
+            await dbContext.Database.ExecuteSqlRawAsync(sql, parameters, cancellationToken);
+        }
+    }
+    
+    private static (string, object[]) GenerateSqlServerUpsert<TEntity>(
+        DbContext dbContext,
+        IList<TEntity> entities,
+        Expression<Func<TEntity, string>> keySelector)
+        where TEntity : class
+    {
+        var entityType = dbContext.Model.FindEntityType(typeof(TEntity))!;
+        var tableName = $"[{entityType.GetSchema()}].[{entityType.GetTableName()}]";
+        var storeObject = StoreObjectIdentifier.Table(entityType.GetTableName()!, entityType.GetSchema());
+
+        // Include shadow properties
+        var props = entityType.GetProperties().ToList();
+
+        var keyProp = entityType.FindProperty(keySelector.GetMemberAccess().Name)!;
+        var keyColumnName = $"[{keyProp.GetColumnName(storeObject)}]";
+        var columnNames = props
+            .Select(p => $"[{p.GetColumnName(storeObject)}]")
+            .ToList();
+
+        var mergeSql = new StringBuilder();
+        mergeSql.AppendLine($"MERGE {tableName} AS Target");
+        mergeSql.AppendLine("USING (VALUES");
+
+        var parameters = new List<object>();
+        for (var i = 0; i < entities.Count; i++)
+        {
+            var entity = entities[i];
+            var values = new List<string>();
+
+            for (var j = 0; j < props.Count; j++)
+            {
+                var property = props[j];
+                var paramName = $"@p{i}_{j}";
+
+                // If it's a shadow property, retrieve value via Entry(..).Property(..)
+                object? value = property.IsShadowProperty()
+                    ? dbContext.Entry(entity).Property(property.Name).CurrentValue
+                    : property.PropertyInfo?.GetValue(entity);
+
+                values.Add(paramName);
+                parameters.Add(value);
+            }
+
+            var line = $"({string.Join(", ", values)}){(i < entities.Count - 1 ? "," : string.Empty)}";
+            mergeSql.AppendLine(line);
+        }
+
+        mergeSql.AppendLine($") AS Source ({string.Join(", ", columnNames)})");
+        mergeSql.AppendLine($"ON Target.{keyColumnName} = Source.{keyColumnName}");
+        mergeSql.AppendLine("WHEN MATCHED THEN");
+        mergeSql.AppendLine($"    UPDATE SET {string.Join(", ", columnNames.Where(c => c != keyColumnName).Select(c => $"Target.{c} = Source.{c}"))}");
+        mergeSql.AppendLine("WHEN NOT MATCHED THEN");
+        mergeSql.AppendLine($"    INSERT ({string.Join(", ", columnNames)})");
+        mergeSql.AppendLine($"    VALUES ({string.Join(", ", columnNames.Select(c => $"Source.{c}"))});");
+
+        return (mergeSql.ToString(), parameters.ToArray());
+    }
+
+    private static (string, object[]) GenerateSqliteUpsert<TEntity>(
+        DbContext dbContext,
+        IList<TEntity> entities,
+        Expression<Func<TEntity, string>> keySelector)
+        where TEntity : class
+    {
+        var entityType = dbContext.Model.FindEntityType(typeof(TEntity))!;
+        var tableName = entityType.GetTableName();
+        var storeObject = StoreObjectIdentifier.Table(tableName!, entityType.GetSchema());
+
+        var props = entityType.GetProperties().ToList();
+
+        var keyProp = entityType.FindProperty(keySelector.GetMemberAccess().Name)!;
+        var keyColumnName = keyProp.GetColumnName(storeObject);
+        var columnNames = props
+            .Select(p => p.GetColumnName(storeObject)!)
+            .ToList();
+
+        var sb = new StringBuilder();
+        var parameters = new List<object>();
+
+        sb.Append($"INSERT INTO \"{tableName}\" ({string.Join(", ", columnNames.Select(c => $"\"{c}\""))}) VALUES ");
+
+        for (var i = 0; i < entities.Count; i++)
+        {
+            var entity = entities[i];
+            var placeholders = new List<string>();
+
+            for (var j = 0; j < props.Count; j++)
+            {
+                var property = props[j];
+                var paramName = $"@p{i}_{j}";
+
+                object? value = property.IsShadowProperty()
+                    ? dbContext.Entry(entity).Property(property.Name).CurrentValue
+                    : property.PropertyInfo?.GetValue(entity);
+
+                placeholders.Add(paramName);
+                parameters.Add(value);
+            }
+
+            sb.Append($"({string.Join(", ", placeholders)})");
+            if (i < entities.Count - 1)
+                sb.Append(", ");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine($"ON CONFLICT(\"{keyColumnName}\") DO UPDATE SET");
+
+        var updateAssignments = columnNames
+            .Where(c => c != keyColumnName)
+            .Select(c => $"\"{c}\"=excluded.\"{c}\"");
+
+        sb.AppendLine(string.Join(", ", updateAssignments) + ";");
+
+        return (sb.ToString(), parameters.ToArray());
+    }
+
+    private static (string, object[]) GeneratePostgresUpsert<TEntity>(
+        DbContext dbContext,
+        IList<TEntity> entities,
+        Expression<Func<TEntity, string>> keySelector)
+        where TEntity : class
+    {
+        var entityType = dbContext.Model.FindEntityType(typeof(TEntity))!;
+        var tableName = entityType.GetTableName();
+        var storeObject = StoreObjectIdentifier.Table(tableName!, entityType.GetSchema());
+
+        var props = entityType.GetProperties().ToList();
+
+        var keyProp = entityType.FindProperty(keySelector.GetMemberAccess().Name)!;
+        var keyColumnName = keyProp.GetColumnName(storeObject);
+        var columnNames = props
+            .Select(p => p.GetColumnName(storeObject)!)
+            .ToList();
+
+        var sb = new StringBuilder();
+        var parameters = new List<object>();
+        var parameterCount = 0;
+
+        sb.Append($"INSERT INTO \"{storeObject.Schema}\".\"{storeObject.Name}\" ({string.Join(", ", columnNames.Select(c => $"\"{c}\""))}) VALUES ");
+
+        for (var i = 0; i < entities.Count; i++)
+        {
+            var entity = entities[i];
+            var placeholders = new List<string>();
+
+            foreach (var property in props)
+            {
+                var paramName = $"{{{parameterCount++}}}";
+
+                object? value = property.IsShadowProperty()
+                    ? dbContext.Entry(entity).Property(property.Name).CurrentValue
+                    : property.PropertyInfo?.GetValue(entity);
+
+                placeholders.Add(paramName);
+                parameters.Add(value);
+            }
+
+            sb.Append($"({string.Join(", ", placeholders)})");
+            if (i < entities.Count - 1)
+                sb.Append(", ");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine($"ON CONFLICT (\"{keyColumnName}\") DO UPDATE SET");
+
+        var updateAssignments = columnNames
+            .Where(c => c != keyColumnName)
+            .Select(c => $"\"{c}\" = EXCLUDED.\"{c}\"");
+
+        sb.AppendLine(string.Join(", ", updateAssignments) + ";");
+
+        return (sb.ToString(), parameters.ToArray());
+    }
+
+    private static (string, object[]) GenerateMySqlUpsert<TEntity>(
+        DbContext dbContext,
+        IList<TEntity> entities,
+        Expression<Func<TEntity, string>> keySelector)
+        where TEntity : class
+    {
+        var entityType = dbContext.Model.FindEntityType(typeof(TEntity))!;
+        var tableName = entityType.GetTableName();
+        var storeObject = StoreObjectIdentifier.Table(tableName!, entityType.GetSchema());
+
+        var props = entityType.GetProperties().ToList();
+
+        var keyProp = entityType.FindProperty(keySelector.GetMemberAccess().Name)!;
+        var keyColumnName = keyProp.GetColumnName(storeObject);
+        var columnNames = props
+            .Select(p => p.GetColumnName(storeObject)!)
+            .ToList();
+
+        var sb = new StringBuilder();
+        var parameters = new List<object>();
+
+        sb.Append($"INSERT INTO `{tableName}` ({string.Join(", ", columnNames.Select(c => $"`{c}`"))}) VALUES ");
+
+        for (var i = 0; i < entities.Count; i++)
+        {
+            var entity = entities[i];
+            var placeholders = new List<string>();
+
+            for (var j = 0; j < props.Count; j++)
+            {
+                var property = props[j];
+                var paramName = $"@p{i}_{j}";
+
+                object? value = property.IsShadowProperty()
+                    ? dbContext.Entry(entity).Property(property.Name).CurrentValue
+                    : property.PropertyInfo?.GetValue(entity);
+
+                placeholders.Add(paramName);
+                parameters.Add(value);
+            }
+
+            sb.Append($"({string.Join(", ", placeholders)})");
+            if (i < entities.Count - 1)
+                sb.Append(", ");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("ON DUPLICATE KEY UPDATE");
+
+        var updateAssignments = columnNames
+            .Where(c => c != keyColumnName)
+            .Select(c => $"`{c}` = VALUES(`{c}`)");
+
+        sb.AppendLine(string.Join(", ", updateAssignments) + ";");
+
+        return (sb.ToString(), parameters.ToArray());
+    }
+
+    private static (string, object[]) GenerateOracleUpsert<TEntity>(
+        DbContext dbContext,
+        IList<TEntity> entities,
+        Expression<Func<TEntity, string>> keySelector)
+        where TEntity : class
+    {
+        var entityType = dbContext.Model.FindEntityType(typeof(TEntity))!;
+        var schema = entityType.GetSchema();
+        var tableName = entityType.GetTableName();
+        var storeObject = StoreObjectIdentifier.Table(tableName!, schema);
+        var fullName = !string.IsNullOrEmpty(schema) ? $"{schema}.{tableName}" : tableName;
+
+        var props = entityType.GetProperties().ToList();
+
+        var keyProp = entityType.FindProperty(keySelector.GetMemberAccess().Name)!;
+        var keyColumnName = keyProp.GetColumnName(storeObject);
+
+        var columnNames = props
+            .Select(p => p.GetColumnName(storeObject)!)
+            .ToList();
+
+        var sb = new StringBuilder();
+        var parameters = new List<object>();
+
+        sb.AppendLine($"MERGE INTO {fullName} Target");
+        sb.AppendLine("USING (SELECT");
+
+        for (var i = 0; i < entities.Count; i++)
+        {
+            var entity = entities[i];
+            var lineParts = new List<string>();
+
+            for (var j = 0; j < props.Count; j++)
+            {
+                var property = props[j];
+                var paramName = $":p{i}_{j}";
+
+                object? value = property.IsShadowProperty()
+                    ? dbContext.Entry(entity).Property(property.Name).CurrentValue
+                    : property.PropertyInfo?.GetValue(entity);
+
+                parameters.Add(value);
+
+                // Oracle aliases must match the column name
+                var alias = property.GetColumnName(storeObject);
+                lineParts.Add($"{paramName} AS {alias}");
+            }
+
+            // Comma if not last
+            var suffix = (i < entities.Count - 1) ? " FROM DUAL UNION ALL SELECT" : " FROM DUAL";
+            sb.AppendLine(string.Join(", ", lineParts) + suffix);
+        }
+
+        sb.AppendLine($") Source ON (Target.{keyColumnName} = Source.{keyColumnName})");
+        sb.AppendLine("WHEN MATCHED THEN UPDATE SET");
+
+        var updateSetClauses = columnNames
+            .Where(c => c != keyColumnName)
+            .Select(c => $"Target.{c} = Source.{c}");
+
+        sb.AppendLine(string.Join(", ", updateSetClauses));
+        sb.AppendLine("WHEN NOT MATCHED THEN");
+        sb.AppendLine($"INSERT ({string.Join(", ", columnNames)})");
+        sb.AppendLine($"VALUES ({string.Join(", ", columnNames.Select(c => $"Source.{c}"))});");
+
+        return (sb.ToString(), parameters.ToArray());
+    }
+}

--- a/src/modules/Elsa.EntityFrameworkCore.Common/Extensions/QueryableExtensions.cs
+++ b/src/modules/Elsa.EntityFrameworkCore.Common/Extensions/QueryableExtensions.cs
@@ -13,31 +13,6 @@ namespace Elsa.EntityFrameworkCore.Extensions;
 public static class QueryableExtensions
 {
     /// <summary>
-    /// Inserts or updates a list of entities in bulk.
-    /// </summary>
-    public static async Task BulkUpsertAsync<TDbContext, TEntity>(this TDbContext dbContext, IList<TEntity> entities, Expression<Func<TEntity, string>> keySelector, CancellationToken cancellationToken = default) where TDbContext : DbContext where TEntity : class, new()
-    {
-        var set = dbContext.Set<TEntity>();
-        var compiledKeySelector = keySelector.Compile();
-        var containsLambda = entities.Any() ? keySelector.BuildContainsExpression(entities) : default;
-        var existingEntitiesQuery = set.AsNoTracking();
-
-        if (containsLambda != null)
-            existingEntitiesQuery = existingEntitiesQuery.Where(containsLambda);
-
-        var existingEntities = await existingEntitiesQuery.ToListAsync(cancellationToken);
-        var entitiesToUpdate = entities.IntersectBy(existingEntities.Select(compiledKeySelector), compiledKeySelector).ToList();
-        var entitiesToInsert = entities.Except(entitiesToUpdate).ToList();
-
-        if (entitiesToUpdate.Any())
-            set.UpdateRange(entitiesToUpdate);
-        if (entitiesToInsert.Any())
-            await set.AddRangeAsync(entitiesToInsert, cancellationToken);
-
-        await dbContext.SaveChangesAsync(cancellationToken);
-    }
-
-    /// <summary>
     /// Inserts a list of entities in bulk.
     /// </summary>
     public static async Task BulkInsertAsync<TDbContext, TEntity>(this TDbContext dbContext, IList<TEntity> entities, CancellationToken cancellationToken = default) where TDbContext : DbContext where TEntity : class, new()

--- a/src/modules/Elsa.EntityFrameworkCore/Modules/Runtime/ActivityExecutionLogStore.cs
+++ b/src/modules/Elsa.EntityFrameworkCore/Modules/Runtime/ActivityExecutionLogStore.cs
@@ -36,6 +36,9 @@ public class EFCoreActivityExecutionStore(
     public async Task SaveManyAsync(IEnumerable<ActivityExecutionRecord> records, CancellationToken cancellationToken = default) => await store.SaveManyAsync(records, OnSaveAsync, cancellationToken);
 
     /// <inheritdoc />
+    public async Task AddManyAsync(IEnumerable<ActivityExecutionRecord> records, CancellationToken cancellationToken = default) => await store.AddManyAsync(records, OnSaveAsync, cancellationToken);
+
+    /// <inheritdoc />
     [RequiresUnreferencedCode("Calls Elsa.EntityFrameworkCore.Modules.Runtime.EFCoreActivityExecutionStore.DeserializeActivityState(RuntimeElsaDbContext, ActivityExecutionRecord, CancellationToken)")]
     public async Task<ActivityExecutionRecord?> FindAsync(ActivityExecutionRecordFilter filter, CancellationToken cancellationToken = default)
     {

--- a/src/modules/Elsa.MongoDb/Modules/Runtime/ActivityExecutionLogStore.cs
+++ b/src/modules/Elsa.MongoDb/Modules/Runtime/ActivityExecutionLogStore.cs
@@ -29,6 +29,12 @@ public class MongoActivityExecutionLogStore(MongoDbStore<ActivityExecutionRecord
     }
 
     /// <inheritdoc />
+    public Task AddManyAsync(IEnumerable<ActivityExecutionRecord> records, CancellationToken cancellationToken = default)
+    {
+        return mongoDbStore.AddManyAsync(records, cancellationToken);
+    }
+
+    /// <inheritdoc />
     public Task<ActivityExecutionRecord?> FindAsync(ActivityExecutionRecordFilter filter, CancellationToken cancellationToken = default)
     {
         return mongoDbStore.FindAsync(queryable => Filter(queryable, filter), cancellationToken);

--- a/src/modules/Elsa.Workflows.Runtime/Contracts/ILogRecordStore.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Contracts/ILogRecordStore.cs
@@ -10,4 +10,9 @@ public interface ILogRecordStore<in T> where T : ILogRecord
     /// If a record does not already exist, it is added to the store; if it does exist, its existing entry is updated.
     /// </remarks>
     Task SaveManyAsync(IEnumerable<T> records, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Adds a collection of log records to the store.
+    /// </summary>
+    Task AddManyAsync(IEnumerable<T> records, CancellationToken cancellationToken = default);
 }

--- a/src/modules/Elsa.Workflows.Runtime/Stores/MemoryActivityExecutionStore.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Stores/MemoryActivityExecutionStore.cs
@@ -37,6 +37,13 @@ public class MemoryActivityExecutionStore : IActivityExecutionStore
     }
 
     /// <inheritdoc />
+    public Task AddManyAsync(IEnumerable<ActivityExecutionRecord> records, CancellationToken cancellationToken = default)
+    {
+        _store.AddMany(records, x => x.Id);
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
     public Task<ActivityExecutionRecord?> FindAsync(ActivityExecutionRecordFilter filter, CancellationToken cancellationToken = default)
     {
         var result = _store.Query(query => Filter(query, filter)).FirstOrDefault();

--- a/src/modules/Elsa.Workflows.Runtime/Stores/NoopActivityExecutionStore.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Stores/NoopActivityExecutionStore.cs
@@ -17,6 +17,11 @@ public class NoopActivityExecutionStore : IActivityExecutionStore
         return Task.CompletedTask;
     }
 
+    public Task AddManyAsync(IEnumerable<ActivityExecutionRecord> records, CancellationToken cancellationToken = default)
+    {
+        return Task.CompletedTask;
+    }
+
     public Task<ActivityExecutionRecord?> FindAsync(ActivityExecutionRecordFilter filter, CancellationToken cancellationToken = default)
     {
         return Task.FromResult<ActivityExecutionRecord?>(null);


### PR DESCRIPTION
Introduced a new AddManyAsync method across multiple activity execution stores to add collections of log records. This enhancement ensures consistency in handling bulk additions and aligns with existing store interfaces.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6416)
<!-- Reviewable:end -->
