### PR TITLE
Propagating  input and correlation id from parent workflow to child workflow

### DIFF
--- a/src/modules/Elsa.Workflows.Runtime/Activities/ExecuteWorkflow.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Activities/ExecuteWorkflow.cs
@@ -88,7 +88,15 @@ public class ExecuteWorkflow : Activity<ExecuteWorkflowResult>
 
         var parentInstanceId = context.WorkflowExecutionContext.Id;
         var input = Input.GetOrDefault(context) ?? new Dictionary<string, object>();
-        var correlationId = CorrelationId.GetOrDefault(context);
+        // propagate inout from parent workflow to child workflow
+        if (input.Count == 0 && context.WorkflowExecutionContext.Input != null)
+        {
+            input = context.WorkflowExecutionContext.Input;
+        }
+
+        // propagate correlation id from parent workflow to child workflow
+        var correlationId = context.WorkflowExecutionContext.CorrelationId;
+
         var workflowInvoker = context.GetRequiredService<IWorkflowInvoker>();
         var identityGenerator = context.GetRequiredService<IIdentityGenerator>();
         var properties = new Dictionary<string, object>
@@ -117,7 +125,8 @@ public class ExecuteWorkflow : Activity<ExecuteWorkflowResult>
             WorkflowInstanceId = options.WorkflowInstanceId,
             Status = workflowResult.WorkflowState.Status,
             SubStatus = workflowResult.WorkflowState.SubStatus,
-            Output = workflowResult.WorkflowState.Output
+            Output = workflowResult.WorkflowState.Output,
+            CorrelationId = correlationId
         };
 
         return info;

--- a/test/component/Elsa.Workflows.ComponentTests/Scenarios/ExecuteWorkflows/ExecuteWorkflowsTests.cs
+++ b/test/component/Elsa.Workflows.ComponentTests/Scenarios/ExecuteWorkflows/ExecuteWorkflowsTests.cs
@@ -1,10 +1,14 @@
-﻿using Elsa.Common.Models;
+﻿using Elsa.Common.Entities;
+using Elsa.Common.Models;
+using Elsa.Workflows.Activities;
 using Elsa.Workflows.ComponentTests.Abstractions;
 using Elsa.Workflows.ComponentTests.Fixtures;
 using Elsa.Workflows.ComponentTests.Scenarios.ExecuteWorkflows.Workflows;
 using Elsa.Workflows.Models;
 using Elsa.Workflows.Runtime;
+using Elsa.Workflows.Runtime.Filters;
 using Elsa.Workflows.Runtime.Messages;
+using Elsa.Workflows.Runtime.OrderDefinitions;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Elsa.Workflows.ComponentTests.Scenarios.ExecuteWorkflows;
@@ -24,8 +28,39 @@ public class ExecuteWorkflowsTests : AppComponentTest
         var workflowClient = await _workflowRuntime.CreateClientAsync();
         await workflowClient.CreateInstanceAsync(new CreateWorkflowInstanceRequest
         {
-            WorkflowDefinitionHandle = WorkflowDefinitionHandle.ByDefinitionId(MainWorkflow.DefinitionId, VersionOptions.Published)
+            WorkflowDefinitionHandle = WorkflowDefinitionHandle.ByDefinitionId(MainWorkflow.DefinitionId, VersionOptions.Published),
+            CorrelationId = "test-correlation-id",
+            Input = new Dictionary<string, object>
+            {
+                ["Value"] = 2163
+            }
         });
-        await workflowClient.RunInstanceAsync(RunWorkflowInstanceRequest.Empty);
+        
+        var response = await workflowClient.RunInstanceAsync(RunWorkflowInstanceRequest.Empty);
+
+        // child activity
+        var filter = new ActivityExecutionRecordFilter { };
+        var activityExecutionStore = Scope.ServiceProvider.GetRequiredService<IActivityExecutionStore>();
+        var orderBy = new ActivityExecutionRecordOrder<DateTimeOffset>(x => x.StartedAt, OrderDirection.Ascending);
+        var activityExecutionRecords = await activityExecutionStore.FindManyAsync(filter, orderBy);
+
+        var textEntries = activityExecutionRecords
+            .Where(r => r.ActivityState != null && r.WorkflowInstanceId != response.WorkflowInstanceId)
+            .SelectMany(r => r.ActivityState.Where(x => x.Key == nameof(WriteLine.Text)))
+            .Select(r => r.Value)
+            .ToList();
+        Assert.Single(textEntries);
+        Assert.Equal("Running subroutine on value 2163 ..., correlation id is 'test-correlation-id'.", textEntries[0]);
+        
+        // parent activity
+        textEntries = activityExecutionRecords
+            .Where(r => r.ActivityState != null && r.WorkflowInstanceId == response.WorkflowInstanceId)
+            .SelectMany(r => r.ActivityState.Where(x => x.Key == nameof(WriteLine.Text)))
+            .Select(r => r.Value)
+            .ToList();
+        Assert.Single(textEntries);
+        var childWorkflowInstanceId = activityExecutionRecords.Select(r => r.WorkflowInstanceId).Where(r => r != response.WorkflowInstanceId).FirstOrDefault();
+        Assert.Equal("Subroutine output: {\"WorkflowDefinitionVersionId\":null,\"WorkflowInstanceId\":\"" + childWorkflowInstanceId +
+            "\",\"CorrelationId\":\"test-correlation-id\",\"Status\":1,\"SubStatus\":3,\"Output\":{\"Output\":4326}}", textEntries[0]);
     }
 }

--- a/test/component/Elsa.Workflows.ComponentTests/Scenarios/ExecuteWorkflows/Workflows/MainWorkflow.cs
+++ b/test/component/Elsa.Workflows.ComponentTests/Scenarios/ExecuteWorkflows/Workflows/MainWorkflow.cs
@@ -20,10 +20,6 @@ public class MainWorkflow : WorkflowBase
                 new ExecuteWorkflow
                 {
                     WorkflowDefinitionId = new(SubroutineWorkflow.DefinitionId),
-                    Input = new(new Dictionary<string, object>
-                    {
-                        ["Value"] = 21
-                    }),
                     Result = new(workflowResult)
                 },
                 new WriteLine(context => $"Subroutine output: {JsonSerializer.Serialize(workflowResult.Get(context))}")

--- a/test/component/Elsa.Workflows.ComponentTests/Scenarios/ExecuteWorkflows/Workflows/SubroutineWorkflow.cs
+++ b/test/component/Elsa.Workflows.ComponentTests/Scenarios/ExecuteWorkflows/Workflows/SubroutineWorkflow.cs
@@ -19,7 +19,8 @@ public class SubroutineWorkflow : WorkflowBase
         {
             Activities =
             {
-                new WriteLine(context => $"Running subroutine on value {context.GetInput<double>(valueInput)}..."),
+                new WriteLine(context => $"Running subroutine on value {context.GetInput<double>(valueInput)} ..., " +
+                    $"correlation id is '" + context.GetWorkflowExecutionContext().CorrelationId + "'."),
                 new SetOutput
                 {
                     OutputName = new(output.Name),


### PR DESCRIPTION
Input and correlation id is not propagated to child workflow from parent workflow. This PR fixes the ExecuteWorkflow activity to propagate the input and correlation id from parent workflow to child workflow.

If the ExecuteWorkflow activity exists to execute a child workflow, then it is reasonable to assume that the child workflow might be reused by other workflows as well and the input from parent workflows should be propagated to child workflows. 

Correlation id is propagated for tracking purposes.

See this issue https://github.com/elsa-workflows/elsa-core/issues/6706.

The test is not pretty, it would be great to have guidelines on how to test things in Elsa. I tried to create test similar to other tests in Elsa.Workflows.IntegrationTests.Scenarios.RunAsynchronousActivityOutput namespace but it did not capture any text in activity execution records.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6709)
<!-- Reviewable:end -->
