### PR TITLE
Add OpenTelemetry error span handling infrastructure

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,197 +1,199 @@
 <Project>
-    <PropertyGroup>
-        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-        <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-      </PropertyGroup>
-      <ItemGroup>
-        <PackageVersion Include="Antlr4.Runtime.Standard" Version="4.13.1"/>
-        <PackageVersion Include="AppAny.Quartz.EntityFrameworkCore.Migrations" Version="0.5.1"/>
-        <PackageVersion Include="AppAny.Quartz.EntityFrameworkCore.Migrations.MySql" Version="0.5.1"/>
-        <PackageVersion Include="AppAny.Quartz.EntityFrameworkCore.Migrations.PostgreSQL" Version="0.5.1"/>
-        <PackageVersion Include="AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite" Version="0.5.1"/>
-        <PackageVersion Include="AppAny.Quartz.EntityFrameworkCore.Migrations.SqlServer" Version="0.5.1"/>
-        <PackageVersion Include="AutoMapper" Version="13.0.1" PrivateAssets="All"/>
-        <PackageVersion Include="Azure.Identity" Version="1.13.2"/>
-        <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.18.3"/>
-        <PackageVersion Include="Azure.ResourceManager" Version="1.13.0"/>
-        <PackageVersion Include="Azure.ResourceManager.AppContainers" Version="1.3.0"/>
-        <PackageVersion Include="Azure.ResourceManager.Resources" Version="1.9.0"/>
-        <PackageVersion Include="Azure.ResourceManager.ServiceBus" Version="1.1.0"/>
-        <PackageVersion Include="BenchmarkDotNet" Version="0.14.0"/>
-        <PackageVersion Include="Bogus" Version="35.6.1"/>
-        <PackageVersion Include="ConfigureAwait.Fody" Version="3.3.2" PrivateAssets="All"/>
-        <PackageVersion Include="Confluent.Kafka" Version="2.8.0"/>
-        <PackageVersion Include="Confluent.SchemaRegistry.Serdes.Avro" Version="2.8.0"/>
-        <PackageVersion Include="coverlet.collector" Version="6.0.4" PrivateAssets="All"/>
-        <PackageVersion Include="Cronos" Version="0.9.0"/>
-        <PackageVersion Include="Dapper" Version="2.1.35"/>
-        <PackageVersion Include="DistributedLock.Core" Version="1.0.8"/>
-        <PackageVersion Include="DistributedLock.FileSystem" Version="1.0.3"/>
-        <PackageVersion Include="DistributedLock.Postgres" Version="1.2.1"/>
-        <PackageVersion Include="DistributedLock.Redis" Version="1.0.3"/>
-        <PackageVersion Include="Elastic.Clients.Elasticsearch" Version="8.17.1"/>
-        <PackageVersion Include="Elsa.Studio" Version="3.3.1"/>
-        <PackageVersion Include="Elsa.Studio.Agents" Version="3.3.1"/>
-        <PackageVersion Include="Elsa.Studio.Core.BlazorWasm" Version="3.3.1"/>
-        <PackageVersion Include="Elsa.Studio.Login.BlazorWasm" Version="3.3.1"/>
-        <PackageVersion Include="FastEndpoints" Version="5.33.0"/>
-        <PackageVersion Include="FastEndpoints.Security" Version="5.33.0"/>
-        <PackageVersion Include="FastEndpoints.Swagger" Version="5.33.0"/>
-        <PackageVersion Include="FluentMigrator" Version="6.2.0"/>
-        <PackageVersion Include="FluentMigrator.Runner" Version="6.2.0"/>
-        <PackageVersion Include="FluentStorage" Version="5.6.0"/>
-        <PackageVersion Include="FluentStorage.Azure.Blobs" Version="5.3.0"/>
-        <PackageVersion Include="Fluid.Core" Version="2.19.0"/>
-        <PackageVersion Include="Fody" Version="6.9.1"/>
-        <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1"/>
-        <PackageVersion Include="Google.Protobuf" Version="3.29.3"/>
-        <PackageVersion Include="Grpc.Net.Client" Version="2.67.0"/>
-        <PackageVersion Include="Grpc.Tools" Version="2.69.0"/>
-        <PackageVersion Include="Hangfire" Version="1.8.17"/>
-        <PackageVersion Include="Hangfire.MemoryStorage" Version="1.8.1.1"/>
-        <PackageVersion Include="Hangfire.PostgreSql" Version="1.20.10"/>
-        <PackageVersion Include="Hangfire.Storage.SQLite" Version="0.4.2"/>
-        <PackageVersion Include="Humanizer.Core" Version="2.14.1"/>
-        <PackageVersion Include="IronCompress" Version="1.6.3"/>
-        <PackageVersion Include="JetBrains.Annotations" Version="2024.3.0"/>
-        <PackageVersion Include="Jint" Version="4.1.0"/>
-        <PackageVersion Include="LinqKit.Core" Version="1.2.8"/>
-        <PackageVersion Include="MailKit" Version="4.9.0"/>
-        <PackageVersion Include="MassTransit" Version="8.3.4"/>
-        <PackageVersion Include="MassTransit.Azure.ServiceBus.Core" Version="8.3.4"/>
-        <PackageVersion Include="MassTransit.RabbitMQ" Version="8.3.4"/>
-        <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.12.0"/>
-        <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.2.2"/>
-        <PackageVersion Include="Microsoft.Identity.Client" Version="4.67.2"/>
-        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
-        <PackageVersion Include="Microsoft.SemanticKernel" Version="1.34.0"/>
-        <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0"/>
-        <PackageVersion Include="MongoDB.Driver" Version="3.1.0"/>
-        <PackageVersion Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="2.0.0"/>
-        <PackageVersion Include="MongoDB.Driver.Extensions" Version="2.0.2"/>
-        <PackageVersion Include="MySql.Data" Version="9.1.0"/>
-        <PackageVersion Include="Newtonsoft.Json" Version="13.0.3"/>
-        <PackageVersion Include="NSubstitute" Version="5.3.0"/>
-        <PackageVersion Include="NuGet.Packaging" Version="6.12.1"/>
-        <PackageVersion Include="NuGet.Protocol" Version="6.12.1"/>
-        <PackageVersion Include="Nuke.Components" Version="9.0.4"/>
-        <PackageVersion Include="Open.Linq.AsyncExtensions" Version="1.2.0"/>
-        <PackageVersion Include="Polly.Extensions.Http" Version="3.0.0"/>
-        <PackageVersion Include="PolySharp" Version="1.15.0"/>
-        <PackageVersion Include="Proto.Actor" Version="1.7.0"/>
-        <PackageVersion Include="Proto.Cluster" Version="1.7.0"/>
-        <PackageVersion Include="Proto.Cluster.AzureContainerApps" Version="1.7.0"/>
-        <PackageVersion Include="Proto.Cluster.CodeGen" Version="1.7.0"/>
-        <PackageVersion Include="Proto.Cluster.Kubernetes" Version="1.7.0"/>
-        <PackageVersion Include="Proto.Cluster.TestProvider" Version="1.7.0"/>
-        <PackageVersion Include="Proto.OpenTelemetry" Version="1.7.0"/>
-        <PackageVersion Include="Proto.Persistence" Version="1.7.0"/>
-        <PackageVersion Include="Proto.Persistence.Sqlite" Version="1.7.0"/>
-        <PackageVersion Include="Proto.Persistence.SqlServer" Version="1.7.0"/>
-        <PackageVersion Include="Proto.Remote" Version="1.7.0"/>
-        <PackageVersion Include="pythonnet" Version="3.1.0-preview2024-09-06"/>
-        <PackageVersion Include="Quartz.Extensions.Hosting" Version="3.13.1"/>
-        <PackageVersion Include="Quartz.Serialization.Json" Version="3.13.1"/>
-        <PackageVersion Include="Scrutor" Version="6.0.1"/>
-        <PackageVersion Include="ShortGuid" Version="2.0.1"/>
-        <PackageVersion Include="StackExchange.Redis" Version="2.8.24"/>
-        <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1"/>
-        <PackageVersion Include="System.Data.SqlClient" Version="4.9.0"/>
-        <PackageVersion Include="System.Linq.Async" Version="6.0.1"/>
-        <PackageVersion Include="System.Linq.Dynamic.Core" Version="1.6.0-preview-02"/>
-        <PackageVersion Include="System.Net.Http" Version="4.3.4"/>
-        <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1"/>
-        <PackageVersion Include="Testcontainers" Version="4.1.0"/>
-        <PackageVersion Include="Testcontainers.PostgreSql" Version="4.1.0"/>
-        <PackageVersion Include="Testcontainers.RabbitMq" Version="4.1.0"/>
-        <PackageVersion Include="Testcontainers.Redis" Version="4.1.0"/>
-        <PackageVersion Include="ThrottleDebounce" Version="2.0.0"/>
-        <PackageVersion Include="WebhooksCore" Version="0.0.1"/>
-        <PackageVersion Include="xunit" Version="2.9.3"/>
-        <PackageVersion Include="xunit.abstractions" Version="2.0.3"/>
-        <PackageVersion Include="xunit.extensibility.core" Version="2.9.3"/>
-        <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.1"/>
-        <PackageVersion Include="Yarp.ReverseProxy" Version="2.2.0"/>
-        <PackageVersion Include="AspNetCore.Authentication.ApiKey" Version="8.0.1"/>
-    </ItemGroup>
-    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-        <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="8.0.12"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.12"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.12"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.12"/>
-        <PackageVersion Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="8.0.12"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.12"/>
-        <PackageVersion Include="Microsoft.Data.Sqlite" Version="8.0.12"/>
-        <PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="8.0.12"/>
-        <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.12"/>
-        <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.12"/>
-        <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.12"/>
-        <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.12"/>
-        <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.12"/>
-        <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0"/>
-        <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1"/>
-        <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0"/>
-        <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0"/>
-        <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1"/>
-        <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1"/>
-        <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2"/>
-        <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="8.0.2"/>
-        <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1"/>
-        <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.1"/>
-        <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="8.0.12"/>
-        <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.1"/>
-        <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2"/>
-        <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.1"/>
-        <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.2"/>
-        <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0"/>
-        <PackageVersion Include="Npgsql" Version="8.0.6"/>
-        <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11"/>
-        <PackageVersion Include="Oracle.EntityFrameworkCore" Version="8.23.70"/>
-        <PackageVersion Include="Polly" Version="8.5.1"/>
-        <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.2"/>
-        <PackageVersion Include="Refit" Version="8.0.0"/>
-        <PackageVersion Include="Refit.HttpClientFactory" Version="8.0.0"/>
-        <PackageVersion Include="System.Formats.Asn1" Version="8.0.1"/>
-        <PackageVersion Include="System.Text.Json" Version="8.0.5"/>
-    </ItemGroup>
-    <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-        <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="9.0.1"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.1"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.1"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="9.0.1"/>
-        <PackageVersion Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="9.0.1"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.1"/>
-        <PackageVersion Include="Microsoft.Data.Sqlite" Version="9.0.1"/>
-        <PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="9.0.1"/>
-        <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.1"/>
-        <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.1"/>
-        <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.1"/>
-        <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.1"/>
-        <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.1"/>
-        <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.1"/>
-        <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="9.0.1"/>
-        <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.1"/>
-        <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.1"/>
-        <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="9.0.1"/>
-        <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1"/>
-        <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.1"/>
-        <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="9.0.1"/>
-        <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.1"/>
-        <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.1"/>
-        <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="9.0.1"/>
-        <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.1"/>
-        <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.1"/>
-        <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.1"/>
-        <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.1"/>
-        <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.1"/>
-        <PackageVersion Include="Npgsql" Version="9.0.2"/>
-        <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.3"/>
-        <PackageVersion Include="Oracle.EntityFrameworkCore" Version="9.23.60"/>
-        <PackageVersion Include="Polly" Version="8.5.1"/>
-        <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="9.0.0-preview.2.efcore.9.0.0"/>
-        <PackageVersion Include="Refit" Version="8.0.0"/>
-        <PackageVersion Include="Refit.HttpClientFactory" Version="8.0.0"/>
-        <PackageVersion Include="System.Formats.Asn1" Version="9.0.1"/>
-        <PackageVersion Include="System.Text.Json" Version="9.0.1"/>
-    </ItemGroup>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Antlr4.Runtime.Standard" Version="4.13.1" />
+    <PackageVersion Include="AppAny.Quartz.EntityFrameworkCore.Migrations" Version="0.5.1" />
+    <PackageVersion Include="AppAny.Quartz.EntityFrameworkCore.Migrations.MySql" Version="0.5.1" />
+    <PackageVersion Include="AppAny.Quartz.EntityFrameworkCore.Migrations.PostgreSQL" Version="0.5.1" />
+    <PackageVersion Include="AppAny.Quartz.EntityFrameworkCore.Migrations.SQLite" Version="0.5.1" />
+    <PackageVersion Include="AppAny.Quartz.EntityFrameworkCore.Migrations.SqlServer" Version="0.5.1" />
+    <PackageVersion Include="AutoMapper" Version="13.0.1" PrivateAssets="All" />
+    <PackageVersion Include="Azure.Identity" Version="1.13.2" />
+    <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.18.3" />
+    <PackageVersion Include="Azure.ResourceManager" Version="1.13.0" />
+    <PackageVersion Include="Azure.ResourceManager.AppContainers" Version="1.3.0" />
+    <PackageVersion Include="Azure.ResourceManager.Resources" Version="1.9.0" />
+    <PackageVersion Include="Azure.ResourceManager.ServiceBus" Version="1.1.0" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
+    <PackageVersion Include="Bogus" Version="35.6.1" />
+    <PackageVersion Include="ConfigureAwait.Fody" Version="3.3.2" PrivateAssets="All" />
+    <PackageVersion Include="Confluent.Kafka" Version="2.8.0" />
+    <PackageVersion Include="Confluent.SchemaRegistry.Serdes.Avro" Version="2.8.0" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.4" PrivateAssets="All" />
+    <PackageVersion Include="Cronos" Version="0.9.0" />
+    <PackageVersion Include="Dapper" Version="2.1.35" />
+    <PackageVersion Include="DistributedLock.Core" Version="1.0.8" />
+    <PackageVersion Include="DistributedLock.FileSystem" Version="1.0.3" />
+    <PackageVersion Include="DistributedLock.Postgres" Version="1.2.1" />
+    <PackageVersion Include="DistributedLock.Redis" Version="1.0.3" />
+    <PackageVersion Include="Elastic.Clients.Elasticsearch" Version="8.17.1" />
+    <PackageVersion Include="Elsa.Studio" Version="3.3.1" />
+    <PackageVersion Include="Elsa.Studio.Agents" Version="3.3.1" />
+    <PackageVersion Include="Elsa.Studio.Core.BlazorWasm" Version="3.3.1" />
+    <PackageVersion Include="Elsa.Studio.Login.BlazorWasm" Version="3.3.1" />
+    <PackageVersion Include="FastEndpoints" Version="5.33.0" />
+    <PackageVersion Include="FastEndpoints.Security" Version="5.33.0" />
+    <PackageVersion Include="FastEndpoints.Swagger" Version="5.33.0" />
+    <PackageVersion Include="FluentMigrator" Version="6.2.0" />
+    <PackageVersion Include="FluentMigrator.Runner" Version="6.2.0" />
+    <PackageVersion Include="FluentStorage" Version="5.6.0" />
+    <PackageVersion Include="FluentStorage.Azure.Blobs" Version="5.3.0" />
+    <PackageVersion Include="Fluid.Core" Version="2.19.0" />
+    <PackageVersion Include="Fody" Version="6.9.1" />
+    <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
+    <PackageVersion Include="Google.Protobuf" Version="3.29.3" />
+    <PackageVersion Include="Grpc.Net.Client" Version="2.67.0" />
+    <PackageVersion Include="Grpc.Tools" Version="2.69.0" />
+    <PackageVersion Include="Hangfire" Version="1.8.17" />
+    <PackageVersion Include="Hangfire.MemoryStorage" Version="1.8.1.1" />
+    <PackageVersion Include="Hangfire.PostgreSql" Version="1.20.10" />
+    <PackageVersion Include="Hangfire.Storage.SQLite" Version="0.4.2" />
+    <PackageVersion Include="Humanizer.Core" Version="2.14.1" />
+    <PackageVersion Include="IronCompress" Version="1.6.3" />
+    <PackageVersion Include="JetBrains.Annotations" Version="2024.3.0" />
+    <PackageVersion Include="Jint" Version="4.1.0" />
+    <PackageVersion Include="LinqKit.Core" Version="1.2.8" />
+    <PackageVersion Include="MailKit" Version="4.9.0" />
+    <PackageVersion Include="MassTransit" Version="8.3.4" />
+    <PackageVersion Include="MassTransit.Azure.ServiceBus.Core" Version="8.3.4" />
+    <PackageVersion Include="MassTransit.RabbitMQ" Version="8.3.4" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.12.0" />
+    <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.2.2" />
+    <PackageVersion Include="Microsoft.Identity.Client" Version="4.67.2" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageVersion Include="Microsoft.SemanticKernel" Version="1.34.0" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+    <PackageVersion Include="MongoDB.Driver" Version="3.1.0" />
+    <PackageVersion Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="2.0.0" />
+    <PackageVersion Include="MongoDB.Driver.Extensions" Version="2.0.2" />
+    <PackageVersion Include="MySql.Data" Version="9.1.0" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageVersion Include="NSubstitute" Version="5.3.0" />
+    <PackageVersion Include="NuGet.Packaging" Version="6.12.1" />
+    <PackageVersion Include="NuGet.Protocol" Version="6.12.1" />
+    <PackageVersion Include="Nuke.Components" Version="9.0.4" />
+    <PackageVersion Include="Open.Linq.AsyncExtensions" Version="1.2.0" />
+    <PackageVersion Include="OpenTelemetry.AutoInstrumentation" Version="1.10.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.11.0-beta.1" />
+    <PackageVersion Include="Polly.Extensions.Http" Version="3.0.0" />
+    <PackageVersion Include="PolySharp" Version="1.15.0" />
+    <PackageVersion Include="Proto.Actor" Version="1.7.0" />
+    <PackageVersion Include="Proto.Cluster" Version="1.7.0" />
+    <PackageVersion Include="Proto.Cluster.AzureContainerApps" Version="1.7.0" />
+    <PackageVersion Include="Proto.Cluster.CodeGen" Version="1.7.0" />
+    <PackageVersion Include="Proto.Cluster.Kubernetes" Version="1.7.0" />
+    <PackageVersion Include="Proto.Cluster.TestProvider" Version="1.7.0" />
+    <PackageVersion Include="Proto.OpenTelemetry" Version="1.7.0" />
+    <PackageVersion Include="Proto.Persistence" Version="1.7.0" />
+    <PackageVersion Include="Proto.Persistence.Sqlite" Version="1.7.0" />
+    <PackageVersion Include="Proto.Persistence.SqlServer" Version="1.7.0" />
+    <PackageVersion Include="Proto.Remote" Version="1.7.0" />
+    <PackageVersion Include="pythonnet" Version="3.1.0-preview2024-09-06" />
+    <PackageVersion Include="Quartz.Extensions.Hosting" Version="3.13.1" />
+    <PackageVersion Include="Quartz.Serialization.Json" Version="3.13.1" />
+    <PackageVersion Include="Scrutor" Version="6.0.1" />
+    <PackageVersion Include="ShortGuid" Version="2.0.1" />
+    <PackageVersion Include="StackExchange.Redis" Version="2.8.24" />
+    <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <PackageVersion Include="System.Data.SqlClient" Version="4.9.0" />
+    <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
+    <PackageVersion Include="System.Linq.Dynamic.Core" Version="1.6.0-preview-02" />
+    <PackageVersion Include="System.Net.Http" Version="4.3.4" />
+    <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
+    <PackageVersion Include="Testcontainers" Version="4.1.0" />
+    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.1.0" />
+    <PackageVersion Include="Testcontainers.RabbitMq" Version="4.1.0" />
+    <PackageVersion Include="Testcontainers.Redis" Version="4.1.0" />
+    <PackageVersion Include="ThrottleDebounce" Version="2.0.0" />
+    <PackageVersion Include="WebhooksCore" Version="0.0.1" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.abstractions" Version="2.0.3" />
+    <PackageVersion Include="xunit.extensibility.core" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.1" />
+    <PackageVersion Include="Yarp.ReverseProxy" Version="2.2.0" />
+    <PackageVersion Include="AspNetCore.Authentication.ApiKey" Version="8.0.1" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="8.0.12" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.12" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.12" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.12" />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="8.0.12" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.12" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="8.0.12" />
+    <PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="8.0.12" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.12" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.12" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.12" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.12" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.12" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="8.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="8.0.12" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+    <PackageVersion Include="Npgsql" Version="8.0.6" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
+    <PackageVersion Include="Oracle.EntityFrameworkCore" Version="8.23.70" />
+    <PackageVersion Include="Polly" Version="8.5.1" />
+    <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.2" />
+    <PackageVersion Include="Refit" Version="8.0.0" />
+    <PackageVersion Include="Refit.HttpClientFactory" Version="8.0.0" />
+    <PackageVersion Include="System.Formats.Asn1" Version="8.0.1" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+    <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.1" />
+    <PackageVersion Include="Npgsql" Version="9.0.2" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.3" />
+    <PackageVersion Include="Oracle.EntityFrameworkCore" Version="9.23.60" />
+    <PackageVersion Include="Polly" Version="8.5.1" />
+    <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="9.0.0-preview.2.efcore.9.0.0" />
+    <PackageVersion Include="Refit" Version="8.0.0" />
+    <PackageVersion Include="Refit.HttpClientFactory" Version="8.0.0" />
+    <PackageVersion Include="System.Formats.Asn1" Version="9.0.1" />
+    <PackageVersion Include="System.Text.Json" Version="9.0.1" />
+  </ItemGroup>
 </Project>

--- a/src/apps/Elsa.Server.Web/Program.cs
+++ b/src/apps/Elsa.Server.Web/Program.cs
@@ -68,6 +68,8 @@ using Medallion.Threading.Postgres;
 using Medallion.Threading.Redis;
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Options;
+using OpenTelemetry;
+using OpenTelemetry.Trace;
 using Proto.Cluster.Kubernetes;
 using Proto.Persistence.Sqlite;
 using Proto.Persistence.SqlServer;
@@ -120,6 +122,14 @@ var sqlDatabaseProvider = Enum.Parse<SqlDatabaseProvider>(configuration["Databas
 // Optionally create type aliases for easier configuration.
 TypeAliasRegistry.RegisterAlias("OrderReceivedProducerFactory", typeof(GenericProducerFactory<string, OrderReceived>));
 TypeAliasRegistry.RegisterAlias("OrderReceivedConsumerFactory", typeof(GenericConsumerFactory<string, OrderReceived>));
+
+// Configure OpenTelemetry Tracing
+using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+    .AddSource("Elsa.Workflows") // Match your ActivitySource name here
+    .SetSampler(new AlwaysOnSampler()) // Always record traces for testing
+    .AddConsoleExporter() // Export spans to the console (optional)
+    .Build();
+
 
 // Add Elsa services.
 services
@@ -455,6 +465,7 @@ services
                     alterations.UseMassTransitDispatcher();
                 }
             })
+            .UseOpenTelemetry()
             .UseWorkflowContexts();
 
         if (useQuartz)

--- a/src/modules/Elsa.OpenTelemetry/Abstractions/ErrorSpanHandlerBase.cs
+++ b/src/modules/Elsa.OpenTelemetry/Abstractions/ErrorSpanHandlerBase.cs
@@ -1,0 +1,9 @@
+using Elsa.OpenTelemetry.Contracts;
+using Elsa.OpenTelemetry.Models;
+
+namespace Elsa.OpenTelemetry.Abstractions;
+
+public abstract class ErrorSpanHandlerBase : IErrorSpanHandler
+{
+    public abstract void Handle(ErrorSpanContext context);
+}

--- a/src/modules/Elsa.OpenTelemetry/Contracts/IErrorSpanHandler.cs
+++ b/src/modules/Elsa.OpenTelemetry/Contracts/IErrorSpanHandler.cs
@@ -1,0 +1,10 @@
+using Elsa.OpenTelemetry.Abstractions;
+using Elsa.OpenTelemetry.Models;
+
+namespace Elsa.OpenTelemetry.Contracts;
+
+public interface IErrorSpanHandler
+{
+    void Handle(ErrorSpanContext context);
+}
+

--- a/src/modules/Elsa.OpenTelemetry/Extensions/ModuleExtensions.cs
+++ b/src/modules/Elsa.OpenTelemetry/Extensions/ModuleExtensions.cs
@@ -1,0 +1,14 @@
+using Elsa.Features.Services;
+using Elsa.OpenTelemetry.Features;
+
+// ReSharper disable once CheckNamespace
+namespace Elsa.Extensions;
+
+public static class ModuleExtensions
+{
+    public static IModule UseOpenTelemetry(this IModule configuration, Action<OpenTelemetryFeature>? configure = null)
+    {
+        configuration.Configure(configure);
+        return configuration;
+    }
+}

--- a/src/modules/Elsa.OpenTelemetry/Features/OpenTelemetryFeature.cs
+++ b/src/modules/Elsa.OpenTelemetry/Features/OpenTelemetryFeature.cs
@@ -1,5 +1,8 @@
 using Elsa.Features.Abstractions;
 using Elsa.Features.Services;
+using Elsa.OpenTelemetry.Contracts;
+using Elsa.OpenTelemetry.Handlers;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Elsa.OpenTelemetry.Features;
 
@@ -7,5 +10,8 @@ public class OpenTelemetryFeature(IModule module) : FeatureBase(module)
 {
     public override void Configure()
     {
+        Services
+            .AddScoped<IErrorSpanHandler, DefaultErrorSpanHandler>()
+            .AddScoped<IErrorSpanHandler, FaultExceptionErrorSpanHandler>();
     }
 }

--- a/src/modules/Elsa.OpenTelemetry/Handlers/DefaultErrorSpanHandler.cs
+++ b/src/modules/Elsa.OpenTelemetry/Handlers/DefaultErrorSpanHandler.cs
@@ -1,0 +1,24 @@
+using Elsa.OpenTelemetry.Abstractions;
+using Elsa.OpenTelemetry.Models;
+
+namespace Elsa.OpenTelemetry.Handlers;
+
+public class DefaultErrorSpanHandler : ErrorSpanHandlerBase
+{
+    public override void Handle(ErrorSpanContext context)
+    {
+        var span = context.Span;
+        var exception = context.Exception;
+        var errorMessage = string.IsNullOrWhiteSpace(exception?.Message) ? "Unknown error" : exception.Message;
+        span.SetTag("error", true);
+        span.SetTag("error.message", errorMessage);
+
+        if (exception != null)
+        {
+            span.SetTag("error.exceptionType", exception.GetType().FullName);
+
+            if (!string.IsNullOrEmpty(exception.StackTrace))
+                span.SetTag("error.stackTrace", exception.StackTrace);
+        }
+    }
+}

--- a/src/modules/Elsa.OpenTelemetry/Handlers/FaultExceptionErrorSpanHandler.cs
+++ b/src/modules/Elsa.OpenTelemetry/Handlers/FaultExceptionErrorSpanHandler.cs
@@ -1,0 +1,19 @@
+using Elsa.OpenTelemetry.Abstractions;
+using Elsa.OpenTelemetry.Models;
+using Elsa.Workflows.Exceptions;
+
+namespace Elsa.OpenTelemetry.Handlers;
+
+public class FaultExceptionErrorSpanHandler : ErrorSpanHandlerBase
+{
+    public override void Handle(ErrorSpanContext context)
+    {
+        if(context.Exception is not FaultException faultException)
+            return;
+        
+        var span = context.Span;
+        span.SetTag("error.code", faultException.Code);
+        span.SetTag("error.category", faultException.Category);
+        span.SetTag("error.faultType", faultException.Type);
+    }
+}

--- a/src/modules/Elsa.OpenTelemetry/Models/ErrorSpanContext.cs
+++ b/src/modules/Elsa.OpenTelemetry/Models/ErrorSpanContext.cs
@@ -1,0 +1,9 @@
+using System.Diagnostics;
+
+namespace Elsa.OpenTelemetry.Models;
+
+public class ErrorSpanContext(Activity span, Exception? exception)
+{
+    public Activity Span => span;
+    public Exception? Exception => exception;
+}


### PR DESCRIPTION
Introduce infrastructure for handling error spans with OpenTelemetry, including `DefaultErrorSpanHandler` and `FaultExceptionErrorSpanHandler`. Define core abstractions (`ErrorSpanHandlerBase`, `IErrorSpanHandler`) and utilities for customizing OpenTelemetry integration. This enables improved error tracing and categorization in workflows.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6427)
<!-- Reviewable:end -->
