### PR TITLE
Introduce custom activity input evaluators and support evaluator type registration.

### DIFF
--- a/src/modules/Elsa.Logging/Activities/Log.cs
+++ b/src/modules/Elsa.Logging/Activities/Log.cs
@@ -2,11 +2,10 @@ using System.Dynamic;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using Elsa.Expressions.Contracts;
-using Elsa.Expressions.Models;
 using Elsa.Extensions;
 using Elsa.Logging.Contracts;
 using Elsa.Logging.Models;
+using Elsa.Logging.Services;
 using Elsa.Logging.UI;
 using Elsa.Workflows;
 using Elsa.Workflows.Attributes;
@@ -64,7 +63,8 @@ public class Log : CodeActivity
         Description = "Flat dictionary of key/value pairs to include as attributes.",
         DisplayName = "Attributes",
         UIHint = InputUIHints.Dictionary,
-        UIHandler = typeof(DictionaryUIHintHandler)
+        UIHandler = typeof(DictionaryUIHintHandler),
+        EvaluatorType = typeof(DictionaryValueEvaluator)
         )] 
     public Input<IDictionary<string, object>?> Attributes { get; set; } = null!;
 

--- a/src/modules/Elsa.Logging/Features/LoggingFeature.cs
+++ b/src/modules/Elsa.Logging/Features/LoggingFeature.cs
@@ -53,6 +53,7 @@ public class LoggingFeature(IModule module) : FeatureBase(module)
             .AddScoped<ILogSinkProvider, StaticLogSinkProvider>()
             .AddScoped<ILogSinkRouter, LogSinkRouter>()
             .AddScoped<IPropertyUIHandler, LogSinkCheckListUIHintHandler>()
+            .AddScoped<DictionaryValueEvaluator>()
             .AddSingleton<ILogEntryQueue, LogEntryQueue>()
             .AddSingleton<ILogSinkCatalog, LogSinkCatalog>();
     }

--- a/src/modules/Elsa.Logging/Services/DictionaryValueEvaluator.cs
+++ b/src/modules/Elsa.Logging/Services/DictionaryValueEvaluator.cs
@@ -1,0 +1,39 @@
+using System.Text.Json;
+using Elsa.Expressions.Models;
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.UIHints;
+
+namespace Elsa.Logging.Services;
+
+public class DictionaryValueEvaluator : IActivityInputEvaluator
+{
+    public async Task<object?> EvaluateAsync(ActivityInputEvaluatorContext context)
+    {
+        var wrappedInput = context.Input;
+        var evaluator = context.ExpressionEvaluator;
+        var expressionExecutionContext = context.ExpressionExecutionContext;
+        var inputDescriptor = context.InputDescriptor;
+        var defaultValue = inputDescriptor.DefaultValue;
+        var value = wrappedInput.Expression != null ? await evaluator.EvaluateAsync(wrappedInput, expressionExecutionContext) : defaultValue;
+        if (value is IDictionary<string, object> dictionary && inputDescriptor.UIHint == InputUIHints.Dictionary)
+        {
+            var tempDictionary = new Dictionary<string, object?>(dictionary.Count);
+            foreach (var dict in dictionary)
+            {
+                if (dict.Value is not JsonElement json)
+                    continue;
+                        
+                json.TryGetProperty("type" , out var typeProperty);
+                json.TryGetProperty("value" , out var valueProperty);
+                        
+                var expression = new Expression(typeProperty.ToString(), valueProperty.ToString());
+                var val = await evaluator.EvaluateAsync<string>(expression, expressionExecutionContext);
+                tempDictionary[dict.Key] = val;
+            }
+            value = tempDictionary;
+        }
+        
+        return value;
+    }
+}

--- a/src/modules/Elsa.Workflows.Core/Attributes/InputAttribute.cs
+++ b/src/modules/Elsa.Workflows.Core/Attributes/InputAttribute.cs
@@ -79,6 +79,12 @@ public class InputAttribute : Attribute
     public bool AutoEvaluate { get; set; } = true;
 
     /// <summary>
+    /// Specifies the type of a custom evaluator to use for evaluating the input property value.
+    /// The evaluator type determines how the value for the property is resolved at runtime.
+    /// </summary>
+    public Type? EvaluatorType { get; set; }
+
+    /// <summary>
     /// A value indicating whether this input can be serialized as part of the workflow instance,
     /// </summary>
     public bool IsSerializable { get; set; } = true;

--- a/src/modules/Elsa.Workflows.Core/Contexts/ActivityInputEvaluatorContext.cs
+++ b/src/modules/Elsa.Workflows.Core/Contexts/ActivityInputEvaluatorContext.cs
@@ -1,0 +1,12 @@
+using Elsa.Expressions.Contracts;
+using Elsa.Expressions.Models;
+using Elsa.Workflows.Models;
+
+namespace Elsa.Workflows;
+
+public record ActivityInputEvaluatorContext(
+    ActivityExecutionContext ActivityExecutionContext, 
+    ExpressionExecutionContext ExpressionExecutionContext, 
+    InputDescriptor InputDescriptor, 
+    Input Input, 
+    IExpressionEvaluator ExpressionEvaluator);

--- a/src/modules/Elsa.Workflows.Core/Contracts/IActivityInputEvaluator.cs
+++ b/src/modules/Elsa.Workflows.Core/Contracts/IActivityInputEvaluator.cs
@@ -1,0 +1,6 @@
+namespace Elsa.Workflows;
+
+public interface IActivityInputEvaluator
+{
+    Task<object?> EvaluateAsync(ActivityInputEvaluatorContext context);
+}

--- a/src/modules/Elsa.Workflows.Core/Features/WorkflowsFeature.cs
+++ b/src/modules/Elsa.Workflows.Core/Features/WorkflowsFeature.cs
@@ -188,6 +188,7 @@ public class WorkflowsFeature : FeatureBase
             .AddScoped<IActivityStateFilterManager, DefaultActivityStateFilterManager>()
             .AddScoped<IWorkflowInstanceVariableReader, DefaultWorkflowInstanceVariableReader>()
             .AddScoped<IWorkflowInstanceVariableWriter, DefaultWorkflowInstanceVariableWriter>()
+            .AddScoped<DefaultActivityInputEvaluator>()
 
             // Incident Strategies.
             .AddTransient<IIncidentStrategy, FaultStrategy>()

--- a/src/modules/Elsa.Workflows.Core/Models/InputDescriptor.cs
+++ b/src/modules/Elsa.Workflows.Core/Models/InputDescriptor.cs
@@ -21,19 +21,20 @@ public class InputDescriptor : PropertyDescriptor
         bool isWrapped,
         string uiHint,
         string displayName,
-        string? description = default,
-        string? category = default,
+        string? description = null,
+        string? category = null,
         float order = 0,
-        object? defaultValue = default,
+        object? defaultValue = null,
         string? defaultSyntax = "Literal",
         bool isReadOnly = false,
         bool isBrowsable = true,
         bool isSerializable = true,
         bool isSynthetic = false,
         bool autoEvaluate = true,
-        Type? storageDriverType = default,
-        PropertyInfo? propertyInfo = default,
-        IDictionary<string, object>? uiSpecifications = default
+        Type? evaluatorType = null,
+        Type? storageDriverType = null,
+        PropertyInfo? propertyInfo = null,
+        IDictionary<string, object>? uiSpecifications = null
         )
     {
         Name = name;
@@ -50,6 +51,7 @@ public class InputDescriptor : PropertyDescriptor
         DefaultSyntax = defaultSyntax;
         IsReadOnly = isReadOnly;
         AutoEvaluate = autoEvaluate;
+        EvaluatorType = evaluatorType;
         StorageDriverType = storageDriverType;
         IsSynthetic = isSynthetic;
         IsBrowsable = isBrowsable;
@@ -66,7 +68,7 @@ public class InputDescriptor : PropertyDescriptor
     /// <summary>
     /// A string value that hints at what UI control might be used to render in a UI tool.  
     /// </summary>
-    public string UIHint { get; set; } = default!;
+    public string UIHint { get; set; } = null!;
 
     /// <summary>
     /// The category to which this input belongs. Can be used by UI to e.g. render different inputs in different tabs.
@@ -104,6 +106,12 @@ public class InputDescriptor : PropertyDescriptor
     /// True if the expression should be evaluated automatically, false otherwise. Defaults to true.
     /// </summary>
     public bool AutoEvaluate { get; set; } = true;
+    
+    /// <summary>
+    /// Specifies the type of a custom evaluator to use for evaluating the input property value.
+    /// The evaluator type determines how the value for the property is resolved at runtime.
+    /// </summary>
+    public Type? EvaluatorType { get; set; }
 
     /// <summary>
     /// A dictionary of UI specifications to be used by the UI.

--- a/src/modules/Elsa.Workflows.Core/Services/ActivityDescriber.cs
+++ b/src/modules/Elsa.Workflows.Core/Services/ActivityDescriber.cs
@@ -150,8 +150,7 @@ public class ActivityDescriber(IPropertyDefaultValueResolver defaultValueResolve
 
         var uiSpecification = await propertyUIHandlerResolver.GetUIPropertiesAsync(propertyInfo, null, cancellationToken);
 
-        return new InputDescriptor
-        (
+        return new(
             inputAttribute?.Name ?? propertyInfo.Name,
             wrappedPropertyType,
             propertyInfo.GetValue,
@@ -169,7 +168,8 @@ public class ActivityDescriber(IPropertyDefaultValueResolver defaultValueResolve
             inputAttribute?.IsSerializable ?? true,
             false,
             autoEvaluate,
-            default,
+            inputAttribute?.EvaluatorType,
+            null,
             propertyInfo,
             uiSpecification
         );

--- a/src/modules/Elsa.Workflows.Core/Services/DefaultActivityInputEvaluator.cs
+++ b/src/modules/Elsa.Workflows.Core/Services/DefaultActivityInputEvaluator.cs
@@ -1,0 +1,14 @@
+using Elsa.Extensions;
+
+namespace Elsa.Workflows;
+
+public class DefaultActivityInputEvaluator : IActivityInputEvaluator
+{
+    public async Task<object?> EvaluateAsync(ActivityInputEvaluatorContext context)
+    {
+        var wrappedInput = context.Input;
+        var evaluator = context.ExpressionEvaluator;
+        var expressionExecutionContext = context.ExpressionExecutionContext;
+        return await evaluator.EvaluateAsync(wrappedInput, expressionExecutionContext);
+    }
+}


### PR DESCRIPTION
Added `DefaultActivityInputEvaluator` and `DictionaryValueEvaluator` for custom input evaluation logic. Modified `InputAttribute` and `InputDescriptor` to support specifying evaluator types. Updated relevant activity, service, and feature registrations to integrate the new evaluators.
