### PR TITLE
Catch exceptions and log instead of crashing

### DIFF
--- a/src/modules/Elsa.EntityFrameworkCore/Modules/Management/WorkflowDefinitionStore.cs
+++ b/src/modules/Elsa.EntityFrameworkCore/Modules/Management/WorkflowDefinitionStore.cs
@@ -13,12 +13,13 @@ using Elsa.Common.Entities;
 using Elsa.Workflows;
 using Elsa.Workflows.Management;
 using JetBrains.Annotations;
+using Microsoft.Extensions.Logging;
 
 namespace Elsa.EntityFrameworkCore.Modules.Management;
 
 /// <inheritdoc />
 [UsedImplicitly]
-public class EFCoreWorkflowDefinitionStore(EntityStore<ManagementElsaDbContext, WorkflowDefinition> store, IPayloadSerializer payloadSerializer)
+public class EFCoreWorkflowDefinitionStore(EntityStore<ManagementElsaDbContext, WorkflowDefinition> store, IPayloadSerializer payloadSerializer, ILogger<EFCoreWorkflowDefinitionStore> logger)
     : IWorkflowDefinitionStore
 {
     /// <inheritdoc />
@@ -178,8 +179,15 @@ public class EFCoreWorkflowDefinitionStore(EntityStore<ManagementElsaDbContext, 
         var data = new WorkflowDefinitionState(entity.Options, entity.Variables, entity.Inputs, entity.Outputs, entity.Outcomes, entity.CustomProperties);
         var json = (string?)managementElsaDbContext.Entry(entity).Property("Data").CurrentValue;
 
-        if (!string.IsNullOrWhiteSpace(json))
-            data = payloadSerializer.Deserialize<WorkflowDefinitionState>(json);
+        try
+        {
+            if (!string.IsNullOrWhiteSpace(json))
+                data = payloadSerializer.Deserialize<WorkflowDefinitionState>(json);
+        }
+        catch (Exception exp)
+        {
+            logger.LogWarning(exp, "Could not deserialize workflow definition state: {DefinitionId}. Reverting to default state", entity!.DefinitionId);
+        }
 
         entity.Options = data.Options;
         entity.Variables = data.Variables;

--- a/src/modules/Elsa.Retention/Jobs/CleanupJob.cs
+++ b/src/modules/Elsa.Retention/Jobs/CleanupJob.cs
@@ -71,7 +71,14 @@ public class CleanupJob(
 
                     await foreach (var entities in collector.GetRelatedEntitiesGeneric(page.Items).WithCancellation(cancellationToken))
                     {
-                        await cleanupService.Cleanup(entities);
+                        try
+                        {
+                            await cleanupService.Cleanup(entities);
+                        }
+                        catch (Exception exp)
+                        {
+                            _logger.LogError(exp, "Failed to clean up {Type} because exception thrown", collectorService.Key.Name);
+                        }
                     }
                 }
                 


### PR DESCRIPTION
Modified both WorkflowInstance and WorkflowDefinition state loading to prevent throwing exceptions if the state fails to load successfully.

Also modified the CleanupJob to catch exceptions thrown by cleaning up and logging as errors and continuing instead of crashing.

Fixes #6473