### PR TITLE
Disable Retry Policy for DispatchWorkflowRequestConsumer to Prevent Duplicate Executions

### DIFF
--- a/src/modules/Elsa.MassTransit/ConsumerDefinitions/DispatchWorkflowRequestConsumerDefinition.cs
+++ b/src/modules/Elsa.MassTransit/ConsumerDefinitions/DispatchWorkflowRequestConsumerDefinition.cs
@@ -22,7 +22,11 @@ public class DispatchWorkflowRequestConsumerDefinition : ConsumerDefinition<Disp
     /// <inheritdoc />
     protected override void ConfigureConsumer(IReceiveEndpointConfigurator endpointConfigurator, IConsumerConfigurator<DispatchWorkflowRequestConsumer> consumerConfigurator, IRegistrationContext context)
     {
-        endpointConfigurator.UseMessageRetry(r => r.Interval(5, 1000));
+        endpointConfigurator.UseMessageRetry(r =>
+        {
+            r.Ignore<InvalidOperationException>(); // Ignore exceptions due to e.g. serialization errors.
+            r.Interval(5, 1000);
+        });
         endpointConfigurator.UseInMemoryOutbox(context);
     }
 }

--- a/src/modules/Elsa.MassTransit/ConsumerDefinitions/DispatchWorkflowRequestConsumerDefinition.cs
+++ b/src/modules/Elsa.MassTransit/ConsumerDefinitions/DispatchWorkflowRequestConsumerDefinition.cs
@@ -22,11 +22,6 @@ public class DispatchWorkflowRequestConsumerDefinition : ConsumerDefinition<Disp
     /// <inheritdoc />
     protected override void ConfigureConsumer(IReceiveEndpointConfigurator endpointConfigurator, IConsumerConfigurator<DispatchWorkflowRequestConsumer> consumerConfigurator, IRegistrationContext context)
     {
-        endpointConfigurator.UseMessageRetry(r =>
-        {
-            r.Ignore<InvalidOperationException>(); // Ignore exceptions due to e.g. serialization errors.
-            r.Interval(5, 1000);
-        });
         endpointConfigurator.UseInMemoryOutbox(context);
     }
 }


### PR DESCRIPTION
Updated the retry policy for DispatchWorkflowRequestConsumer to not retry. Retrying this consumer could lead to duplicate executions of the same workflow instance, which is not desirable. Workflow retries should be handled explicitly to avoid unintended side effects.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6505)
<!-- Reviewable:end -->
