### PR TITLE
Fix serialization of composite activities

### DIFF
--- a/scripts/docker/docker-compose.yml
+++ b/scripts/docker/docker-compose.yml
@@ -1,5 +1,4 @@
-﻿version: '3.7'
-services:
+﻿services:
 
   consul-agent-1: &consul-agent
     image: consul:latest
@@ -30,14 +29,15 @@ services:
     command: "agent -server -bootstrap-expect 3 -ui -client 0.0.0.0"
   
   sqlserver:
-    image: "mcr.microsoft.com/mssql/server:2019-latest"
+    image: mcr.microsoft.com/mssql/server:2022-latest
     ports:
-      - "3433:1433"
+      - 1433:1433
     environment:
-      SA_PASSWORD: "Elsa2022!"
+      MSSQL_SA_PASSWORD: "Elsa2022!"
       ACCEPT_EULA: "Y"
     volumes:
-      - c:\data\docker\sqlserver2019:/var/opt/mssql/data
+      - sqlserver_data:/var/opt/mssql
+    restart: unless-stopped
   
   postgres:
     image: postgres:13.3-alpine
@@ -123,5 +123,6 @@ networks:
 volumes:
   mongodb_data:
   pgdata-3:
+  sqlserver_data:
   elasticsearch-data:
     driver: local

--- a/src/apps/Elsa.Server.Web/Program.cs
+++ b/src/apps/Elsa.Server.Web/Program.cs
@@ -96,6 +96,7 @@ const bool useTenantsFromConfiguration = true;
 const bool useSecrets = false;
 const bool disableVariableWrappers = false;
 const bool disableVariableCopying = false;
+const bool useOtel = false;
 
 var builder = WebApplication.CreateBuilder(args);
 var services = builder.Services;
@@ -120,13 +121,15 @@ var sqlDatabaseProvider = Enum.Parse<SqlDatabaseProvider>(configuration["Databas
 TypeAliasRegistry.RegisterAlias("OrderReceivedProducerFactory", typeof(GenericProducerFactory<string, OrderReceived>));
 TypeAliasRegistry.RegisterAlias("OrderReceivedConsumerFactory", typeof(GenericConsumerFactory<string, OrderReceived>));
 
+if (useOtel)
+{
 // Configure OpenTelemetry Tracing
-using var tracerProvider = Sdk.CreateTracerProviderBuilder()
-    .AddSource("Elsa.Workflows") // Match your ActivitySource name here
-    .SetSampler(new AlwaysOnSampler()) // Always record traces for testing
-    .AddConsoleExporter() // Export spans to the console (optional)
-    .Build();
-
+    using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+        .AddSource("Elsa.Workflows") // Match your ActivitySource name here
+        .SetSampler(new AlwaysOnSampler()) // Always record traces for testing
+        .AddConsoleExporter() // Export spans to the console (optional)
+        .Build();
+}
 
 // Add Elsa services.
 services

--- a/src/modules/Elsa.Workflows.Core/Serialization/Converters/ActivityJsonConverter.cs
+++ b/src/modules/Elsa.Workflows.Core/Serialization/Converters/ActivityJsonConverter.cs
@@ -6,6 +6,7 @@ using Elsa.Workflows.Activities;
 using Elsa.Workflows.Helpers;
 using Elsa.Workflows.Models;
 using Elsa.Workflows.Serialization.Helpers;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Elsa.Workflows.Serialization.Converters;
 
@@ -64,7 +65,7 @@ public class ActivityJsonConverter(
     /// <inheritdoc />
     public override void Write(Utf8JsonWriter writer, IActivity value, JsonSerializerOptions options)
     {
-        var clonedOptions = GetClonedOptions(options);
+        var clonedOptions = GetClonedWriterOptions(options);
         var activityDescriptor = activityRegistry.Find(value.Type, value.Version);
 
         // Give the activity descriptor a chance to customize the serializer options.
@@ -114,6 +115,13 @@ public class ActivityJsonConverter(
         clonedOptions.Converters.Add(new InputJsonConverterFactory(serviceProvider));
         clonedOptions.Converters.Add(new OutputJsonConverterFactory(serviceProvider));
         clonedOptions.Converters.Add(new ExpressionJsonConverterFactory(expressionDescriptorRegistry));
+        return clonedOptions;
+    }
+    
+    private JsonSerializerOptions GetClonedWriterOptions(JsonSerializerOptions options)
+    {
+        var clonedOptions = GetClonedOptions(options);
+        clonedOptions.Converters.Add(new JsonIgnoreCompositeRootConverterFactory(serviceProvider.GetRequiredService<ActivityWriter>()));
         return clonedOptions;
     }
 }

--- a/src/modules/Elsa.Workflows.Management/Activities/WorkflowDefinitionActivity/WorkflowDefinitionActivityProvider.cs
+++ b/src/modules/Elsa.Workflows.Management/Activities/WorkflowDefinitionActivity/WorkflowDefinitionActivityProvider.cs
@@ -109,11 +109,6 @@ public class WorkflowDefinitionActivityProvider(IWorkflowDefinitionStore store, 
                 activity.LatestAvailablePublishedVersionId = latestPublishedVersion?.Id;
 
                 return activity;
-            },
-            ConfigureSerializerOptions = options =>
-            {
-                options.Converters.Add(new JsonIgnoreCompositeRootConverterFactory(activityWriter));
-                return options;
             }
         };
     }


### PR DESCRIPTION
Fixes that composite activities' Root property (by means of the `JsonIgnoreCompositeRootConverterFactory`) does not get serialized, just like the `WorkflowDefinitionActivity`.

Composite activities added to a workflow should not include their children when being serialized.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6478)
<!-- Reviewable:end -->
