### PR TITLE
Expose IBusRegistrationContext while configure Mass Transit Bus

### DIFF
--- a/src/apps/Elsa.Server.Web/Program.cs
+++ b/src/apps/Elsa.Server.Web/Program.cs
@@ -481,7 +481,7 @@ services
 
                 if (massTransitBroker == MassTransitBroker.AzureServiceBus)
                 {
-                    massTransit.UseAzureServiceBus(azureServiceBusConnectionString, serviceBusFeature => serviceBusFeature.ConfigureServiceBus = bus =>
+                    massTransit.UseAzureServiceBus(azureServiceBusConnectionString, serviceBusFeature => serviceBusFeature.ConfigureServiceBus = (context, bus) =>
                     {
                         bus.PrefetchCount = 50;
                         bus.LockDuration = TimeSpan.FromMinutes(5);
@@ -493,7 +493,7 @@ services
 
                 if (massTransitBroker == MassTransitBroker.RabbitMq)
                 {
-                    massTransit.UseRabbitMq(rabbitMqConnectionString, rabbit => rabbit.ConfigureServiceBus = bus =>
+                    massTransit.UseRabbitMq(rabbitMqConnectionString, rabbit => rabbit.ConfigureServiceBus = (context, bus) =>
                     {
                         bus.PrefetchCount = 50;
                         bus.Durable = true;

--- a/src/modules/Elsa.MassTransit.AzureServiceBus/Features/AzureServiceBusFeature.cs
+++ b/src/modules/Elsa.MassTransit.AzureServiceBus/Features/AzureServiceBusFeature.cs
@@ -53,7 +53,7 @@ public class AzureServiceBusFeature : FeatureBase
     /// <summary>
     /// A delegate that configures the Azure Service Bus transport options.
     /// </summary>
-    public Action<IServiceBusBusFactoryConfigurator>? ConfigureServiceBus { get; set; }
+    public Action<IBusRegistrationContext, IServiceBusBusFactoryConfigurator>? ConfigureServiceBus { get; set; }
 
     /// <summary>
     /// A delegate to configure <see cref="AzureServiceBusOptions"/>.
@@ -103,7 +103,7 @@ public class AzureServiceBusFeature : FeatureBase
                     configurator.ConcurrentMessageLimit = options.ConcurrentMessageLimit;
 
                     configurator.UseServiceBusMessageScheduler();
-                    ConfigureServiceBus?.Invoke(configurator);
+                    ConfigureServiceBus?.Invoke(context, configurator);
                     var instanceNameProvider = context.GetRequiredService<IApplicationInstanceNameProvider>();
 
                     foreach (var consumer in temporaryConsumers)

--- a/src/modules/Elsa.MassTransit.RabbitMq/Features/RabbitMqServiceBusFeature.cs
+++ b/src/modules/Elsa.MassTransit.RabbitMq/Features/RabbitMqServiceBusFeature.cs
@@ -39,7 +39,7 @@ public class RabbitMqServiceBusFeature : FeatureBase
     /// <summary>
     /// Configures the RabbitMQ bus.
     /// </summary>
-    public Action<IRabbitMqBusFactoryConfigurator>? ConfigureServiceBus { get; set; }
+    public Action<IBusRegistrationContext, IRabbitMqBusFactoryConfigurator>? ConfigureServiceBus { get; set; }
 
     /// <inheritdoc />
     public override void Configure()
@@ -68,7 +68,7 @@ public class RabbitMqServiceBusFeature : FeatureBase
                         configurator.PrefetchCount = options.PrefetchCount.Value;
                     configurator.ConcurrentMessageLimit = options.ConcurrentMessageLimit;
 
-                    ConfigureServiceBus?.Invoke(configurator);
+                    ConfigureServiceBus?.Invoke(context, configurator);
 
                     foreach (var consumer in temporaryConsumers)
                     {


### PR DESCRIPTION
Expose `Masstransit.IBusRegistrationContext` within configuration-Callback to enable Filter-Configuration for MassTransit

solution for Feature Request #6552 