### PR TITLE
Code cleanup

### DIFF
--- a/src/modules/Elsa.Workflows.Runtime/Extensions/DependencyInjectionExtensions.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Extensions/DependencyInjectionExtensions.cs
@@ -31,6 +31,6 @@ public static class DependencyInjectionExtensions
     /// <summary>
     /// Adds the specified workflows provider type to the service collection.
     /// </summary>
-    /// <typeparam name="T">The type of the workflow provider to add. Must implement <see cref="IWorkflowsProvider"/>.</typeparam>
+    /// <typeparam name="T">The type of the workflows provider to add. Must implement <see cref="IWorkflowsProvider"/>.</typeparam>
     public static IServiceCollection AddWorkflowsProvider<T>(this IServiceCollection services) where T : class, IWorkflowsProvider => services.AddScoped<IWorkflowsProvider, T>();
 }

--- a/src/modules/Elsa.Workflows.Runtime/Features/WorkflowRuntimeFeature.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Features/WorkflowRuntimeFeature.cs
@@ -334,8 +334,8 @@ public class WorkflowRuntimeFeature(IModule module) : FeatureBase(module)
             // Distributed locking.
             .AddSingleton(DistributedLockProvider)
 
-            // Workflow definition providers.
-            .AddWorkflowDefinitionProvider<ClrWorkflowsProvider>()
+            // Workflow providers.
+            .AddWorkflowsProvider<ClrWorkflowsProvider>()
             
             // UI property handlers.
             .AddScoped<IPropertyUIHandler, DispatcherChannelOptionsProvider>()

--- a/src/modules/Elsa.Workflows.Runtime/Providers/ClrWorkflowsProvider.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Providers/ClrWorkflowsProvider.cs
@@ -35,8 +35,8 @@ public class ClrWorkflowsProvider(
         await workflowBuilder.BuildAsync(builder, cancellationToken);
         var workflow = await builder.BuildWorkflowAsync(cancellationToken);
         var versionSuffix = $"v{workflow.Version}";
-        var definitionId = string.IsNullOrEmpty(workflow.Identity.DefinitionId) ? workflowBuilderType.Name : $"{workflow.Identity.DefinitionId}";
-        var id = string.IsNullOrEmpty(workflow.Identity.Id) ? $"{workflowBuilderType.Name}:{versionSuffix}" : $"{workflow.Identity.Id}";
+        var definitionId = string.IsNullOrEmpty(workflow.Identity.DefinitionId) ? workflowBuilderType.Name : workflow.Identity.DefinitionId;
+        var id = string.IsNullOrEmpty(workflow.Identity.Id) ? $"{workflowBuilderType.Name}:{versionSuffix}" : workflow.Identity.Id;
         
         workflow.Identity = workflow.Identity with
         {

--- a/src/modules/Elsa.Workflows.Runtime/ShellFeatures/WorkflowRuntimeFeature.cs
+++ b/src/modules/Elsa.Workflows.Runtime/ShellFeatures/WorkflowRuntimeFeature.cs
@@ -227,8 +227,8 @@ public class WorkflowRuntimeFeature : IShellFeature
             // Distributed locking.
             .AddSingleton(DistributedLockProvider)
 
-            // Workflow definition providers.
-            .AddWorkflowDefinitionProvider<ClrWorkflowsProvider>()
+            // Workflow providers.
+            .AddWorkflowsProvider<ClrWorkflowsProvider>()
 
             // UI property handlers.
             .AddScoped<IPropertyUIHandler, DispatcherChannelOptionsProvider>()


### PR DESCRIPTION
* Replace `AddWorkflowDefinitionProvider` usage with `AddWorkflowsProvider` 
```cs
[Obsolete("Use AddWorkflowsProvider instead.", false)]
public static IServiceCollection AddWorkflowDefinitionProvider<T>(this IServiceCollection services)
```
* refactor: remove unnecessary string interpolation
No need to use String Interpolation for string value `$"{workflow.Identity.Id}"`