### PR TITLE
Add optional workflow output flag

### DIFF
--- a/src/modules/Elsa.Workflows.Runtime.Distributed/Services/DistributedWorkflowClient.cs
+++ b/src/modules/Elsa.Workflows.Runtime.Distributed/Services/DistributedWorkflowClient.cs
@@ -50,7 +50,8 @@ public class DistributedWorkflowClient(
             Variables = request.Variables,
             Properties = request.Properties,
             TriggerActivityId = request.TriggerActivityId,
-            ActivityHandle = request.ActivityHandle
+            ActivityHandle = request.ActivityHandle,
+            IncludeWorkflowOutput = request.IncludeWorkflowOutput
         }, cancellationToken));
     }
 

--- a/src/modules/Elsa.Workflows.Runtime.ProtoActor/Actors/WorkflowInstance.cs
+++ b/src/modules/Elsa.Workflows.Runtime.ProtoActor/Actors/WorkflowInstance.cs
@@ -73,6 +73,7 @@ internal class WorkflowInstance(
     public override Task Run(RunWorkflowInstanceRequest request, Action<RunWorkflowInstanceResponse> respond, Action<string> onError)
     {
         var mappedRequest = mappers.RunWorkflowParamsMapper.Map(request);
+        var includeOutput = request.IncludeWorkflowOutput;
         Context.ReenterAfter(RunAsync(mappedRequest), async completedTask =>
         {
             if (completedTask.IsFaulted)
@@ -80,7 +81,7 @@ internal class WorkflowInstance(
             else
             {
                 var result = await completedTask;
-                respond(mappers.RunWorkflowInstanceResponseMapper.Map(result));
+                respond(mappers.RunWorkflowInstanceResponseMapper.Map(result, includeOutput));
             }
         });
 
@@ -144,7 +145,7 @@ internal class WorkflowInstance(
 
         var result = await RunAsync(runWorkflowOptions);
 
-        return mappers.RunWorkflowInstanceResponseMapper.Map(result);
+        return mappers.RunWorkflowInstanceResponseMapper.Map(result, request.IncludeWorkflowOutput);
     }
 
     public override Task Stop()

--- a/src/modules/Elsa.Workflows.Runtime.ProtoActor/Extensions/ProtoOutputExtensions.cs
+++ b/src/modules/Elsa.Workflows.Runtime.ProtoActor/Extensions/ProtoOutputExtensions.cs
@@ -1,0 +1,15 @@
+using Elsa.Workflows.Runtime.ProtoActor.ProtoBuf;
+
+namespace Elsa.Workflows.Runtime.ProtoActor.Extensions;
+
+internal static class ProtoOutputExtensions
+{
+    public static IDictionary<string, object> DeserializeOutput(this Output output) => output.Data.Deserialize();
+
+    public static Output SerializeOutput(this IDictionary<string, object> output)
+    {
+        var result = new Output();
+        output.Serialize(result.Data);
+        return result;
+    }
+}

--- a/src/modules/Elsa.Workflows.Runtime.ProtoActor/Mappers/CreateAndRunWorkflowInstanceRequestMapper.cs
+++ b/src/modules/Elsa.Workflows.Runtime.ProtoActor/Mappers/CreateAndRunWorkflowInstanceRequestMapper.cs
@@ -30,6 +30,7 @@ public class CreateAndRunWorkflowInstanceRequestMapper(WorkflowDefinitionHandleM
             Properties = source.Properties?.SerializeProperties() ?? new ProtoProperties(),
             TriggerActivityId = source.TriggerActivityId.EmptyIfNull(),
             ActivityHandle = activityHandleMapper.Map(source?.ActivityHandle) ?? new(),
+            IncludeWorkflowOutput = source.IncludeWorkflowOutput,
         };
     }
 
@@ -49,6 +50,7 @@ public class CreateAndRunWorkflowInstanceRequestMapper(WorkflowDefinitionHandleM
             Input = source.Input?.DeserializeInput(),
             Properties = source.Properties?.DeserializeProperties(),
             ActivityHandle = activityHandleMapper.Map(source.ActivityHandle),
+            IncludeWorkflowOutput = source.IncludeWorkflowOutput,
         };
     }
 }

--- a/src/modules/Elsa.Workflows.Runtime.ProtoActor/Mappers/RunWorkflowInstanceRequestMapper.cs
+++ b/src/modules/Elsa.Workflows.Runtime.ProtoActor/Mappers/RunWorkflowInstanceRequestMapper.cs
@@ -22,6 +22,7 @@ public class RunWorkflowInstanceRequestMapper(ActivityHandleMapper activityHandl
             TriggerActivityId = source?.TriggerActivityId.EmptyIfNull(),
             Input = source?.Input?.SerializeInput(),
             Properties = source?.Properties?.SerializeProperties(),
+            IncludeWorkflowOutput = source?.IncludeWorkflowOutput ?? false,
         };
     }
 
@@ -37,6 +38,7 @@ public class RunWorkflowInstanceRequestMapper(ActivityHandleMapper activityHandl
             TriggerActivityId = source.TriggerActivityId,
             Input = source.Input?.DeserializeInput(),
             Properties = source.Properties?.DeserializeProperties(),
+            IncludeWorkflowOutput = source.IncludeWorkflowOutput,
         };
     }
 }

--- a/src/modules/Elsa.Workflows.Runtime.ProtoActor/Mappers/RunWorkflowInstanceResponseMapper.cs
+++ b/src/modules/Elsa.Workflows.Runtime.ProtoActor/Mappers/RunWorkflowInstanceResponseMapper.cs
@@ -2,6 +2,7 @@ using Elsa.Extensions;
 using Elsa.Workflows.Models;
 using Elsa.Workflows.Runtime.Messages;
 using ProtoRunWorkflowInstanceResponse = Elsa.Workflows.Runtime.ProtoActor.ProtoBuf.RunWorkflowInstanceResponse;
+using Elsa.Workflows.Runtime.ProtoActor.Extensions;
 
 namespace Elsa.Workflows.Runtime.ProtoActor.Mappers;
 
@@ -16,11 +17,11 @@ public class RunWorkflowInstanceResponseMapper(
     /// <summary>
     /// Maps <see cref="RunWorkflowResult"/> to <see cref="ProtoRunWorkflowInstanceResponse"/>.
     /// </summary>
-    public ProtoRunWorkflowInstanceResponse Map(RunWorkflowResult source)
+    public ProtoRunWorkflowInstanceResponse Map(RunWorkflowResult source, bool includeOutput)
     {
         if(source.WorkflowState == null!)
             return new();
-        
+
         var response = new ProtoRunWorkflowInstanceResponse
         {
             Status = workflowStatusMapper.Map(source.WorkflowState.Status),
@@ -28,6 +29,9 @@ public class RunWorkflowInstanceResponseMapper(
         };
 
         response.Incidents.AddRange(activityIncidentMapper.Map(source.WorkflowState.Incidents));
+
+        if (includeOutput)
+            response.Output = source.WorkflowState.Output.SerializeOutput();
         return response;
     }
 
@@ -41,10 +45,11 @@ public class RunWorkflowInstanceResponseMapper(
             WorkflowInstanceId = workflowInstanceId,
             Status = workflowStatusMapper.Map(source.Status),
             SubStatus = workflowSubStatusMapper.Map(source.SubStatus),
+            Output = source.Output?.DeserializeOutput()
         };
 
         response.Incidents.AddRange(activityIncidentMapper.Map(source.Incidents));
         return response;
-        
+
     }
 }

--- a/src/modules/Elsa.Workflows.Runtime.ProtoActor/Proto/Shared.proto
+++ b/src/modules/Elsa.Workflows.Runtime.ProtoActor/Proto/Shared.proto
@@ -18,6 +18,10 @@ message Properties {
   map<string, Json> Data = 1;
 }
 
+message Output {
+  map<string, Json> Data = 1;
+}
+
 message ExceptionState {
   string Type = 1;
   string Message = 2;

--- a/src/modules/Elsa.Workflows.Runtime.ProtoActor/Proto/WorkflowInstance.Messages.proto
+++ b/src/modules/Elsa.Workflows.Runtime.ProtoActor/Proto/WorkflowInstance.Messages.proto
@@ -61,12 +61,14 @@ message RunWorkflowInstanceRequest{
   optional Input input = 3;
   optional Properties properties = 4;
   optional string TriggerActivityId = 5;
+  bool IncludeWorkflowOutput = 6;
 }
 
 message RunWorkflowInstanceResponse {
   WorkflowStatus Status = 1;
   WorkflowSubStatus SubStatus = 2;
   repeated ActivityIncident Incidents = 3;
+  optional Output output = 4;
 }
 
 message CreateAndRunWorkflowInstanceRequest{
@@ -79,6 +81,7 @@ message CreateAndRunWorkflowInstanceRequest{
   optional Properties properties = 7;
   optional ActivityHandle ActivityHandle = 8;
   optional string TriggerActivityId = 9;
+  bool IncludeWorkflowOutput = 10;
 }
 
 message ExportWorkflowStateResponse {

--- a/src/modules/Elsa.Workflows.Runtime/Messages/CreateAndRunWorkflowInstanceRequest.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Messages/CreateAndRunWorkflowInstanceRequest.cs
@@ -53,4 +53,9 @@ public class CreateAndRunWorkflowInstanceRequest
     /// The handle of the activity to schedule, if any.
     /// </summary>
     public ActivityHandle? ActivityHandle { get; set; }
+
+    /// <summary>
+    /// When set to <c>true</c>, include workflow output in the response.
+    /// </summary>
+    public bool IncludeWorkflowOutput { get; set; }
 }

--- a/src/modules/Elsa.Workflows.Runtime/Messages/RunWorkflowInstanceRequest.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Messages/RunWorkflowInstanceRequest.cs
@@ -40,6 +40,11 @@ public class RunWorkflowInstanceRequest
     public IDictionary<string, object>? Variables { get; set; }
 
     /// <summary>
+    /// When set to <c>true</c>, include workflow output in the response.
+    /// </summary>
+    public bool IncludeWorkflowOutput { get; set; }
+
+    /// <summary>
     /// Represents an empty <see cref="RunWorkflowInstanceRequest"/> object used as a default value.
     /// </summary>
     public static RunWorkflowInstanceRequest Empty => new();

--- a/src/modules/Elsa.Workflows.Runtime/Messages/RunWorkflowInstanceResponse.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Messages/RunWorkflowInstanceResponse.cs
@@ -28,4 +28,9 @@ public record RunWorkflowInstanceResponse
     /// Any incidents that occurred during the execution of the workflow instance.
     /// </summary>
     public ICollection<ActivityIncident> Incidents { get; set; } = new List<ActivityIncident>();
+
+    /// <summary>
+    /// The output produced by the workflow instance.
+    /// </summary>
+    public IDictionary<string, object>? Output { get; set; }
 }

--- a/src/modules/Elsa.Workflows.Runtime/Services/LocalWorkflowClient.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Services/LocalWorkflowClient.cs
@@ -71,7 +71,8 @@ public class LocalWorkflowClient(
             Variables = request.Variables,
             Properties = request.Properties,
             TriggerActivityId = request.TriggerActivityId,
-            ActivityHandle = request.ActivityHandle
+            ActivityHandle = request.ActivityHandle,
+            IncludeWorkflowOutput = request.IncludeWorkflowOutput
         }, cancellationToken);
     }
 
@@ -139,7 +140,8 @@ public class LocalWorkflowClient(
             WorkflowInstanceId = WorkflowInstanceId,
             Status = workflowState.Status,
             SubStatus = workflowState.SubStatus,
-            Incidents = workflowState.Incidents
+            Incidents = workflowState.Incidents,
+            Output = request.IncludeWorkflowOutput ? new Dictionary<string, object>(workflowState.Output) : null
         };
     }
     


### PR DESCRIPTION
## Summary
- add `IncludeWorkflowOutput` option to workflow run request messages
- return workflow output when flag is enabled
- propagate setting through local, distributed and ProtoActor clients
- extend ProtoActor protocol and mappers

## Testing
- `dotnet test` *(fails: `dotnet` command not found)*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6659)
<!-- Reviewable:end -->
