### PR TITLE
Use full name for workflow dictionary

### DIFF
--- a/src/modules/Elsa.Workflows.Core/Extensions/ItemSourceActivityExecutionContextExtensions.cs
+++ b/src/modules/Elsa.Workflows.Core/Extensions/ItemSourceActivityExecutionContextExtensions.cs
@@ -36,8 +36,12 @@ public static class ItemSourceActivityExecutionContextExtensions
                         yield return item;
             }
         }
-
-        if (items is IEnumerable<T> enumerable)
+        else if (items is IAsyncEnumerable<T> asyncEnumerable)
+        {
+            await foreach (T item in asyncEnumerable)
+                yield return item;
+        }
+        else if (items is IEnumerable<T> enumerable)
         {
             foreach (T item in enumerable)
                 yield return item;

--- a/src/modules/Elsa.Workflows.Runtime/Extensions/WorkflowDictionaryExtensions.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Extensions/WorkflowDictionaryExtensions.cs
@@ -14,7 +14,8 @@ public static class WorkflowDictionaryExtensions
     /// </summary>
     public static void Add<TWorkflow>(this IDictionary<string, Func<IServiceProvider, ValueTask<IWorkflow>>> dictionary) where TWorkflow : IWorkflow
     {
-        dictionary.Add(typeof(TWorkflow).Name, sp =>
+        // FullName should never be null here, as we filter out generic types
+        dictionary.Add(typeof(TWorkflow).FullName!, sp =>
         {
             var workflow = ActivatorUtilities.GetServiceOrCreateInstance<TWorkflow>(sp);
             return new ValueTask<IWorkflow>(workflow);
@@ -26,7 +27,8 @@ public static class WorkflowDictionaryExtensions
     /// </summary>
     public static void Add(this IDictionary<string, Func<IServiceProvider, ValueTask<IWorkflow>>> dictionary, Type workflowType)
     {
-        dictionary.Add(workflowType.Name, sp =>
+        // FullName should never be null here, as we filter out generic types
+        dictionary.Add(workflowType.FullName!, sp =>
         {
             var workflow = (IWorkflow)ActivatorUtilities.GetServiceOrCreateInstance(sp, workflowType);
             return new ValueTask<IWorkflow>(workflow);


### PR DESCRIPTION
The code currenlty crashes when you have two workflows with the same class name in different Namespaces.

I've looked through the usages of the dictionary and I don't think the key is actually relevant.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6922)
<!-- Reviewable:end -->
