### PR TITLE
Refactor `ObjectConverter` to improve readability and add backward-compatible default value handling in non-strict mode.

### DIFF
--- a/src/modules/Elsa.Expressions/Helpers/ObjectConverter.cs
+++ b/src/modules/Elsa.Expressions/Helpers/ObjectConverter.cs
@@ -310,7 +310,7 @@ public static class ObjectConverter
         object? ReturnOrThrow(Exception e)
         {
             if (!strictMode)
-                return underlyingTargetType.GetDefaultValue(); // Backward compatibility: return default value if strict mode is off.
+                return targetType.GetDefaultValue(); // Backward compatibility: return default value if strict mode is off.
 
             throw new TypeConversionException($"Failed to convert an object of type {sourceType} to {underlyingTargetType}", value, underlyingTargetType, e);
         }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6852)
<!-- Reviewable:end -->
