### PR TITLE
Fix BulkDispatchWorkflows sharing input dictionary across dispatches

### DIFF
--- a/src/modules/Elsa.Workflows.Runtime/Activities/BulkDispatchWorkflows.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Activities/BulkDispatchWorkflows.cs
@@ -156,7 +156,8 @@ public class BulkDispatchWorkflows : Activity
             throw new($"No published version of workflow definition with ID {workflowDefinitionId} found.");
 
         var parentInstanceId = context.WorkflowExecutionContext.Id;
-        var input = Input.GetOrDefault(context) ?? new Dictionary<string, object>();
+        var baseInput = Input.GetOrDefault(context);
+        var input = baseInput != null ? new Dictionary<string, object>(baseInput) : new Dictionary<string, object>();
         var channelName = ChannelName.GetOrDefault(context);
         var defaultInputItemKey = DefaultItemInputKey.GetOrDefault(context, () => "Item")!;
         var properties = new Dictionary<string, object>

--- a/test/integration/Elsa.Workflows.IntegrationTests/Scenarios/BulkDispatchWithInput/Spy.cs
+++ b/test/integration/Elsa.Workflows.IntegrationTests/Scenarios/BulkDispatchWithInput/Spy.cs
@@ -1,0 +1,17 @@
+using Elsa.Workflows.Runtime.Requests;
+
+namespace Elsa.Workflows.IntegrationTests.Scenarios.BulkDispatchWithInput;
+
+public class Spy
+{
+    public List<IDictionary<string, object>?> CapturedInputReferences { get; } = [];
+    public List<IDictionary<string, object>?> CapturedInputSnapshots { get; } = [];
+
+    public void CaptureDispatch(DispatchWorkflowDefinitionRequest request)
+    {
+        CapturedInputReferences.Add(request.Input);
+        CapturedInputSnapshots.Add(request.Input != null 
+            ? new Dictionary<string, object>(request.Input) 
+            : null);
+    }
+}

--- a/test/integration/Elsa.Workflows.IntegrationTests/Scenarios/BulkDispatchWithInput/TestHandler.cs
+++ b/test/integration/Elsa.Workflows.IntegrationTests/Scenarios/BulkDispatchWithInput/TestHandler.cs
@@ -1,0 +1,13 @@
+using Elsa.Mediator.Contracts;
+using Elsa.Workflows.Runtime.Notifications;
+
+namespace Elsa.Workflows.IntegrationTests.Scenarios.BulkDispatchWithInput;
+
+public class TestHandler(Spy spy) : INotificationHandler<WorkflowDefinitionDispatching>
+{
+    public Task HandleAsync(WorkflowDefinitionDispatching notification, CancellationToken cancellationToken)
+    {
+        spy.CaptureDispatch(notification.Request);
+        return Task.CompletedTask;
+    }
+}

--- a/test/integration/Elsa.Workflows.IntegrationTests/Scenarios/BulkDispatchWithInput/Tests.cs
+++ b/test/integration/Elsa.Workflows.IntegrationTests/Scenarios/BulkDispatchWithInput/Tests.cs
@@ -1,0 +1,51 @@
+using Elsa.Extensions;
+using Elsa.Testing.Shared;
+using Elsa.Workflows.Runtime.Notifications;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit.Abstractions;
+
+namespace Elsa.Workflows.IntegrationTests.Scenarios.BulkDispatchWithInput;
+
+public class Tests
+{
+    private readonly IServiceProvider _services;
+    private readonly Spy _spy;
+
+    public Tests(ITestOutputHelper testOutputHelper)
+    {
+        _services = new TestApplicationBuilder(testOutputHelper)
+            .AddWorkflow<ParentWorkflow>()
+            .AddWorkflow<ChildWorkflow>()
+            .ConfigureServices(services =>
+            {
+                services.AddSingleton<Spy>();
+                services.AddNotificationHandler<TestHandler, WorkflowDefinitionDispatching>();
+            })
+            .Build();
+        
+        _spy = _services.GetRequiredService<Spy>();
+    }
+
+    [Fact(DisplayName = "Each dispatched child workflow receives its own input dictionary")]
+    public async Task BulkDispatch_EachChildReceivesDistinctInputDictionary()
+    {
+        // Arrange
+        await _services.PopulateRegistriesAsync();
+
+        // Act
+        await _services.RunWorkflowUntilEndAsync(nameof(ParentWorkflow));
+
+        // Assert - each dispatch should receive a distinct dictionary instance
+        Assert.Equal(3, _spy.CapturedInputReferences.Count);
+        Assert.Equal(3, _spy.CapturedInputReferences.Distinct().Count());
+
+        // Assert - each dispatch should have its corresponding item value
+        var items = _spy.CapturedInputSnapshots
+            .Select(s => s?.GetValueOrDefault<string>("Item"))
+            .ToList();
+        
+        Assert.Contains("Apple", items);
+        Assert.Contains("Banana", items);
+        Assert.Contains("Cherry", items);
+    }
+}

--- a/test/integration/Elsa.Workflows.IntegrationTests/Scenarios/BulkDispatchWithInput/Workflows.cs
+++ b/test/integration/Elsa.Workflows.IntegrationTests/Scenarios/BulkDispatchWithInput/Workflows.cs
@@ -1,0 +1,26 @@
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Runtime.Activities;
+
+namespace Elsa.Workflows.IntegrationTests.Scenarios.BulkDispatchWithInput;
+
+public class ParentWorkflow : WorkflowBase
+{
+    protected override void Build(IWorkflowBuilder builder)
+    {
+        builder.Root = new BulkDispatchWorkflows
+        {
+            WorkflowDefinitionId = new(nameof(ChildWorkflow)),
+            Items = new(new[] { "Apple", "Banana", "Cherry" }),
+            Input = new(new Dictionary<string, object> { ["ExtraData"] = "SharedValue" }),
+            WaitForCompletion = new(false)
+        };
+    }
+}
+
+public class ChildWorkflow : WorkflowBase
+{
+    protected override void Build(IWorkflowBuilder builder)
+    {
+        builder.Root = new WriteLine("Child executed");
+    }
+}


### PR DESCRIPTION
Fixes a bug in `BulkDispatchWorkflows` where child workflows received corrupted input when using both `Items` and `Input` properties together.

### Problem

When dispatching multiple child workflows with additional input:

```csharp
new BulkDispatchWorkflows
{
    Items = new(["Apple", "Banana", "Cherry"]),
    Input = new(new Dictionary<string, object> { ["ExtraData"] = "SharedValue" })
}
```

All child workflows would receive the **same dictionary reference**. Since the dictionary was mutated with each item before dispatch, by the time child workflows executed, they all saw the last item's value (`"Cherry"`) instead of their respective values.


This happens because in `DispatchChildWorkflowAsync`, the input dictionary was retrieved once and reused:

```csharp
var input = Input.GetOrDefault(context) ?? new Dictionary<string, object>();
input["ParentInstanceId"] = parentInstanceId;
input.Merge(inputDictionary);  // Mutates the shared dictionary
```

This fix creates a copy of the base input dictionary for each iteration:

```csharp
var baseInput = Input.GetOrDefault(context);
var input = baseInput != null 
    ? new Dictionary<string, object>(baseInput) 
    : new Dictionary<string, object>();
```