### PR TITLE
Add support for passing initial variables

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -8,6 +8,7 @@ on:
       - 'perf/*'
       - 'patch/*'
       - 'feat/*'
+      - 'enh/*'
   release:
     types: [ prereleased, published ]
 env:

--- a/src/modules/Elsa.Quartz/Jobs/RunWorkflowJob.cs
+++ b/src/modules/Elsa.Quartz/Jobs/RunWorkflowJob.cs
@@ -33,6 +33,7 @@ public class RunWorkflowJob(
                 CorrelationId = (string?)map.Get(nameof(ScheduleNewWorkflowInstanceRequest.CorrelationId)),
                 TriggerActivityId = (string?)map.Get(nameof(ScheduleNewWorkflowInstanceRequest.TriggerActivityId)),
                 Input = map.GetDictionary(nameof(ScheduleNewWorkflowInstanceRequest.Input)),
+                Variables = map.GetDictionary(nameof(ScheduleNewWorkflowInstanceRequest.Variables)),
                 Properties = map.GetDictionary(nameof(ScheduleNewWorkflowInstanceRequest.Properties)),
                 ParentId = (string?)map.Get(nameof(ScheduleNewWorkflowInstanceRequest.ParentId))
             };

--- a/src/modules/Elsa.Scheduling/Requests/ScheduleNewWorkflowInstanceRequest.cs
+++ b/src/modules/Elsa.Scheduling/Requests/ScheduleNewWorkflowInstanceRequest.cs
@@ -20,6 +20,11 @@ public class ScheduleNewWorkflowInstanceRequest
     public IDictionary<string, object>? Input { get; set; }
 
     /// <summary>
+    /// A collection of variables to pass to the workflow instance during scheduling.
+    /// </summary>
+    public IDictionary<string, object>? Variables { get; set; }
+
+    /// <summary>
     /// Any properties to assign to the workflow instance.
     /// </summary>
     public IDictionary<string, object>? Properties { get; set; }

--- a/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/Execute/EndpointBase.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/Execute/EndpointBase.cs
@@ -44,6 +44,7 @@ internal abstract class EndpointBase<T>(
             Workflow = workflowGraph.Workflow,
             CorrelationId = request.CorrelationId,
             Input = request.GetInputAsDictionary(),
+            Variables = request.GetVariablesAsDictionary(),
             TriggerActivityId = request.TriggerActivityId,
             ActivityHandle = request.ActivityHandle
         };

--- a/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/Execute/Models.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/Execute/Models.cs
@@ -18,11 +18,12 @@ public interface IExecutionRequest
     VersionOptions? VersionOptions { get; }
 
     IDictionary<string, object>? GetInputAsDictionary();
+    IDictionary<string, object>? GetVariablesAsDictionary();
 }
 
 public class PostRequest : IExecutionRequest
 {
-    public string DefinitionId { get; set; } = default!;
+    public string DefinitionId { get; set; } = null!;
     public string? CorrelationId { get; set; }
     public string? TriggerActivityId { get; set; }
     public ActivityHandle? ActivityHandle { get; set; }
@@ -30,24 +31,32 @@ public class PostRequest : IExecutionRequest
 
     [JsonConverter(typeof(ExpandoObjectConverterFactory))]
     public object? Input { get; set; }
+    
+    [JsonConverter(typeof(ExpandoObjectConverterFactory))]
+    public object? Variables { get; set; }
 
     public IDictionary<string, object>? GetInputAsDictionary() => (IDictionary<string, object>?)Input;
+    public IDictionary<string, object>? GetVariablesAsDictionary() => (IDictionary<string, object>?)Variables;
 }
 
 public class GetRequest : IExecutionRequest
 {
-    public string DefinitionId { get; set; } = default!;
+    public string DefinitionId { get; set; } = null!;
     public string? CorrelationId { get; set; }
     public string? TriggerActivityId { get; set; }
     public ActivityHandle? ActivityHandle { get; set; }
     public VersionOptions? VersionOptions { get; set; }
     public string? Input { get; set; }
+    public string? Variables { get; set; }
 
-    public IDictionary<string, object>? GetInputAsDictionary()
+    public IDictionary<string, object>? GetInputAsDictionary() => ParseStringAsDictionary(Input);
+    public IDictionary<string, object>? GetVariablesAsDictionary() => ParseStringAsDictionary(Variables);
+
+    private IDictionary<string, object>? ParseStringAsDictionary(string? value)
     {
-        var result = Input?.TryConvertTo<ExpandoObject>(new ObjectConverterOptions
+        var result = value?.TryConvertTo<ExpandoObject>(new()
         {
-            SerializerOptions = new JsonSerializerOptions
+            SerializerOptions = new()
             {
                 Converters = { new ExpandoObjectConverter() }
             }

--- a/src/modules/Elsa.Workflows.Core/Extensions/ActivityExecutionContextExtensions.cs
+++ b/src/modules/Elsa.Workflows.Core/Extensions/ActivityExecutionContextExtensions.cs
@@ -93,6 +93,31 @@ public static partial class ActivityExecutionContextExtensions
     public static Variable SetVariable(this ActivityExecutionContext context, string name, object? value, Action<MemoryBlock>? configure = null) =>
         context.ExpressionExecutionContext.SetVariable(name, value, configure);
 
+    public static Variable SetDynamicVariable<T>(this ActivityExecutionContext context, string name, T value, Action<MemoryBlock>? configure = null)
+    {
+        // Check if a predefined variable already exists.
+        var predefinedVariable = context.ExpressionExecutionContext.GetVariable(name);
+
+        if (predefinedVariable != null)
+        {
+            context.SetVariable(name, value);
+            return predefinedVariable;
+        }
+        
+        // No predefined variable exists, so we will add a dynamic variable to the current container in scope.
+        var container = context.FindParentWithVariableContainer();
+
+        if (container == null)
+            throw new("No parent variable container found");
+
+        var existingVariable = container.DynamicVariables.FirstOrDefault(x => x.Name == name);
+
+        if (existingVariable == null)
+            container.DynamicVariables.Add(new Variable<T>(name, value));
+
+        return context.SetVariable(name, value);
+    }
+
     /// <summary>
     /// Gets a workflow variable by name.
     /// </summary>
@@ -140,7 +165,7 @@ public static partial class ActivityExecutionContextExtensions
         {
             var activity = node.Activity;
             var activityDescriptor = await activityRegistryLookup.FindAsync(activity.Type, activity.Version);
-            if (activityDescriptor != null && activityDescriptor.Outputs.Any()) 
+            if (activityDescriptor != null && activityDescriptor.Outputs.Any())
                 yield return (activity, activityDescriptor);
         }
     }
@@ -188,7 +213,10 @@ public static partial class ActivityExecutionContextExtensions
     /// </summary>
     public static async ValueTask SendSignalAsync(this ActivityExecutionContext context, object signal)
     {
-        var receivingContexts = new[] { context }.Concat(context.GetAncestors()).ToList();
+        var receivingContexts = new[]
+        {
+            context
+        }.Concat(context.GetAncestors()).ToList();
         var logger = context.GetRequiredService<ILogger<ActivityExecutionContext>>();
         var signalType = signal.GetType();
         var signalTypeName = signalType.Name;
@@ -243,7 +271,7 @@ public static partial class ActivityExecutionContextExtensions
         // Send a signal.
         await context.SendSignalAsync(new ScheduleActivityOutcomes(outcomes));
     }
-    
+
     /// <summary>
     /// Cancel the activity. For blocking activities, it means their bookmarks will be removed. For job activities, the background work will be cancelled.
     /// </summary>
@@ -300,7 +328,7 @@ public static partial class ActivityExecutionContextExtensions
 
         return null;
     }
-    
+
     /// <summary>
     /// Returns a flattened list of the current context's ancestors.
     /// </summary>

--- a/src/modules/Elsa.Workflows.Core/Extensions/WorkflowExecutionContextExtensions.cs
+++ b/src/modules/Elsa.Workflows.Core/Extensions/WorkflowExecutionContextExtensions.cs
@@ -1,4 +1,5 @@
 using Elsa.Workflows;
+using Elsa.Workflows.Memory;
 using Elsa.Workflows.Models;
 using Elsa.Workflows.Options;
 using Microsoft.Extensions.Logging;
@@ -14,10 +15,10 @@ public static class WorkflowExecutionContextExtensions
     /// <summary>
     /// Schedules the workflow for execution.
     /// </summary>
-    public static ActivityWorkItem ScheduleWorkflow(this WorkflowExecutionContext workflowExecutionContext, IDictionary<string, object>? input = null)
+    public static ActivityWorkItem ScheduleWorkflow(this WorkflowExecutionContext workflowExecutionContext, IDictionary<string, object>? input = null, IEnumerable<Variable>? variables = null)
     {
         var workflow = workflowExecutionContext.Workflow;
-        var workItem = new ActivityWorkItem(workflow, input: input);
+        var workItem = new ActivityWorkItem(workflow, input: input, variables: variables);
         workflowExecutionContext.Scheduler.Schedule(workItem);
         return workItem;
     }
@@ -25,10 +26,10 @@ public static class WorkflowExecutionContextExtensions
     /// <summary>
     /// Schedules the root activity of the workflow.
     /// </summary>
-    public static ActivityWorkItem ScheduleRoot(this WorkflowExecutionContext workflowExecutionContext, IDictionary<string, object>? input = null)
+    public static ActivityWorkItem ScheduleRoot(this WorkflowExecutionContext workflowExecutionContext, IDictionary<string, object>? input = null, IEnumerable<Variable>? variables = null)
     {
         var workflow = workflowExecutionContext.Workflow;
-        var workItem = new ActivityWorkItem(workflow.Root, input: input);
+        var workItem = new ActivityWorkItem(workflow.Root, input: input, variables: variables);
         workflowExecutionContext.Scheduler.Schedule(workItem);
         return workItem;
     }
@@ -36,9 +37,9 @@ public static class WorkflowExecutionContextExtensions
     /// <summary>
     /// Schedules the specified activity of the workflow.
     /// </summary>
-    public static ActivityWorkItem ScheduleActivity(this WorkflowExecutionContext workflowExecutionContext, IActivity activity, IDictionary<string, object>? input = null)
+    public static ActivityWorkItem ScheduleActivity(this WorkflowExecutionContext workflowExecutionContext, IActivity activity, IDictionary<string, object>? input = null, IEnumerable<Variable>? variables = null)
     {
-        var workItem = new ActivityWorkItem(activity, input: input);
+        var workItem = new ActivityWorkItem(activity, input: input, variables: variables);
         workflowExecutionContext.Scheduler.Schedule(workItem);
         return workItem;
     }
@@ -46,9 +47,13 @@ public static class WorkflowExecutionContextExtensions
     /// <summary>
     /// Schedules the specified activity execution context of the workflow.
     /// </summary>
-    public static ActivityWorkItem ScheduleActivityExecutionContext(this WorkflowExecutionContext workflowExecutionContext, ActivityExecutionContext activityExecutionContext, IDictionary<string, object>? input = null)
+    public static ActivityWorkItem ScheduleActivityExecutionContext(this WorkflowExecutionContext workflowExecutionContext, ActivityExecutionContext activityExecutionContext, IDictionary<string, object>? input = null, IEnumerable<Variable>? variables = null)
     {
-        var workItem = new ActivityWorkItem(activityExecutionContext.Activity, input: input, existingActivityExecutionContext: activityExecutionContext);
+        var workItem = new ActivityWorkItem(
+            activityExecutionContext.Activity, 
+            input: input, 
+            variables: variables,
+            existingActivityExecutionContext: activityExecutionContext);
         workflowExecutionContext.Scheduler.Schedule(workItem);
         return workItem;
     }
@@ -57,7 +62,7 @@ public static class WorkflowExecutionContextExtensions
     /// Schedules the activity of the specified bookmark.
     /// </summary>
     /// <returns>The created work item, or <c>null</c> if the specified bookmark doesn't exist in the <see cref="WorkflowExecutionContext"/></returns> 
-    public static ActivityWorkItem? ScheduleBookmark(this WorkflowExecutionContext workflowExecutionContext, Bookmark bookmark, IDictionary<string, object>? input = null)
+    public static ActivityWorkItem? ScheduleBookmark(this WorkflowExecutionContext workflowExecutionContext, Bookmark bookmark, IDictionary<string, object>? input = null, IEnumerable<Variable>? variables = null)
     {
         // Get the activity execution context that owns the bookmark.
         var bookmarkedActivityContext = workflowExecutionContext.ActivityExecutionContexts.FirstOrDefault(x => x.Id == bookmark.ActivityInstanceId);
@@ -75,7 +80,8 @@ public static class WorkflowExecutionContextExtensions
         var workItem = new ActivityWorkItem(bookmarkedActivity)
         {
             ExistingActivityExecutionContext = bookmarkedActivityContext,
-            Input = input ?? new Dictionary<string, object>()
+            Input = input ?? new Dictionary<string, object>(),
+            Variables = variables
         };
         workflowExecutionContext.Scheduler.Schedule(workItem);
 

--- a/src/modules/Elsa.Workflows.Core/Options/RunWorkflowOptions.cs
+++ b/src/modules/Elsa.Workflows.Core/Options/RunWorkflowOptions.cs
@@ -12,6 +12,7 @@ public class RunWorkflowOptions
     public string? BookmarkId { get; set; }
     public ActivityHandle? ActivityHandle { get; set; }
     public IDictionary<string, object>? Input { get; set; }
+    public IDictionary<string, object>? Variables { get; set; }
     public IDictionary<string, object>? Properties { get; set; }
     public string? TriggerActivityId { get; set; }
     public string? ParentWorkflowInstanceId { get; set; }

--- a/src/modules/Elsa.Workflows.Management/Services/WorkflowInstanceFactory.cs
+++ b/src/modules/Elsa.Workflows.Management/Services/WorkflowInstanceFactory.cs
@@ -14,7 +14,7 @@ public class WorkflowInstanceFactory(IIdentityGenerator identityGenerator, ISyst
     public WorkflowState CreateWorkflowState(Workflow workflow, WorkflowInstanceOptions? options = null)
     {
         var now = systemClock.UtcNow;
-        return new WorkflowState
+        return new()
         {
             Id = string.IsNullOrEmpty(options?.WorkflowInstanceId) ? identityGenerator.GenerateId() : options.WorkflowInstanceId,
             DefinitionId = workflow.Identity.DefinitionId,
@@ -36,7 +36,7 @@ public class WorkflowInstanceFactory(IIdentityGenerator identityGenerator, ISyst
     public WorkflowInstance CreateWorkflowInstance(Workflow workflow, WorkflowInstanceOptions? options = null)
     {
         var workflowState = CreateWorkflowState(workflow, options);
-        return new WorkflowInstance
+        return new()
         {
             Id = workflowState.Id,
             ParentWorkflowInstanceId = workflowState.ParentWorkflowInstanceId,

--- a/src/modules/Elsa.Workflows.Runtime/Messages/CreateAndRunWorkflowInstanceRequest.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Messages/CreateAndRunWorkflowInstanceRequest.cs
@@ -12,7 +12,7 @@ public class CreateAndRunWorkflowInstanceRequest
     /// <summary>
     /// The ID of the workflow definition version to create an instance of.
     /// </summary>
-    public WorkflowDefinitionHandle WorkflowDefinitionHandle { get; set; } = default!;
+    public WorkflowDefinitionHandle WorkflowDefinitionHandle { get; set; } = null!;
 
     /// <summary>
     /// The correlation ID of the workflow, if any.
@@ -23,6 +23,11 @@ public class CreateAndRunWorkflowInstanceRequest
     /// The input to the workflow instance, if any.
     /// </summary>
     public IDictionary<string, object>? Input { get; set; }
+
+    /// <summary>
+    /// A collection of custom variables used within the workflow instance.
+    /// </summary>
+    public IDictionary<string, object>? Variables { get; set; }
 
     /// <summary>
     /// Any properties to assign to the workflow instance.

--- a/src/modules/Elsa.Workflows.Runtime/Messages/RunWorkflowInstanceRequest.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Messages/RunWorkflowInstanceRequest.cs
@@ -35,6 +35,11 @@ public class RunWorkflowInstanceRequest
     public IDictionary<string, object>? Input { get; set; }
 
     /// <summary>
+    /// A collection of variables to be used during the execution of a workflow instance.
+    /// </summary>
+    public IDictionary<string, object>? Variables { get; set; }
+
+    /// <summary>
     /// Represents an empty <see cref="RunWorkflowInstanceRequest"/> object used as a default value.
     /// </summary>
     public static RunWorkflowInstanceRequest Empty => new();

--- a/src/modules/Elsa.Workflows.Runtime/Requests/InvokeTriggerRequest.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Requests/InvokeTriggerRequest.cs
@@ -4,10 +4,11 @@ namespace Elsa.Workflows.Runtime;
 
 public class InvokeTriggerRequest
 {
-    public Workflow Workflow { get; set; } = default!;
-    public string ActivityId { get; set; } = default!;
+    public Workflow Workflow { get; set; } = null!;
+    public string ActivityId { get; set; } = null!;
     public string? CorrelationId { get; set; }
     public IDictionary<string, object>? Input { get; set; }
+    public IDictionary<string, object>? Variables { get; set; }
     public IDictionary<string, object>? Properties { get; set; }
     public string? ParentWorkflowInstanceId { get; set; }
     

--- a/src/modules/Elsa.Workflows.Runtime/Requests/StartWorkflowRequest.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Requests/StartWorkflowRequest.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using Elsa.Workflows.Activities;
 using Elsa.Workflows.Models;
 
@@ -26,6 +27,11 @@ public class StartWorkflowRequest
     /// The input to the workflow instance, if any.
     /// </summary>
     public IDictionary<string, object>? Input { get; set; }
+
+    /// <summary>
+    /// Any variables to set before starting the workflow.
+    /// </summary>
+    public IDictionary<string, object>? Variables { get; set; }
 
     /// <summary>
     /// Any properties to assign to the workflow instance.

--- a/src/modules/Elsa.Workflows.Runtime/Services/DefaultWorkflowStarter.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Services/DefaultWorkflowStarter.cs
@@ -30,6 +30,7 @@ public class DefaultWorkflowStarter(IWorkflowDefinitionService workflowDefinitio
             WorkflowDefinitionHandle = WorkflowDefinitionHandle.ByDefinitionVersionId(workflow.Identity.Id),
             CorrelationId = request.CorrelationId,
             Input = request.Input,
+            Variables = request.Variables,
             TriggerActivityId = request.TriggerActivityId,
             ActivityHandle = request.ActivityHandle,
             Properties = request.Properties,

--- a/src/modules/Elsa.Workflows.Runtime/Services/LocalWorkflowClient.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Services/LocalWorkflowClient.cs
@@ -66,6 +66,7 @@ public class LocalWorkflowClient(
         return await RunInstanceAsync(workflowInstance, new()
         {
             Input = request.Input,
+            Variables = request.Variables,
             Properties = request.Properties,
             TriggerActivityId = request.TriggerActivityId,
             ActivityHandle = request.ActivityHandle
@@ -119,6 +120,7 @@ public class LocalWorkflowClient(
         var runWorkflowOptions = new RunWorkflowOptions
         {
             Input = request.Input,
+            Variables = request.Variables,
             Properties = request.Properties,
             BookmarkId = request.BookmarkId,
             TriggerActivityId = request.TriggerActivityId,

--- a/src/modules/Elsa.Workflows.Runtime/Services/TriggerInvoker.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Services/TriggerInvoker.cs
@@ -9,6 +9,7 @@ public class TriggerInvoker(IWorkflowStarter workflowStarter) : ITriggerInvoker
             Workflow = request.Workflow,
             CorrelationId = request.CorrelationId,
             Input = request.Input,
+            Variables = request.Variables,
             Properties = request.Properties,
             ParentId = request.ParentWorkflowInstanceId,
             TriggerActivityId = request.ActivityId,


### PR DESCRIPTION
Introduce the ability to pass (dynamic) variables into workflow invocations. 

Example passing dynamic variable (i.e. a variable that is not defined on the workflow) when starting a workflow:

```csharp
var variables = new Dictionary<string, object>
{
    ["MyDynamicVariable"] = "Hello dynamic variable!"
};

var startRequest = new StartWorkflowRequest
{
    WorkflowDefinitionHandle = WorkflowDefinitionHandle.ByDefinitionId(workflowDefinitionId, VersionOptions.Published),
    Variables = variables
};
await workflowStarter.StartWorkflowAsync(startRequest, cancellationToken);
```

The workflow being started can now access this variable even if the variable wasn't predefined on the workflow definition. For example, the following JS expression will return the variable value:

```javascript
return getMyDynamicVariable();
```

It was already possible to dynamically define variables from custom activities, but this has been made easier with the introduction of the `SetDynamicVariable` extension method. This method will first try and see if the specified variable already exist in scope, and, if so, will update that variable.
If the variable doesn't exist, a variable will be dynamically created on the first variable container in scope, such as the Flowchart.

Example:

```csharp
public class CustomActivity : CodeActivity
{
    protected override void Execute(ActivityExecutionContext context)
    {
        context.SetDynamicVariable("SecretMessage", "Hello from custom activity!");
    }
}
```

**Note:** dynamically added variables, like any other variable not predefined on the workflow definition, do not currently participate in the variable persistence process.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6476)
<!-- Reviewable:end -->
