### PR TITLE
Fix spelling in hosted service LogError messages

### DIFF
--- a/src/common/Elsa.Mediator/HostedServices/BackgroundCommandSenderHostedService.cs
+++ b/src/common/Elsa.Mediator/HostedServices/BackgroundCommandSenderHostedService.cs
@@ -67,7 +67,7 @@ public class BackgroundCommandSenderHostedService : BackgroundService
             }
             catch (Exception e)
             {
-                _logger.LogError(e, "An unhandled exception occured while processing the queue");
+                _logger.LogError(e, "An unhandled exception occurred while processing the queue");
             }
         }
     }

--- a/src/common/Elsa.Mediator/HostedServices/BackgroundEventPublisherHostedService.cs
+++ b/src/common/Elsa.Mediator/HostedServices/BackgroundEventPublisherHostedService.cs
@@ -73,7 +73,7 @@ public class BackgroundEventPublisherHostedService : BackgroundService
             }
             catch (Exception e)
             {
-                _logger.LogError(e, "An unhandled exception occured while processing the queue");
+                _logger.LogError(e, "An unhandled exception occurred while processing the queue");
             }
         }
     }


### PR DESCRIPTION
## Summary
- fix typo "occured" -> "occurred" in hosted services

## Testing
- `git status --short`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6654)
<!-- Reviewable:end -->
