### PR TITLE
fix: code fixed to allow loading all the descriptors in the UI

### DIFF
--- a/src/modules/Elsa.Workflows.Core/Services/ActivityRegistry.cs
+++ b/src/modules/Elsa.Workflows.Core/Services/ActivityRegistry.cs
@@ -24,7 +24,7 @@ public class ActivityRegistry(IActivityDescriber activityDescriber, IEnumerable<
     }
 
     /// <inheritdoc />
-    public IEnumerable<ActivityDescriptor> ListAll() => _activityDescriptors.Values.DistinctBy(x => x.TypeName);
+    public IEnumerable<ActivityDescriptor> ListAll() => _activityDescriptors.Values;
 
     /// <inheritdoc />
     public IEnumerable<ActivityDescriptor> ListByProvider(Type providerType) => _providedActivityDescriptors.TryGetValue(providerType, out var descriptors) ? descriptors : ArraySegment<ActivityDescriptor>.Empty;


### PR DESCRIPTION
@sfmskywalker 
This bug fix addresses the inconsistency in loading workflows marked as "Usable As Activity" in the Activity Panel.

Previously, when a user loaded a main workflow that included a sub-workflow with multiple versions (e.g., the third version), the system was sometimes unable to locate it in the activity descriptors. This issue was caused by a Distinct filter that excluded the intended version.

The fix resolves both the loading inconsistency and the version-mismatch problem.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6648)
<!-- Reviewable:end -->
