### PR TITLE
DateTimePicker UI Hint Missing

### DIFF
--- a/src/modules/Elsa.Workflows.Core/UIHints/InputUIHints.cs
+++ b/src/modules/Elsa.Workflows.Core/UIHints/InputUIHints.cs
@@ -6,20 +6,21 @@ namespace Elsa.Workflows.UIHints;
 /// </summary>
 public static class InputUIHints
 {
-    public const string SingleLine = "singleline";
-    public const string MultiLine = "multiline";
     public const string Checkbox = "checkbox";
     public const string CheckList = "checklist";
-    public const string RadioList = "radiolist";
-    public const string DropDown = "dropdown";
-    public const string MultiText = "multitext";
     public const string CodeEditor = "code-editor";
+    public const string DateTimePicker = "datetime-picker";
+    public const string DropDown = "dropdown";
+    public const string DynamicOutcomes = "dynamic-outcomes";
     public const string ExpressionEditor = "expression-editor";
-    public const string VariablePicker = "variable-picker";
-    public const string TypePicker = "type-picker";
-    public const string WorkflowDefinitionPicker = "workflow-definition-picker";
+    public const string JsonEditor = "json-editor";
+    public const string MultiLine = "multiline";
+    public const string MultiText = "multitext";
     public const string OutputPicker = "output-picker";
     public const string OutcomePicker = "outcome-picker";
-    public const string JsonEditor = "json-editor";
-    public const string DynamicOutcomes = "dynamic-outcomes";
+    public const string RadioList = "radiolist";
+    public const string SingleLine = "singleline";
+    public const string TypePicker = "type-picker";
+    public const string VariablePicker = "variable-picker";
+    public const string WorkflowDefinitionPicker = "workflow-definition-picker";
 }


### PR DESCRIPTION
This PR helps close https://github.com/elsa-workflows/elsa-studio/issues/455

This adds the supporting `InputUIHint.DateTimePicker` for this new component.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6494)
<!-- Reviewable:end -->
