### PR TITLE
Fix: Remove duplicate enum values in HttpStatusCode dropdown for WriteHttpResponse

### DIFF
--- a/src/modules/Elsa.Workflows.Core/UIHints/Dropdown/StaticDropDownOptionsProvider.cs
+++ b/src/modules/Elsa.Workflows.Core/UIHints/Dropdown/StaticDropDownOptionsProvider.cs
@@ -39,7 +39,11 @@ public class StaticDropDownOptionsProvider : IPropertyUIHandler
                 }
             }
 
-            var enumValues = Enum.GetValues(wrappedPropertyType).Cast<object>().ToList();
+            var enumValues = Enum.GetValues(wrappedPropertyType)
+                .Cast<Enum>()
+                .GroupBy(Convert.ToInt32)
+                .Select(g => g.First())
+                .ToList();
             var enumSelectListItems = enumValues.Select(x => new SelectListItem(x.ToString()!, x.ToString()!)).ToList();
             if (isNullableEnum)
                 enumSelectListItems.Insert(0, new SelectListItem("-",""));


### PR DESCRIPTION
When generating the dropdown list for the `status` input in the `WriteHttpResponse` activity, duplicate enum values were included due to `Enum.GetValues()` returning multiple names with the same underlying numeric value from `System.Net.HttpStatusCode`.

This fix filters the list to include only distinct values, grouped by their underlying integer representation.

Related issue: #6845

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6846)
<!-- Reviewable:end -->
