### PR TITLE
Add object converters for Enum and JsonElement handling

### DIFF
--- a/src/modules/Elsa.JavaScript/ObjectConverters/EnumToStringConverter.cs
+++ b/src/modules/Elsa.JavaScript/ObjectConverters/EnumToStringConverter.cs
@@ -1,0 +1,21 @@
+using System.Diagnostics.CodeAnalysis;
+using Jint;
+using Jint.Native;
+using Jint.Runtime.Interop;
+
+namespace Elsa.JavaScript.ObjectConverters;
+
+internal class EnumToStringConverter : IObjectConverter
+{
+    public bool TryConvert(Engine engine, object value, [NotNullWhen(true)] out JsValue? result)
+    {
+        if (value is Enum)
+        {
+            result = value.ToString();
+            return true;
+        }
+
+        result = JsValue.Null;
+        return false;
+    }
+}

--- a/src/modules/Elsa.JavaScript/ObjectConverters/JsonElementConverter.cs
+++ b/src/modules/Elsa.JavaScript/ObjectConverters/JsonElementConverter.cs
@@ -1,0 +1,37 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Jint;
+using Jint.Native;
+using Jint.Runtime.Interop;
+
+namespace Elsa.JavaScript.ObjectConverters;
+
+internal class JsonElementConverter : IObjectConverter
+{
+    public bool TryConvert(Engine engine, object value, [NotNullWhen(true)] out JsValue? result)
+    {
+        if (value is JsonElement jsonElement)
+        {
+            result = ConvertJsonElementToJsValue(engine, jsonElement);
+            return true;
+        }
+
+        result = JsValue.Null;
+        return false;
+    }
+
+    private static JsValue ConvertJsonElementToJsValue(Engine engine, JsonElement element) =>
+        element.ValueKind switch
+        {
+            JsonValueKind.Object => JsValue.FromObject(engine, JsonObject.Create(element)),
+            JsonValueKind.Array => JsValue.FromObject(engine, JsonArray.Create(element)),
+            JsonValueKind.String => JsValue.FromObject(engine, element.GetString()),
+            JsonValueKind.Number => element.TryGetInt32(out var intValue) ? JsNumber.Create(intValue) : JsNumber.Create(element.GetDouble()),
+            JsonValueKind.True => JsBoolean.True,
+            JsonValueKind.False => JsBoolean.False,
+            JsonValueKind.Undefined => JsValue.Undefined,
+            JsonValueKind.Null => JsValue.Null,
+            _ => throw new InvalidOperationException($"Unsupported JsonValueKind: {element.ValueKind}")
+        };
+}

--- a/src/modules/Elsa.JavaScript/Services/JintJavaScriptEvaluator.cs
+++ b/src/modules/Elsa.JavaScript/Services/JintJavaScriptEvaluator.cs
@@ -65,7 +65,7 @@ public class JintJavaScriptEvaluator(IConfiguration configuration, INotification
         if (_jintOptions.AllowClrAccess)
             options.AllowClr();
     }
-    
+
     private void ConfigureObjectWrapper(Jint.Options options)
     {
         options.SetWrapObjectHandler((engine, target, type) =>
@@ -81,7 +81,7 @@ public class JintJavaScriptEvaluator(IConfiguration configuration, INotification
 
     private void ConfigureObjectConverters(Jint.Options options)
     {
-        options.Interop.ObjectConverters.AddRange([new ByteArrayConverter()]);
+        options.Interop.ObjectConverters.AddRange([new ByteArrayConverter(), new EnumToStringConverter(), new JsonElementConverter()]);
     }
 
     private void ConfigureArgumentGetters(Engine engine, ExpressionEvaluatorOptions options)
@@ -89,7 +89,7 @@ public class JintJavaScriptEvaluator(IConfiguration configuration, INotification
         foreach (var argument in options.Arguments)
             engine.SetValue($"get{argument.Key}", (Func<object?>)(() => argument.Value));
     }
-    
+
     private void ConfigureConfigurationAccess(Engine engine)
     {
         if (_jintOptions.AllowConfigurationAccess)
@@ -118,16 +118,10 @@ public class JintJavaScriptEvaluator(IConfiguration configuration, INotification
 
     private Prepared<Script> PrepareScript(string expression)
     {
-        var prepareOptions = new ScriptPreparationOptions
-        {
-            ParsingOptions = new ScriptParsingOptions
-            {
-                AllowReturnOutsideFunction = true
-            }
-        };
+        var prepareOptions = new ScriptPreparationOptions { ParsingOptions = new ScriptParsingOptions { AllowReturnOutsideFunction = true } };
         return Engine.PrepareScript(expression, options: prepareOptions);
     }
-    
+
     private string Hash(string input)
     {
         var bytes = Encoding.UTF8.GetBytes(input);


### PR DESCRIPTION
Introduce `EnumToStringConverter` and `JsonElementConverter` to support conversion of enums and JSON elements in the JavaScript evaluation process. Update `JintJavaScriptEvaluator` to include these converters in the object conversion pipeline.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6515)
<!-- Reviewable:end -->
