### PR TITLE
Fix: Update Swagger support for .NET 10.0 in v2.x to fix runtime exception

### DIFF
--- a/common.props
+++ b/common.props
@@ -15,7 +15,7 @@
         <!-- https://github.com/dotnet/sourcelink -->
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-        <Version>2.15</Version>
+        <Version>2.16</Version>
 
         <IsTrimmable>false</IsTrimmable>
         <EnableTrimAnalyzer>false</EnableTrimAnalyzer>

--- a/src/server/Elsa.Server.Api/Elsa.Server.Api.csproj
+++ b/src/server/Elsa.Server.Api/Elsa.Server.Api.csproj
@@ -26,6 +26,10 @@
         <PackageReference Include="System.Linq.Async" Version="6.0.1">
             <ExcludeAssets>compile</ExcludeAssets>
         </PackageReference>
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
+        <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.1.7" />
+        <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="10.0.1" />
+        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.1.7" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/server/Elsa.Server.Api/Extensions/SchemaFilters/XEnumNamesSchemaFilter.cs
+++ b/src/server/Elsa.Server.Api/Extensions/SchemaFilters/XEnumNamesSchemaFilter.cs
@@ -1,9 +1,14 @@
+#if NET10_0_OR_GREATER
+using Microsoft.OpenApi;
+using System.Text.Json.Nodes;
+using System.Collections.Generic;
+#else
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
+#endif
 using Swashbuckle.AspNetCore.SwaggerGen;
 using System;
 using System.Linq;
-using System.Reflection;
 
 namespace Elsa.Server.Api.Extensions.SchemaFilters
 {
@@ -13,6 +18,64 @@ namespace Elsa.Server.Api.Extensions.SchemaFilters
         private const string openapiGenerator = "x-enum-varnames";
 
 
+#if NET10_0_OR_GREATER
+        public void Apply(IOpenApiSchema schema, SchemaFilterContext context)
+        {
+            if (context.Type.IsEnum && schema is OpenApiSchema model)
+            {
+                AddGeneratorSupport(model, context, nswag);
+                AddGeneratorSupport(model, context, openapiGenerator);
+                AddSwaggerUiSupport(model, context);
+            }
+        }
+        private void AddGeneratorSupport(OpenApiSchema model, SchemaFilterContext context, string generatorType)
+        {
+            if (model.Extensions?.ContainsKey(generatorType) != true)
+            {
+                var names = Enum.GetNames(context.Type).Select(x => (JsonNode)x).ToList();
+                model.Extensions ??= new Dictionary<string, IOpenApiExtension>();
+                model.Extensions.Add(generatorType, new EnumNamesOpenApiExtension(names));
+            }
+        }
+
+        private void AddSwaggerUiSupport(OpenApiSchema model, SchemaFilterContext context)
+        {
+            model.Enum?.Clear();
+            model.Enum ??= [];
+            Enum.GetNames(context.Type)
+                .ToList()
+                .ForEach(n =>
+                {
+                    model.Enum.Add((JsonNode)n);
+                    model.Type = JsonSchemaType.String;
+                    model.Format = null;
+                });
+        }
+
+        internal class EnumNamesOpenApiExtension : IOpenApiExtension
+        {
+            public EnumNamesOpenApiExtension(List<JsonNode> enumDescriptions)
+            {
+                EnumDescriptions = enumDescriptions;
+            }
+
+            public List<JsonNode> EnumDescriptions { get; }
+
+            public void Write(IOpenApiWriter writer, OpenApiSpecVersion specVersion)
+            {
+                if (writer is null)
+                {
+                    throw new ArgumentNullException(nameof(writer));
+                }
+                writer.WriteStartArray();
+                foreach (var description in EnumDescriptions)
+                {
+                    writer.WriteAny(description);
+                }
+                writer.WriteEndArray();
+            }
+        }
+#else
         public void Apply(OpenApiSchema model, SchemaFilterContext context)
         {
             if (context.Type.IsEnum)
@@ -47,5 +110,7 @@ namespace Elsa.Server.Api.Extensions.SchemaFilters
                     model.Format = null;
                 });
         }
+#endif
+
     }
 }

--- a/src/server/Elsa.Server.Api/Extensions/ServiceCollectionExtensions.cs
+++ b/src/server/Elsa.Server.Api/Extensions/ServiceCollectionExtensions.cs
@@ -7,9 +7,12 @@ using Elsa.Server.Api.Extensions.SchemaFilters;
 using Elsa.Server.Api.Mapping;
 using Elsa.Server.Api.Services;
 using Elsa.Server.Api.Swagger.Examples;
-using Microsoft.AspNetCore.Mvc;
+#if NET10_0_OR_GREATER
+using Microsoft.OpenApi;
+#else
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
+#endif
 using Swashbuckle.AspNetCore.Filters;
 using Swashbuckle.AspNetCore.SwaggerGen;
 using System;
@@ -73,17 +76,29 @@ namespace Microsoft.Extensions.DependencyInjection
                     //c.ExampleFilters(); I don't know why, this line will make swagger error
                     c.MapType<VersionOptions?>(() => new OpenApiSchema
                     {
+#if NET10_0_OR_GREATER
+                        Type = JsonSchemaType.String | JsonSchemaType.Null,
+                        Example = "Latest",
+                        Description = "Any of Latest, Published, Draft, LatestOrPublished or a specific version number.",
+                        Default = "Latest"
+#else
                         Type = PrimitiveType.String.ToString().ToLower(),
                         Example = new OpenApiString("Latest"),
                         Description = "Any of Latest, Published, Draft, LatestOrPublished or a specific version number.",
                         Nullable = true,
                         Default = new OpenApiString("Latest")
+#endif
                     });
 
                     c.MapType<Type>(() => new OpenApiSchema
                     {
+#if NET10_0_OR_GREATER
+                        Type = JsonSchemaType.String,
+                        Example = "System.String, mscorlib"
+#else
                         Type = PrimitiveType.String.ToString().ToLower(),
                         Example = new OpenApiString("System.String, mscorlib")
+#endif
                     });
 
                     //Allow enums to be displayed


### PR DESCRIPTION
## Purpose

Fix a runtime missing method exception when targeting .NET 10 with **Elsa.Server.Api** related to Swashbuckle.AspNetCore.

---

## Scope

Select one primary concern:

- [ ] Bug fix (behavior change)
- [ ] Refactor (no behavior change)
- [ ] Documentation update
- [ ] Formatting / code cleanup
- [x] Dependency / build update

---

## Description

- Add Swashbuckle.AspNetCore packages for .NET 10.0 builds.
- Refactor XEnumNamesSchemaFilter with conditional logic for .NET 10.0+ using new OpenAPI APIs.
- Update ServiceCollectionExtensions to use new schema types and mappings for .NET 10.0+.
- Preserve compatibility with earlier .NET versions.

### Problem

Elsa.Server.Api has a reference to `Swashbuckle.AspNetCore` v6.3.0 with custom code that is binary incompatible with the .NET 10 version of `Microsoft.OpenApi`. When building for .NET 10, the API types used by Swashbuckle have changed, causing runtime failures. Specifically:

- `IOpenApiSchema` interface signature differs between versions
- Schema type mapping changed from `PrimitiveType` to `JsonSchemaType` enum
- Extensions handling requires different implementations for the new `IOpenApiExtension` contract

### Solution

The solution provides version-specific implementations using conditional compilation directives (`#if NET10_0_OR_GREATER`):

1. **Project File Updates** (`Elsa.Server.Api.csproj`):
   - Added Swashbuckle.AspNetCore packages (v10.1.7) specifically for .NET 10.0 builds
   - These newer versions are compatible with the updated Microsoft.OpenApi APIs in .NET 10

2. **XEnumNamesSchemaFilter Refactoring**:
   - Created dual implementation paths: one for .NET 10.0+ and one for earlier versions
   - **For .NET 10.0+**: Uses `IOpenApiSchema`, `JsonSchemaType`, and `JsonNode` for enum handling with custom `IOpenApiExtension` implementation
   - **For .NET 8/9**: Preserves original implementation using

3. **ServiceCollectionExtensions Updates**:
   - Added conditional type mappings for `VersionOptions?` and `Type`
   - **For .NET 10.0+**: Uses `JsonSchemaType` enum with direct property assignments
   - **For .NET 8/9**: Preserves original implementation

---

## Verification

Steps to verify this change:

1. Build the solution targeting .NET 10.0 (**dotnet build -f net10.0**)
2. Verify no compilation errors or warnings
3. Run Elsa.Server.Api tests targeting .NET 10.0: (**dotnet test -f net10.0 Elsa.Server.Api.Tests**)
4. Start the Elsa API with .NET 10.0 and verify Swagger/OpenAPI documentation generates correctly
5. Test enum serialization in API responses and verify enum names appear correctly in Swagger UI
6. Build and test against .NET 8.0 and .NET 9.0 to confirm backward compatibility: (**dotnet build -f net8.0** and **dotnet build -f net9.0**)

**Expected outcome:**
- No runtime "missing method" exceptions when targeting .NET 10
- Swagger documentation generates successfully with proper enum name support across all targeted frameworks
- Enum values display correctly with their names in generated client code
- All existing functionality works unchanged on .NET 8.0 and .NET 9.0

---

## Screenshots / Recordings (if applicable)

Not applicable - this is an infrastructure/dependency fix with no UI changes. 
- Exception before the fix 
<img width="2493" height="400" alt="image" src="https://github.com/user-attachments/assets/5460c4bc-18a8-46b3-811c-02045ad4e82c" />

- The open api swagger json generated by swashbuckle gen after the fix: [swagger.json](https://github.com/user-attachments/files/26352564/swagger.json)


---

## Commit Convention

Recommended commit prefix for this PR:

- `chore:` – This is a dependency/build configuration update to support .NET 10 compatibility

Example: `chore: add .NET 10 support to Elsa.Server.Api Swagger integration`

---

## Checklist

- [x] The PR is focused on a single concern (adding .NET 10 compatibility)
- [x] Commit messages follow the recommended convention
- [ ] Tests added or updated (if applicable) - *Consider adding .NET 10 specific integration tests if not already present*
- [ ] Documentation updated (if applicable)
- [x] No unrelated cleanup included
- [ ] All tests pass (pending verification in CI/CD pipeline)