### PR TITLE
Simplify registration of IWorkflowResumer

### DIFF
--- a/src/modules/Elsa.Workflows.Runtime/Features/WorkflowRuntimeFeature.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Features/WorkflowRuntimeFeature.cs
@@ -119,6 +119,14 @@ public class WorkflowRuntimeFeature(IModule module) : FeatureBase(module)
     /// </summary>
     public Func<IServiceProvider, ICommandHandler> DispatchWorkflowCommandHandler { get; set; } = sp => sp.GetRequiredService<DispatchWorkflowCommandHandler>();
 
+    /// <summary>
+    /// A factory that instantiates an <see cref="IWorkflowResumer"/>.
+    /// </summary>
+    public Func<IServiceProvider, IWorkflowResumer> WorkflowResumer { get; set; } = sp => sp.GetRequiredService<WorkflowResumer>();
+
+    /// <summary>
+    /// A factory that instantiates an <see cref="IBookmarkQueueWorker"/>.
+    /// </summary>
     public Func<IServiceProvider, IBookmarkQueueWorker> BookmarkQueueWorker { get; set; } = sp => sp.GetRequiredService<BookmarkQueueWorker>();
 
     /// <summary>
@@ -250,7 +258,7 @@ public class WorkflowRuntimeFeature(IModule module) : FeatureBase(module)
             .AddSingleton(BackgroundActivityScheduler)
             .AddSingleton<RandomLongIdentityGenerator>()
             .AddSingleton<IBookmarkQueueSignaler, BookmarkQueueSignaler>()
-            .AddScoped<IBookmarkQueueWorker, BookmarkQueueWorker>()
+            .AddScoped(BookmarkQueueWorker)
             .AddScoped<IBookmarkManager, DefaultBookmarkManager>()
             .AddScoped<IActivityExecutionManager, DefaultActivityExecutionManager>()
             .AddScoped<IActivityExecutionStatsService, ActivityExecutionStatsService>()
@@ -276,7 +284,7 @@ public class WorkflowRuntimeFeature(IModule module) : FeatureBase(module)
             .AddScoped<IBookmarksPersister, BookmarksPersister>()
             .AddScoped<IBookmarkResumer, BookmarkResumer>()
             .AddScoped<IBookmarkQueue, StoreBookmarkQueue>()
-            .AddScoped<IWorkflowResumer, WorkflowResumer>()
+            .AddScoped(WorkflowResumer)
             .AddScoped<ITriggerInvoker, TriggerInvoker>()
             .AddScoped<IWorkflowCanceler, WorkflowCanceler>()
             .AddScoped<IWorkflowCancellationService, WorkflowCancellationService>()


### PR DESCRIPTION
Added support to register a custom IWorkflowResumer like this:

```
elsa.UseWorkflowRuntime(workflowRuntime =>
{
    workflowRuntime.WorkflowResumer = sp => sp.GetRequiredService<CustomWorkflowResumer>();
});
```

Also fixed so that `workflowRuntime.BookmarkQueueWorker` configuration is properly applied.

Issue: https://github.com/elsa-workflows/elsa-core/issues/6981

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/6983)
<!-- Reviewable:end -->
