### PR TITLE
Downgrading JetBrains.Annotations for fixing the packages build

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -61,7 +61,7 @@
     <PackageVersion Include="Hangfire.Storage.SQLite" Version="0.4.2"/>
     <PackageVersion Include="Humanizer.Core" Version="2.14.1"/>
     <PackageVersion Include="IronCompress" Version="1.6.3"/>
-    <PackageVersion Include="JetBrains.Annotations" Version="2025.2.0"/>
+    <PackageVersion Include="JetBrains.Annotations" Version="2024.3.0"/>
     <PackageVersion Include="Jint" Version="4.4.1"/>
     <PackageVersion Include="LinqKit.Core" Version="1.2.8"/>
     <PackageVersion Include="MailKit" Version="4.12.1"/>


### PR DESCRIPTION
The latest version of `JetBrains.Annotation package` was causing a problem in the package build pipeline, in the test step, causing it to run forever and get the pipeline execution cancelled for timeout.

This PR fixes the elsa 3 package build by downgrading the `JetBrains.Annotation` package.