### PR TITLE
#6721 - fix: custom schema causing migration issues

### DIFF
--- a/src/modules/Elsa.EntityFrameworkCore.Common/ElsaDbContextBase.cs
+++ b/src/modules/Elsa.EntityFrameworkCore.Common/ElsaDbContextBase.cs
@@ -12,6 +12,8 @@ namespace Elsa.EntityFrameworkCore;
 /// </summary>
 public abstract class ElsaDbContextBase : DbContext, IElsaDbContextSchema
 {
+    public const string DefaultElsaSchema = "Elsa";
+
     private static readonly ISet<EntityState> ModifiedEntityStates = new HashSet<EntityState>
     {
         EntityState.Added,
@@ -25,7 +27,7 @@ public abstract class ElsaDbContextBase : DbContext, IElsaDbContextSchema
     /// <summary>
     /// The default schema used by Elsa.
     /// </summary>
-    public static string ElsaSchema { get; set; } = "Elsa";
+    public static string ElsaSchema { get; set; } = DefaultElsaSchema;
 
     /// <inheritdoc/>
     public string Schema { get; }


### PR DESCRIPTION
Added a runtime schema patching for scenarios where custom schema name is used.
This avoids failing ef core migrations on new databases as described in https://github.com/elsa-workflows/elsa-core/issues/6721

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6844)
<!-- Reviewable:end -->
