### PR TITLE
Add tenant headers support to BackgroundWorkflowCancellationDispatcher

### DIFF
--- a/src/modules/Elsa.Workflows.Runtime/Services/BackgroundWorkflowCancellationDispatcher.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Services/BackgroundWorkflowCancellationDispatcher.cs
@@ -9,7 +9,7 @@ using Elsa.Workflows.Runtime.Responses;
 namespace Elsa.Workflows.Runtime;
 
 /// <summary>
-/// Dispatches workflow cancellation requests to a local background worker.
+///     Dispatches workflow cancellation requests to a local background worker.
 /// </summary>
 public class BackgroundWorkflowCancellationDispatcher(ICommandSender commandSender, ITenantAccessor tenantAccessor) : IWorkflowCancellationDispatcher
 {
@@ -17,11 +17,10 @@ public class BackgroundWorkflowCancellationDispatcher(ICommandSender commandSend
     public async Task<DispatchCancelWorkflowsResponse> DispatchAsync(DispatchCancelWorkflowRequest request, CancellationToken cancellationToken = default)
     {
         var command = new CancelWorkflowsCommand(request);
-        await commandSender.SendAsync(command, CommandStrategy.Background, cancellationToken);
+        await commandSender.SendAsync(command, CommandStrategy.Background, CreateHeaders(), cancellationToken);
         return new DispatchCancelWorkflowsResponse();
     }
-    
-    
+
     private IDictionary<object, object> CreateHeaders()
     {
         return TenantHeaders.CreateHeaders(tenantAccessor.Tenant?.Id);


### PR DESCRIPTION
This PR fixes #7034. By passing in the tenant headers when executing Cancel to a suspended workflow with the default cancellation dispatcher.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/7040)
<!-- Reviewable:end -->
