### PR TITLE
Register `FlowScope` class map in MongoDB feature to handle serialization and ignore extra elements.

### DIFF
--- a/src/modules/Elsa.MongoDb/Features/MongoDbFeature.cs
+++ b/src/modules/Elsa.MongoDb/Features/MongoDbFeature.cs
@@ -78,6 +78,12 @@ public class MongoDbFeature(IModule module) : FeatureBase(module)
             map.SetIgnoreExtraElements(true); // Needed for missing ID property
             map.MapProperty(x => x.Key); // Needed for non-setter property
         });
+        
+        BsonClassMap.TryRegisterClassMap<FlowScope>(map =>
+        {
+            map.AutoMap();
+            map.SetIgnoreExtraElements(true);
+        });
     }
 
     private static void TryRegisterSerializerOrSkipWhenExist(Type type, IBsonSerializer serializer)


### PR DESCRIPTION
Fixes #6729