### PR TITLE
Fix tenant scope for interrupted workflow restarts

### DIFF
--- a/src/modules/Elsa.Workflows.Management/Models/WorkflowInstanceSummary.cs
+++ b/src/modules/Elsa.Workflows.Management/Models/WorkflowInstanceSummary.cs
@@ -16,6 +16,7 @@ public class WorkflowInstanceSummary
         return new()
         {
             Id = workflowInstance.Id,
+            TenantId = workflowInstance.TenantId,
             DefinitionId = workflowInstance.DefinitionId,
             DefinitionVersionId = workflowInstance.DefinitionVersionId,
             Version = workflowInstance.Version,
@@ -36,6 +37,7 @@ public class WorkflowInstanceSummary
     public static Expression<Func<WorkflowInstance, WorkflowInstanceSummary>> FromInstanceExpression() => workflowInstance => new()
     {
         Id = workflowInstance.Id,
+        TenantId = workflowInstance.TenantId,
         DefinitionId = workflowInstance.DefinitionId,
         DefinitionVersionId = workflowInstance.DefinitionVersionId,
         Version = workflowInstance.Version,
@@ -52,6 +54,9 @@ public class WorkflowInstanceSummary
 
     /// <summary>The ID of the workflow instance.</summary>
     public string Id { get; set; } = null!;
+
+    /// <summary>The ID of the tenant that owns the workflow instance.</summary>
+    public string? TenantId { get; set; }
 
     /// <summary>The ID of the workflow definition.</summary>
     public string DefinitionId { get; set; } = null!;

--- a/src/modules/Elsa.Workflows.Runtime/Tasks/RestartInterruptedWorkflowsTask.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Tasks/RestartInterruptedWorkflowsTask.cs
@@ -39,7 +39,7 @@ public class RestartInterruptedWorkflowsTask(
                 continue;
             }
 
-            var tenant = await tenantService.FindAsync(tenantId, cancellationToken) ?? new Tenant { Id = tenantId };
+            var tenant = await tenantService.FindAsync(tenantId, cancellationToken) ?? new Tenant { Id = tenantId, Name = tenantId };
 
             using (tenantAccessor.PushContext(tenant))
                 await workflowRestarter.RestartWorkflowAsync(workflowInstance.Id, cancellationToken: cancellationToken);

--- a/src/modules/Elsa.Workflows.Runtime/Tasks/RestartInterruptedWorkflowsTask.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Tasks/RestartInterruptedWorkflowsTask.cs
@@ -13,13 +13,13 @@ namespace Elsa.Workflows.Runtime.Tasks;
 [SingleNodeTask]
 [UsedImplicitly]
 public class RestartInterruptedWorkflowsTask(
-    IWorkflowInstanceStore workflowInstanceStore, 
-    ITenantAccessor tenantAccessor,
-    ITenantService tenantService,
     IWorkflowRestarter workflowRestarter, 
+    IWorkflowInstanceStore workflowInstanceStore,
+    ILogger<RestartInterruptedWorkflowsTask> logger,
     IOptions<RuntimeOptions> options, 
     ISystemClock systemClock,
-    ILogger<RestartInterruptedWorkflowsTask> logger) : RecurringTask
+    ITenantService? tenantService = null,
+    ITenantAccessor? tenantAccessor = null) : RecurringTask
 {
     /// <inheritdoc />
     public override async Task ExecuteAsync(CancellationToken cancellationToken)
@@ -35,16 +35,17 @@ public class RestartInterruptedWorkflowsTask(
             {
                 var tenantId = workflowInstance.TenantId ?? string.Empty;
 
-                if (string.IsNullOrWhiteSpace(tenantId) || tenantId == Tenant.AgnosticTenantId)
+                if (tenantService != null && tenantAccessor != null && !string.IsNullOrWhiteSpace(tenantId) && tenantId != Tenant.AgnosticTenantId)
                 {
-                    await workflowRestarter.RestartWorkflowAsync(workflowInstance.Id, cancellationToken: cancellationToken);
+                    var tenant = await tenantService.FindAsync(tenantId, cancellationToken) ?? new Tenant { Id = tenantId, Name = tenantId };
+
+                    using (tenantAccessor.PushContext(tenant))
+                        await workflowRestarter.RestartWorkflowAsync(workflowInstance.Id, cancellationToken: cancellationToken);
+
                     continue;
                 }
 
-                var tenant = await tenantService.FindAsync(tenantId, cancellationToken) ?? new Tenant { Id = tenantId, Name = tenantId };
-
-                using (tenantAccessor.PushContext(tenant))
-                    await workflowRestarter.RestartWorkflowAsync(workflowInstance.Id, cancellationToken: cancellationToken);
+                await workflowRestarter.RestartWorkflowAsync(workflowInstance.Id, cancellationToken: cancellationToken);
             }
             catch (Exception ex)
             {

--- a/src/modules/Elsa.Workflows.Runtime/Tasks/RestartInterruptedWorkflowsTask.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Tasks/RestartInterruptedWorkflowsTask.cs
@@ -1,4 +1,5 @@
 using Elsa.Common;
+using Elsa.Common.Multitenancy;
 using Elsa.Common.RecurringTasks;
 using Elsa.Workflows.Management;
 using Elsa.Workflows.Management.Filters;
@@ -13,6 +14,8 @@ namespace Elsa.Workflows.Runtime.Tasks;
 [UsedImplicitly]
 public class RestartInterruptedWorkflowsTask(
     IWorkflowInstanceStore workflowInstanceStore, 
+    ITenantAccessor tenantAccessor,
+    ITenantService tenantService,
     IWorkflowRestarter workflowRestarter, 
     IOptions<RuntimeOptions> options, 
     ISystemClock systemClock,
@@ -28,7 +31,18 @@ public class RestartInterruptedWorkflowsTask(
         logger.LogInformation("Restarting interrupted workflows.");
         await foreach (var workflowInstance in workflowInstances)
         {
-            await workflowRestarter.RestartWorkflowAsync(workflowInstance.Id, cancellationToken: cancellationToken);
+            var tenantId = workflowInstance.TenantId ?? string.Empty;
+
+            if (string.IsNullOrWhiteSpace(tenantId) || tenantId == Tenant.AgnosticTenantId)
+            {
+                await workflowRestarter.RestartWorkflowAsync(workflowInstance.Id, cancellationToken: cancellationToken);
+                continue;
+            }
+
+            var tenant = await tenantService.FindAsync(tenantId, cancellationToken) ?? new Tenant { Id = tenantId };
+
+            using (tenantAccessor.PushContext(tenant))
+                await workflowRestarter.RestartWorkflowAsync(workflowInstance.Id, cancellationToken: cancellationToken);
         }
         logger.LogInformation("Finished restarting interrupted workflows.");
     }

--- a/src/modules/Elsa.Workflows.Runtime/Tasks/RestartInterruptedWorkflowsTask.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Tasks/RestartInterruptedWorkflowsTask.cs
@@ -31,18 +31,25 @@ public class RestartInterruptedWorkflowsTask(
         logger.LogInformation("Restarting interrupted workflows.");
         await foreach (var workflowInstance in workflowInstances)
         {
-            var tenantId = workflowInstance.TenantId ?? string.Empty;
-
-            if (string.IsNullOrWhiteSpace(tenantId) || tenantId == Tenant.AgnosticTenantId)
+            try
             {
-                await workflowRestarter.RestartWorkflowAsync(workflowInstance.Id, cancellationToken: cancellationToken);
-                continue;
+                var tenantId = workflowInstance.TenantId ?? string.Empty;
+
+                if (string.IsNullOrWhiteSpace(tenantId) || tenantId == Tenant.AgnosticTenantId)
+                {
+                    await workflowRestarter.RestartWorkflowAsync(workflowInstance.Id, cancellationToken: cancellationToken);
+                    continue;
+                }
+
+                var tenant = await tenantService.FindAsync(tenantId, cancellationToken) ?? new Tenant { Id = tenantId, Name = tenantId };
+
+                using (tenantAccessor.PushContext(tenant))
+                    await workflowRestarter.RestartWorkflowAsync(workflowInstance.Id, cancellationToken: cancellationToken);
             }
-
-            var tenant = await tenantService.FindAsync(tenantId, cancellationToken) ?? new Tenant { Id = tenantId, Name = tenantId };
-
-            using (tenantAccessor.PushContext(tenant))
-                await workflowRestarter.RestartWorkflowAsync(workflowInstance.Id, cancellationToken: cancellationToken);
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to restart interrupted workflow {WorkflowInstanceId}", workflowInstance.Id);
+            }
         }
         logger.LogInformation("Finished restarting interrupted workflows.");
     }

--- a/test/unit/Elsa.Workflows.Runtime.UnitTests/Services/RestartInterruptedWorkflowsTaskTests.cs
+++ b/test/unit/Elsa.Workflows.Runtime.UnitTests/Services/RestartInterruptedWorkflowsTaskTests.cs
@@ -1,0 +1,126 @@
+using Elsa.Common;
+using Elsa.Common.Models;
+using Elsa.Common.Multitenancy;
+using Elsa.Workflows.Management;
+using Elsa.Workflows.Management.Filters;
+using Elsa.Workflows.Management.Models;
+using Elsa.Workflows.Runtime.Options;
+using Elsa.Workflows.Runtime.Tasks;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Elsa.Workflows.Runtime.UnitTests.Services;
+
+public class RestartInterruptedWorkflowsTaskTests
+{
+    [Fact(DisplayName = "ExecuteAsync restarts each workflow within its tenant context")]
+    public async Task ExecuteAsync_RestartsWithinWorkflowTenantContext()
+    {
+        var workflowInstanceStore = Substitute.For<IWorkflowInstanceStore>();
+        var tenantAccessor = new DefaultTenantAccessor();
+        var tenantService = Substitute.For<ITenantService>();
+        var workflowRestarter = Substitute.For<IWorkflowRestarter>();
+        var clock = Substitute.For<ISystemClock>();
+        var logger = Substitute.For<ILogger<RestartInterruptedWorkflowsTask>>();
+        var now = DateTimeOffset.Parse("2026-04-14T12:00:00Z");
+        var workflowInstances = new List<WorkflowInstanceSummary>
+        {
+            CreateWorkflowInstance("workflow-1", "tenant-a", now),
+            CreateWorkflowInstance("workflow-2", "tenant-b", now)
+        };
+        var observedTenantIds = new List<string?>();
+
+        clock.UtcNow.Returns(now);
+        tenantService.FindAsync("tenant-a", Arg.Any<CancellationToken>()).Returns(new Tenant { Id = "tenant-a", Name = "Tenant A" });
+        tenantService.FindAsync("tenant-b", Arg.Any<CancellationToken>()).Returns(new Tenant { Id = "tenant-b", Name = "Tenant B" });
+        workflowInstanceStore
+            .SummarizeManyAsync(Arg.Any<WorkflowInstanceFilter>(), Arg.Any<PageArgs>(), Arg.Any<CancellationToken>())
+            .Returns(
+                callInfo =>
+                {
+                    var pageArgs = callInfo.ArgAt<PageArgs>(1);
+                    var items = pageArgs.Offset == 0 ? workflowInstances : new List<WorkflowInstanceSummary>();
+                    return new ValueTask<Page<WorkflowInstanceSummary>>(Page.Of(items, workflowInstances.Count));
+                });
+        workflowRestarter
+            .When(x => x.RestartWorkflowAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()))
+            .Do(_ => observedTenantIds.Add(tenantAccessor.Tenant?.Id));
+
+        var options = Microsoft.Extensions.Options.Options.Create(new RuntimeOptions
+        {
+            RestartInterruptedWorkflowsBatchSize = 10,
+            InactivityThreshold = TimeSpan.FromMinutes(5)
+        });
+        var task = new RestartInterruptedWorkflowsTask(workflowInstanceStore, tenantAccessor, tenantService, workflowRestarter, options, clock, logger);
+
+        await task.ExecuteAsync(CancellationToken.None);
+
+        Assert.Equal(new[] { "tenant-a", "tenant-b" }, observedTenantIds);
+        Assert.Null(tenantAccessor.Tenant);
+        await workflowRestarter.Received(1).RestartWorkflowAsync("workflow-1", Arg.Any<CancellationToken>());
+        await workflowRestarter.Received(1).RestartWorkflowAsync("workflow-2", Arg.Any<CancellationToken>());
+    }
+
+    [Theory(DisplayName = "ExecuteAsync does not push tenant context for default or agnostic tenant instances")]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("*")]
+    public async Task ExecuteAsync_DefaultOrAgnosticTenant_DoesNotPushContext(string? tenantId)
+    {
+        var workflowInstanceStore = Substitute.For<IWorkflowInstanceStore>();
+        var tenantAccessor = new DefaultTenantAccessor();
+        var tenantService = Substitute.For<ITenantService>();
+        var workflowRestarter = Substitute.For<IWorkflowRestarter>();
+        var clock = Substitute.For<ISystemClock>();
+        var logger = Substitute.For<ILogger<RestartInterruptedWorkflowsTask>>();
+        var now = DateTimeOffset.Parse("2026-04-14T12:00:00Z");
+        var workflowInstances = new List<WorkflowInstanceSummary>
+        {
+            CreateWorkflowInstance("workflow-1", tenantId, now)
+        };
+        var observedTenantIds = new List<string?>();
+
+        clock.UtcNow.Returns(now);
+        workflowInstanceStore
+            .SummarizeManyAsync(Arg.Any<WorkflowInstanceFilter>(), Arg.Any<PageArgs>(), Arg.Any<CancellationToken>())
+            .Returns(
+                callInfo =>
+                {
+                    var pageArgs = callInfo.ArgAt<PageArgs>(1);
+                    var items = pageArgs.Offset == 0 ? workflowInstances : new List<WorkflowInstanceSummary>();
+                    return new ValueTask<Page<WorkflowInstanceSummary>>(Page.Of(items, workflowInstances.Count));
+                });
+        workflowRestarter
+            .When(x => x.RestartWorkflowAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()))
+            .Do(_ => observedTenantIds.Add(tenantAccessor.Tenant?.Id));
+
+        var options = Microsoft.Extensions.Options.Options.Create(new RuntimeOptions
+        {
+            RestartInterruptedWorkflowsBatchSize = 10,
+            InactivityThreshold = TimeSpan.FromMinutes(5)
+        });
+        var task = new RestartInterruptedWorkflowsTask(workflowInstanceStore, tenantAccessor, tenantService, workflowRestarter, options, clock, logger);
+
+        await task.ExecuteAsync(CancellationToken.None);
+
+        Assert.Equal(new string?[] { null }, observedTenantIds);
+        Assert.Null(tenantAccessor.Tenant);
+        await tenantService.DidNotReceive().FindAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await workflowRestarter.Received(1).RestartWorkflowAsync("workflow-1", Arg.Any<CancellationToken>());
+    }
+
+    private static WorkflowInstanceSummary CreateWorkflowInstance(string id, string? tenantId, DateTimeOffset updatedAt)
+    {
+        return new WorkflowInstanceSummary
+        {
+            Id = id,
+            TenantId = tenantId,
+            DefinitionId = "definition",
+            DefinitionVersionId = "definition:1",
+            Status = WorkflowStatus.Running,
+            SubStatus = WorkflowSubStatus.Pending,
+            CreatedAt = updatedAt.AddMinutes(-10),
+            UpdatedAt = updatedAt.AddMinutes(-10)
+        };
+    }
+}

--- a/test/unit/Elsa.Workflows.Runtime.UnitTests/Services/RestartInterruptedWorkflowsTaskTests.cs
+++ b/test/unit/Elsa.Workflows.Runtime.UnitTests/Services/RestartInterruptedWorkflowsTaskTests.cs
@@ -109,6 +109,48 @@ public class RestartInterruptedWorkflowsTaskTests
         await workflowRestarter.Received(1).RestartWorkflowAsync("workflow-1", Arg.Any<CancellationToken>());
     }
 
+    [Fact(DisplayName = "ExecuteAsync continues restarting later workflows after a failure")]
+    public async Task ExecuteAsync_ContinuesAfterFailure()
+    {
+        var workflowInstanceStore = Substitute.For<IWorkflowInstanceStore>();
+        var tenantAccessor = new DefaultTenantAccessor();
+        var tenantService = Substitute.For<ITenantService>();
+        var workflowRestarter = Substitute.For<IWorkflowRestarter>();
+        var clock = Substitute.For<ISystemClock>();
+        var logger = Substitute.For<ILogger<RestartInterruptedWorkflowsTask>>();
+        var now = DateTimeOffset.Parse("2026-04-14T12:00:00Z");
+        var workflowInstances = new List<WorkflowInstanceSummary>
+        {
+            CreateWorkflowInstance("workflow-1", "tenant-a", now),
+            CreateWorkflowInstance("workflow-2", "tenant-b", now)
+        };
+
+        clock.UtcNow.Returns(now);
+        tenantService.FindAsync("tenant-a", Arg.Any<CancellationToken>()).Returns(_ => Task.FromException<Tenant?>(new InvalidOperationException("Transient tenant lookup failure")));
+        tenantService.FindAsync("tenant-b", Arg.Any<CancellationToken>()).Returns(new Tenant { Id = "tenant-b", Name = "Tenant B" });
+        workflowInstanceStore
+            .SummarizeManyAsync(Arg.Any<WorkflowInstanceFilter>(), Arg.Any<PageArgs>(), Arg.Any<CancellationToken>())
+            .Returns(
+                callInfo =>
+                {
+                    var pageArgs = callInfo.ArgAt<PageArgs>(1);
+                    var items = pageArgs.Offset == 0 ? workflowInstances : new List<WorkflowInstanceSummary>();
+                    return new ValueTask<Page<WorkflowInstanceSummary>>(Page.Of(items, workflowInstances.Count));
+                });
+
+        var options = Microsoft.Extensions.Options.Options.Create(new RuntimeOptions
+        {
+            RestartInterruptedWorkflowsBatchSize = 10,
+            InactivityThreshold = TimeSpan.FromMinutes(5)
+        });
+        var task = new RestartInterruptedWorkflowsTask(workflowInstanceStore, tenantAccessor, tenantService, workflowRestarter, options, clock, logger);
+
+        await task.ExecuteAsync(CancellationToken.None);
+
+        await workflowRestarter.DidNotReceive().RestartWorkflowAsync("workflow-1", Arg.Any<CancellationToken>());
+        await workflowRestarter.Received(1).RestartWorkflowAsync("workflow-2", Arg.Any<CancellationToken>());
+    }
+
     private static WorkflowInstanceSummary CreateWorkflowInstance(string id, string? tenantId, DateTimeOffset updatedAt)
     {
         return new WorkflowInstanceSummary

--- a/test/unit/Elsa.Workflows.Runtime.UnitTests/Services/RestartInterruptedWorkflowsTaskTests.cs
+++ b/test/unit/Elsa.Workflows.Runtime.UnitTests/Services/RestartInterruptedWorkflowsTaskTests.cs
@@ -51,7 +51,7 @@ public class RestartInterruptedWorkflowsTaskTests
             RestartInterruptedWorkflowsBatchSize = 10,
             InactivityThreshold = TimeSpan.FromMinutes(5)
         });
-        var task = new RestartInterruptedWorkflowsTask(workflowInstanceStore, tenantAccessor, tenantService, workflowRestarter, options, clock, logger);
+        var task = new RestartInterruptedWorkflowsTask(workflowRestarter, workflowInstanceStore, logger, options, clock, tenantService, tenantAccessor);
 
         await task.ExecuteAsync(CancellationToken.None);
 
@@ -99,7 +99,7 @@ public class RestartInterruptedWorkflowsTaskTests
             RestartInterruptedWorkflowsBatchSize = 10,
             InactivityThreshold = TimeSpan.FromMinutes(5)
         });
-        var task = new RestartInterruptedWorkflowsTask(workflowInstanceStore, tenantAccessor, tenantService, workflowRestarter, options, clock, logger);
+        var task = new RestartInterruptedWorkflowsTask(workflowRestarter, workflowInstanceStore, logger, options, clock, tenantService, tenantAccessor);
 
         await task.ExecuteAsync(CancellationToken.None);
 
@@ -143,12 +143,48 @@ public class RestartInterruptedWorkflowsTaskTests
             RestartInterruptedWorkflowsBatchSize = 10,
             InactivityThreshold = TimeSpan.FromMinutes(5)
         });
-        var task = new RestartInterruptedWorkflowsTask(workflowInstanceStore, tenantAccessor, tenantService, workflowRestarter, options, clock, logger);
+        var task = new RestartInterruptedWorkflowsTask(workflowRestarter, workflowInstanceStore, logger, options, clock, tenantService, tenantAccessor);
 
         await task.ExecuteAsync(CancellationToken.None);
 
         await workflowRestarter.DidNotReceive().RestartWorkflowAsync("workflow-1", Arg.Any<CancellationToken>());
         await workflowRestarter.Received(1).RestartWorkflowAsync("workflow-2", Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "ExecuteAsync restarts tenant-specific workflows when tenant services are unavailable")]
+    public async Task ExecuteAsync_WithoutTenantServices_RestartsWorkflow()
+    {
+        var workflowInstanceStore = Substitute.For<IWorkflowInstanceStore>();
+        var workflowRestarter = Substitute.For<IWorkflowRestarter>();
+        var clock = Substitute.For<ISystemClock>();
+        var logger = Substitute.For<ILogger<RestartInterruptedWorkflowsTask>>();
+        var now = DateTimeOffset.Parse("2026-04-14T12:00:00Z");
+        var workflowInstances = new List<WorkflowInstanceSummary>
+        {
+            CreateWorkflowInstance("workflow-1", "tenant-a", now)
+        };
+
+        clock.UtcNow.Returns(now);
+        workflowInstanceStore
+            .SummarizeManyAsync(Arg.Any<WorkflowInstanceFilter>(), Arg.Any<PageArgs>(), Arg.Any<CancellationToken>())
+            .Returns(
+                callInfo =>
+                {
+                    var pageArgs = callInfo.ArgAt<PageArgs>(1);
+                    var items = pageArgs.Offset == 0 ? workflowInstances : new List<WorkflowInstanceSummary>();
+                    return new ValueTask<Page<WorkflowInstanceSummary>>(Page.Of(items, workflowInstances.Count));
+                });
+
+        var options = Microsoft.Extensions.Options.Options.Create(new RuntimeOptions
+        {
+            RestartInterruptedWorkflowsBatchSize = 10,
+            InactivityThreshold = TimeSpan.FromMinutes(5)
+        });
+        var task = new RestartInterruptedWorkflowsTask(workflowRestarter, workflowInstanceStore, logger, options, clock);
+
+        await task.ExecuteAsync(CancellationToken.None);
+
+        await workflowRestarter.Received(1).RestartWorkflowAsync("workflow-1", Arg.Any<CancellationToken>());
     }
 
     private static WorkflowInstanceSummary CreateWorkflowInstance(string id, string? tenantId, DateTimeOffset updatedAt)


### PR DESCRIPTION
## Purpose

This PR fixes interrupted workflow restarts in multitenant environments by restoring the workflow instance's tenant context before dispatching the restart. It also adds targeted unit tests to verify tenant-scoped and non-tenant-scoped restart behavior.

---

## Scope

Select one primary concern:

- [x] Bug fix (behavior change)
- [ ] Refactor (no behavior change)
- [ ] Documentation update
- [ ] Formatting / code cleanup
- [ ] Dependency / build update
- [ ] New feature

---

## Description

### Problem
`RestartInterruptedWorkflowsTask` restarted interrupted workflow instances without restoring the tenant context of the workflow instance being restarted. In multitenant and distributed setups, this could cause tenant-scoped workflow instances to be restarted under the wrong ambient tenant context.

### Solution
This change extends `WorkflowInstanceSummary` with `TenantId`, allowing `RestartInterruptedWorkflowsTask` to inspect tenant ownership while still using summary enumeration. The task now restores tenant context before restarting tenant-scoped instances, while intentionally skipping tenant context for default-tenant and tenant-agnostic instances. Targeted unit tests were added to verify both cases.

---

## Verification

Steps:
1. Run `dotnet test test/unit/Elsa.Workflows.Runtime.UnitTests/Elsa.Workflows.Runtime.UnitTests.csproj --no-restore --filter "FullyQualifiedName~RestartInterruptedWorkflowsTaskTests"`
2. Confirm that tenant-scoped restart tests pass.
3. Confirm that default-tenant and agnostic-tenant restart tests pass without pushing tenant context.

Expected outcome:

The restart task uses the correct tenant scope for tenant-specific workflow instances, skips tenant context for default or agnostic instances, and all targeted tests pass.

---

## Screenshots / Recordings (if applicable)

Not applicable.

---

## Checklist

- [x] The PR is focused on a single concern
- [ ] Commit messages follow the recommended convention
- [x] Tests added or updated (if applicable)
- [ ] Documentation updated (if applicable)
- [x] No unrelated cleanup included
- [x] All tests pass