### PR TITLE
Add unit tests for `ReadLine` activity (#7110)

### DIFF
--- a/test/unit/Elsa.Activities.UnitTests/Console/ReadLineTests.cs
+++ b/test/unit/Elsa.Activities.UnitTests/Console/ReadLineTests.cs
@@ -21,13 +21,13 @@ public class ReadLineTests
         _mockProvider.GetTextReader().Returns(_mockTextReader);
     }
 
-    [Theory(DisplayName = "ReadLine reads text from input")]
+    [Theory(DisplayName = "ReadLine reads text from input and completes successfully")]
     [InlineData("Hello, World!")]
     [InlineData("Test input")]
     [InlineData("")]
     [InlineData(" ")]
     [InlineData("\t")]
-    public async Task Should_Read_Text_From_Input(string inputText)
+    public async Task Should_Read_Text_From_Input_And_Complete(string inputText)
     {
         // Arrange
         var readLine = new ReadLine();
@@ -36,41 +36,68 @@ public class ReadLineTests
         var context = await ExecuteAsync(readLine, inputText);
 
         // Assert
+        Assert.Equal(ActivityStatus.Completed, context.Status);
         var result = (string)context.GetActivityOutput(() => readLine.Result)!;
         Assert.Equal(inputText, result);
-    }
-
-    [Fact(DisplayName = "ReadLine completes successfully")]
-    public async Task Should_Complete_Successfully()
-    {
-        // Arrange
-        var readLine = new ReadLine();
-
-        // Act
-        var context = await ExecuteAsync(readLine);
-
-        // Assert
-        Assert.Equal(ActivityStatus.Completed, context.Status);
     }
 
     [Fact(DisplayName = "ReadLine uses provided stream provider")]
     public async Task Should_Use_Provided_Stream_Provider()
     {
-        // Arrange
-        var readLine = new ReadLine();
-
         // Act
-        await ExecuteAsync(readLine);
+        await ExecuteAsync(new ReadLine());
 
         // Assert
         _mockProvider.Received(1).GetTextReader();
         _mockTextReader.Received(1).ReadLine();
     }
 
-    private async Task<ActivityExecutionContext> ExecuteAsync(IActivity activity, string inputText = "Test")
+    [Fact(DisplayName = "ReadLine handles null return value from stream")]
+    public async Task Should_Handle_Null_Return_Value()
+    {
+        // Arrange
+        var readLine = new ReadLine();
+
+        // Act
+        var context = await ExecuteAsync(readLine, null);
+
+        // Assert - The null-forgiving operator in ReadLine implementation means it expects non-null,
+        // but null can occur at end of stream. Verify the behavior stores null.
+        var result = context.GetActivityOutput(() => readLine.Result);
+        Assert.Null(result);
+    }
+
+    [Fact(DisplayName = "ReadLine uses default provider when none is registered")]
+    public async Task Should_Use_Default_Provider_When_None_Registered()
+    {
+        // Arrange
+        var readLine = new ReadLine();
+        const string expectedInput = "Default provider test";
+        var originalConsoleIn = System.Console.In;
+
+        try
+        {
+            // Redirect Console.In to our StringReader
+            System.Console.SetIn(new StringReader(expectedInput));
+
+            // Act
+            var context = await new ActivityTestFixture(readLine).ExecuteAsync();
+
+            // Assert
+            var result = (string)context.GetActivityOutput(() => readLine.Result)!;
+            Assert.Equal(expectedInput, result);
+        }
+        finally
+        {
+            // Restore original Console.In
+            System.Console.SetIn(originalConsoleIn);
+        }
+    }
+
+    private Task<ActivityExecutionContext> ExecuteAsync(ReadLine readLine, string? inputText = "Test")
     {
         _mockTextReader.ReadLine().Returns(inputText);
-        return await new ActivityTestFixture(activity)
+        return new ActivityTestFixture(readLine)
             .ConfigureServices(services => services.AddSingleton(_mockProvider))
             .ExecuteAsync();
     }


### PR DESCRIPTION
- Implemented `ReadLineTests` to verify the behavior of the `ReadLine` activity.
- Added scenarios for reading input, stream provider usage, and successful completion.
- Refactored `ExecuteAsync` helper to streamline test execution with mock dependencies.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elsa-workflows/elsa-core/7112)
<!-- Reviewable:end -->
