### PR TITLE
Exposes the first uploaded file

### DIFF
--- a/src/modules/Elsa.Http/Activities/HttpEndpoint.cs
+++ b/src/modules/Elsa.Http/Activities/HttpEndpoint.cs
@@ -134,6 +134,12 @@ public class HttpEndpoint : Trigger<HttpRequest>
     public Output<IFormFile[]> Files { get; set; } = null!;
 
     /// <summary>
+    /// The first uploaded file, if any.
+    /// </summary>
+    [Output(Description = "The first uploaded file, if any.", IsSerializable = false)]
+    public Output<IFormFile?> File { get; set; } = null!;
+
+    /// <summary>
     /// The parsed route data, if any.
     /// </summary>
     [Output(Description = "The parsed route data, if any.")]
@@ -246,6 +252,7 @@ public class HttpEndpoint : Trigger<HttpRequest>
                 }
 
                 Files.Set(context, files.ToArray());
+                File.Set(context, files.FirstOrDefault());
             }
         }
         else


### PR DESCRIPTION
Exposes the first uploaded file from the HTTP request. This allows workflows to easily access a single file when only one is expected.

This complements the existing `Files` property, which provides access to all uploaded files.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/7010)
<!-- Reviewable:end -->
