### PR TITLE
Add initial StateMachine activity support

### DIFF
--- a/src/modules/Elsa.Workflows.Core/Activities/StateMachine/State.cs
+++ b/src/modules/Elsa.Workflows.Core/Activities/StateMachine/State.cs
@@ -1,0 +1,32 @@
+using System.Text.Json.Serialization;
+using Elsa.Workflows.Activities;
+
+namespace Elsa.Workflows.Activities.StateMachine;
+
+/// <summary>
+/// Represents a state within a <see cref="StateMachine"/> activity.
+/// </summary>
+public class State
+{
+    /// <summary>
+    /// The name of the state.
+    /// </summary>
+    public string Name { get; set; } = null!;
+
+    /// <summary>
+    /// Activity to execute when entering the state.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IActivity? Entry { get; set; }
+
+    /// <summary>
+    /// Activity to execute when exiting the state.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IActivity? Exit { get; set; }
+
+    /// <summary>
+    /// Transitions leaving this state.
+    /// </summary>
+    public ICollection<Transition> Transitions { get; set; } = new List<Transition>();
+}

--- a/src/modules/Elsa.Workflows.Core/Activities/StateMachine/StateMachine.cs
+++ b/src/modules/Elsa.Workflows.Core/Activities/StateMachine/StateMachine.cs
@@ -1,0 +1,135 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.Attributes;
+using Elsa.Workflows.Signals;
+
+namespace Elsa.Workflows.Activities.StateMachine;
+
+/// <summary>
+/// Executes a workflow as a state machine.
+/// </summary>
+[Activity("Elsa", "Flow", "Execute a workflow as a state machine.")]
+public class StateMachine : Activity
+{
+    /// <inheritdoc />
+    public StateMachine([CallerFilePath] string? source = null, [CallerLineNumber] int? line = null) : base(source, line)
+    {
+    }
+
+    /// <summary>
+    /// The states in this state machine.
+    /// </summary>
+    public ICollection<State> States { get; set; } = new List<State>();
+
+    /// <summary>
+    /// The name of the initial state.
+    /// </summary>
+    public string? InitialState { get; set; }
+
+    /// <summary>
+    /// The name of the currently active state.
+    /// </summary>
+    public string? CurrentState { get; set; }
+
+    /// <inheritdoc />
+    protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
+    {
+        var stateName = CurrentState ?? InitialState;
+        if (stateName == null)
+        {
+            await context.CompleteActivityAsync();
+            return;
+        }
+
+        var state = FindState(stateName);
+        if (state == null)
+        {
+            await context.CompleteActivityAsync();
+            return;
+        }
+
+        CurrentState = state.Name;
+        await EnterStateAsync(context, state);
+    }
+
+    private readonly Dictionary<Transition, ActivityExecutionContext> _triggerContexts = new();
+
+    private State? FindState(string? name) => name == null ? null : States.FirstOrDefault(x => x.Name == name);
+
+    private async ValueTask EnterStateAsync(ActivityExecutionContext context, State state)
+    {
+        await CancelScheduledTriggersAsync();
+
+        if (state.Entry != null)
+            await context.ScheduleActivityAsync(state.Entry);
+
+        foreach (var transition in state.Transitions)
+        {
+            if (transition.Trigger == null)
+                continue;
+
+            var triggerContext = await context.WorkflowExecutionContext.CreateActivityExecutionContextAsync(transition.Trigger);
+            _triggerContexts[transition] = triggerContext;
+            await context.ScheduleActivityAsync(triggerContext.Activity, new()
+            {
+                CompletionCallback = ctx => OnTriggerCompleted(ctx, transition),
+                ExistingActivityExecutionContext = triggerContext
+            });
+        }
+
+        if (!state.Transitions.Any())
+            await context.CompleteActivityAsync();
+    }
+
+    private async ValueTask OnTriggerCompleted(ActivityCompletedContext context, Transition transition)
+    {
+        var stateMachineContext = context.TargetContext;
+        var condition = transition.Condition == null || stateMachineContext.Get(transition.Condition);
+
+        if (!condition)
+            return;
+
+        await CancelScheduledTriggersAsync(transition);
+
+        if (transition.Action != null)
+        {
+            await stateMachineContext.ScheduleActivityAsync(transition.Action, ctx => OnTransitionActionCompleted(ctx, transition));
+        }
+        else
+        {
+            await OnTransitionActionCompleted(context, transition);
+        }
+    }
+
+    private async ValueTask OnTransitionActionCompleted(ActivityCompletedContext context, Transition transition)
+    {
+        var executionContext = context.TargetContext;
+        var fromState = FindState(CurrentState);
+        var toState = FindState(transition.To);
+
+        if (fromState?.Exit != null)
+            await executionContext.ScheduleActivityAsync(fromState.Exit);
+
+        CurrentState = transition.To;
+
+        if (toState != null)
+            await EnterStateAsync(executionContext, toState);
+        else
+            await executionContext.CompleteActivityAsync();
+    }
+
+    private async ValueTask CancelScheduledTriggersAsync(Transition? except = null)
+    {
+        foreach (var (trans, triggerContext) in _triggerContexts.ToList())
+        {
+            if (except != null && ReferenceEquals(trans, except))
+                continue;
+
+            await triggerContext.CancelActivityAsync();
+            _triggerContexts.Remove(trans);
+        }
+    }
+}

--- a/src/modules/Elsa.Workflows.Core/Activities/StateMachine/Transition.cs
+++ b/src/modules/Elsa.Workflows.Core/Activities/StateMachine/Transition.cs
@@ -1,0 +1,44 @@
+using System.Text.Json.Serialization;
+using Elsa.Expressions.Models;
+using Elsa.Workflows.Activities;
+
+namespace Elsa.Workflows.Activities.StateMachine;
+
+/// <summary>
+/// Represents a transition between states.
+/// </summary>
+public class Transition
+{
+    /// <summary>
+    /// The name of the transition.
+    /// </summary>
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// The source state.
+    /// </summary>
+    public string From { get; set; } = null!;
+
+    /// <summary>
+    /// The target state.
+    /// </summary>
+    public string To { get; set; } = null!;
+
+    /// <summary>
+    /// The trigger activity that causes this transition.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IActivity? Trigger { get; set; }
+
+    /// <summary>
+    /// Optional condition that must evaluate to true for the transition to occur.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public Input<bool>? Condition { get; set; }
+
+    /// <summary>
+    /// Activity to execute as part of the transition.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IActivity? Action { get; set; }
+}


### PR DESCRIPTION
## Summary
- add skeleton classes for a State Machine activity
- implement `StateMachine`, `State`, and `Transition` models
- add cancellation of pending triggers when a transition fires

## Testing
- `dotnet test` *(fails: `dotnet` not found)*