### PR TITLE
Refactor activity execution state handling with IDisposable

### DIFF
--- a/src/modules/Elsa.Workflows.Core/Contexts/ActivityExecutionContext.cs
+++ b/src/modules/Elsa.Workflows.Core/Contexts/ActivityExecutionContext.cs
@@ -177,6 +177,11 @@ public partial class ActivityExecutionContext : IExecutionContext, IDisposable
         }
     }
 
+    public IDisposable EnterExecution()
+    {
+        return new WorkflowExecutionState(this);
+    }
+
     /// <summary>
     /// Sets the current status of the activity.
     /// </summary>

--- a/src/modules/Elsa.Workflows.Core/Models/WorkflowExecutionState.cs
+++ b/src/modules/Elsa.Workflows.Core/Models/WorkflowExecutionState.cs
@@ -1,0 +1,17 @@
+namespace Elsa.Workflows;
+
+internal class WorkflowExecutionState : IDisposable
+{
+    private readonly ActivityExecutionContext _activityExecutionContext;
+
+    public WorkflowExecutionState(ActivityExecutionContext activityExecutionContext)
+    {
+        _activityExecutionContext = activityExecutionContext;
+        _activityExecutionContext.IsExecuting = activityExecutionContext.WorkflowExecutionContext.IsExecuting = true;
+    }
+
+    public void Dispose()
+    {
+        _activityExecutionContext.IsExecuting = _activityExecutionContext.WorkflowExecutionContext.IsExecuting = false;
+    }
+}


### PR DESCRIPTION
This fixes an issue where the `IsExecuting` flag would remain set to `true` when an exception occurs during execution, which in turn would lead the workflow recovery service to attempt to retry the workflow.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6501)
<!-- Reviewable:end -->
