### PR TITLE
Add integration and unit tests for `Start` activity across different workflow scenarios

### DIFF
--- a/test/integration/Elsa.Activities.IntegrationTests/Flow/StartTests.cs
+++ b/test/integration/Elsa.Activities.IntegrationTests/Flow/StartTests.cs
@@ -1,0 +1,58 @@
+using Elsa.Activities.IntegrationTests.Flow.Workflows;
+using Elsa.Testing.Shared;
+using Elsa.Workflows;
+using Elsa.Workflows.Activities;
+using Xunit.Abstractions;
+
+namespace Elsa.Activities.IntegrationTests.Flow;
+
+/// <summary>
+/// Integration tests for the <see cref="Start"/> activity.
+/// </summary>
+public class StartTests(ITestOutputHelper testOutputHelper)
+{
+    private readonly WorkflowTestFixture _fixture = new WorkflowTestFixture(testOutputHelper)
+        .AddWorkflow<StartInSequenceWorkflow>()
+        .AddWorkflow<StartInFlowchartAsExplicitStartWorkflow>()
+        .AddWorkflow<StartInFlowchartWithStartPropertyWorkflow>();
+
+    [Fact(DisplayName = "Start completes successfully in sequence")]
+    public async Task Start_CompletesSuccessfullyInSequence()
+    {
+        // Act
+        var workflowState = await _fixture.RunWorkflowAsync(StartInSequenceWorkflow.DefinitionId);
+
+        // Assert
+        Assert.Equal(WorkflowStatus.Finished, workflowState.Status);
+        var lines = _fixture.CapturingTextWriter.Lines.ToList();
+        Assert.Contains("Before Start", lines);
+        Assert.Contains("After Start", lines);
+    }
+
+    [Fact(DisplayName = "Start activity is used as flowchart start when present")]
+    public async Task Start_IsUsedAsFlowchartStart_WhenPresent()
+    {
+        // Act
+        var workflowState = await _fixture.RunWorkflowAsync(StartInFlowchartAsExplicitStartWorkflow.DefinitionId);
+
+        // Assert
+        Assert.Equal(WorkflowStatus.Finished, workflowState.Status);
+        var lines = _fixture.CapturingTextWriter.Lines.ToList();
+        Assert.Contains("Start activity", lines);
+        Assert.Contains("After Start", lines);
+        Assert.DoesNotContain("Should not execute", lines);
+    }
+
+    [Fact(DisplayName = "Flowchart Start property takes precedence over explicit Start activity")]
+    public async Task FlowchartStartProperty_TakesPrecedenceOverExplicitStartActivity()
+    {
+        // Act
+        var workflowState = await _fixture.RunWorkflowAsync(StartInFlowchartWithStartPropertyWorkflow.DefinitionId);
+
+        // Assert
+        Assert.Equal(WorkflowStatus.Finished, workflowState.Status);
+        var lines = _fixture.CapturingTextWriter.Lines.ToList();
+        Assert.Contains("Start property used", lines);
+        Assert.DoesNotContain("Start activity", lines);
+    }
+}

--- a/test/integration/Elsa.Activities.IntegrationTests/Flow/Workflows/StartInFlowchartAsExplicitStartWorkflow.cs
+++ b/test/integration/Elsa.Activities.IntegrationTests/Flow/Workflows/StartInFlowchartAsExplicitStartWorkflow.cs
@@ -1,0 +1,40 @@
+using Elsa.Workflows;
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Activities.Flowchart.Activities;
+using Elsa.Workflows.Activities.Flowchart.Models;
+
+namespace Elsa.Activities.IntegrationTests.Flow.Workflows;
+
+/// <summary>
+/// Workflow demonstrating that an explicit Start activity in a flowchart is used as the starting point.
+/// </summary>
+public class StartInFlowchartAsExplicitStartWorkflow : WorkflowBase
+{
+    public static readonly string DefinitionId = Guid.NewGuid().ToString();
+
+    protected override void Build(IWorkflowBuilder workflow)
+    {
+        workflow.WithDefinitionId(DefinitionId);
+
+        var startActivity = new Start();
+        var startMessage = new WriteLine("Start activity");
+        var afterStart = new WriteLine("After Start");
+        var shouldNotExecute = new WriteLine("Should not execute");
+
+        workflow.Root = new Flowchart
+        {
+            Activities =
+            {
+                startActivity,
+                startMessage,
+                afterStart,
+                shouldNotExecute
+            },
+            Connections =
+            {
+                new Connection(startActivity, startMessage),
+                new Connection(startMessage, afterStart)
+            }
+        };
+    }
+}

--- a/test/integration/Elsa.Activities.IntegrationTests/Flow/Workflows/StartInFlowchartWithStartPropertyWorkflow.cs
+++ b/test/integration/Elsa.Activities.IntegrationTests/Flow/Workflows/StartInFlowchartWithStartPropertyWorkflow.cs
@@ -1,0 +1,41 @@
+using Elsa.Workflows;
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Activities.Flowchart.Activities;
+using Elsa.Workflows.Activities.Flowchart.Models;
+
+namespace Elsa.Activities.IntegrationTests.Flow.Workflows;
+
+/// <summary>
+/// Workflow demonstrating that the Flowchart.Start property takes precedence over an explicit Start activity.
+/// </summary>
+public class StartInFlowchartWithStartPropertyWorkflow : WorkflowBase
+{
+    public static readonly string DefinitionId = Guid.NewGuid().ToString();
+
+    protected override void Build(IWorkflowBuilder workflow)
+    {
+        workflow.WithDefinitionId(DefinitionId);
+
+        var startActivity = new Start();
+        var startActivityMessage = new WriteLine("Start activity");
+        var startPropertyActivity = new WriteLine("Start property used");
+        var afterStart = new WriteLine("After property start");
+
+        workflow.Root = new Flowchart
+        {
+            Start = startPropertyActivity, // This takes precedence
+            Activities =
+            {
+                startActivity, // This should be ignored
+                startActivityMessage,
+                startPropertyActivity,
+                afterStart
+            },
+            Connections =
+            {
+                new Connection(startActivity, startActivityMessage),
+                new Connection(startPropertyActivity, afterStart)
+            }
+        };
+    }
+}

--- a/test/integration/Elsa.Activities.IntegrationTests/Flow/Workflows/StartInSequenceWorkflow.cs
+++ b/test/integration/Elsa.Activities.IntegrationTests/Flow/Workflows/StartInSequenceWorkflow.cs
@@ -1,0 +1,26 @@
+using Elsa.Workflows;
+using Elsa.Workflows.Activities;
+
+namespace Elsa.Activities.IntegrationTests.Flow.Workflows;
+
+/// <summary>
+/// Workflow demonstrating that Start activity completes successfully in a sequence.
+/// </summary>
+public class StartInSequenceWorkflow : WorkflowBase
+{
+    public static readonly string DefinitionId = Guid.NewGuid().ToString();
+
+    protected override void Build(IWorkflowBuilder workflow)
+    {
+        workflow.WithDefinitionId(DefinitionId);
+        workflow.Root = new Sequence
+        {
+            Activities =
+            {
+                new WriteLine("Before Start"),
+                new Start(),
+                new WriteLine("After Start")
+            }
+        };
+    }
+}

--- a/test/unit/Elsa.Activities.UnitTests/Flow/StartTests.cs
+++ b/test/unit/Elsa.Activities.UnitTests/Flow/StartTests.cs
@@ -1,0 +1,35 @@
+using Elsa.Testing.Shared;
+using Elsa.Workflows;
+using Elsa.Workflows.Activities;
+
+namespace Elsa.Activities.UnitTests.Flow;
+
+/// <summary>
+/// Unit tests for the <see cref="Start"/> activity.
+/// </summary>
+public class StartTests
+{
+    [Fact(DisplayName = "Start implements IStartNode interface")]
+    public void Start_ImplementsIStartNode()
+    {
+        // Arrange
+        var startActivity = new Start();
+
+        // Assert
+        Assert.IsAssignableFrom<IStartNode>(startActivity);
+    }
+
+    [Fact(DisplayName = "Start completes execution")]
+    public async Task Start_CompletesExecution()
+    {
+        // Arrange
+        var startActivity = new Start();
+        var fixture = new ActivityTestFixture(startActivity);
+
+        // Act
+        var context = await fixture.ExecuteAsync();
+
+        // Assert
+        Assert.Equal(ActivityStatus.Completed, context.Status);
+    }
+}


### PR DESCRIPTION
- Introduced three test workflows:
  - `StartInFlowchartAsExplicitStartWorkflow`: Verifies the explicit `Start` activity in a flowchart as a starting point.
  - `StartInFlowchartWithStartPropertyWorkflow`: Confirms precedence of `Flowchart.Start` property over the `Start` activity.
  - `StartInSequenceWorkflow`: Demonstrates successful `Start` activity usage in a sequence.

- Added integration tests (`StartTests`) ensuring expected execution flows and `Start` activity behavior for each workflow.
- Added unit tests validating `Start` activity implementation and compliance with `IStartNode`.
- Ensures test coverage for `Start` activity behavior across flowchart, sequence, and property overrides.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/7111)
<!-- Reviewable:end -->
