### PR TITLE
2.x Added data column compression for Entity Framework persistance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,4 @@ src/designer/elsa-workflows-studio/loader
 # Created by developers using GNU/Linux
 .directory
 launchSettings.json
+/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/Properties/PublishProfiles/FolderProfile.pubxml


### PR DESCRIPTION
On the v2 workflows when creating and running large multi-step workflows the data stored on ms sql in json format gets very large.

This change adds compression on the serialized json to reduce the data stored and decompresses it again during loading and serialization.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6457)
<!-- Reviewable:end -->
