### PR TITLE
Fix async callback awaiting in HTTP endpoint

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -11,6 +11,7 @@ on:
       - 'enh/*'
       - 'rc/*'
       - 'develop/*'
+      - 'codex/*'
   release:
     types: [ prereleased, published ]
 env:

--- a/src/modules/Elsa.Http/Activities/HttpEndpoint.cs
+++ b/src/modules/Elsa.Http/Activities/HttpEndpoint.cs
@@ -163,7 +163,7 @@ public class HttpEndpoint : Trigger<HttpRequest>
     {
         var path = Path.Get(context);
         var methods = SupportedMethods.GetOrDefault(context) ?? new List<string> { HttpMethods.Get };
-        context.WaitForHttpRequest(path, methods, OnResumeAsync);
+        await context.WaitForHttpRequest(path, methods, OnResumeAsync);
     }
 
     private async ValueTask OnResumeAsync(ActivityExecutionContext context)
@@ -175,7 +175,7 @@ public class HttpEndpoint : Trigger<HttpRequest>
         {
             // We're executing in a non-HTTP context (e.g. in a virtual actor).
             // Create a bookmark to allow the invoker to export the state and resume execution from there.
-            context.CreateCrossBoundaryBookmark();
+            await context.CreateCrossBoundaryBookmark();
             return;
         }
 

--- a/src/modules/Elsa.Http/Activities/HttpEndpoint.cs
+++ b/src/modules/Elsa.Http/Activities/HttpEndpoint.cs
@@ -175,7 +175,7 @@ public class HttpEndpoint : Trigger<HttpRequest>
         {
             // We're executing in a non-HTTP context (e.g. in a virtual actor).
             // Create a bookmark to allow the invoker to export the state and resume execution from there.
-            await context.CreateCrossBoundaryBookmark();
+            context.CreateCrossBoundaryBookmark();
             return;
         }
 

--- a/src/modules/Elsa.Http/Activities/HttpEndpoint.cs
+++ b/src/modules/Elsa.Http/Activities/HttpEndpoint.cs
@@ -163,7 +163,7 @@ public class HttpEndpoint : Trigger<HttpRequest>
     {
         var path = Path.Get(context);
         var methods = SupportedMethods.GetOrDefault(context) ?? new List<string> { HttpMethods.Get };
-        await context.WaitForHttpRequest(path, methods, OnResumeAsync);
+        await context.WaitForHttpRequestAsync(path, methods, OnResumeAsync);
     }
 
     private async ValueTask OnResumeAsync(ActivityExecutionContext context)

--- a/src/modules/Elsa.Http/Activities/HttpEndpointBase.cs
+++ b/src/modules/Elsa.Http/Activities/HttpEndpointBase.cs
@@ -20,10 +20,10 @@ public abstract class HttpEndpointBase<TResult> : Trigger<TResult>
     {
     }
 
-    protected override void Execute(ActivityExecutionContext context)
+    protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
     {
         var options = GetOptions();
-        context.WaitForHttpRequest(options, HttpRequestReceivedAsync);
+        await context.WaitForHttpRequest(options, HttpRequestReceivedAsync);
     }
 
     protected override IEnumerable<object> GetTriggerPayloads(TriggerIndexingContext context)

--- a/src/modules/Elsa.Http/Activities/HttpEndpointBase.cs
+++ b/src/modules/Elsa.Http/Activities/HttpEndpointBase.cs
@@ -23,7 +23,7 @@ public abstract class HttpEndpointBase<TResult> : Trigger<TResult>
     protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
     {
         var options = GetOptions();
-        await context.WaitForHttpRequest(options, HttpRequestReceivedAsync);
+        await context.WaitForHttpRequestAsync(options, HttpRequestReceivedAsync);
     }
 
     protected override IEnumerable<object> GetTriggerPayloads(TriggerIndexingContext context)

--- a/src/modules/Elsa.Http/Extensions/HttpEndpointActivityExecutionContextExtensions.cs
+++ b/src/modules/Elsa.Http/Extensions/HttpEndpointActivityExecutionContextExtensions.cs
@@ -83,7 +83,7 @@ public static async ValueTask WaitForHttpRequest(this ActivityExecutionContext c
             .ToArray();
     }
 
-    internal static ValueTask CreateCrossBoundaryBookmark(this ActivityExecutionContext context, ExecuteActivityDelegate? callback = null)
+    internal static void CreateCrossBoundaryBookmark(this ActivityExecutionContext context, ExecuteActivityDelegate? callback = null)
     {
         var bookmarkOptions = new CreateBookmarkArgs
         {
@@ -92,6 +92,5 @@ public static async ValueTask WaitForHttpRequest(this ActivityExecutionContext c
             Metadata = BookmarkMetadata.HttpCrossBoundary,
         };
         context.CreateBookmark(bookmarkOptions);
-        return ValueTask.CompletedTask;
     }
 }

--- a/src/modules/Elsa.Http/Extensions/HttpEndpointActivityExecutionContextExtensions.cs
+++ b/src/modules/Elsa.Http/Extensions/HttpEndpointActivityExecutionContextExtensions.cs
@@ -3,34 +3,33 @@ using Elsa.Extensions;
 using Elsa.Http.Bookmarks;
 using Elsa.Workflows;
 using Elsa.Workflows.Models;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Routing.Patterns;
 
 namespace Elsa.Http.Extensions;
 
 public static class HttpEndpointActivityExecutionContextExtensions
 {
-public static async ValueTask WaitForHttpRequest(this ActivityExecutionContext context, string path, string method, ExecuteActivityDelegate? callback = null)
+public static async ValueTask WaitForHttpRequestAsync(this ActivityExecutionContext context, string path, string method, ExecuteActivityDelegate? callback = null)
 {
     var options = new HttpEndpointOptions
     {
         Path = path,
         Methods = [method]
     };
-    await WaitForHttpRequest(context, options, callback);
+    await WaitForHttpRequestAsync(context, options, callback);
 }
 
-public static async ValueTask WaitForHttpRequest(this ActivityExecutionContext context, string path, IEnumerable<string> methods, ExecuteActivityDelegate? callback = null)
+public static async ValueTask WaitForHttpRequestAsync(this ActivityExecutionContext context, string path, IEnumerable<string> methods, ExecuteActivityDelegate? callback = null)
 {
     var options = new HttpEndpointOptions
     {
         Path = path,
         Methods = methods.ToList()
     };
-    await WaitForHttpRequest(context, options, callback);
+    await WaitForHttpRequestAsync(context, options, callback);
 }
 
-    public static async ValueTask WaitForHttpRequest(this ActivityExecutionContext context, HttpEndpointOptions options, ExecuteActivityDelegate? callback = null)
+    public static async ValueTask WaitForHttpRequestAsync(this ActivityExecutionContext context, HttpEndpointOptions options, ExecuteActivityDelegate? callback = null)
     {
         var path = options.Path;
         if (path.Contains("//"))


### PR DESCRIPTION
## Summary
- await HTTP resume callbacks to avoid losing async continuations
- make `WaitForHttpRequest` async and update callers

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6660)
<!-- Reviewable:end -->
