### PR TITLE
Fixed wrong naming in resulting entries when file is inputted from http

### DIFF
--- a/src/modules/Elsa.IO.Compression/Services/Strategies/ZipEntryContentStrategy.cs
+++ b/src/modules/Elsa.IO.Compression/Services/Strategies/ZipEntryContentStrategy.cs
@@ -36,7 +36,7 @@ public class ZipEntryContentStrategy(IServiceProvider serviceProvider) : IConten
         var innerContentName = innerContent.Name?.GetNameAndExtension();
         var innerContentExtension = Path.GetExtension(innerContentName);
         innerContent.Name = !string.IsNullOrWhiteSpace(innerContentExtension) 
-            ? zipEntry.EntryName + innerContentExtension 
+            ? Path.HasExtension(zipEntry.EntryName) ? zipEntry.EntryName : zipEntry.EntryName  + innerContentExtension 
             : innerContent.Name;
 
         return innerContent;


### PR DESCRIPTION
This pull request includes a minor update to the `ResolveAsync` method in the `ZipEntryContentStrategy` class. The change ensures that the `EntryName` property is only appended with the `innerContentExtension` if it does not already have an extension.

* [`src/modules/Elsa.IO.Compression/Services/Strategies/ZipEntryContentStrategy.cs`](diffhunk://#diff-ee222784b0956d06954564b8a2d4ebccb8e4ab3d1aae7be5ab9f71de6a0ed7eaL39-R39): Updated the logic in `ResolveAsync` to check if `zipEntry.EntryName` has an extension before appending `innerContentExtension`.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6806)
<!-- Reviewable:end -->
