### PR TITLE
Fix FileSystemWatcher cleanup

### DIFF
--- a/src/common/Elsa.DropIns/HostedServices/DropInDirectoryMonitorHostedService.cs
+++ b/src/common/Elsa.DropIns/HostedServices/DropInDirectoryMonitorHostedService.cs
@@ -120,4 +120,24 @@ public class DropInDirectoryMonitorHostedService : BackgroundService
         }
         return Task.CompletedTask;
     }
+
+    /// <inheritdoc />
+    public override async Task StopAsync(CancellationToken cancellationToken)
+    {
+        _watcher.EnableRaisingEvents = false;
+        _watcher.Changed -= OnChanged;
+        _watcher.Deleted -= OnDeleted;
+
+        await base.StopAsync(cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public override void Dispose()
+    {
+        _watcher.Changed -= OnChanged;
+        _watcher.Deleted -= OnDeleted;
+        _watcher.Dispose();
+
+        base.Dispose();
+    }
 }


### PR DESCRIPTION
## Summary
- ensure `DropInDirectoryMonitorHostedService` stops watching and disposes the watcher

## Testing
- `dotnet test --no-build` *(fails: `dotnet` command not found)*