### PR TITLE
Handle conversion of enumerables to arrays in ObjectConverter

### DIFF
--- a/src/modules/Elsa.Expressions/Helpers/ObjectConverter.cs
+++ b/src/modules/Elsa.Expressions/Helpers/ObjectConverter.cs
@@ -248,6 +248,21 @@ public static class ObjectConverter
                     return collection;
                 }
             }
+            
+            if(underlyingTargetType.IsArray)
+            {
+                var executedEnumerable = enumerable.Cast<object>().ToList();
+                var underlyingTargetElementType = underlyingTargetType.GetElementType()!;
+                var array = Array.CreateInstance(underlyingTargetElementType, executedEnumerable.Count);
+                var index = 0;
+                foreach (var item in executedEnumerable)
+                {
+                    var convertedItem = ConvertTo(item, underlyingTargetElementType);
+                    array.SetValue(convertedItem, index);
+                    index++;
+                }
+                return array;
+            }
         }
 
         try

--- a/test/unit/Elsa.Workflows.Core.UnitTests/ObjectConversion/Tests.cs
+++ b/test/unit/Elsa.Workflows.Core.UnitTests/ObjectConversion/Tests.cs
@@ -300,4 +300,17 @@ public class Tests
         Assert.Equal("Alice", result[0].Name);
         Assert.Equal("Bob", result[1].Name);
     }
+
+    [Fact]
+    public void ConvertFrom_ObjectArrayOfDoubleToArrayOfDouble_ReturnsArrayOfDouble()
+    {
+        // Arrange
+        object[] objectArray = [1d, 2d, 3d];
+        
+        // Act
+        var result = objectArray.ConvertTo<double[]>();
+        
+        // Assert
+        Assert.NotNull(result);
+    }
 }


### PR DESCRIPTION
Added functionality to convert enumerables to arrays when the target type is an array. The implementation ensures each item is properly cast to the target array's element type and then added to the resulting array.

Fixes #6330

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6508)
<!-- Reviewable:end -->
