### PR TITLE
Fix SetVariable test

### DIFF
--- a/test/unit/Elsa.Workflows.Core.UnitTests/ExpressionExecutionContextExtensionsTests.cs
+++ b/test/unit/Elsa.Workflows.Core.UnitTests/ExpressionExecutionContextExtensionsTests.cs
@@ -78,7 +78,7 @@ public class ExpressionExecutionContextExtensionsTests
         var context = new ExpressionExecutionContext(null!, memoryRegister);
 
         // Act
-        context.CreateVariable("newVariable", 10);
+        context.SetVariable("newVariable", 10);
 
         // Assert
         var variable = context.GetVariable<int>("newVariable");


### PR DESCRIPTION
## Summary
- fix test to use `context.SetVariable` when checking variable creation

## Testing
- `bash build.sh --target test` *(fails: `dotnet` not found)*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6656)
<!-- Reviewable:end -->
