### PR TITLE
Start a new workflow trace when triggered from UI

### DIFF
--- a/src/modules/Elsa.OpenTelemetry/Features/OpenTelemetryFeature.cs
+++ b/src/modules/Elsa.OpenTelemetry/Features/OpenTelemetryFeature.cs
@@ -2,16 +2,34 @@ using Elsa.Features.Abstractions;
 using Elsa.Features.Services;
 using Elsa.OpenTelemetry.Contracts;
 using Elsa.OpenTelemetry.Handlers;
+using Elsa.OpenTelemetry.Options;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Elsa.OpenTelemetry.Features;
 
 public class OpenTelemetryFeature(IModule module) : FeatureBase(module)
 {
+    /// <summary>
+    /// When active this will create a new root Activity if the current Activity has a remote parent.
+    /// </summary>
+    public bool UseNewRootActivityForRemoteParent { get; set; } = true;
+    
+    /// <summary>
+    /// Determines if instead of a empty parent, a dummy parent Activity should be used to create a new Root Activity.
+    /// </summary>
+    /// <remarks>This is needed when middleware is active that uses the previous Parent Activity despite creating an Activity based on an empty Parent.</remarks>
+    public bool UseDummyParentActivityAsRootSpan { get; set; } = false;
+    
     public override void Configure()
     {
         Services
             .AddScoped<IErrorSpanHandler, DefaultErrorSpanHandler>()
             .AddScoped<IErrorSpanHandler, FaultExceptionErrorSpanHandler>();
+
+        Services.Configure<OpenTelemetryOptions>(options =>
+        {
+            options.UseNewRootActivityForRemoteParent = UseNewRootActivityForRemoteParent;
+            options.UseDummyParentActivityAsRootSpan = UseDummyParentActivityAsRootSpan;
+        });
     }
 }

--- a/src/modules/Elsa.OpenTelemetry/Features/OpenTelemetryFeature.cs
+++ b/src/modules/Elsa.OpenTelemetry/Features/OpenTelemetryFeature.cs
@@ -17,7 +17,7 @@ public class OpenTelemetryFeature(IModule module) : FeatureBase(module)
     /// <summary>
     /// Determines if instead of a empty parent, a dummy parent Activity should be used to create a new Root Activity.
     /// </summary>
-    /// <remarks>This is needed when middleware is active that uses the previous Parent Activity despite creating an Activity based on an empty Parent.</remarks>
+    /// <remarks>This is needed for Datadog middleware that uses the previous parent Activity despite creating an Activity based on an empty parent.</remarks>
     public bool UseDummyParentActivityAsRootSpan { get; set; } = false;
     
     public override void Configure()

--- a/src/modules/Elsa.OpenTelemetry/Options/OpenTelemetryOptions.cs
+++ b/src/modules/Elsa.OpenTelemetry/Options/OpenTelemetryOptions.cs
@@ -1,0 +1,7 @@
+namespace Elsa.OpenTelemetry.Options;
+
+public class OpenTelemetryOptions
+{
+    public bool UseNewRootActivityForRemoteParent { get; set; }
+    public bool UseDummyParentActivityAsRootSpan { get; set; }
+}


### PR DESCRIPTION
Adds an option to use a dummy activity as a hack to prevent other middleware of reinstating the parent activity

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6606)
<!-- Reviewable:end -->
