### PR TITLE
Harmonized launchSettings to be inline with appSettings

### DIFF
--- a/src/apps/Elsa.ServerAndStudio.Web/Properties/launchSettings.json
+++ b/src/apps/Elsa.ServerAndStudio.Web/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:42712",
+      "applicationUrl": "http://localhost:8080",
       "sslPort": 44363
     }
   },
@@ -12,7 +12,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      "applicationUrl": "https://localhost:5001;http://localhost:5000",
+      "applicationUrl": "https://localhost:8080",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }


### PR DESCRIPTION
In the appSettings for the ServerAndStudio.Web project the baseUrl is configured as 8080.
This PR will align the launchSettings to be inline with that configuration so that it does not throw errors on startup.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6467)
<!-- Reviewable:end -->
