### PR TITLE
Add OpenTelemetry error span handling infrastructure

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -68,9 +68,10 @@
     <PackageVersion Include="NuGet.Protocol" Version="6.10.1" />
     <PackageVersion Include="Nuke.Components" Version="8.0.0" />
     <PackageVersion Include="Open.Linq.AsyncExtensions" Version="1.2.0" />
-    <PackageVersion Include="OpenTelemetry.AutoInstrumentation" Version="1.7.0" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.0.0-rc9.15" />
+    <PackageVersion Include="OpenTelemetry" Version="1.11.1" />
+    <PackageVersion Include="OpenTelemetry.AutoInstrumentation" Version="1.10.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.11.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.11.0-beta.1" />
     <PackageVersion Include="Polly.Extensions.Http" Version="3.0.0" />
     <PackageVersion Include="PolySharp" Version="1.14.1" />
     <PackageVersion Include="Proto.Actor" Version="1.6.0" />

--- a/src/bundles/Elsa.Server.Web/Program.cs
+++ b/src/bundles/Elsa.Server.Web/Program.cs
@@ -322,6 +322,7 @@ services
                     alterations.UseMassTransitDispatcher();
                 }
             })
+            .UseOpenTelemetry()
             .UseWorkflowContexts();
 
         if (useQuartz)

--- a/src/modules/Elsa.OpenTelemetry/Abstractions/ErrorSpanHandlerBase.cs
+++ b/src/modules/Elsa.OpenTelemetry/Abstractions/ErrorSpanHandlerBase.cs
@@ -1,0 +1,9 @@
+using Elsa.OpenTelemetry.Contracts;
+using Elsa.OpenTelemetry.Models;
+
+namespace Elsa.OpenTelemetry.Abstractions;
+
+public abstract class ErrorSpanHandlerBase : IErrorSpanHandler
+{
+    public abstract void Handle(ErrorSpanContext context);
+}

--- a/src/modules/Elsa.OpenTelemetry/Contracts/IErrorSpanHandler.cs
+++ b/src/modules/Elsa.OpenTelemetry/Contracts/IErrorSpanHandler.cs
@@ -1,0 +1,10 @@
+using Elsa.OpenTelemetry.Abstractions;
+using Elsa.OpenTelemetry.Models;
+
+namespace Elsa.OpenTelemetry.Contracts;
+
+public interface IErrorSpanHandler
+{
+    void Handle(ErrorSpanContext context);
+}
+

--- a/src/modules/Elsa.OpenTelemetry/Contracts/IErrorSpanHandler.cs
+++ b/src/modules/Elsa.OpenTelemetry/Contracts/IErrorSpanHandler.cs
@@ -1,4 +1,3 @@
-using Elsa.OpenTelemetry.Abstractions;
 using Elsa.OpenTelemetry.Models;
 
 namespace Elsa.OpenTelemetry.Contracts;

--- a/src/modules/Elsa.OpenTelemetry/Extensions/ModuleExtensions.cs
+++ b/src/modules/Elsa.OpenTelemetry/Extensions/ModuleExtensions.cs
@@ -1,0 +1,14 @@
+using Elsa.Features.Services;
+using Elsa.OpenTelemetry.Features;
+
+// ReSharper disable once CheckNamespace
+namespace Elsa.Extensions;
+
+public static class ModuleExtensions
+{
+    public static IModule UseOpenTelemetry(this IModule configuration, Action<OpenTelemetryFeature>? configure = null)
+    {
+        configuration.Configure(configure);
+        return configuration;
+    }
+}

--- a/src/modules/Elsa.OpenTelemetry/Features/OpenTelemetryFeature.cs
+++ b/src/modules/Elsa.OpenTelemetry/Features/OpenTelemetryFeature.cs
@@ -1,5 +1,8 @@
 using Elsa.Features.Abstractions;
 using Elsa.Features.Services;
+using Elsa.OpenTelemetry.Contracts;
+using Elsa.OpenTelemetry.Handlers;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Elsa.OpenTelemetry.Features;
 
@@ -7,5 +10,8 @@ public class OpenTelemetryFeature(IModule module) : FeatureBase(module)
 {
     public override void Configure()
     {
+        Services
+            .AddScoped<IErrorSpanHandler, DefaultErrorSpanHandler>()
+            .AddScoped<IErrorSpanHandler, FaultExceptionErrorSpanHandler>();
     }
 }

--- a/src/modules/Elsa.OpenTelemetry/Handlers/DefaultErrorSpanHandler.cs
+++ b/src/modules/Elsa.OpenTelemetry/Handlers/DefaultErrorSpanHandler.cs
@@ -1,0 +1,24 @@
+using Elsa.OpenTelemetry.Abstractions;
+using Elsa.OpenTelemetry.Models;
+
+namespace Elsa.OpenTelemetry.Handlers;
+
+public class DefaultErrorSpanHandler : ErrorSpanHandlerBase
+{
+    public override void Handle(ErrorSpanContext context)
+    {
+        var span = context.Span;
+        var exception = context.Exception;
+        var errorMessage = string.IsNullOrWhiteSpace(exception?.Message) ? "Unknown error" : exception.Message;
+        span.SetTag("error", true);
+        span.SetTag("error.message", errorMessage);
+
+        if (exception != null)
+        {
+            span.SetTag("error.exceptionType", exception.GetType().FullName);
+
+            if (!string.IsNullOrEmpty(exception.StackTrace))
+                span.SetTag("error.stackTrace", exception.StackTrace);
+        }
+    }
+}

--- a/src/modules/Elsa.OpenTelemetry/Handlers/FaultExceptionErrorSpanHandler.cs
+++ b/src/modules/Elsa.OpenTelemetry/Handlers/FaultExceptionErrorSpanHandler.cs
@@ -1,0 +1,19 @@
+using Elsa.OpenTelemetry.Abstractions;
+using Elsa.OpenTelemetry.Models;
+using Elsa.Workflows.Exceptions;
+
+namespace Elsa.OpenTelemetry.Handlers;
+
+public class FaultExceptionErrorSpanHandler : ErrorSpanHandlerBase
+{
+    public override void Handle(ErrorSpanContext context)
+    {
+        if(context.Exception is not FaultException faultException)
+            return;
+        
+        var span = context.Span;
+        span.SetTag("error.code", faultException.Code);
+        span.SetTag("error.category", faultException.Category);
+        span.SetTag("error.faultType", faultException.Type);
+    }
+}

--- a/src/modules/Elsa.OpenTelemetry/Middleware/OpenTelemetryTracingActivityExecutionMiddleware.cs
+++ b/src/modules/Elsa.OpenTelemetry/Middleware/OpenTelemetryTracingActivityExecutionMiddleware.cs
@@ -1,12 +1,13 @@
 using System.Diagnostics;
+using Elsa.Common;
 using Elsa.Common.Contracts;
+using Elsa.OpenTelemetry.Contracts;
 using Elsa.OpenTelemetry.Helpers;
+using Elsa.OpenTelemetry.Models;
 using Elsa.Workflows;
 using Elsa.Workflows.Contracts;
 using Elsa.Workflows.Pipelines.ActivityExecution;
-using Elsa.Workflows.Pipelines.WorkflowExecution;
 using JetBrains.Annotations;
-using Newtonsoft.Json;
 using Activity = System.Diagnostics.Activity;
 using ActivityKind = System.Diagnostics.ActivityKind;
 
@@ -20,7 +21,7 @@ public class OpenTelemetryTracingActivityExecutionMiddleware(ActivityMiddlewareD
     public async ValueTask InvokeAsync(ActivityExecutionContext context)
     {
         var activity = context.Activity;
-        using var span = ElsaOpenTelemetry.ActivitySource.StartActivity($"ActivityExecution", ActivityKind.Internal, Activity.Current?.Context ?? default);
+        using var span = ElsaOpenTelemetry.ActivitySource.StartActivity("ActivityExecution", ActivityKind.Internal, Activity.Current?.Context ?? default);
 
         if (span == null)
         {
@@ -34,26 +35,25 @@ public class OpenTelemetryTracingActivityExecutionMiddleware(ActivityMiddlewareD
         span.SetTag("activityInstance.id", context.Id);
         span.SetTag("activityExecution.startTimeUtc", span.StartTimeUtc);
         
-        span.AddEvent(new ActivityEvent("Executing", tags: CreateStatusTags(context)));
+        span.AddEvent(new("Executing", tags: CreateStatusTags(context)));
         
         await next(context);
 
         if (context.Status == ActivityStatus.Faulted)
         {
-            span.AddEvent(new ActivityEvent("Faulted", tags: CreateStatusTags(context)));
+            span.AddEvent(new("Faulted", tags: CreateStatusTags(context)));
             span.SetStatus(ActivityStatusCode.Error);
-            span.SetTag("error", true);
             span.SetTag("activityInstance.hasIncidents", true);
 
-            var errorMessage = string.IsNullOrWhiteSpace(context.Exception?.Message) ? "Unknown error" : context.Exception.Message;
-            span.SetTag("error.message", errorMessage);
+            var errorSpanHandlers = context.GetServices<IErrorSpanHandler>();
+            var errorSpanHandlerContext = new ErrorSpanContext(span, context.Exception);
             
-            if (!string.IsNullOrEmpty(context.Exception?.StackTrace))
-                span.SetTag("error.stackTrace", context.Exception.StackTrace);
+            foreach (var handler in errorSpanHandlers) 
+                handler.Handle(errorSpanHandlerContext);
         }
         else
         {
-            span.AddEvent(new ActivityEvent("Executed", tags: CreateStatusTags(context)));
+            span.AddEvent(new("Executed", tags: CreateStatusTags(context)));
             span.SetStatus(ActivityStatusCode.Ok);
         }
         
@@ -64,7 +64,7 @@ public class OpenTelemetryTracingActivityExecutionMiddleware(ActivityMiddlewareD
     
     private ActivityTagsCollection CreateStatusTags(ActivityExecutionContext context)
     {
-        return new ActivityTagsCollection(new Dictionary<string, object?>
+        return new(new Dictionary<string, object?>
         {
             ["activityInstance.status"] = context.Status.ToString()
         });
@@ -77,6 +77,8 @@ public class OpenTelemetryTracingActivityExecutionMiddleware(ActivityMiddlewareD
 [UsedImplicitly]
 public static class OpenTelemetryTracingActivityExecutionMiddlewareExtensions
 {
+    /// <summary>
     /// Installs the <see cref="OpenTelemetryTracingActivityExecutionMiddleware"/> component in the workflow execution pipeline.
+    /// </summary>
     public static IActivityExecutionPipelineBuilder UseActivityExecutionTracing(this IActivityExecutionPipelineBuilder pipelineBuilder) => pipelineBuilder.Insert<OpenTelemetryTracingActivityExecutionMiddleware>(0);
 }

--- a/src/modules/Elsa.OpenTelemetry/Models/ErrorSpanContext.cs
+++ b/src/modules/Elsa.OpenTelemetry/Models/ErrorSpanContext.cs
@@ -1,0 +1,9 @@
+using System.Diagnostics;
+
+namespace Elsa.OpenTelemetry.Models;
+
+public class ErrorSpanContext(Activity span, Exception? exception)
+{
+    public Activity Span => span;
+    public Exception? Exception => exception;
+}


### PR DESCRIPTION
Introduce infrastructure for handling error spans with OpenTelemetry, including `DefaultErrorSpanHandler` and `FaultExceptionErrorSpanHandler`. Define core abstractions (`ErrorSpanHandlerBase`, `IErrorSpanHandler`) and utilities for customizing OpenTelemetry integration. This enables improved error tracing and categorization in workflows.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6428)
<!-- Reviewable:end -->
