### PR TITLE
Make input variable names case-insensitive in dictionary

### DIFF
--- a/src/modules/Elsa.JavaScript/Handlers/ConfigureEngineWithVariablesAndInputOutputAccessors.cs
+++ b/src/modules/Elsa.JavaScript/Handlers/ConfigureEngineWithVariablesAndInputOutputAccessors.cs
@@ -55,7 +55,7 @@ public class ConfigureEngineWithVariablesAndInputOutputAccessors(IOptions<JintOp
         if (context.IsContainedWithinCompositeActivity())
             return;
 
-        var inputs = context.GetWorkflowInputs().Where(x => x.Name.IsValidVariableName()).ToDictionary(x => x.Name);
+        var inputs = context.GetWorkflowInputs().Where(x => x.Name.IsValidVariableName()).ToDictionary(x => x.Name, StringComparer.OrdinalIgnoreCase);
 
         if (!context.TryGetWorkflowExecutionContext(out var workflowExecutionContext))
             return;

--- a/src/modules/Elsa.JavaScript/Services/JintJavaScriptEvaluator.cs
+++ b/src/modules/Elsa.JavaScript/Services/JintJavaScriptEvaluator.cs
@@ -32,8 +32,8 @@ public class JintJavaScriptEvaluator(IConfiguration configuration, INotification
     public async Task<object?> EvaluateAsync(string expression,
         Type returnType,
         ExpressionExecutionContext context,
-        ExpressionEvaluatorOptions? options = default,
-        Action<Engine>? configureEngine = default,
+        ExpressionEvaluatorOptions? options = null,
+        Action<Engine>? configureEngine = null,
         CancellationToken cancellationToken = default)
     {
         var engine = await GetConfiguredEngine(configureEngine, context, options, cancellationToken);
@@ -46,7 +46,7 @@ public class JintJavaScriptEvaluator(IConfiguration configuration, INotification
 
     private async Task<Engine> GetConfiguredEngine(Action<Engine>? configureEngine, ExpressionExecutionContext context, ExpressionEvaluatorOptions? options, CancellationToken cancellationToken)
     {
-        options ??= new ExpressionEvaluatorOptions();
+        options ??= new();
 
         var engineOptions = new Jint.Options
         {
@@ -130,7 +130,7 @@ public class JintJavaScriptEvaluator(IConfiguration configuration, INotification
     {
         var prepareOptions = new ScriptPreparationOptions
         {
-            ParsingOptions = new ScriptParsingOptions
+            ParsingOptions = new()
             {
                 AllowReturnOutsideFunction = true
             }


### PR DESCRIPTION
Previously, input variable names were case-sensitive when added to the dictionary, which could lead to potential issues with naming mismatches. This change ensures that input names are now treated as case-insensitive by using `StringComparer.OrdinalIgnoreCase`, improving consistency and usability.

Fixes #6598

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6590)
<!-- Reviewable:end -->
