### PR TITLE
Refactor database extensions and support migrations for V3.6

### DIFF
--- a/src/modules/Elsa.Workflows.Management/Contracts/IWorkflowDefinitionService.cs
+++ b/src/modules/Elsa.Workflows.Management/Contracts/IWorkflowDefinitionService.cs
@@ -55,4 +55,9 @@ public interface IWorkflowDefinitionService
     /// Looks for a <see cref="WorkflowGraph"/> by the specified <see cref="WorkflowDefinitionFilter"/>.
     /// </summary>
     Task<WorkflowGraph?> FindWorkflowGraphAsync(WorkflowDefinitionFilter filter, CancellationToken cancellationToken = default);
+    
+    /// <summary>
+    /// Looks for all <see cref="WorkflowGraph"/>s that match the specified <see cref="WorkflowDefinitionFilter"/>.
+    /// </summary>
+    Task<IEnumerable<WorkflowGraph>> FindWorkflowGraphsAsync(WorkflowDefinitionFilter filter, CancellationToken cancellationToken = default);
 }

--- a/src/modules/Elsa.Workflows.Management/Contracts/IWorkflowDefinitionStore.cs
+++ b/src/modules/Elsa.Workflows.Management/Contracts/IWorkflowDefinitionStore.cs
@@ -111,6 +111,8 @@ public interface IWorkflowDefinitionStore
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The workflow definition.</returns>
     Task<WorkflowDefinition?> FindLastVersionAsync(WorkflowDefinitionFilter filter, CancellationToken cancellationToken);
+    
+    //Task<IEnumerable<string>> JsonQuery(CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Adds or updates the specified <see cref="WorkflowDefinition"/> in the persistence store.

--- a/src/modules/Elsa.Workflows.Management/Contracts/IWorkflowReferenceQuery.cs
+++ b/src/modules/Elsa.Workflows.Management/Contracts/IWorkflowReferenceQuery.cs
@@ -1,0 +1,15 @@
+namespace Elsa.Workflows.Management;
+
+/// <summary>
+/// Finds all latest versions of workflow definitions that reference a specific workflow definition.
+/// </summary>
+public interface IWorkflowReferenceQuery
+{
+    /// <summary>
+    /// Queries all latest versions of workflow definitions that reference the specified workflow definition.
+    /// </summary>
+    /// <param name="workflowDefinitionId">The ID of the workflow definition to query references for.</param>
+    /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+    /// <returns>A collection of workflow definition IDs that reference the specified workflow definition.</returns>
+    Task<IEnumerable<string>> ExecuteAsync(string workflowDefinitionId, CancellationToken cancellationToken = default);
+}

--- a/src/modules/Elsa.Workflows.Management/Features/WorkflowManagementFeature.cs
+++ b/src/modules/Elsa.Workflows.Management/Features/WorkflowManagementFeature.cs
@@ -28,6 +28,7 @@ using Elsa.Workflows.Management.Stores;
 using Elsa.Workflows.Serialization.Serializers;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Elsa.Workflows.Management.Features;
 
@@ -51,6 +52,7 @@ public class WorkflowManagementFeature(IModule module) : FeatureBase(module)
     private const string SystemCategory = "System";
 
     private Func<IServiceProvider, IWorkflowDefinitionPublisher> _workflowDefinitionPublisher = sp => ActivatorUtilities.CreateInstance<WorkflowDefinitionPublisher>(sp);
+    private Func<IServiceProvider, IWorkflowReferenceQuery> _workflowReferenceQuery = sp => ActivatorUtilities.CreateInstance<DefaultWorkflowReferenceQuery>(sp);
 
     private string CompressionAlgorithm { get; set; } = nameof(None);
     private LogPersistenceMode LogPersistenceMode { get; set; } = LogPersistenceMode.Include;
@@ -191,9 +193,21 @@ public class WorkflowManagementFeature(IModule module) : FeatureBase(module)
         return this;
     }
 
-    public WorkflowManagementFeature WithWorkflowDefinitionPublisher(Func<IServiceProvider, IWorkflowDefinitionPublisher> workflowDefinitionPublisher)
+    public WorkflowManagementFeature UseWorkflowDefinitionPublisher(Func<IServiceProvider, IWorkflowDefinitionPublisher> workflowDefinitionPublisher)
     {
         _workflowDefinitionPublisher = workflowDefinitionPublisher;
+        return this;
+    }
+    
+    public WorkflowManagementFeature UseWorkflowReferenceFinder<T>() where T : class, IWorkflowReferenceQuery
+    {
+        Services.TryAddScoped<T>();
+        return UseWorkflowReferenceFinder(sp => sp.GetRequiredService<T>());
+    }
+    
+    public WorkflowManagementFeature UseWorkflowReferenceFinder(Func<IServiceProvider, IWorkflowReferenceQuery> workflowReferenceFinder)
+    {
+        _workflowReferenceQuery = workflowReferenceFinder;
         return this;
     }
 
@@ -217,6 +231,7 @@ public class WorkflowManagementFeature(IModule module) : FeatureBase(module)
             .AddScoped<IWorkflowDefinitionService, WorkflowDefinitionService>()
             .AddScoped<IWorkflowSerializer, WorkflowSerializer>()
             .AddScoped<IWorkflowValidator, WorkflowValidator>()
+            .AddScoped(_workflowReferenceQuery)
             .AddScoped(_workflowDefinitionPublisher)
             .AddScoped<IWorkflowDefinitionImporter, WorkflowDefinitionImporter>()
             .AddScoped<IWorkflowDefinitionManager, WorkflowDefinitionManager>()

--- a/src/modules/Elsa.Workflows.Management/Services/DefaultWorkflowReferenceQuery.cs
+++ b/src/modules/Elsa.Workflows.Management/Services/DefaultWorkflowReferenceQuery.cs
@@ -1,0 +1,67 @@
+using Elsa.Common.Models;
+using Elsa.Workflows.Management.Activities.WorkflowDefinitionActivity;
+using Elsa.Workflows.Management.Filters;
+using Elsa.Workflows.Models;
+
+namespace Elsa.Workflows.Management.Services;
+
+public class DefaultWorkflowReferenceQuery(IWorkflowDefinitionService workflowDefinitionService, IWorkflowDefinitionStore workflowDefinitionStore) : IWorkflowReferenceQuery
+{
+    public async Task<IEnumerable<string>> ExecuteAsync(string workflowDefinitionId, CancellationToken cancellationToken = default)
+    {
+        var workflowGraphs = await FindWorkflowsContainingUpdatedWorkflowDefinitionAsync(workflowDefinitionId, cancellationToken);
+        return workflowGraphs.Select(x => x.Workflow.Identity.DefinitionId).Distinct();
+    }
+    
+    private async Task<IEnumerable<WorkflowGraph>> FindWorkflowsContainingUpdatedWorkflowDefinitionAsync(string updatedWorkflowDefinitionId, CancellationToken cancellationToken)
+    {
+        var allWorkflowGraphs = (await GetAllWorkflowGraphsAsync(cancellationToken)).ToList();
+        var filteredWorkflowGraphs = allWorkflowGraphs
+            .Where(x => FindWorkflowActivityDefinitionActivityNodes(x.Root).Any(y => y.WorkflowDefinitionId == updatedWorkflowDefinitionId))
+            .ToList();
+
+        return filteredWorkflowGraphs;
+    }
+
+    private IEnumerable<WorkflowDefinitionActivity> FindWorkflowActivityDefinitionActivityNodes(ActivityNode parent)
+    {
+        foreach (var child in parent.Children)
+        {
+            if (child.Activity is WorkflowDefinitionActivity workflowDefinitionActivity)
+                yield return workflowDefinitionActivity;
+            else
+            {
+                foreach (var grandChild in FindWorkflowActivityDefinitionActivityNodes(child))
+                    yield return grandChild;
+            }
+        }
+    }
+
+    private async Task<IEnumerable<WorkflowGraph>> GetAllWorkflowGraphsAsync(CancellationToken cancellationToken)
+    {
+        var workflowDefinitionFilter = new WorkflowDefinitionFilter
+        {
+            VersionOptions = VersionOptions.LatestOrPublished,
+            IsReadonly = false
+        };
+        var workflowDefinitionSummaries = await workflowDefinitionStore.FindSummariesAsync(workflowDefinitionFilter, cancellationToken);
+        
+        // If there are workflow definition summaries with the same definition ID, only take the latest version.
+        workflowDefinitionSummaries = workflowDefinitionSummaries
+            .GroupBy(x => x.DefinitionId)
+            .Select(x => x.OrderByDescending(y => y.Version).First())
+            .ToList();
+        
+        var workflowGraphs = new List<WorkflowGraph>();
+
+        foreach (var workflowDefinitionSummary in workflowDefinitionSummaries)
+        {
+            var workflowGraph = await workflowDefinitionService.FindWorkflowGraphAsync(workflowDefinitionSummary.Id, cancellationToken);
+
+            if (workflowGraph != null)
+                workflowGraphs.Add(workflowGraph);
+        }
+
+        return workflowGraphs;
+    }
+}

--- a/src/modules/Elsa.Workflows.Management/Services/WorkflowDefinitionService.cs
+++ b/src/modules/Elsa.Workflows.Management/Services/WorkflowDefinitionService.cs
@@ -95,4 +95,18 @@ public class WorkflowDefinitionService(
 
         return await MaterializeWorkflowAsync(definition, cancellationToken);
     }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<WorkflowGraph>> FindWorkflowGraphsAsync(WorkflowDefinitionFilter filter, CancellationToken cancellationToken = default)
+    {
+        var workflowDefinitions = await workflowDefinitionStore.FindManyAsync(filter, cancellationToken);
+        var workflowGraphs = new List<WorkflowGraph>();
+        foreach (var workflowDefinition in workflowDefinitions)
+        {
+            var workflowGraph = await MaterializeWorkflowAsync(workflowDefinition, cancellationToken);
+            workflowGraphs.Add(workflowGraph);
+        }
+
+        return workflowGraphs;
+    }
 }

--- a/src/modules/Elsa.Workflows.Runtime/Services/DefaultWorkflowDefinitionStorePopulator.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Services/DefaultWorkflowDefinitionStorePopulator.cs
@@ -118,7 +118,7 @@ public class DefaultWorkflowDefinitionStorePopulator : IWorkflowDefinitionStoreP
 
         // Serialize materializer context.
         var materializerContext = materializedWorkflow.MaterializerContext;
-        var materializerContextJson = materializerContext != null ? _payloadSerializer.Serialize(materializerContext) : default;
+        var materializerContextJson = materializerContext != null ? _payloadSerializer.Serialize(materializerContext) : null;
 
         // Serialize the workflow root.
         var workflowJson = _activitySerializer.Serialize(workflow.Root);


### PR DESCRIPTION
Remove `DatabaseFacadeExtensions` and introduce `IWorkflowReferenceQuery` with its default implementation. Implement database schema updates for PostgreSQL, MySQL, and Oracle to enhance compatibility with the V3.6 data structure.
