### PR TITLE
Commits workflow state during alteration

### DIFF
--- a/src/apps/Elsa.Server.Web/appsettings.json
+++ b/src/apps/Elsa.Server.Web/appsettings.json
@@ -1,10 +1,8 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Information",
-      "Microsoft.Hosting.Lifetime": "Information",
-      "Elsa": "Warning",
-      "Elsa.Workflows.Runtime.Middleware.Workflows.WorkflowHeartbeatMiddleware": "Warning"
+      "Default": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
     }
   },
   "HostBuilder": {


### PR DESCRIPTION
Commits the workflow state during alteration execution to persist changes made during the alteration process.

This ensures that the workflow state is consistently saved, even during alterations, preventing data loss and enabling reliable workflow execution.

A potential optimization to avoid redundant database saves is identified and noted as a TODO.

Fixes #6735

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6736)
<!-- Reviewable:end -->
