### PR TITLE
FEAT - Automatic SQL Expression Parameterization

### DIFF
--- a/src/modules/Elsa.Sql.MySql/MySqlClient.cs
+++ b/src/modules/Elsa.Sql.MySql/MySqlClient.cs
@@ -1,74 +1,16 @@
 ﻿using MySql.Data.MySqlClient;
 using Elsa.Sql.Client;
-using System.Data;
-using Elsa.Sql.Models;
+using System.Data.Common;
 
 namespace Elsa.Sql.MySql;
 
-public class MySqlClient : BaseSqlClient, ISqlClient
+/// <summary>
+/// MySql client implementation.
+/// </summary>
+/// <param name="connectionString"></param>
+public class MySqlClient(string connectionString) : BaseSqlClient(connectionString)
 {
-    private string? _connectionString;
+    protected override DbConnection CreateConnection() => new MySqlConnection(_connectionString);
 
-    /// <summary>
-    /// MySql client implementation.
-    /// </summary>
-    /// <param name="connectionString"></param>
-    public MySqlClient(string? connectionString) => _connectionString = connectionString;
-
-    /// <summary>
-    /// <inheritdoc/>
-    /// </summary>
-    public async Task<int?> ExecuteCommandAsync(EvaluatedQuery evaluatedQuery)
-    {
-        using var connection = new MySqlConnection(_connectionString);
-        connection.Open();
-        var command = new MySqlCommand(evaluatedQuery.Query, connection);
-        AddParameters(command, evaluatedQuery.Parameters);
-
-        var result = await command.ExecuteNonQueryAsync();
-        return result;
-    }
-
-    /// <summary>
-    /// <inheritdoc/>
-    /// </summary>
-    public async Task<object?> ExecuteScalarAsync(EvaluatedQuery evaluatedQuery)
-    {
-        using var connection = new MySqlConnection(_connectionString);
-        connection.Open();
-        var command = new MySqlCommand(evaluatedQuery.Query, connection);
-        AddParameters(command, evaluatedQuery.Parameters);
-
-        var result = await command.ExecuteScalarAsync();
-        return result;
-    }
-
-    /// <summary>
-    /// <inheritdoc/>
-    /// </summary>
-    public async Task<DataSet?> ExecuteQueryAsync(EvaluatedQuery evaluatedQuery)
-    {
-        using var connection = new MySqlConnection(_connectionString);
-        connection.Open();
-        var command = new MySqlCommand(evaluatedQuery.Query, connection);
-        AddParameters(command, evaluatedQuery.Parameters);
-
-        using var reader = await command.ExecuteReaderAsync();
-        return await Task.FromResult(ReadAsDataSet(reader));
-    }
-
-    /// <summary>
-    /// Inject parameters into the query to prevent SQL injection.
-    /// </summary>
-    /// <param name="command">Command to add the parameters to</param>
-    /// <param name="parameters">Parameters to add</param>
-    /// <returns></returns>
-    private MySqlCommand AddParameters(MySqlCommand command, Dictionary<string, object?> parameters)
-    {
-        foreach (var param in parameters)
-        {
-            command.Parameters.AddWithValue(param.Key, param.Value ?? DBNull.Value);
-        }
-        return command;
-    }
+    protected override DbCommand CreateCommand(string query, DbConnection connection) => new MySqlCommand(query, (MySqlConnection)connection);
 }

--- a/src/modules/Elsa.Sql.MySql/MySqlClient.cs
+++ b/src/modules/Elsa.Sql.MySql/MySqlClient.cs
@@ -10,6 +10,12 @@ namespace Elsa.Sql.MySql;
 /// <param name="connectionString"></param>
 public class MySqlClient(string connectionString) : BaseSqlClient(connectionString)
 {
+    public override string ParameterMarker { get; set; } = "@";
+
+    public override string ParameterText { get; set; } = "";
+
+    public override bool IncrementParameter { get; set; } = false;
+
     protected override DbConnection CreateConnection() => new MySqlConnection(_connectionString);
 
     protected override DbCommand CreateCommand(string query, DbConnection connection) => new MySqlCommand(query, (MySqlConnection)connection);

--- a/src/modules/Elsa.Sql.MySql/MySqlClient.cs
+++ b/src/modules/Elsa.Sql.MySql/MySqlClient.cs
@@ -1,6 +1,7 @@
 ﻿using MySql.Data.MySqlClient;
 using Elsa.Sql.Client;
 using System.Data;
+using Elsa.Sql.Models;
 
 namespace Elsa.Sql.MySql;
 
@@ -9,7 +10,7 @@ public class MySqlClient : BaseSqlClient, ISqlClient
     private string? _connectionString;
 
     /// <summary>
-    /// MySql client implimentation.
+    /// MySql client implementation.
     /// </summary>
     /// <param name="connectionString"></param>
     public MySqlClient(string? connectionString) => _connectionString = connectionString;
@@ -17,11 +18,12 @@ public class MySqlClient : BaseSqlClient, ISqlClient
     /// <summary>
     /// <inheritdoc/>
     /// </summary>
-    public async Task<int?> ExecuteCommandAsync(string sqlCommand)
+    public async Task<int?> ExecuteCommandAsync(EvaluatedQuery evaluatedQuery)
     {
         using var connection = new MySqlConnection(_connectionString);
         connection.Open();
-        var command = new MySqlCommand(sqlCommand, connection);
+        var command = new MySqlCommand(evaluatedQuery.Query, connection);
+        AddParameters(command, evaluatedQuery.Parameters);
 
         var result = await command.ExecuteNonQueryAsync();
         return result;
@@ -30,11 +32,12 @@ public class MySqlClient : BaseSqlClient, ISqlClient
     /// <summary>
     /// <inheritdoc/>
     /// </summary>
-    public async Task<object?> ExecuteScalarAsync(string sqlQuery)
+    public async Task<object?> ExecuteScalarAsync(EvaluatedQuery evaluatedQuery)
     {
         using var connection = new MySqlConnection(_connectionString);
         connection.Open();
-        var command = new MySqlCommand(sqlQuery, connection);
+        var command = new MySqlCommand(evaluatedQuery.Query, connection);
+        AddParameters(command, evaluatedQuery.Parameters);
 
         var result = await command.ExecuteScalarAsync();
         return result;
@@ -43,13 +46,29 @@ public class MySqlClient : BaseSqlClient, ISqlClient
     /// <summary>
     /// <inheritdoc/>
     /// </summary>
-    public async Task<DataSet?> ExecuteQueryAsync(string sqlQuery)
+    public async Task<DataSet?> ExecuteQueryAsync(EvaluatedQuery evaluatedQuery)
     {
         using var connection = new MySqlConnection(_connectionString);
         connection.Open();
-        var command = new MySqlCommand(sqlQuery, connection);
+        var command = new MySqlCommand(evaluatedQuery.Query, connection);
+        AddParameters(command, evaluatedQuery.Parameters);
 
         using var reader = await command.ExecuteReaderAsync();
         return await Task.FromResult(ReadAsDataSet(reader));
+    }
+
+    /// <summary>
+    /// Inject parameters into the query to prevent SQL injection.
+    /// </summary>
+    /// <param name="command">Command to add the parameters to</param>
+    /// <param name="parameters">Parameters to add</param>
+    /// <returns></returns>
+    private MySqlCommand AddParameters(MySqlCommand command, Dictionary<string, object?> parameters)
+    {
+        foreach (var param in parameters)
+        {
+            command.Parameters.AddWithValue(param.Key, param.Value ?? DBNull.Value);
+        }
+        return command;
     }
 }

--- a/src/modules/Elsa.Sql.MySql/MySqlClient.cs
+++ b/src/modules/Elsa.Sql.MySql/MySqlClient.cs
@@ -10,12 +10,6 @@ namespace Elsa.Sql.MySql;
 /// <param name="connectionString"></param>
 public class MySqlClient(string connectionString) : BaseSqlClient(connectionString)
 {
-    public override string ParameterMarker { get; set; } = "@";
-
-    public override string ParameterText { get; set; } = "";
-
-    public override bool IncrementParameter { get; set; } = false;
-
     protected override DbConnection CreateConnection() => new MySqlConnection(_connectionString);
 
     protected override DbCommand CreateCommand(string query, DbConnection connection) => new MySqlCommand(query, (MySqlConnection)connection);

--- a/src/modules/Elsa.Sql.PostgreSql/PostgreSqlClient.cs
+++ b/src/modules/Elsa.Sql.PostgreSql/PostgreSqlClient.cs
@@ -1,74 +1,16 @@
 ﻿using Npgsql;
 using Elsa.Sql.Client;
-using System.Data;
-using Elsa.Sql.Models;
+using System.Data.Common;
 
 namespace Elsa.Sql.PostgreSql;
 
-public class PostgreSqlClient : BaseSqlClient, ISqlClient
+/// <summary>
+/// PostgreSQL client implementation.
+/// </summary>
+/// <param name="connectionString"></param>
+public class PostgreSqlClient(string connectionString) : BaseSqlClient(connectionString)
 {
-    private string? _connectionString;
+    protected override DbConnection CreateConnection() => new NpgsqlConnection(_connectionString);
 
-    /// <summary>
-    /// PostgreSQL client implementation.
-    /// </summary>
-    /// <param name="connectionString"></param>
-    public PostgreSqlClient(string? connectionString) => _connectionString = connectionString;
-
-    /// <summary>
-    /// <inheritdoc/>
-    /// </summary>
-    public async Task<int?> ExecuteCommandAsync(EvaluatedQuery evaluatedQuery)
-    {
-        using var connection = new NpgsqlConnection(_connectionString);
-        connection.Open();
-        var command = new NpgsqlCommand(evaluatedQuery.Query, connection);
-        AddParameters(command, evaluatedQuery.Parameters);
-
-        var result = await command.ExecuteNonQueryAsync();
-        return result;
-    }
-
-    /// <summary>
-    /// <inheritdoc/>
-    /// </summary>
-    public async Task<object?> ExecuteScalarAsync(EvaluatedQuery evaluatedQuery)
-    {
-        using var connection = new NpgsqlConnection(_connectionString);
-        connection.Open();
-        var command = new NpgsqlCommand(evaluatedQuery.Query, connection);
-        AddParameters(command, evaluatedQuery.Parameters);
-
-        var result = await command.ExecuteScalarAsync();
-        return result;
-    }
-
-    /// <summary>
-    /// <inheritdoc/>
-    /// </summary>
-    public async Task<DataSet?> ExecuteQueryAsync(EvaluatedQuery evaluatedQuery)
-    {
-        using var connection = new NpgsqlConnection(_connectionString);
-        connection.Open();
-        var command = new NpgsqlCommand(evaluatedQuery.Query, connection);
-        AddParameters(command, evaluatedQuery.Parameters);
-
-        using var reader = await command.ExecuteReaderAsync();
-        return await Task.FromResult(ReadAsDataSet(reader));
-    }
-
-    /// <summary>
-    /// Inject parameters into the query to prevent SQL injection.
-    /// </summary>
-    /// <param name="command">Command to add the parameters to</param>
-    /// <param name="parameters">Parameters to add</param>
-    /// <returns></returns>
-    private NpgsqlCommand AddParameters(NpgsqlCommand command, Dictionary<string, object?> parameters)
-    {
-        foreach (var param in parameters)
-        {
-            command.Parameters.AddWithValue(param.Key, param.Value ?? DBNull.Value);
-        }
-        return command;
-    }
+    protected override DbCommand CreateCommand(string query, DbConnection connection) => new NpgsqlCommand(query, (NpgsqlConnection)connection);
 }

--- a/src/modules/Elsa.Sql.PostgreSql/PostgreSqlClient.cs
+++ b/src/modules/Elsa.Sql.PostgreSql/PostgreSqlClient.cs
@@ -1,6 +1,7 @@
 ﻿using Npgsql;
 using Elsa.Sql.Client;
 using System.Data;
+using Elsa.Sql.Models;
 
 namespace Elsa.Sql.PostgreSql;
 
@@ -9,7 +10,7 @@ public class PostgreSqlClient : BaseSqlClient, ISqlClient
     private string? _connectionString;
 
     /// <summary>
-    /// PostgreSQL client implimentation.
+    /// PostgreSQL client implementation.
     /// </summary>
     /// <param name="connectionString"></param>
     public PostgreSqlClient(string? connectionString) => _connectionString = connectionString;
@@ -17,11 +18,12 @@ public class PostgreSqlClient : BaseSqlClient, ISqlClient
     /// <summary>
     /// <inheritdoc/>
     /// </summary>
-    public async Task<int?> ExecuteCommandAsync(string sqlCommand)
+    public async Task<int?> ExecuteCommandAsync(EvaluatedQuery evaluatedQuery)
     {
         using var connection = new NpgsqlConnection(_connectionString);
         connection.Open();
-        var command = new NpgsqlCommand(sqlCommand, connection);
+        var command = new NpgsqlCommand(evaluatedQuery.Query, connection);
+        AddParameters(command, evaluatedQuery.Parameters);
 
         var result = await command.ExecuteNonQueryAsync();
         return result;
@@ -30,11 +32,12 @@ public class PostgreSqlClient : BaseSqlClient, ISqlClient
     /// <summary>
     /// <inheritdoc/>
     /// </summary>
-    public async Task<object?> ExecuteScalarAsync(string sqlQuery)
+    public async Task<object?> ExecuteScalarAsync(EvaluatedQuery evaluatedQuery)
     {
         using var connection = new NpgsqlConnection(_connectionString);
         connection.Open();
-        var command = new NpgsqlCommand(sqlQuery, connection);
+        var command = new NpgsqlCommand(evaluatedQuery.Query, connection);
+        AddParameters(command, evaluatedQuery.Parameters);
 
         var result = await command.ExecuteScalarAsync();
         return result;
@@ -43,13 +46,29 @@ public class PostgreSqlClient : BaseSqlClient, ISqlClient
     /// <summary>
     /// <inheritdoc/>
     /// </summary>
-    public async Task<DataSet?> ExecuteQueryAsync(string sqlQuery)
+    public async Task<DataSet?> ExecuteQueryAsync(EvaluatedQuery evaluatedQuery)
     {
         using var connection = new NpgsqlConnection(_connectionString);
         connection.Open();
-        var command = new NpgsqlCommand(sqlQuery, connection);
+        var command = new NpgsqlCommand(evaluatedQuery.Query, connection);
+        AddParameters(command, evaluatedQuery.Parameters);
 
         using var reader = await command.ExecuteReaderAsync();
         return await Task.FromResult(ReadAsDataSet(reader));
+    }
+
+    /// <summary>
+    /// Inject parameters into the query to prevent SQL injection.
+    /// </summary>
+    /// <param name="command">Command to add the parameters to</param>
+    /// <param name="parameters">Parameters to add</param>
+    /// <returns></returns>
+    private NpgsqlCommand AddParameters(NpgsqlCommand command, Dictionary<string, object?> parameters)
+    {
+        foreach (var param in parameters)
+        {
+            command.Parameters.AddWithValue(param.Key, param.Value ?? DBNull.Value);
+        }
+        return command;
     }
 }

--- a/src/modules/Elsa.Sql.SqlServer/SqlServerClient.cs
+++ b/src/modules/Elsa.Sql.SqlServer/SqlServerClient.cs
@@ -1,74 +1,16 @@
-﻿using System.Data;
+﻿using System.Data.Common;
 using Elsa.Sql.Client;
-using Elsa.Sql.Models;
 using Microsoft.Data.SqlClient;
 
 namespace Elsa.Sql.SqlServer;
 
-public class SqlServerClient : BaseSqlClient, ISqlClient
+/// <summary>
+/// Microsoft SQL server client implementation.
+/// </summary>
+/// <param name="connectionString"></param>
+public class SqlServerClient(string connectionString) : BaseSqlClient(connectionString)
 {
-    private string? _connectionString;
+    protected override DbConnection CreateConnection() => new SqlConnection(_connectionString);
 
-    /// <summary>
-    /// Microsoft SQL server client implementation.
-    /// </summary>
-    /// <param name="connectionString"></param>
-    public SqlServerClient(string? connectionString) => _connectionString = connectionString;
-
-    /// <summary>
-    /// <inheritdoc/>
-    /// </summary>
-    public async Task<int?> ExecuteCommandAsync(EvaluatedQuery evaluatedQuery)
-    {
-        using var connection = new SqlConnection(_connectionString);
-        connection.Open();
-        var command = new SqlCommand(evaluatedQuery.Query, connection);
-        AddParameters(command, evaluatedQuery.Parameters);
-
-        var result = await command.ExecuteNonQueryAsync();
-        return result;
-    }
-
-    /// <summary>
-    /// <inheritdoc/>
-    /// </summary>
-    public async Task<object?> ExecuteScalarAsync(EvaluatedQuery evaluatedQuery)
-    {
-        using var connection = new SqlConnection(_connectionString);
-        connection.Open();
-        var command = new SqlCommand(evaluatedQuery.Query, connection);
-        AddParameters(command, evaluatedQuery.Parameters);
-
-        var result = await command.ExecuteScalarAsync();
-        return result;
-    }
-
-    /// <summary>
-    /// <inheritdoc/>
-    /// </summary>
-    public async Task<DataSet?> ExecuteQueryAsync(EvaluatedQuery evaluatedQuery)
-    {
-        using var connection = new SqlConnection(_connectionString);
-        connection.Open();
-        var command = new SqlCommand(evaluatedQuery.Query, connection);
-        AddParameters(command, evaluatedQuery.Parameters);
-
-        using var reader = await command.ExecuteReaderAsync();
-        return await Task.FromResult(ReadAsDataSet(reader));
-    }
-
-    /// <summary>
-    /// Inject parameters into the query to prevent SQL injection.
-    /// </summary>
-    /// <param name="command">Command to add the parameters to</param>
-    /// <param name="parameters">Parameters to add</param>
-    /// <returns></returns>
-    private SqlCommand AddParameters(SqlCommand command, Dictionary<string, object?> parameters)
-    {
-        foreach (var param in parameters)
-        {
-            command.Parameters.AddWithValue(param.Key, param.Value ?? DBNull.Value);
-        }
-        return command;
-    }
+    protected override DbCommand CreateCommand(string query, DbConnection connection) => new SqlCommand(query, (SqlConnection)connection);
 }

--- a/src/modules/Elsa.Sql.SqlServer/SqlServerClient.cs
+++ b/src/modules/Elsa.Sql.SqlServer/SqlServerClient.cs
@@ -10,6 +10,8 @@ namespace Elsa.Sql.SqlServer;
 /// <param name="connectionString"></param>
 public class SqlServerClient(string connectionString) : BaseSqlClient(connectionString)
 {
+    public override string ParameterText { get; set; } = "p";
+
     protected override DbConnection CreateConnection() => new SqlConnection(_connectionString);
 
     protected override DbCommand CreateCommand(string query, DbConnection connection) => new SqlCommand(query, (SqlConnection)connection);

--- a/src/modules/Elsa.Sql.SqlServer/SqlServerClient.cs
+++ b/src/modules/Elsa.Sql.SqlServer/SqlServerClient.cs
@@ -10,8 +10,6 @@ namespace Elsa.Sql.SqlServer;
 /// <param name="connectionString"></param>
 public class SqlServerClient(string connectionString) : BaseSqlClient(connectionString)
 {
-    public override string ParameterText { get; set; } = "p";
-
     protected override DbConnection CreateConnection() => new SqlConnection(_connectionString);
 
     protected override DbCommand CreateCommand(string query, DbConnection connection) => new SqlCommand(query, (SqlConnection)connection);

--- a/src/modules/Elsa.Sql.SqlServer/SqlServerClient.cs
+++ b/src/modules/Elsa.Sql.SqlServer/SqlServerClient.cs
@@ -1,5 +1,6 @@
 ﻿using System.Data;
 using Elsa.Sql.Client;
+using Elsa.Sql.Models;
 using Microsoft.Data.SqlClient;
 
 namespace Elsa.Sql.SqlServer;
@@ -9,7 +10,7 @@ public class SqlServerClient : BaseSqlClient, ISqlClient
     private string? _connectionString;
 
     /// <summary>
-    /// Microsoft SQL server client implimentation.
+    /// Microsoft SQL server client implementation.
     /// </summary>
     /// <param name="connectionString"></param>
     public SqlServerClient(string? connectionString) => _connectionString = connectionString;
@@ -17,11 +18,12 @@ public class SqlServerClient : BaseSqlClient, ISqlClient
     /// <summary>
     /// <inheritdoc/>
     /// </summary>
-    public async Task<int?> ExecuteCommandAsync(string sqlCommand)
+    public async Task<int?> ExecuteCommandAsync(EvaluatedQuery evaluatedQuery)
     {
         using var connection = new SqlConnection(_connectionString);
         connection.Open();
-        var command = new SqlCommand(sqlCommand, connection);
+        var command = new SqlCommand(evaluatedQuery.Query, connection);
+        AddParameters(command, evaluatedQuery.Parameters);
 
         var result = await command.ExecuteNonQueryAsync();
         return result;
@@ -30,11 +32,12 @@ public class SqlServerClient : BaseSqlClient, ISqlClient
     /// <summary>
     /// <inheritdoc/>
     /// </summary>
-    public async Task<object?> ExecuteScalarAsync(string sqlQuery)
+    public async Task<object?> ExecuteScalarAsync(EvaluatedQuery evaluatedQuery)
     {
         using var connection = new SqlConnection(_connectionString);
         connection.Open();
-        var command = new SqlCommand(sqlQuery, connection);
+        var command = new SqlCommand(evaluatedQuery.Query, connection);
+        AddParameters(command, evaluatedQuery.Parameters);
 
         var result = await command.ExecuteScalarAsync();
         return result;
@@ -43,13 +46,29 @@ public class SqlServerClient : BaseSqlClient, ISqlClient
     /// <summary>
     /// <inheritdoc/>
     /// </summary>
-    public async Task<DataSet?> ExecuteQueryAsync(string sqlQuery)
+    public async Task<DataSet?> ExecuteQueryAsync(EvaluatedQuery evaluatedQuery)
     {
         using var connection = new SqlConnection(_connectionString);
         connection.Open();
-        var command = new SqlCommand(sqlQuery, connection);
+        var command = new SqlCommand(evaluatedQuery.Query, connection);
+        AddParameters(command, evaluatedQuery.Parameters);
 
         using var reader = await command.ExecuteReaderAsync();
         return await Task.FromResult(ReadAsDataSet(reader));
+    }
+
+    /// <summary>
+    /// Inject parameters into the query to prevent SQL injection.
+    /// </summary>
+    /// <param name="command">Command to add the parameters to</param>
+    /// <param name="parameters">Parameters to add</param>
+    /// <returns></returns>
+    private SqlCommand AddParameters(SqlCommand command, Dictionary<string, object?> parameters)
+    {
+        foreach (var param in parameters)
+        {
+            command.Parameters.AddWithValue(param.Key, param.Value ?? DBNull.Value);
+        }
+        return command;
     }
 }

--- a/src/modules/Elsa.Sql.Sqlite/SqliteClient.cs
+++ b/src/modules/Elsa.Sql.Sqlite/SqliteClient.cs
@@ -10,8 +10,6 @@ namespace Elsa.Sql.Sqlite;
 /// <param name="connectionString"></param>
 public class SqliteClient(string connectionString) : BaseSqlClient(connectionString)
 {
-    public override string ParameterText { get; set; } = "p";
-
     protected override DbConnection CreateConnection() => new SqliteConnection(_connectionString);
 
     protected override DbCommand CreateCommand(string query, DbConnection connection) => new SqliteCommand(query, (SqliteConnection)connection);

--- a/src/modules/Elsa.Sql.Sqlite/SqliteClient.cs
+++ b/src/modules/Elsa.Sql.Sqlite/SqliteClient.cs
@@ -1,74 +1,16 @@
-﻿using System.Data;
+﻿using System.Data.Common;
 using Elsa.Sql.Client;
-using Elsa.Sql.Models;
 using Microsoft.Data.Sqlite;
 
 namespace Elsa.Sql.Sqlite;
 
-public class SqliteClient : BaseSqlClient, ISqlClient
+/// <summary>
+/// Sqlite client implementation.
+/// </summary>
+/// <param name="connectionString"></param>
+public class SqliteClient(string connectionString) : BaseSqlClient(connectionString)
 {
-    private string? _connectionString;
+    protected override DbConnection CreateConnection() => new SqliteConnection(_connectionString);
 
-    /// <summary>
-    /// Sqlite client implementation.
-    /// </summary>
-    /// <param name="connectionString"></param>
-    public SqliteClient(string? connectionString) => _connectionString = connectionString;
-
-    /// <summary>
-    /// <inheritdoc/>
-    /// </summary>
-    public async Task<int?> ExecuteCommandAsync(EvaluatedQuery evaluatedQuery)
-    {
-        using var connection = new SqliteConnection(_connectionString);
-        connection.Open();
-        var command = new SqliteCommand(evaluatedQuery.Query, connection);
-        AddParameters(command, evaluatedQuery.Parameters);
-
-        var result = await command.ExecuteNonQueryAsync();
-        return result;
-    }
-
-    /// <summary>
-    /// <inheritdoc/>
-    /// </summary>
-    public async Task<object?> ExecuteScalarAsync(EvaluatedQuery evaluatedQuery)
-    {
-        using var connection = new SqliteConnection(_connectionString);
-        connection.Open();
-        var command = new SqliteCommand(evaluatedQuery.Query, connection);
-        AddParameters(command, evaluatedQuery.Parameters);
-
-        var result = await command.ExecuteScalarAsync();
-        return result;
-    }
-
-    /// <summary>
-    /// <inheritdoc/>
-    /// </summary>
-    public async Task<DataSet?> ExecuteQueryAsync(EvaluatedQuery evaluatedQuery)
-    {
-        using var connection = new SqliteConnection(_connectionString);
-        connection.Open();
-        var command = new SqliteCommand(evaluatedQuery.Query, connection);
-        AddParameters(command, evaluatedQuery.Parameters);
-
-        using var reader = await command.ExecuteReaderAsync();
-        return await Task.FromResult(ReadAsDataSet(reader));
-    }
-
-    /// <summary>
-    /// Inject parameters into the query to prevent SQL injection.
-    /// </summary>
-    /// <param name="command">Command to add the parameters to</param>
-    /// <param name="parameters">Parameters to add</param>
-    /// <returns></returns>
-    private SqliteCommand AddParameters(SqliteCommand command, Dictionary<string, object?> parameters)
-    {
-        foreach (var param in parameters)
-        {
-            command.Parameters.AddWithValue(param.Key, param.Value ?? DBNull.Value);
-        }
-        return command;
-    }
+    protected override DbCommand CreateCommand(string query, DbConnection connection) => new SqliteCommand(query, (SqliteConnection)connection);
 }

--- a/src/modules/Elsa.Sql.Sqlite/SqliteClient.cs
+++ b/src/modules/Elsa.Sql.Sqlite/SqliteClient.cs
@@ -10,6 +10,8 @@ namespace Elsa.Sql.Sqlite;
 /// <param name="connectionString"></param>
 public class SqliteClient(string connectionString) : BaseSqlClient(connectionString)
 {
+    public override string ParameterText { get; set; } = "p";
+
     protected override DbConnection CreateConnection() => new SqliteConnection(_connectionString);
 
     protected override DbCommand CreateCommand(string query, DbConnection connection) => new SqliteCommand(query, (SqliteConnection)connection);

--- a/src/modules/Elsa.Sql.Sqlite/SqliteClient.cs
+++ b/src/modules/Elsa.Sql.Sqlite/SqliteClient.cs
@@ -1,5 +1,6 @@
 ﻿using System.Data;
 using Elsa.Sql.Client;
+using Elsa.Sql.Models;
 using Microsoft.Data.Sqlite;
 
 namespace Elsa.Sql.Sqlite;
@@ -9,7 +10,7 @@ public class SqliteClient : BaseSqlClient, ISqlClient
     private string? _connectionString;
 
     /// <summary>
-    /// Sqlite client implimentation.
+    /// Sqlite client implementation.
     /// </summary>
     /// <param name="connectionString"></param>
     public SqliteClient(string? connectionString) => _connectionString = connectionString;
@@ -17,11 +18,12 @@ public class SqliteClient : BaseSqlClient, ISqlClient
     /// <summary>
     /// <inheritdoc/>
     /// </summary>
-    public async Task<int?> ExecuteCommandAsync(string sqlCommand)
+    public async Task<int?> ExecuteCommandAsync(EvaluatedQuery evaluatedQuery)
     {
         using var connection = new SqliteConnection(_connectionString);
         connection.Open();
-        var command = new SqliteCommand(sqlCommand, connection);
+        var command = new SqliteCommand(evaluatedQuery.Query, connection);
+        AddParameters(command, evaluatedQuery.Parameters);
 
         var result = await command.ExecuteNonQueryAsync();
         return result;
@@ -30,11 +32,12 @@ public class SqliteClient : BaseSqlClient, ISqlClient
     /// <summary>
     /// <inheritdoc/>
     /// </summary>
-    public async Task<object?> ExecuteScalarAsync(string sqlQuery)
+    public async Task<object?> ExecuteScalarAsync(EvaluatedQuery evaluatedQuery)
     {
         using var connection = new SqliteConnection(_connectionString);
         connection.Open();
-        var command = new SqliteCommand(sqlQuery, connection);
+        var command = new SqliteCommand(evaluatedQuery.Query, connection);
+        AddParameters(command, evaluatedQuery.Parameters);
 
         var result = await command.ExecuteScalarAsync();
         return result;
@@ -43,13 +46,29 @@ public class SqliteClient : BaseSqlClient, ISqlClient
     /// <summary>
     /// <inheritdoc/>
     /// </summary>
-    public async Task<DataSet?> ExecuteQueryAsync(string sqlQuery)
+    public async Task<DataSet?> ExecuteQueryAsync(EvaluatedQuery evaluatedQuery)
     {
         using var connection = new SqliteConnection(_connectionString);
         connection.Open();
-        var command = new SqliteCommand(sqlQuery, connection);
+        var command = new SqliteCommand(evaluatedQuery.Query, connection);
+        AddParameters(command, evaluatedQuery.Parameters);
 
         using var reader = await command.ExecuteReaderAsync();
         return await Task.FromResult(ReadAsDataSet(reader));
+    }
+
+    /// <summary>
+    /// Inject parameters into the query to prevent SQL injection.
+    /// </summary>
+    /// <param name="command">Command to add the parameters to</param>
+    /// <param name="parameters">Parameters to add</param>
+    /// <returns></returns>
+    private SqliteCommand AddParameters(SqliteCommand command, Dictionary<string, object?> parameters)
+    {
+        foreach (var param in parameters)
+        {
+            command.Parameters.AddWithValue(param.Key, param.Value ?? DBNull.Value);
+        }
+        return command;
     }
 }

--- a/src/modules/Elsa.Sql/Client/BaseSqlClient.cs
+++ b/src/modules/Elsa.Sql/Client/BaseSqlClient.cs
@@ -1,15 +1,103 @@
 using System.Data;
+using System.Data.Common;
+using Elsa.Sql.Models;
 
 namespace Elsa.Sql.Client;
 
-public abstract class BaseSqlClient
+public abstract class BaseSqlClient : ISqlClient
 {
+    /// <summary>
+    /// The connection string used to connect with the database.
+    /// </summary>
+    protected readonly string _connectionString;
+
+    /// <summary>
+    /// Create a connection using the client specific connection.
+    /// </summary>
+    /// <returns></returns>
+    protected abstract DbConnection CreateConnection();
+
+    /// <summary>
+    /// Create a command using the client specific connection.
+    /// </summary>
+    /// <param name="query"></param>
+    /// <param name="connection"></param>
+    /// <returns></returns>
+    protected abstract DbCommand CreateCommand(string query, DbConnection connection);
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="connectionString"></param>
+    protected BaseSqlClient(string connectionString) => _connectionString = connectionString;
+
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    public async Task<int?> ExecuteCommandAsync(EvaluatedQuery evaluatedQuery)
+    {
+        using var connection = CreateConnection();
+        connection.Open();
+        var command = CreateCommand(evaluatedQuery.Query, connection);
+        AddParameters(command, evaluatedQuery.Parameters);
+
+        var result = await command.ExecuteNonQueryAsync();
+        return result;
+    }
+
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    public async Task<object?> ExecuteScalarAsync(EvaluatedQuery evaluatedQuery)
+    {
+        using var connection = CreateConnection();
+        connection.Open();
+        var command = CreateCommand(evaluatedQuery.Query, connection);
+        AddParameters(command, evaluatedQuery.Parameters);
+
+        var result = await command.ExecuteScalarAsync();
+        return result;
+    }
+
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    public async Task<DataSet?> ExecuteQueryAsync(EvaluatedQuery evaluatedQuery)
+    {
+        using var connection = CreateConnection();
+        connection.Open();
+        var command = CreateCommand(evaluatedQuery.Query, connection);
+        AddParameters(command, evaluatedQuery.Parameters);
+
+        using var reader = await command.ExecuteReaderAsync();
+        return await Task.FromResult(ReadAsDataSet(reader));
+    }
+
+    /// <summary>
+    /// Inject parameters into the query to prevent SQL injection.
+    /// </summary>
+    /// <param name="command">Command to add the parameters to</param>
+    /// <param name="parameters">Parameters to add</param>
+    /// <returns></returns>
+    private DbCommand AddParameters(DbCommand command, Dictionary<string, object?> parameters)
+    {
+        // Add parameters dynamically
+        foreach (var param in parameters)
+        {
+            var dbParam = command.CreateParameter();
+            dbParam.ParameterName = param.Key;
+            dbParam.Value = param.Value ?? DBNull.Value;
+            command.Parameters.Add(dbParam);
+        }
+        return command;
+    }
+
     /// <summary>
     /// Returns <see cref="IDataReader"/> data as a <see cref="DataSet"/>.
     /// </summary>
     /// <param name="reader">Reader to return data from.</param>
     /// <returns><see cref="DataSet"/> of data.</returns>
-    protected static DataSet ReadAsDataSet(IDataReader reader)
+    private DataSet ReadAsDataSet(IDataReader reader)
     {
         var dataSet  = new DataSet("dataset");
         dataSet.Tables.Add(ReadAsDataTable(reader));
@@ -21,7 +109,7 @@ public abstract class BaseSqlClient
     /// </summary>
     /// <param name="reader">Reader to return data from.</param>
     /// <returns><see cref="DataTable"/> of data.</returns>
-    protected static DataTable ReadAsDataTable(IDataReader reader)
+    private DataTable ReadAsDataTable(IDataReader reader)
     {
         var data = new DataTable();
         var schemaTable =reader.GetSchemaTable();

--- a/src/modules/Elsa.Sql/Client/BaseSqlClient.cs
+++ b/src/modules/Elsa.Sql/Client/BaseSqlClient.cs
@@ -30,6 +30,12 @@ public abstract class BaseSqlClient : ISqlClient
     public virtual bool IncrementParameter { get; set; } = true;
 
     /// <summary>
+    /// Default base implementation for an SQL client.
+    /// </summary>
+    /// <param name="connectionString"></param>
+    protected BaseSqlClient(string connectionString) => _connectionString = connectionString;
+
+    /// <summary>
     /// Create a connection using the client specific connection.
     /// </summary>
     /// <returns></returns>
@@ -42,12 +48,6 @@ public abstract class BaseSqlClient : ISqlClient
     /// <param name="connection"></param>
     /// <returns></returns>
     protected abstract DbCommand CreateCommand(string query, DbConnection connection);
-
-    /// <summary>
-    /// 
-    /// </summary>
-    /// <param name="connectionString"></param>
-    protected BaseSqlClient(string connectionString) => _connectionString = connectionString;
 
     /// <summary>
     /// <inheritdoc/>
@@ -99,7 +99,6 @@ public abstract class BaseSqlClient : ISqlClient
     /// <returns></returns>
     private DbCommand AddCommandParameters(DbCommand command, Dictionary<string, object?> parameters)
     {
-        // Add parameters dynamically
         foreach (var param in parameters)
         {
             var dbParam = command.CreateParameter();

--- a/src/modules/Elsa.Sql/Client/ISqlClient.cs
+++ b/src/modules/Elsa.Sql/Client/ISqlClient.cs
@@ -1,4 +1,5 @@
 ﻿using System.Data;
+using Elsa.Sql.Models;
 
 namespace Elsa.Sql.Client;
 
@@ -7,21 +8,21 @@ public interface ISqlClient
     /// <summary>
     /// Asynchronously executes a Transact-SQL statement against the connection and returns the number of rows affected.
     /// </summary>
-    /// <param name="sqlCommand">The command to execute</param>
+    /// <param name="evaluatedQuery">The evaluated query to execute.</param>
     /// <returns>The number of rows affected.</returns>
-    public Task<int?> ExecuteCommandAsync(string sqlCommand);
+    public Task<int?> ExecuteCommandAsync(EvaluatedQuery evaluatedQuery);
 
     /// <summary>
     /// Asynchronously executes the query, and returns the first column of the first row in the result set returned by the query. Additional columns or rows are ignored.
     /// </summary>
-    /// <param name="sqlQuery">The query to execute</param>
+    /// <param name="evaluatedQuery">The evaluated query to execute.</param>
     /// <returns>The first column of the first row in the result set, or a null reference if the result set is empty. Returns a maximum of 2033 characters.</returns>
-    public Task<object?> ExecuteScalarAsync(string sqlQuery);
+    public Task<object?> ExecuteScalarAsync(EvaluatedQuery evaluatedQuery);
 
     /// <summary>
     /// Asynchronously executes the query, and returns a dataset of data returned by the query.
     /// </summary>
-    /// <param name="sqlQuery">Query to execute</param>
+    /// <param name="evaluatedQuery">The evaluated query to execute.</param>
     /// <returns>DataSet of the queried data</returns>
-    public Task<DataSet?> ExecuteQueryAsync(string sqlQuery);
+    public Task<DataSet?> ExecuteQueryAsync(EvaluatedQuery evaluatedQuery);
 }

--- a/src/modules/Elsa.Sql/Client/ISqlClient.cs
+++ b/src/modules/Elsa.Sql/Client/ISqlClient.cs
@@ -6,6 +6,21 @@ namespace Elsa.Sql.Client;
 public interface ISqlClient
 {
     /// <summary>
+    /// The marker used when injecting parameters into a query.
+    /// </summary>
+    public string ParameterMarker { get; set; }
+
+    /// <summary>
+    /// The text following the <c>ParameterMarker</c> when injecting parameters into a query.
+    /// </summary>
+    public string ParameterText { get; set; }
+
+    /// <summary>
+    /// Set to true to add a counter to the end of the parameter string.
+    /// </summary>
+    public bool IncrementParameter { get; set; }
+
+    /// <summary>
     /// Asynchronously executes a Transact-SQL statement against the connection and returns the number of rows affected.
     /// </summary>
     /// <param name="evaluatedQuery">The evaluated query to execute.</param>

--- a/src/modules/Elsa.Sql/Contracts/ISqlEvaluator.cs
+++ b/src/modules/Elsa.Sql/Contracts/ISqlEvaluator.cs
@@ -1,4 +1,5 @@
 ﻿using Elsa.Expressions.Models;
+using Elsa.Sql.Models;
 using JetBrains.Annotations;
 
 namespace Elsa.Sql.Contracts;
@@ -16,8 +17,8 @@ public interface ISqlEvaluator
     /// <param name="context">The context in which the expression is evaluated.</param>
     /// <param name="options">A set of options.</param>
     /// <param name="cancellationToken">An optional cancellation token.</param>
-    /// <returns>The result of the evaluation.</returns>
-    Task<string?> EvaluateAsync(
+    /// <returns>The <see cref="EvaluatedQuery"/> result.</returns>
+    Task<EvaluatedQuery> EvaluateAsync(
         string expression,
         ExpressionExecutionContext context,
         ExpressionEvaluatorOptions options,

--- a/src/modules/Elsa.Sql/Elsa.Sql.csproj
+++ b/src/modules/Elsa.Sql/Elsa.Sql.csproj
@@ -9,7 +9,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\common\Elsa.Features\Elsa.Features.csproj" />
-    <ProjectReference Include="..\Elsa.Sql.Models\Elsa.Sql.Models.csproj" />
     <ProjectReference Include="..\Elsa.Workflows.Api\Elsa.Workflows.Api.csproj" />
   </ItemGroup>
 

--- a/src/modules/Elsa.Sql/Elsa.Sql.csproj
+++ b/src/modules/Elsa.Sql/Elsa.Sql.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\common\Elsa.Features\Elsa.Features.csproj" />
+    <ProjectReference Include="..\Elsa.Sql.Models\Elsa.Sql.Models.csproj" />
     <ProjectReference Include="..\Elsa.Workflows.Api\Elsa.Workflows.Api.csproj" />
   </ItemGroup>
 

--- a/src/modules/Elsa.Sql/Models/EvaluatedQuery.cs
+++ b/src/modules/Elsa.Sql/Models/EvaluatedQuery.cs
@@ -8,12 +8,12 @@
         /// <summary>
         /// Query with parameterized values
         /// </summary>
-        public string Query { get; }
+        public string Query { get; set; }
 
         /// <summary>
         /// Parameters to inject into the query at execution
         /// </summary>
-        public Dictionary<string, object?> Parameters { get; } = new Dictionary<string, object?>();
+        public Dictionary<string, object?> Parameters { get; set; } = new Dictionary<string, object?>();
 
         /// <summary>
         /// An evaluated query response.

--- a/src/modules/Elsa.Sql/Models/EvaluatedQuery.cs
+++ b/src/modules/Elsa.Sql/Models/EvaluatedQuery.cs
@@ -1,0 +1,35 @@
+﻿namespace Elsa.Sql.Models
+{
+    /// <summary>
+    /// Represents a safely formatted SQL expression result.
+    /// </summary>
+    public class EvaluatedQuery
+    {
+        /// <summary>
+        /// Query with parameterized values
+        /// </summary>
+        public string Query { get; }
+
+        /// <summary>
+        /// Parameters to inject into the query at execution
+        /// </summary>
+        public Dictionary<string, object?> Parameters { get; } = new Dictionary<string, object?>();
+
+        /// <summary>
+        /// An evaluated query response.
+        /// </summary>
+        /// <param name="query">The evaluated query</param>
+        public EvaluatedQuery(string query) => Query = query;
+
+        /// <summary>
+        /// An evaluated query response.
+        /// </summary>
+        /// <param name="query">The evaluated query</param>
+        /// <param name="parameters">Parameters to pass into the parameterized query</param>
+        public EvaluatedQuery(string query, Dictionary<string, object?> parameters)
+        {
+            Query = query;
+            Parameters = parameters;
+        }
+    }
+}


### PR DESCRIPTION
As raised by #6500, variables could originate from outside the Studio (from an external source) and therefore could expose the SQL queries to SQL Injection. To address this, the following has been implemented & changed:

- Variables are now inserted via `{{ }}` rather than `@`. I.e. `{{Variables.SomeVariable}}` or `{{Input.SomeInput}}`. This simplifies the SqlEvaluator logic and removes the issue with `@` being used within the query itself.
- Inserted variables/inputs/etc are automatically parameterised to prevent SQL Injection. No front end user code required.
- The parameter string format used in parameterising can be overridden in the base classes should another client need access to this, i.e. potentially oracle. Default configuration is `@p0`.
- Simplified client implementations to reduce duplication of code.
- Tested implementation against all four available clients - SqlServer, Sqlite, MySql & PostgreSQL.


This PR closes #6500 - Thanks for a great suggestion @ghazisarhan!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6503)
<!-- Reviewable:end -->
