### PR TITLE
fix: correct workflow summary pagination

### DIFF
--- a/src/modules/Elsa.Common/Models/PageArgs.cs
+++ b/src/modules/Elsa.Common/Models/PageArgs.cs
@@ -67,5 +67,5 @@ public record PageArgs
     /// Returns pagination arguments for the next page.
     /// </summary>
     /// <returns>The arguments for the next page.</returns>
-    public PageArgs Next() => this with { Offset = Page + 1 };
+    public PageArgs Next() => this with { Offset = Offset + Limit };
 }

--- a/test/unit/Elsa.Common.UnitTests/Models/PageArgsTests.cs
+++ b/test/unit/Elsa.Common.UnitTests/Models/PageArgsTests.cs
@@ -1,0 +1,39 @@
+using Elsa.Common.Models;
+
+namespace Elsa.Common.UnitTests.Models;
+
+public class PageArgsTests
+{
+    [Fact]
+    public void Next_FromPage_AdvancesByPageSize()
+    {
+        // Arrange
+        var pageArgs = PageArgs.FromPage(0, 10);
+
+        // Act
+        var nextPage = pageArgs.Next();
+        var thirdPage = nextPage.Next();
+
+        // Assert
+        Assert.Equal(10, nextPage.Offset);
+        Assert.Equal(10, nextPage.Limit);
+        Assert.Equal(1, nextPage.Page);
+        Assert.Equal(20, thirdPage.Offset);
+        Assert.Equal(2, thirdPage.Page);
+    }
+
+    [Fact]
+    public void Next_AllPages_RemainsUnbounded()
+    {
+        // Arrange
+        var pageArgs = PageArgs.All;
+
+        // Act
+        var nextPage = pageArgs.Next();
+
+        // Assert
+        Assert.Null(nextPage.Offset);
+        Assert.Null(nextPage.Limit);
+        Assert.Null(nextPage.Page);
+    }
+}

--- a/test/unit/Elsa.Workflows.Runtime.UnitTests/Extensions/WorkflowInstanceStoreExtensionsTests.cs
+++ b/test/unit/Elsa.Workflows.Runtime.UnitTests/Extensions/WorkflowInstanceStoreExtensionsTests.cs
@@ -1,0 +1,63 @@
+using Elsa.Common.Models;
+using Elsa.Workflows.Management;
+using Elsa.Workflows.Management.Filters;
+using Elsa.Workflows.Management.Models;
+using NSubstitute;
+
+namespace Elsa.Workflows.Runtime.UnitTests.Extensions;
+
+public class WorkflowInstanceStoreExtensionsTests
+{
+    [Fact]
+    public async Task EnumerateSummariesAsync_AdvancesAcrossPagesWithoutRepeatingOffsets()
+    {
+        // Arrange
+        var store = Substitute.For<IWorkflowInstanceStore>();
+        var filter = new WorkflowInstanceFilter();
+        var requestedPages = new List<PageArgs>();
+        var page1 = new List<WorkflowInstanceSummary>
+        {
+            CreateSummary("workflow-1"),
+            CreateSummary("workflow-2")
+        };
+        var page2 = new List<WorkflowInstanceSummary>
+        {
+            CreateSummary("workflow-3"),
+            CreateSummary("workflow-4")
+        };
+
+        store
+            .SummarizeManyAsync(Arg.Any<WorkflowInstanceFilter>(), Arg.Any<PageArgs>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var pageArgs = callInfo.ArgAt<PageArgs>(1);
+                requestedPages.Add(pageArgs with { });
+
+                var items = pageArgs.Offset switch
+                {
+                    0 => page1,
+                    2 => page2,
+                    _ => new List<WorkflowInstanceSummary>()
+                };
+
+                return new ValueTask<Page<WorkflowInstanceSummary>>(Page.Of(items, page1.Count + page2.Count));
+            });
+
+        // Act
+        var results = new List<WorkflowInstanceSummary>();
+        await foreach (var workflowInstance in store.EnumerateSummariesAsync(filter, 2, CancellationToken.None))
+            results.Add(workflowInstance);
+
+        // Assert
+        Assert.Equal(["workflow-1", "workflow-2", "workflow-3", "workflow-4"], results.Select(x => x.Id).ToArray());
+        Assert.Equal([(int?)0, 2, 4], requestedPages.Select(x => x.Offset).ToArray());
+        Assert.All(requestedPages, x => Assert.Equal(2, x.Limit));
+    }
+
+    private static WorkflowInstanceSummary CreateSummary(string id) => new()
+    {
+        Id = id,
+        DefinitionId = "definition",
+        DefinitionVersionId = "definition:1"
+    };
+}


### PR DESCRIPTION
## Purpose

Fix pagination advancement for workflow instance summary enumeration on `release/3.6.1`. This corrects `PageArgs.Next()` so paged enumeration advances by a full page instead of getting stuck at `Offset = 1`.

---

## Scope

- [x] Bug fix (behavior change)

---

## Description

### Problem

`WorkflowInstanceStoreExtensions.EnumerateSummariesAsync` advances pagination by calling `pageArgs.Next()`. On `release/3.6.1`, `PageArgs.Next()` sets `Offset = Page + 1`, which is incorrect for paged range-based iteration.

With a batch size greater than `1`, pagination can become stuck at `Offset = 1`, causing the same page to be requested repeatedly and potentially preventing enumeration from completing.

### Solution

This change fixes `PageArgs.Next()` at the root cause by advancing pagination using `Offset + Limit`.

It also adds regression tests to verify:

1. `PageArgs.Next()` advances by a full page.
2. `WorkflowInstanceStoreExtensions.EnumerateSummariesAsync` progresses across multiple pages without repeating offsets.

---

## Verification

Steps:
1. Run `dotnet test test/unit/Elsa.Common.UnitTests/Elsa.Common.UnitTests.csproj --filter FullyQualifiedName~PageArgsTests`
2. Run `dotnet test test/unit/Elsa.Workflows.Runtime.UnitTests/Elsa.Workflows.Runtime.UnitTests.csproj --filter FullyQualifiedName~WorkflowInstanceStoreExtensionsTests`
3. Confirm all targeted tests pass and that requested page offsets progress as expected.

Expected outcome:

- `PageArgs.Next()` advances from `(Offset=0, Limit=10)` to `(Offset=10, Limit=10)` and then `(Offset=20, Limit=10)`.
- Workflow summary enumeration completes after the empty page instead of repeating `Offset = 1`.
- Targeted regression tests pass.

---

## Checklist

- [x] The PR is focused on a single concern
- [x] Commit messages follow the recommended convention
- [x] Tests added or updated
- [x] No unrelated cleanup included
- [x] All targeted tests pass