### PR TITLE
refactor | Added a new property to expose the ability to disable the sorting

### DIFF
--- a/src/clients/Elsa.Api.Client/Shared/UIHints/DropDown/SelectList.cs
+++ b/src/clients/Elsa.Api.Client/Shared/UIHints/DropDown/SelectList.cs
@@ -6,4 +6,4 @@ namespace Elsa.Api.Client.Shared.UIHints.DropDown;
 /// <param name="Items">The items.</param>
 /// <param name="IsFlagsEnum">Whether the select list represents a flags enum.</param>
 /// <param name="SortItems">Whether to sort the items alphabetically otherwise will just use the order provided.</param>
-public record SelectList(ICollection<SelectListItem> Items, bool IsFlagsEnum = false, bool SortItems = false);
+public record SelectList(ICollection<SelectListItem> Items, bool IsFlagsEnum = false, bool SortItems = true);

--- a/src/clients/Elsa.Api.Client/Shared/UIHints/DropDown/SelectList.cs
+++ b/src/clients/Elsa.Api.Client/Shared/UIHints/DropDown/SelectList.cs
@@ -5,4 +5,5 @@ namespace Elsa.Api.Client.Shared.UIHints.DropDown;
 /// </summary>
 /// <param name="Items">The items.</param>
 /// <param name="IsFlagsEnum">Whether the select list represents a flags enum.</param>
-public record SelectList(ICollection<SelectListItem> Items, bool IsFlagsEnum = false);
+/// <param name="SortItems">Whether to sort the items alphabetically otherwise will just use the order provided.</param>
+public record SelectList(ICollection<SelectListItem> Items, bool IsFlagsEnum = false, bool SortItems = false);


### PR DESCRIPTION
## Purpose
Currently the DropDown control has the following logic 

```cs
   protected override void OnInitialized()
   {
       var selectList = EditorContext.InputDescriptor.GetSelectList();
       _items = selectList.Items.OrderBy(x => x.Text).ToList();
   }
```

Sorting by the text is not always desirable. For example I have a drop down that has a list of versions. So sorting by the Text field does not make sense anymore.  If I were to rewrite this I would not add any sorting and just use the original collection order that was provided. However I don't want to break the current feature set. So I added a boolean `SortItems` which will allow user to disable this feature. 

---

## Scope

Select one primary concern:

- [ ] Bug fix (behavior change)
- [X] Refactor (no behavior change)
- [ ] Documentation update
- [ ] Formatting / code cleanup
- [ ] Dependency / build update
- [ ] New feature
---

## Description
Exposed a new boolean to disable sorting of items in a dropdown. The actual logic change needs to happen in Studio and that would be another PR.

### Problem
Have the ability to disable the auto sorting of items in the dropdown. For example if the user case of the drop down having version numbers. 

### Solution
Added a boolean 

---

## Verification

Right now it's just a boolean the validation would need to come from studio

## Checklist

- [X] The PR is focused on a single concern
- [X] Commit messages follow the recommended convention
- [X] Tests added or updated (if applicable)
- [X] Documentation updated (if applicable)
- [X] No unrelated cleanup included
- [X] All tests pass
