### PR TITLE
Refactor checklists and radio lists to use records

### DIFF
--- a/src/clients/Elsa.Api.Client/Shared/UIHints/CheckList/CheckList.cs
+++ b/src/clients/Elsa.Api.Client/Shared/UIHints/CheckList/CheckList.cs
@@ -1,3 +1,8 @@
 namespace Elsa.Api.Client.Shared.UIHints.CheckList;
 
+/// <summary>
+/// Represents a list of check list items.
+/// </summary>
+/// <param name="Items">The items.</param>
+/// <param name="IsFlagsEnum">Whether the select list represents a flags enum.</param>
 public record CheckList(IEnumerable<CheckListItem> Items, bool IsFlagsEnum = false);

--- a/src/clients/Elsa.Api.Client/Shared/UIHints/CheckList/CheckListItem.cs
+++ b/src/clients/Elsa.Api.Client/Shared/UIHints/CheckList/CheckListItem.cs
@@ -1,10 +1,6 @@
 namespace Elsa.Api.Client.Shared.UIHints.CheckList;
 
-public class CheckListItem
-{
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-    public string Text { get; set; }
-    public string Value { get; set; }
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-    public bool IsChecked { get; set; }
-}
+/// <summary>
+/// Represents an item in a <see cref="CheckList"/>.
+/// </summary>
+public record CheckListItem(string Text, string Value, bool IsChecked);

--- a/src/clients/Elsa.Api.Client/Shared/UIHints/CheckList/CheckListProps.cs
+++ b/src/clients/Elsa.Api.Client/Shared/UIHints/CheckList/CheckListProps.cs
@@ -1,5 +1,8 @@
 namespace Elsa.Api.Client.Shared.UIHints.CheckList;
 
+/// <summary>
+/// Provides properties for the <c>checklist</c> UI hint.
+/// </summary>
 public class CheckListProps
 {
     /// <summary>

--- a/src/clients/Elsa.Api.Client/Shared/UIHints/RadioList/RadioList.cs
+++ b/src/clients/Elsa.Api.Client/Shared/UIHints/RadioList/RadioList.cs
@@ -1,3 +1,8 @@
 namespace Elsa.Api.Client.Shared.UIHints.RadioList;
 
+/// <summary>
+/// Represents a list of radio list items.
+/// </summary>
+/// <param name="Items">The items.</param>
+/// <param name="IsFlagsEnum">Whether the select list represents a flags enum.</param>
 public record RadioList(IEnumerable<RadioListItem> Items, bool IsFlagsEnum = false);

--- a/src/clients/Elsa.Api.Client/Shared/UIHints/RadioList/RadioListItem.cs
+++ b/src/clients/Elsa.Api.Client/Shared/UIHints/RadioList/RadioListItem.cs
@@ -1,9 +1,6 @@
 namespace Elsa.Api.Client.Shared.UIHints.RadioList;
 
-public class RadioListItem
-{
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-    public string Text { get; set; }
-    public string Value { get; set; }
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-}
+/// <summary>
+/// Represents an item in a <see cref="RadioList"/>.
+/// </summary>
+public record RadioListItem(string Text, string Value);

--- a/src/clients/Elsa.Api.Client/Shared/UIHints/RadioList/RadioListProps.cs
+++ b/src/clients/Elsa.Api.Client/Shared/UIHints/RadioList/RadioListProps.cs
@@ -1,5 +1,8 @@
 namespace Elsa.Api.Client.Shared.UIHints.RadioList;
 
+/// <summary>
+/// Provides properties for the <c>radiolist</c> UI hint.
+/// </summary>
 public class RadioListProps
 {
     /// <summary>

--- a/src/modules/Elsa.Workflows.Core/UIHints/CheckList/CheckList.cs
+++ b/src/modules/Elsa.Workflows.Core/UIHints/CheckList/CheckList.cs
@@ -1,7 +1,17 @@
 namespace Elsa.Workflows.UIHints.CheckList;
 
+/// <summary>
+/// Provides properties for the <see cref="InputUIHints.CheckList"/> UI hint.
+/// </summary>
 public class CheckList
 {
+    /// <summary>
+    /// The radio list.
+    /// </summary>
     public IEnumerable<CheckListItem> Items { get; set; }
+
+    /// <summary>
+    /// The name of the provider that will provide the select list.
+    /// </summary>
     public bool IsFlagsEnum { get; set; }
 }

--- a/src/modules/Elsa.Workflows.Core/UIHints/CheckList/CheckListProps.cs
+++ b/src/modules/Elsa.Workflows.Core/UIHints/CheckList/CheckListProps.cs
@@ -1,5 +1,8 @@
 namespace Elsa.Workflows.UIHints.CheckList;
 
+/// <summary>
+/// Provides properties for the <see cref="InputUIHints.CheckList"/> UI hint.
+/// </summary>
 public class CheckListProps
 {
     /// <summary>

--- a/src/modules/Elsa.Workflows.Core/UIHints/Dropdown/DropDownOptionsProviderBase.cs
+++ b/src/modules/Elsa.Workflows.Core/UIHints/Dropdown/DropDownOptionsProviderBase.cs
@@ -4,7 +4,8 @@ using Elsa.Extensions;
 namespace Elsa.Workflows.UIHints.Dropdown;
 
 /// <summary>
-/// 
+/// A base class for providing options to populate a dropdown UI component. This class is intended to be inherited to implement
+/// custom dropdown data logic by overriding the `GetItemsAsync` method.
 /// </summary>
 public abstract class DropDownOptionsProviderBase : IPropertyUIHandler
 {

--- a/src/modules/Elsa.Workflows.Core/UIHints/RadioList/RadioList.cs
+++ b/src/modules/Elsa.Workflows.Core/UIHints/RadioList/RadioList.cs
@@ -1,7 +1,17 @@
 namespace Elsa.Workflows.UIHints.RadioList;
 
+/// <summary>
+/// Provides properties for the <see cref="InputUIHints.RadioList"/> UI hint.
+/// </summary>
 public class RadioList
 {
+    /// <summary>
+     /// The radio list.
+     /// </summary>
     public IEnumerable<RadioListItem> Items { get; set; }
+
+    /// <summary>
+    /// The name of the provider that will provide the select list.
+    /// </summary>
     public bool IsFlagsEnum { get; set; }
 }

--- a/src/modules/Elsa.Workflows.Core/UIHints/RadioList/RadioListOptionsProviderBase.cs
+++ b/src/modules/Elsa.Workflows.Core/UIHints/RadioList/RadioListOptionsProviderBase.cs
@@ -34,7 +34,7 @@ public abstract class RadioListOptionsProviderBase : PropertyUIHandlerBase
     }
 
     /// <summary>
-    /// Implement this to provide items to the dropdown list.
+    /// Implement this to provide items to the radio list.
     /// </summary>
     protected abstract ValueTask<ICollection<RadioListItem>> GetItemsAsync(PropertyInfo propertyInfo, object? context, CancellationToken cancellationToken);
 

--- a/src/modules/Elsa.Workflows.Core/UIHints/RadioList/RadioListProps.cs
+++ b/src/modules/Elsa.Workflows.Core/UIHints/RadioList/RadioListProps.cs
@@ -1,5 +1,8 @@
 namespace Elsa.Workflows.UIHints.RadioList;
 
+/// <summary>
+/// Provides properties for the <see cref="InputUIHints.RadioList"/> UI hint.
+/// </summary>
 public class RadioListProps
 {
     /// <summary>


### PR DESCRIPTION
This PR does the following:

Overall improvements for readability and maintainability.
Converted `CheckList` and `CheckListItem` to records, adding XML documentation for clarity.
Updated properties in `CheckListProps`, `RadioList`, and `RadioListItem` with similar changes.
Enhanced documentation in `DropDownOptionsProviderBase` and modified `RadioListOptionsProviderBase` to reflect new
functionality.