### PR TITLE
Enable configurable toggle for workflow inbox cleanup job

### DIFF
--- a/src/modules/Elsa.Workflows.Runtime/Features/WorkflowRuntimeFeature.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Features/WorkflowRuntimeFeature.cs
@@ -31,8 +31,6 @@ namespace Elsa.Workflows.Runtime.Features;
 [DependsOn(typeof(SystemClockFeature))]
 public class WorkflowRuntimeFeature(IModule module) : FeatureBase(module)
 {
-    private bool _enableWorkflowInboxCleanupJob = true;
-
     private IDictionary<string, DispatcherChannel> WorkflowDispatcherChannels { get; set; } = new Dictionary<string, DispatcherChannel>();
 
     /// <summary>
@@ -134,7 +132,7 @@ public class WorkflowRuntimeFeature(IModule module) : FeatureBase(module)
     /// </summary>
     public WorkflowRuntimeFeature EnableWorkflowInboxCleanupJob()
     {
-        _enableWorkflowInboxCleanupJob = true;
+        Services.Configure<WorkflowInboxCleanupOptions>(options => { options.IsEnabled = true; });
         return this;
     }
 
@@ -143,7 +141,7 @@ public class WorkflowRuntimeFeature(IModule module) : FeatureBase(module)
     /// </summary>
     public WorkflowRuntimeFeature DisableWorkflowInboxCleanupJob()
     {
-        _enableWorkflowInboxCleanupJob = false;
+        Services.Configure<WorkflowInboxCleanupOptions>(options => { options.IsEnabled = false; });
         return this;
     }
 
@@ -203,7 +201,7 @@ public class WorkflowRuntimeFeature(IModule module) : FeatureBase(module)
     public override void ConfigureHostedServices()
     {
         Module.ConfigureHostedService<PopulateRegistriesHostedService>();
-        if (_enableWorkflowInboxCleanupJob) Module.ConfigureHostedService<WorkflowInboxCleanupHostedService>();
+        Module.ConfigureHostedService<WorkflowInboxCleanupHostedService>();
     }
 
     /// <inheritdoc />

--- a/src/modules/Elsa.Workflows.Runtime/HostedServices/WorkflowInboxCleanupHostedService.cs
+++ b/src/modules/Elsa.Workflows.Runtime/HostedServices/WorkflowInboxCleanupHostedService.cs
@@ -32,6 +32,12 @@ public class WorkflowInboxCleanupHostedService : BackgroundService
     /// <inheritdoc />
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
+        if (!_options.Value.IsEnabled)
+        {
+            _logger.LogInformation("Expired workflow inbox messages cleanup service is disabled");
+            return;
+        }
+
         while (!stoppingToken.IsCancellationRequested)
         {
             _logger.LogInformation("Entering expired workflow inbox messages cleanup service loop");

--- a/src/modules/Elsa.Workflows.Runtime/Options/WorkflowInboxCleanupOptions.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Options/WorkflowInboxCleanupOptions.cs
@@ -14,4 +14,9 @@ public class WorkflowInboxCleanupOptions
     /// The number of messages to clean up per sweep.
     /// </summary>
     public int BatchSize { get; set; } = 1000;
+
+    /// <summary>
+    /// Whether the workflow inbox cleanup is enabled.
+    /// </summary>
+    public bool IsEnabled { get; set; } = true;
 }


### PR DESCRIPTION
Introduced an `IsEnabled` property in `WorkflowInboxCleanupOptions` to allow enabling or disabling the cleanup service. Updated related logic to respect this configuration, removing the redundant `_enableWorkflowInboxCleanupJob` field. Ensures easier management of the inbox cleanup feature via configuration.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6429)
<!-- Reviewable:end -->
