### PR TITLE
Update RawStringContent encoding in JsonContentFactory

### DIFF
--- a/src/modules/Elsa.Http/ContentWriters/JsonContentFactory.cs
+++ b/src/modules/Elsa.Http/ContentWriters/JsonContentFactory.cs
@@ -22,6 +22,6 @@ public class JsonContentFactory : IHttpContentFactory
         if (string.IsNullOrWhiteSpace(contentType))
             contentType = MediaTypeNames.Application.Json;
 
-        return new RawStringContent(text, Encoding.UTF8, contentType);
+        return new RawStringContent(text, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false), contentType);
     }
 }

--- a/src/modules/Elsa.Http/ContentWriters/JsonContentFactory.cs
+++ b/src/modules/Elsa.Http/ContentWriters/JsonContentFactory.cs
@@ -13,6 +13,8 @@ public class JsonContentFactory : IHttpContentFactory
     /// <inheritdoc />
     public IEnumerable<string> SupportedContentTypes => new[] { MediaTypeNames.Application.Json, "text/json" };
 
+    private static readonly UTF8Encoding _utf8Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
     /// <inheritdoc />
     [RequiresUnreferencedCode("The JsonSerializer type is not trim-compatible.")]
     public HttpContent CreateHttpContent(object content, string contentType)
@@ -22,6 +24,6 @@ public class JsonContentFactory : IHttpContentFactory
         if (string.IsNullOrWhiteSpace(contentType))
             contentType = MediaTypeNames.Application.Json;
 
-        return new RawStringContent(text, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false), contentType);
+        return new RawStringContent(text, _utf8Encoding, contentType);
     }
 }


### PR DESCRIPTION
Modified the instantiation of `RawStringContent` to use a new `UTF8Encoding` instance with `encoderShouldEmitUTF8Identifier` set to `false`, affecting the handling of the UTF-8 byte order mark (BOM) in serialized JSON content. Fixes a bug with content length being different than expected.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6786)
<!-- Reviewable:end -->
