### PR TITLE
Stop DefaultBookmarkQueuePurger log spamming

### DIFF
--- a/src/modules/Elsa.Workflows.Runtime/Services/DefaultBookmarkQueuePurger.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Services/DefaultBookmarkQueuePurger.cs
@@ -19,7 +19,7 @@ public class DefaultBookmarkQueuePurger(IBookmarkQueueStore store, ISystemClock 
         var now = systemClock.UtcNow;
         var thresholdDate = now - options.Value.Ttl;
 
-        logger.LogInformation("Purging bookmark queue items older than {ThresholdDate}.", thresholdDate);
+        logger.LogDebug("Purging bookmark queue items older than {ThresholdDate}.", thresholdDate);
 
         while (true)
         {
@@ -46,6 +46,6 @@ public class DefaultBookmarkQueuePurger(IBookmarkQueueStore store, ISystemClock 
             currentPage++;
         }
 
-        logger.LogInformation("Finished purging bookmark queue items.");
+        logger.LogDebug("Finished purging bookmark queue items.");
     }
 }


### PR DESCRIPTION
Based on default scheduling, DefaultBookmarkQueuePurger logs two low value information log entries every 10 seconds. I could filter all of the logging out with logging config, but that would also filter out this seemingly useful log entry too
`logger.LogInformation("Purged {Count} bookmark queue items.", items.Count);`

This is how our logs looked before this change
![image](https://github.com/user-attachments/assets/1474ddf2-5062-47c5-ac79-b3c5417b0d9f)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6452)
<!-- Reviewable:end -->
