### PR TITLE
Remove Dictionary `UIHint` attribute in `Log` activity

### DIFF
--- a/src/modules/Elsa.Logging/Activities/Log.cs
+++ b/src/modules/Elsa.Logging/Activities/Log.cs
@@ -69,7 +69,7 @@ public class Log : CodeActivity
     /// <summary>
     /// Additional attributes to include in the log entry.
     /// </summary>
-    [Input(Description = "Flat dictionary of key/value pairs to include as attributes.",)] 
+    [Input(Description = "Flat dictionary of key/value pairs to include as attributes.")] 
     public Input<IDictionary<string, object?>> Attributes { get; set; } = null!;
 
     /// <summary>

--- a/src/modules/Elsa.Logging/Activities/Log.cs
+++ b/src/modules/Elsa.Logging/Activities/Log.cs
@@ -69,10 +69,7 @@ public class Log : CodeActivity
     /// <summary>
     /// Additional attributes to include in the log entry.
     /// </summary>
-    [Input(
-        Description = "Flat dictionary of key/value pairs to include as attributes.",
-        UIHint = InputUIHints.Dictionary
-    )] 
+    [Input(Description = "Flat dictionary of key/value pairs to include as attributes.",)] 
     public Input<IDictionary<string, object?>> Attributes { get; set; } = null!;
 
     /// <summary>


### PR DESCRIPTION
This (temporarily) disables the Dictionary UI editor until that component has been finalized.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6886)
<!-- Reviewable:end -->
