### PR TITLE
Fix Dispatch Workflow Resumption

### DIFF
--- a/src/modules/Elsa.Workflows.Runtime/Services/LocalWorkflowClient.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Services/LocalWorkflowClient.cs
@@ -104,7 +104,7 @@ public class LocalWorkflowClient(
         return workflowInstanceManager.ExistsAsync(workflowInstanceId, cancellationToken);
     }
 
-    private async Task<RunWorkflowInstanceResponse> RunInstanceAsync(WorkflowInstance workflowInstance, RunWorkflowInstanceRequest request, CancellationToken cancellationToken = default)
+    public async Task<RunWorkflowInstanceResponse> RunInstanceAsync(WorkflowInstance workflowInstance, RunWorkflowInstanceRequest request, CancellationToken cancellationToken = default)
     {
         var workflowState = workflowInstance.WorkflowState;
 


### PR DESCRIPTION
Updated `CreateAndRunInstanceAsync` to separate instance creation and execution with locking to handle nested workflow scenarios. Made `RunInstanceAsync` public to facilitate reuse in the distributed workflow client.

Fixes #6577

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6586)
<!-- Reviewable:end -->
