### PR TITLE
2.x Fix array enumeration in JsonFilter

### DIFF
--- a/src/scripting/Elsa.Scripting.Liquid/Filters/JsonFilter.cs
+++ b/src/scripting/Elsa.Scripting.Liquid/Filters/JsonFilter.cs
@@ -15,7 +15,7 @@ namespace Elsa.Scripting.Liquid.Filters
             switch (input.Type)
             {
                 case FluidValues.Array:
-                    return new ValueTask<FluidValue>(new StringValue(JsonConvert.SerializeObject(input.Enumerate().Select(o => o.ToObjectValue()))));
+                    return new ValueTask<FluidValue>(new StringValue(JsonConvert.SerializeObject(input.Enumerate(context).Select(o => o.ToObjectValue()))));
 
                 case FluidValues.Boolean:
                     return new ValueTask<FluidValue>(new StringValue(JsonConvert.SerializeObject(input.ToBooleanValue())));


### PR DESCRIPTION
Use Enumerate(TemplateContext) instead of Enumerate() (which is obsolete and returns an empty array)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6564)
<!-- Reviewable:end -->
