### PR TITLE
Refactor Get Endpoints to use ExecuteAsync to explicitly show return …

### DIFF
--- a/src/modules/Elsa.Expressions.JavaScript/Endpoints/TypeDefinitions/Endpoint.cs
+++ b/src/modules/Elsa.Expressions.JavaScript/Endpoints/TypeDefinitions/Endpoint.cs
@@ -57,10 +57,3 @@ internal class Get : ElsaEndpoint<Request>
         return await _workflowDefinitionService.FindWorkflowGraphAsync(workflowDefinitionId, VersionOptions.Latest, cancellationToken);
     }
 }
-
-internal record Request(string WorkflowDefinitionId, string? ActivityTypeName, string? PropertyName)
-{
-    public Request() : this(default!, default!, default)
-    {
-    }
-}

--- a/src/modules/Elsa.Expressions.JavaScript/Endpoints/TypeDefinitions/Models.cs
+++ b/src/modules/Elsa.Expressions.JavaScript/Endpoints/TypeDefinitions/Models.cs
@@ -1,0 +1,8 @@
+namespace Elsa.Expressions.JavaScript.Endpoints.TypeDefinitions;
+
+internal record Request(string WorkflowDefinitionId, string? ActivityTypeName, string? PropertyName)
+{
+    public Request() : this(default!, default!, default)
+    {
+    }
+}

--- a/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/GetByDefinitionId/Endpoint.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/GetByDefinitionId/Endpoint.cs
@@ -1,5 +1,6 @@
 using Elsa.Abstractions;
 using Elsa.Common.Models;
+using Elsa.Workflows.Api.Models;
 using Elsa.Workflows.Management;
 using Elsa.Workflows.Models;
 using JetBrains.Annotations;
@@ -7,7 +8,7 @@ using JetBrains.Annotations;
 namespace Elsa.Workflows.Api.Endpoints.WorkflowDefinitions.GetByDefinitionId;
 
 [PublicAPI]
-internal class GetByDefinitionId(IWorkflowDefinitionStore store, IWorkflowDefinitionLinker linker) : ElsaEndpoint<Request>
+internal class GetByDefinitionId(IWorkflowDefinitionStore store, IWorkflowDefinitionLinker linker) : ElsaEndpoint<Request, LinkedWorkflowDefinitionModel>
 {
     public override void Configure()
     {
@@ -15,7 +16,7 @@ internal class GetByDefinitionId(IWorkflowDefinitionStore store, IWorkflowDefini
         ConfigurePermissions("read:workflow-definitions");
     }
 
-    public override async Task HandleAsync(Request request, CancellationToken cancellationToken)
+    public override async Task<LinkedWorkflowDefinitionModel> ExecuteAsync(Request request, CancellationToken cancellationToken)
     {
         var versionOptions = request.VersionOptions != null ? VersionOptions.FromString(request.VersionOptions) : VersionOptions.Latest;
         var filter = WorkflowDefinitionHandle.ByDefinitionId(request.DefinitionId, versionOptions).ToFilter();
@@ -24,10 +25,10 @@ internal class GetByDefinitionId(IWorkflowDefinitionStore store, IWorkflowDefini
         if (definition == null)
         {
             await SendNotFoundAsync(cancellationToken);
-            return;
+            return null!;
         }
 
         var model = await linker.MapAsync(definition, cancellationToken);
-        await SendOkAsync(model, cancellationToken);
+        return model;
     }
 }

--- a/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/GetById/Endpoint.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/GetById/Endpoint.cs
@@ -1,4 +1,5 @@
 using Elsa.Abstractions;
+using Elsa.Workflows.Api.Models;
 using Elsa.Workflows.Management;
 using Elsa.Workflows.Management.Filters;
 using JetBrains.Annotations;
@@ -7,7 +8,7 @@ using Microsoft.AspNetCore.Builder;
 namespace Elsa.Workflows.Api.Endpoints.WorkflowDefinitions.GetById;
 
 [PublicAPI]
-internal class GetById(IWorkflowDefinitionStore store, IWorkflowDefinitionLinker linker) : ElsaEndpoint<Request>
+internal class GetById(IWorkflowDefinitionStore store, IWorkflowDefinitionLinker linker) : ElsaEndpoint<Request, LinkedWorkflowDefinitionModel>
 {
     public override void Configure()
     {
@@ -16,7 +17,7 @@ internal class GetById(IWorkflowDefinitionStore store, IWorkflowDefinitionLinker
         Options(x => x.WithName("GetWorkflowDefinitionById"));
     }
 
-    public override async Task HandleAsync(Request request, CancellationToken cancellationToken)
+    public override async Task<LinkedWorkflowDefinitionModel> ExecuteAsync(Request request, CancellationToken cancellationToken)
     {
         var filter = new WorkflowDefinitionFilter
         {
@@ -28,10 +29,10 @@ internal class GetById(IWorkflowDefinitionStore store, IWorkflowDefinitionLinker
         if (definition == null)
         {
             await SendNotFoundAsync(cancellationToken);
-            return;
+            return null!;
         }
 
         var model = await linker.MapAsync(definition, cancellationToken);
-        await SendOkAsync(model, cancellationToken);
+        return model;
     }
 }

--- a/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/GetManyById/Endpoint.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/GetManyById/Endpoint.cs
@@ -8,7 +8,7 @@ using JetBrains.Annotations;
 namespace Elsa.Workflows.Api.Endpoints.WorkflowDefinitions.GetManyById;
 
 [PublicAPI]
-internal class GetManyById(IWorkflowDefinitionStore store, IWorkflowDefinitionLinker linker) : ElsaEndpoint<Request>
+internal class GetManyById(IWorkflowDefinitionStore store, IWorkflowDefinitionLinker linker) : ElsaEndpoint<Request, ListResponse<LinkedWorkflowDefinitionModel>>
 {
     public override void Configure()
     {
@@ -16,7 +16,7 @@ internal class GetManyById(IWorkflowDefinitionStore store, IWorkflowDefinitionLi
         ConfigurePermissions("read:workflow-definitions");
     }
 
-    public override async Task HandleAsync(Request request, CancellationToken cancellationToken)
+    public override async Task<ListResponse<LinkedWorkflowDefinitionModel>> ExecuteAsync(Request request, CancellationToken cancellationToken)
     {
         var filter = new WorkflowDefinitionFilter
         {
@@ -26,6 +26,6 @@ internal class GetManyById(IWorkflowDefinitionStore store, IWorkflowDefinitionLi
         var definitions = (await store.FindManyAsync(filter, cancellationToken)).ToList();
         var models = await linker.MapAsync(definitions, cancellationToken);
         var response = new ListResponse<LinkedWorkflowDefinitionModel>(models);
-        await SendOkAsync(response, cancellationToken);
+        return response;
     }
 }

--- a/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/Graph/Endpoint.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/Graph/Endpoint.cs
@@ -1,6 +1,7 @@
 using Elsa.Abstractions;
 using Elsa.Extensions;
 using Elsa.Workflows.Management;
+using Elsa.Workflows.Models;
 using Elsa.Workflows.Serialization.Converters;
 using Elsa.Workflows.Serialization.Helpers;
 using JetBrains.Annotations;
@@ -9,7 +10,7 @@ using Microsoft.AspNetCore.Http;
 namespace Elsa.Workflows.Api.Endpoints.WorkflowDefinitions.Graph;
 
 [PublicAPI]
-internal class Graph(IWorkflowDefinitionService workflowDefinitionService, IApiSerializer apiSerializer, ActivityWriter activityWriter) : ElsaEndpoint<Request>
+internal class Graph(IWorkflowDefinitionService workflowDefinitionService, IApiSerializer apiSerializer, ActivityWriter activityWriter) : ElsaEndpoint<Request, ActivityNode>
 {
     public override void Configure()
     {

--- a/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/Graph/Segments/Endpoint.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/Graph/Segments/Endpoint.cs
@@ -12,7 +12,7 @@ using Microsoft.AspNetCore.Http;
 namespace Elsa.Workflows.Api.Endpoints.WorkflowDefinitions.Graph.Segments;
 
 [PublicAPI]
-internal class Nodes(IWorkflowDefinitionService workflowDefinitionService, IApiSerializer apiSerializer, ActivityWriter activityWriter) : ElsaEndpoint<Request>
+internal class Nodes(IWorkflowDefinitionService workflowDefinitionService, IApiSerializer apiSerializer, ActivityWriter activityWriter) : ElsaEndpoint<Request, Response>
 {
     public override void Configure()
     {

--- a/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/ImportFiles/Models.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/ImportFiles/Models.cs
@@ -1,0 +1,8 @@
+using System.Text.Json.Serialization;
+
+namespace Elsa.Workflows.Api.Endpoints.WorkflowDefinitions.ImportFiles;
+
+internal class Response(long importedCount)
+{
+    [JsonPropertyName("imported")] public long ImportedCount { get; } = importedCount;
+}

--- a/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/IsNameUnique/Endpoint.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/IsNameUnique/Endpoint.cs
@@ -8,7 +8,7 @@ namespace Elsa.Workflows.Api.Endpoints.WorkflowDefinitions.IsNameUnique;
 /// Checks if a workflow definition name is unique.
 /// </summary>
 [PublicAPI]
-internal class IsNameUnique(IWorkflowDefinitionStore store) : ElsaEndpoint<Request>
+internal class IsNameUnique(IWorkflowDefinitionStore store) : ElsaEndpoint<Request, Response>
 {
     public override void Configure()
     {
@@ -16,11 +16,11 @@ internal class IsNameUnique(IWorkflowDefinitionStore store) : ElsaEndpoint<Reque
         ConfigurePermissions("read:workflow-definitions");
     }
 
-    public override async Task HandleAsync(Request request, CancellationToken cancellationToken)
+    public override async Task<Response> ExecuteAsync(Request request, CancellationToken cancellationToken)
     {
         var isUnique = await store.GetIsNameUnique(request.Name.Trim(), request.DefinitionId, cancellationToken);
         var response = new Response(isUnique);
         
-        await SendOkAsync(response, cancellationToken);
+        return response;
     }
 }

--- a/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/Refresh/Endpoint.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/Refresh/Endpoint.cs
@@ -7,7 +7,7 @@ using JetBrains.Annotations;
 namespace Elsa.Workflows.Api.Endpoints.WorkflowDefinitions.Refresh;
 
 [PublicAPI]
-internal class Refresh(IWorkflowDefinitionsRefresher workflowDefinitionsRefresher) : ElsaEndpoint<Request>
+internal class Refresh(IWorkflowDefinitionsRefresher workflowDefinitionsRefresher) : ElsaEndpoint<Request, Response>
 {
     private const int BatchSize = 10;
 
@@ -17,10 +17,10 @@ internal class Refresh(IWorkflowDefinitionsRefresher workflowDefinitionsRefreshe
         ConfigurePermissions("actions:workflow-definitions:refresh");
     }
 
-    public override async Task HandleAsync(Request request, CancellationToken cancellationToken)
+    public override async Task<Response> ExecuteAsync(Request request, CancellationToken cancellationToken)
     {
         var result = await RefreshWorkflowDefinitionsAsync(request.DefinitionIds, cancellationToken);
-        await SendOkAsync(new Response(result.Refreshed, result.NotFound), cancellationToken);
+        return new Response(result.Refreshed, result.NotFound);
     }
 
     private async Task<RefreshWorkflowDefinitionsResponse> RefreshWorkflowDefinitionsAsync(ICollection<string>? definitionIds, CancellationToken cancellationToken)


### PR DESCRIPTION
Several get endpoints didn't explicitly set their return type on the method and ElsaEndpoint<TReq,TResp>. Changes were made to use the ExecuteAsync rather than the HandleAsync method, explicitly setting the return type on the method, to use ElsaEndpoint<TRequest, TResponse>, and a couple smaller refactors to align with the coding standards.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6746)
<!-- Reviewable:end -->
