### PR TITLE
Fix Content-Length mismatch by reworking RawStringContent

### DIFF
--- a/src/modules/Elsa.Http/ContentWriters/JsonContentFactory.cs
+++ b/src/modules/Elsa.Http/ContentWriters/JsonContentFactory.cs
@@ -11,7 +11,7 @@ namespace Elsa.Http.ContentWriters;
 public class JsonContentFactory : IHttpContentFactory
 {
     /// <inheritdoc />
-    public IEnumerable<string> SupportedContentTypes => new[] { MediaTypeNames.Application.Json, "text/json" };
+    public IEnumerable<string> SupportedContentTypes => [MediaTypeNames.Application.Json, "text/json"];
 
     /// <inheritdoc />
     [RequiresUnreferencedCode("The JsonSerializer type is not trim-compatible.")]


### PR DESCRIPTION
- Replace StreamWriter-based RawStringContent with ByteArrayContent-based implementation to guarantee bytes written == Content-Length.
- Pre-encode string to byte[] using provided Encoding (no BOM), and set Content-Type without charset.
- Update JsonContentFactory to use the new RawStringContent to avoid length mismatches under load/bulk dispatch.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/7027)
<!-- Reviewable:end -->
