### PR TITLE
Add backward compatibility for `WorkflowInstance.Name` mapping in `WorkflowStateMapper`

### DIFF
--- a/src/modules/Elsa.Workflows.Management/Mappers/WorkflowStateMapper.cs
+++ b/src/modules/Elsa.Workflows.Management/Mappers/WorkflowStateMapper.cs
@@ -12,6 +12,7 @@ public class WorkflowStateMapper
     /// <summary>
     /// [Obsolete] The property key name used to store the workflow instance name.
     /// </summary>
+    [Obsolete("This constant is obsolete and retained only for backward compatibility. Avoid using it in new code.")]
     private const string WorkflowInstanceNameKey = "WorkflowInstanceName";
     
     /// <summary>

--- a/src/modules/Elsa.Workflows.Management/Mappers/WorkflowStateMapper.cs
+++ b/src/modules/Elsa.Workflows.Management/Mappers/WorkflowStateMapper.cs
@@ -1,5 +1,4 @@
 using Elsa.Extensions;
-using Elsa.Workflows.Activities;
 using Elsa.Workflows.Management.Entities;
 using Elsa.Workflows.State;
 

--- a/src/modules/Elsa.Workflows.Management/Mappers/WorkflowStateMapper.cs
+++ b/src/modules/Elsa.Workflows.Management/Mappers/WorkflowStateMapper.cs
@@ -1,3 +1,5 @@
+using Elsa.Extensions;
+using Elsa.Workflows.Activities;
 using Elsa.Workflows.Management.Entities;
 using Elsa.Workflows.State;
 
@@ -8,6 +10,11 @@ namespace Elsa.Workflows.Management.Mappers;
 /// </summary>
 public class WorkflowStateMapper
 {
+    /// <summary>
+    /// [Obsolete] The property key name used to store the workflow instance name.
+    /// </summary>
+    private const string WorkflowInstanceNameKey = "WorkflowInstanceName";
+    
     /// <summary>
     /// Maps a workflow state to a workflow instance.
     /// </summary>
@@ -43,6 +50,10 @@ public class WorkflowStateMapper
         target.UpdatedAt = source.UpdatedAt;
         target.FinishedAt = source.FinishedAt;
         target.WorkflowState = source;
+        
+        // Keep for backward compatibility with workflow instances created before the introduction of the Name property.
+        if (source.Properties.TryGetValue<string>(WorkflowInstanceNameKey, out var name))
+            target.Name = name;
     }
 
     /// <summary>


### PR DESCRIPTION
- Introduced constant `WorkflowInstanceNameKey` to handle legacy workflow instance name properties.
- Updated `MapWorkflowStateToWorkflowInstance` method to set `Name` property for older instances.

Fixes #6748

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6767)
<!-- Reviewable:end -->
