### PR TITLE
Implementing better base64 evaluation + appropriate zip entry naming

### DIFF
--- a/src/modules/Elsa.IO.Compression/Activities/CreateZipArchive.cs
+++ b/src/modules/Elsa.IO.Compression/Activities/CreateZipArchive.cs
@@ -125,8 +125,7 @@ public class CreateZipArchive : CodeActivity<Stream>
     
         var entryName = binaryContent.Name?.GetNameAndExtension()
                         ?? string.Format(DefaultEntryNameFormat, entryIndex + 1);
-    
-        // Get a unique name following Windows convention
+        
         entryName = GetUniqueEntryName(zipArchive, entryName);
     
         var archiveEntry = zipArchive.CreateEntry(entryName, compressionLevel);

--- a/src/modules/Elsa.IO/Extensions/ContentTypeExtensions.cs
+++ b/src/modules/Elsa.IO/Extensions/ContentTypeExtensions.cs
@@ -102,7 +102,7 @@ public static class ContentTypeExtensions
         switch (paddingIndex)
         {
             // Padding cannot be at index 0
-            case <= 0:
+            case 0:
             // Padding must be at the end
             case > 0 when paddingIndex < s.Length - 2:
             // All characters after first '=' must also be '='

--- a/src/modules/Elsa.IO/Extensions/ContentTypeExtensions.cs
+++ b/src/modules/Elsa.IO/Extensions/ContentTypeExtensions.cs
@@ -98,19 +98,20 @@ public static class ContentTypeExtensions
 
         // Check padding position and count
         var paddingIndex = s.IndexOf('=');
-        if (paddingIndex > 0)
+        
+        switch (paddingIndex)
         {
+            // Padding cannot be at index 0
+            case <= 0:
             // Padding must be at the end
-            if (paddingIndex < s.Length - 2)
-                return false;
-            
+            case > 0 when paddingIndex < s.Length - 2:
             // All characters after first '=' must also be '='
-            if (s.Substring(paddingIndex).Any(c => c != '='))
+            case > 0 when s[paddingIndex..].Any(c => c != '='):
                 return false;
         }
 
         // Check for valid Base64 characters
-        for (int i = 0; i < (paddingIndex > 0 ? paddingIndex : s.Length); i++)
+        for (var i = 0; i < paddingIndex; i++)
         {
             var c = s[i];
             var isValid = 
@@ -124,7 +125,7 @@ public static class ContentTypeExtensions
         }
 
         // Additional check for short strings that are just lowercase+numbers
-        // This catches "content2" and similar false positives
+        // This catches "whatever" and similar false positives
         if (s.Length <= 10 && s.All(c => char.IsLower(c) || char.IsDigit(c)))
             return false;
 


### PR DESCRIPTION
This pull request introduces enhancements to the `CreateZipArchive` activity for handling duplicate entry names, updates the logic for validating Base64 strings, and refines code behavior to improve reliability and maintainability.

### Enhancements to Base64 Validation:
* Refined the `IsBase64String` method to validate padding positions and count, ensuring padding is correctly placed at the end and all trailing characters after the first '=' are also '='.
* Added checks to prevent false positives for short strings that consist only of lowercase letters and digits, improving the robustness of Base64 validation.


### Improvements to Zip Archive Creation:
* Changed the `ZipArchiveMode` from `Create` to `Update` in `CreateZipStreamFromEntries`, allowing read operations inside the entries besides just creating them.
* Added logic to generate unique entry names in `ProcessZipEntry` to prevent overwriting existing entries with the same name, following Windows naming conventions. This includes the new helper method `GetUniqueEntryName` for determining the next available name based on existing entries. [[1]](diffhunk://#diff-a78fb3ecdf96a52f900846139b12f877c93f2be449c511d3dd20fff814498c6fR129-R131) [[2]](diffhunk://#diff-a78fb3ecdf96a52f900846139b12f877c93f2be449c511d3dd20fff814498c6fR143-R193)



<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6783)
<!-- Reviewable:end -->
