### PR TITLE
Refactor activity execution record serialization with snapshots

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,6 +5,7 @@
     </PropertyGroup>
     <PropertyGroup>
         <ElsaStudioVersion>3.5.0-preview.1092</ElsaStudioVersion>
+        <MicrosoftVersion>9.0.7</MicrosoftVersion>
     </PropertyGroup>
     <ItemGroup>
         <PackageVersion Include="Antlr4.Runtime.Standard" Version="4.13.1"/>
@@ -34,7 +35,7 @@
         <PackageVersion Include="DistributedLock.FileSystem" Version="1.0.3"/>
         <PackageVersion Include="DistributedLock.Postgres" Version="1.3.0"/>
         <PackageVersion Include="DistributedLock.Redis" Version="1.0.3"/>
-        <PackageVersion Include="Elastic.Clients.Elasticsearch" Version="9.0.6"/>
+        <PackageVersion Include="Elastic.Clients.Elasticsearch" Version="$(MicrosoftVersion)"/>
         <PackageVersion Include="Elsa.Studio" Version="$(ElsaStudioVersion)"/>
         <PackageVersion Include="Elsa.Studio.Agents" Version="$(ElsaStudioVersion)"/>
         <PackageVersion Include="Elsa.Studio.Core.BlazorWasm" Version="$(ElsaStudioVersion)"/>
@@ -118,8 +119,8 @@
         <PackageVersion Include="System.Linq.Dynamic.Core" Version="1.6.5"/>
         <PackageVersion Include="System.Net.Http" Version="4.3.4"/>
         <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1"/>
-        <PackageVersion Include="System.Formats.Asn1" Version="9.0.6"/>
-        <PackageVersion Include="System.Text.Json" Version="9.0.6"/>
+        <PackageVersion Include="System.Formats.Asn1" Version="$(MicrosoftVersion)"/>
+        <PackageVersion Include="System.Text.Json" Version="$(MicrosoftVersion)"/>
         <PackageVersion Include="Testcontainers" Version="4.5.0"/>
         <PackageVersion Include="Testcontainers.PostgreSql" Version="4.5.0"/>
         <PackageVersion Include="Testcontainers.RabbitMq" Version="4.5.0"/>
@@ -127,36 +128,36 @@
         <PackageVersion Include="ThrottleDebounce" Version="2.0.1"/>
         <PackageVersion Include="WebhooksCore" Version="0.0.1"/>
         <PackageVersion Include="Yarp.ReverseProxy" Version="2.3.0"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="9.0.6"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components" Version="9.0.6"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.6"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.6"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="9.0.6"/>
-        <PackageVersion Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="9.0.6"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.6"/>
-        <PackageVersion Include="Microsoft.Data.Sqlite" Version="9.0.6"/>
-        <PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="9.0.6"/>
-        <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.6"/>
-        <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.6"/>
-        <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.6"/>
-        <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.6"/>
-        <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.6"/>
-        <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.6"/>
-        <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="9.0.6"/>
-        <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.6"/>
-        <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.6"/>
-        <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="9.0.6"/>
-        <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.6"/>
-        <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.6"/>
-        <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="9.0.6"/>
-        <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.6"/>
-        <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.6"/>
-        <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="9.0.6"/>
-        <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.6"/>
-        <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.6"/>
-        <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.6"/>
-        <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.6"/>
-        <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.6"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="$(MicrosoftVersion)"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Components" Version="$(MicrosoftVersion)"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="$(MicrosoftVersion)"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="$(MicrosoftVersion)"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="$(MicrosoftVersion)"/>
+        <PackageVersion Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="$(MicrosoftVersion)"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="$(MicrosoftVersion)"/>
+        <PackageVersion Include="Microsoft.Data.Sqlite" Version="$(MicrosoftVersion)"/>
+        <PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="$(MicrosoftVersion)"/>
+        <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="$(MicrosoftVersion)"/>
+        <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="$(MicrosoftVersion)"/>
+        <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="$(MicrosoftVersion)"/>
+        <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="$(MicrosoftVersion)"/>
+        <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="$(MicrosoftVersion)"/>
+        <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="$(MicrosoftVersion)"/>
+        <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="$(MicrosoftVersion)"/>
+        <PackageVersion Include="Microsoft.Extensions.Configuration" Version="$(MicrosoftVersion)"/>
+        <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="$(MicrosoftVersion)"/>
+        <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="$(MicrosoftVersion)"/>
+        <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftVersion)"/>
+        <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftVersion)"/>
+        <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftVersion)"/>
+        <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(MicrosoftVersion)"/>
+        <PackageVersion Include="Microsoft.Extensions.Http" Version="$(MicrosoftVersion)"/>
+        <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="$(MicrosoftVersion)"/>
+        <PackageVersion Include="Microsoft.Extensions.Logging" Version="$(MicrosoftVersion)"/>
+        <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftVersion)"/>
+        <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftVersion)"/>
+        <PackageVersion Include="Microsoft.Extensions.Options" Version="$(MicrosoftVersion)"/>
+        <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(MicrosoftVersion)"/>
         <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.6.0"/>
         <PackageVersion Include="Microsoft.Extensions.Resilience" Version="9.6.0"/>
         <PackageVersion Include="MySql.Data" Version="9.3.0"/>

--- a/src/modules/Elsa.Common/Entities/Entity.cs
+++ b/src/modules/Elsa.Common/Entities/Entity.cs
@@ -8,7 +8,7 @@ public abstract class Entity
     /// <summary>
     /// Gets or sets the ID of this entity.
     /// </summary>
-    public string Id { get; set; } = default!;
+    public string Id { get; set; } = null!;
 
     /// <summary>
     /// Gets or sets the ID of the tenant that own this entity.

--- a/src/modules/Elsa.Workflows.Runtime/Entities/ActivityExecutionRecord.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Entities/ActivityExecutionRecord.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json.Serialization;
 using Elsa.Common;
 using Elsa.Common.Entities;
 using Elsa.Workflows.State;
@@ -99,11 +100,5 @@ public partial class ActivityExecutionRecord : Entity, ILogRecord
 
 public partial class ActivityExecutionRecord
 {
-    [NotMapped] public string? SerializedActivityState { get; set; }
-    [NotMapped] public string? SerializedOutputs { get; set; }
-    [NotMapped] public string? SerializedProperties { get; set; }
-    [NotMapped] public string? SerializedPayload { get; set; }
-    [NotMapped] public string? SerializedMetadata { get; set; }
-    [NotMapped] public string? SerializedException { get; set; }
-    [NotMapped] public string? SerializedActivityStateCompressionAlgorithm { get; set; }
+    [NotMapped] [JsonIgnore] public ActivityExecutionRecordSnapshot? SerializedSnapshot { get; set; }
 }

--- a/src/modules/Elsa.Workflows.Runtime/Models/ActivityExecutionRecordSnapshot.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Models/ActivityExecutionRecordSnapshot.cs
@@ -1,0 +1,25 @@
+namespace Elsa.Workflows.Runtime;
+
+public class ActivityExecutionRecordSnapshot
+{
+    public string Id { get; set; } = null!;
+    public string? TenantId { get; set; }
+    public string WorkflowInstanceId { get; set; } = null!;
+    public string ActivityId { get; set; } = null!;
+    public string ActivityNodeId { get; set; } = null!;
+    public string ActivityType { get; set; } = null!;
+    public int ActivityTypeVersion { get; set; }
+    public string? ActivityName { get; set; }
+    public DateTimeOffset StartedAt { get; set; }
+    public bool HasBookmarks { get; set; }
+    public ActivityStatus Status { get; set; }
+    public int AggregateFaultCount { get; set; }
+    public DateTimeOffset? CompletedAt { get; set; }
+    public string? SerializedActivityState { get; set; }
+    public string? SerializedOutputs { get; set; }
+    public string? SerializedProperties { get; set; }
+    public string? SerializedPayload { get; set; }
+    public string? SerializedMetadata { get; set; }
+    public string? SerializedException { get; set; }
+    public string? SerializedActivityStateCompressionAlgorithm { get; set; }
+}


### PR DESCRIPTION
- Introduced `ActivityExecutionRecordSnapshot` for encapsulated serialized data.
- Updated `DefaultActivityExecutionMapper` to build serialized snapshots.
- Adjusted `ActivityExecutionLogStore` to persist pre-serialized snapshots.
- Streamlined package version management with `MicrosoftVersion` property.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6807)
<!-- Reviewable:end -->
