### PR TITLE
Add toggle for WorkflowInboxCleanupJob in WorkflowRuntimeFeature

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - 'blueberry'
       - 'feature/*'
+      - 'enh/*'
   release:
     types: [ prereleased, published ]
 env:


### PR DESCRIPTION
Introduced methods to enable or disable the WorkflowInboxCleanupJob. Updated service configuration logic to conditionally register WorkflowInboxCleanupHostedService based on the toggle. This adds flexibility to control cleanup job behavior programmatically.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6418)
<!-- Reviewable:end -->
