### PR TITLE
Fixes issue with FlowJoin(WaitAny) where activities can be executed multiple times

### DIFF
--- a/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Models/FlowScope.cs
+++ b/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Models/FlowScope.cs
@@ -89,7 +89,10 @@ public class FlowScope
     public bool HasFollowedInboundConnection(FlowGraph flowGraph, IActivity activity)
     {
         var forwardInboundConnections = flowGraph.GetForwardInboundConnections(activity);
-        return forwardInboundConnections.Any(c => GetConnectionLastVisitFollowed(c));
+        var outboundActivityVisitCount = GetActivityVisitCount(activity);
+        var maxConnectionVisitCount = forwardInboundConnections.Max(c => GetConnectionVisitCount(c));
+        return maxConnectionVisitCount > outboundActivityVisitCount 
+            && forwardInboundConnections.Any(c => GetConnectionVisitCount(c) == maxConnectionVisitCount && GetConnectionLastVisitFollowed(c));
     }
 
     /// <summary>


### PR DESCRIPTION
This fixes an issue where activities are executed more times than expected. See https://github.com/elsa-workflows/elsa-core/issues/6479 for more details.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6480)
<!-- Reviewable:end -->
