### PR TITLE
Correct the issue with DeleteAsync not executing due to a premature p…

### DIFF
--- a/src/modules/Elsa.Dapper/Services/Store.cs
+++ b/src/modules/Elsa.Dapper/Services/Store.cs
@@ -452,13 +452,13 @@ public class Store<T>(IDbConnectionProvider dbConnectionProvider, ITenantAccesso
     public async Task<long> DeleteAsync(Action<ParameterizedQuery> filter, CancellationToken cancellationToken = default)
     {
         var query = dbConnectionProvider.CreateQuery().Delete(TableName);
+        filter(query);
 
         // If there are no conditions, we don't want to delete all records.
         if (!query.Parameters.ParameterNames.Any())
             return 0;
 
         ApplyTenantFilter(query);
-        filter(query);
 
         using var connection = dbConnectionProvider.GetConnection();
         return await query.ExecuteAsync(connection);
@@ -476,13 +476,13 @@ public class Store<T>(IDbConnectionProvider dbConnectionProvider, ITenantAccesso
     public async Task<long> DeleteAsync(Action<ParameterizedQuery> filter, PageArgs pageArgs, IEnumerable<OrderField> orderFields, string primaryKey = "Id", CancellationToken cancellationToken = default)
     {
         var selectQuery = dbConnectionProvider.CreateQuery().From(TableName, primaryKey);
+        filter(selectQuery);
 
         // If there are no conditions, we don't want to delete all records.
         if (!selectQuery.Parameters.ParameterNames.Any())
             return 0;
 
         ApplyTenantFilter(selectQuery, false);
-        filter(selectQuery);
         selectQuery = selectQuery.OrderBy(orderFields.ToArray()).Page(pageArgs);
 
         var deleteQuery = dbConnectionProvider.CreateQuery().Delete(TableName, primaryKey, selectQuery);


### PR DESCRIPTION
The DeleteAsync method was terminating prematurely because the presence of query parameters was checked before filters were applied. As a result, the deletion queries never executed since the query parameters were always empty before applying the filters.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6491)
<!-- Reviewable:end -->
