### PR TITLE
Fixed ParentWorkflowInstanceId not being set

### DIFF
--- a/src/modules/Elsa.Workflows.Runtime/Services/BackgroundWorkflowDispatcher.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Services/BackgroundWorkflowDispatcher.cs
@@ -22,7 +22,8 @@ public class BackgroundWorkflowDispatcher(ICommandSender commandSender, ITenantA
             Properties = request.Properties,
             CorrelationId = request.CorrelationId,
             InstanceId = request.InstanceId,
-            TriggerActivityId = request.TriggerActivityId
+            TriggerActivityId = request.TriggerActivityId,
+            ParentWorkflowInstanceId = request.ParentWorkflowInstanceId,
         };
         
         await commandSender.SendAsync(command, CommandStrategy.Background, CreateHeaders(), cancellationToken);


### PR DESCRIPTION
Hello,

Whilst working with sub-workflows and trying to gather their data I noticed the `ParentWorflowInstanceId` value, however this value is always null.

After a lot of digging it appears that the value is being set on the `DispatchWorkflowDefinitionRequest`, but is not being passed to the `DispatchWorkflowDefinitionCommand`.

This PR adds this value.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/7029)
<!-- Reviewable:end -->
