### PR TITLE
ActivityExecutionContext Children property not populated

### DIFF
--- a/src/modules/Elsa.Workflows.Core/Contexts/ActivityExecutionContext.cs
+++ b/src/modules/Elsa.Workflows.Core/Contexts/ActivityExecutionContext.cs
@@ -44,7 +44,7 @@ public partial class ActivityExecutionContext : IExecutionContext, IDisposable
         ActivityState = new ChangeTrackingDictionary<string, object>(Taint);
         ActivityInput = new ChangeTrackingDictionary<string, object>(Taint);
         WorkflowExecutionContext = workflowExecutionContext;
-        _parentActivityExecutionContext = parentActivityExecutionContext;
+        ParentActivityExecutionContext = parentActivityExecutionContext;
         var expressionExecutionContextProps = ExpressionExecutionContextExtensions.CreateActivityExecutionContextPropertiesFrom(workflowExecutionContext, workflowExecutionContext.Input);
         expressionExecutionContextProps[ExpressionExecutionContextExtensions.ActivityKey] = activity;
         ExpressionExecutionContext = new(workflowExecutionContext.ServiceProvider, new(), parentActivityExecutionContext?.ExpressionExecutionContext ?? workflowExecutionContext.ExpressionExecutionContext, expressionExecutionContextProps, Taint, CancellationToken);

--- a/src/modules/Elsa.Workflows.Core/Extensions/ActivityExecutionContextExtensions.cs
+++ b/src/modules/Elsa.Workflows.Core/Extensions/ActivityExecutionContextExtensions.cs
@@ -254,7 +254,7 @@ public static partial class ActivityExecutionContextExtensions
             return;
 
         // Select all child contexts.
-        var childContexts = context.WorkflowExecutionContext.ActivityExecutionContexts.Where(x => x.ParentActivityExecutionContext == context).ToList();
+        var childContexts = context.Children.ToList();
 
         foreach (var childContext in childContexts)
             await CancelActivityAsync(childContext);
@@ -320,7 +320,7 @@ public static partial class ActivityExecutionContextExtensions
     /// </summary>
     public static IEnumerable<ActivityExecutionContext> GetDescendents(this ActivityExecutionContext context)
     {
-        var children = context.WorkflowExecutionContext.ActivityExecutionContexts.Where(x => x.ParentActivityExecutionContext == context).ToList();
+        var children = context.Children.ToList();
 
         foreach (var child in children)
         {
@@ -336,7 +336,7 @@ public static partial class ActivityExecutionContextExtensions
     /// </summary>
     public static IEnumerable<ActivityExecutionContext> GetActiveChildren(this ActivityExecutionContext context)
     {
-        return context.WorkflowExecutionContext.ActivityExecutionContexts.Where(x => x.ParentActivityExecutionContext == context);
+        return context.Children;
     }
 
     /// <summary>
@@ -344,7 +344,7 @@ public static partial class ActivityExecutionContextExtensions
     /// </summary>
     public static IEnumerable<ActivityExecutionContext> GetChildren(this ActivityExecutionContext context)
     {
-        return context.WorkflowExecutionContext.ActivityExecutionContexts.Where(x => x.ParentActivityExecutionContext == context);
+        return context.Children;
     }
 
     /// <summary>
@@ -352,7 +352,7 @@ public static partial class ActivityExecutionContextExtensions
     /// </summary>
     public static IEnumerable<ActivityExecutionContext> GetDescendants(this ActivityExecutionContext context)
     {
-        var children = context.WorkflowExecutionContext.ActivityExecutionContexts.Where(x => x.ParentActivityExecutionContext == context).ToList();
+        var children = context.Children.ToList();
 
         foreach (var child in children)
         {


### PR DESCRIPTION
I updated ActivityExecutionContext to set the parent context to use the ParentActivityExecutionContext setter, which populates the parent's Children set. I also updated a few places to use the Children set instead of searching through all of the workflow's activity contexts.

See https://github.com/elsa-workflows/elsa-core/issues/6421 for more details.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6423)
<!-- Reviewable:end -->
