### PR TITLE
fix: 7335 - Call ScheduleOutboundActivityAsync before calling CancelRemainingInboundActivitiesAsync …

### DIFF
--- a/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Activities/Flowchart.cs
+++ b/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Activities/Flowchart.cs
@@ -352,11 +352,12 @@ public class Flowchart : Container
 
         if (flowScope.AnyInboundConnectionsFollowed(flowGraph, outboundActivity))
         {
+            // This is the first inbound connection followed; schedule the outbound activity
+            var scheduleResponse = await ScheduleOutboundActivityAsync(flowchartContext, outboundActivity, completionCallback);
             // An inbound connection has been followed; cancel remaining inbound activities
             await CancelRemainingInboundActivitiesAsync(flowchartContext, outboundActivity);
 
-            // This is the first inbound connection followed; schedule the outbound activity
-            return await ScheduleOutboundActivityAsync(flowchartContext, outboundActivity, completionCallback);
+            return scheduleResponse;
         }
 
         if (flowScope.AllInboundConnectionsVisited(flowGraph, outboundActivity))


### PR DESCRIPTION
… in order to avoid the "Lost an owner context" exception.

Issue description: this was happenning because of how Elsa Workflows handles flowchart completion together with the commit behavior. When a workflow contains a Join Activity with WaitAny, that joins together several branches, out of which at least one contain a loop (with it's own flowchart): The flowchart is marked as completed before the Join activity is scheduled. When the Commit option is set to “Always Commit”, the workflow state is saved to the database at every step, including exactly when the Join executes. At that moment, the commit logic runs and attempts to process the Join’s completion callback. However, since the flowchart has already been marked as completed (and completed flowcharts are filtered out), it can no longer find the flowchart context.

## Purpose
Call ScheduleOutboundActivityAsync before calling CancelRemainingInboundActivitiesAsync in order to avoid the "Lost an owner context" exception.



---

## Scope

Select one primary concern:

- [X ] Bug fix (behavior change)
- [ ] Refactor (no behavior change)
- [ ] Documentation update
- [ ] Formatting / code cleanup
- [ ] Dependency / build update
- [ ] New feature

> If this PR includes multiple unrelated concerns, please split it before requesting review.

---

## Description

### Problem
This resolves a "Lost an owner context" exception described in https://github.com/elsa-workflows/elsa-core/issues/7335.

### Solution
By scheduling the activities ahead of calling the cancelation, this avoids situations in which scheduling is attempted on activities that are part of a FlowChart that has already been canceled.

---

## Verification
Run the workflow definition attached to the mentioned issue.

Steps:
1. Import the worklfow definition
2. Run an instance of the provided definition

Expected outcome:
The workflow should end up in state Finished without incidents.
---
