### PR TITLE
Fixing unit tests

### DIFF
--- a/src/modules/Elsa.Workflows.Core/Extensions/ActivityExecutionContextExtensions.cs
+++ b/src/modules/Elsa.Workflows.Core/Extensions/ActivityExecutionContextExtensions.cs
@@ -443,14 +443,11 @@ public static partial class ActivityExecutionContextExtensions
     /// </summary>
     public static void SetExtensionsMetadata(this ActivityExecutionContext context, string key, object? value)
     {
-        var extensionsDictionary = context.GetExtensionsMetadata();
-        
-        if(extensionsDictionary == null) extensionsDictionary = new();
-        
+        var extensionsDictionary = context.GetExtensionsMetadata() ?? new Dictionary<string, object?>();
+
         extensionsDictionary[key] = value;
         
         context.Metadata[ExtensionsMetadataKey] = extensionsDictionary;
-        
     }
 
     /// <summary>
@@ -458,7 +455,7 @@ public static partial class ActivityExecutionContextExtensions
     /// </summary>
     public static Dictionary<string, object?>? GetExtensionsMetadata(this ActivityExecutionContext context)
     {
-        return context.Metadata[ExtensionsMetadataKey] as Dictionary<string, object?>;
+        return context.Metadata.TryGetValue(ExtensionsMetadataKey, out var value) ? value as Dictionary<string, object?> : null;
     }
 
     internal static bool GetHasEvaluatedProperties(this ActivityExecutionContext context) => context.TransientProperties.TryGetValue<bool>("HasEvaluatedProperties", out var value) && value;

--- a/src/modules/Elsa.Workflows.Core/Extensions/ActivityExecutionContextExtensions.cs
+++ b/src/modules/Elsa.Workflows.Core/Extensions/ActivityExecutionContextExtensions.cs
@@ -451,7 +451,7 @@ public static partial class ActivityExecutionContextExtensions
     }
 
     /// <summary>
-    /// Retrives the extensin data from the metdata. Represents specific data that is exposed generically for an activity.
+    /// Retrieves the extension data from the metadata. Represents specific data that is exposed generically for an activity.
     /// </summary>
     public static Dictionary<string, object?>? GetExtensionsMetadata(this ActivityExecutionContext context)
     {


### PR DESCRIPTION
This pull request refactors the way extension metadata is handled in `ActivityExecutionContextExtensions.cs`, focusing on improving null handling and dictionary initialization. The changes streamline the logic for retrieving and setting extension metadata.

Improvements to extension metadata handling:

* Simplified dictionary initialization in `SetExtensionsMetadata` by using the null-coalescing operator to ensure a dictionary is always available.
* Improved null safety in `GetExtensionsMetadata` by using `TryGetValue` instead of direct casting, which makes the code more robust and less error-prone.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6891)
<!-- Reviewable:end -->
