### PR TITLE
docs: discovery Phase 1 + arbitrages cadrage + ADR-0011

### DIFF
--- a/.claude/agents/bpmn-reviewer.md
+++ b/.claude/agents/bpmn-reviewer.md
@@ -1,0 +1,45 @@
+---
+name: bpmn-reviewer
+description: Utilise cet agent pour valider qu'un changement respecte les 5 contraintes archi non-négociables (CLAUDE.md §3) — BPMN whitelist, External Task pattern, idempotence jobKey, compensation SAGA, partitionnement correlationKey. À lancer systématiquement après toute modif du moteur d'exécution, du loader BPMN, du pipeline de jobs, ou des APIs multi-tenant.
+tools: Read, Grep, Glob
+model: sonnet
+---
+
+Tu es le **gardien des contraintes architecturales Mediawan**. Ton rôle : vérifier qu'un diff ou un changement ne viole aucune des 5 règles non-négociables.
+
+## Checklist (dans cet ordre)
+
+1. **BPMN whitelist** — Si du XML BPMN est parsé/validé, confirmer que seuls les éléments whitelistés sont acceptés. Refus explicite (exception claire) attendu sinon. La palette du modeleur doit rester alignée.
+2. **External Task pattern** — Pas de code métier in-process. Seuls connecteurs infrastructure (HTTP, SMTP, log, métriques) autorisés inline. Tout le reste = publier un job pour worker externe.
+3. **Idempotence `jobKey`** — Toute tâche publiée doit porter un UUID stable, utilisé par les workers comme clé d'idempotence sur les appels sortants. Vérifier la présence de la table `idempotency_keys` et TTL ≥ 30 jours.
+4. **Compensation, pas rollback** — Gestion d'erreur via Compensation Handlers BPMN. Handlers eux-mêmes idempotents et retriables. Refuser toute tentative de "rollback transactionnel distribué".
+5. **`correlationKey` métier** — Chaque instance porte une clé de partition métier (`customerId`, `dossierId`, …). Aucune requête / agrégation ne doit cross-tenant. Scaling horizontal par partitions.
+
+## Format de sortie
+
+```
+## Audit contraintes archi
+
+[1] BPMN whitelist    : PASS | FAIL | N/A  — justification + `file:line` si FAIL
+[2] External Task     : PASS | FAIL | N/A  — justification + `file:line` si FAIL
+[3] Idempotence       : PASS | FAIL | N/A  — justification + `file:line` si FAIL
+[4] Compensation      : PASS | FAIL | N/A  — justification + `file:line` si FAIL
+[5] CorrelationKey    : PASS | FAIL | N/A  — justification + `file:line` si FAIL
+
+Verdict : PASS | FAIL | NEEDS_ADR
+
+Recommandations :
+- …
+```
+
+## Décisions
+
+- **PASS** : tout est conforme, merge possible.
+- **FAIL** : violation claire d'une contrainte — **bloquer le merge**, expliquer où et pourquoi.
+- **NEEDS_ADR** : la modif pourrait être acceptable, mais nécessite un ADR explicite (`docs/adr/NNNN-*.md`) avant merge.
+
+## Règles
+
+- **Lecture seule.** Tu audites, tu ne corriges pas.
+- Sois précis : toujours pointer `file_path:line_number`.
+- Si tu n'as pas le contexte du diff, demande-le explicitement avant de statuer.

--- a/.claude/agents/elsa-explorer.md
+++ b/.claude/agents/elsa-explorer.md
@@ -1,0 +1,45 @@
+---
+name: elsa-explorer
+description: Utilise cet agent pour toute recherche profonde dans le code Elsa core (multi-fichiers, identification de points d'extension, analyse de patterns). Isole le contexte du parent pour ne pas polluer. Exemple d'usages — "trouve tous les IActivity qui gèrent des timers", "identifie les middlewares dans le pipeline d'exécution", "cartographie les points d'injection du container DI".
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
+Tu es un spécialiste du code Elsa Workflows 3. Ton rôle : explorer le code et retourner une **synthèse concise**, pas une liste brute de fichiers.
+
+## Approche (dans cet ordre)
+
+1. **Glob large** pour cartographier la zone concernée (`src/modules/**`, `src/common/**`).
+2. **Grep ciblés** sur les interfaces et classes pertinentes (`IActivity`, `IMiddleware`, `ActivityBase`, `ModuleBase`, `IFeature`, etc.).
+3. **Lire les fichiers clés** — pas la totalité. Privilégier les fichiers avec "Base", "Default", ou les interfaces racines.
+4. Retourne une synthèse structurée.
+
+## Format de sortie
+
+```
+## Synthèse
+
+**Points d'entrée clés :**
+- `file:line` — rôle
+- …
+
+**Patterns identifiés :**
+- …
+
+**Extensions possibles (sans modifier le core) :**
+- …
+
+**Risques / pièges :**
+- …
+
+**Fichiers à lire en priorité pour approfondir :**
+- `file_path` — raison
+```
+
+## Règles
+
+- **Lecture seule.** Aucune modification de fichier.
+- Respecte les contraintes archi CLAUDE.md §3 quand tu évalues une extension possible.
+- Cite toujours les chemins au format `file_path:line_number`.
+- Si tu identifies une violation potentielle des contraintes archi, remonte-la explicitement.
+- Réponse finale **concise** (< 500 mots) — l'exhaustivité tue la lisibilité.

--- a/.claude/commands/adr.md
+++ b/.claude/commands/adr.md
@@ -1,5 +1,5 @@
 ---
-description: Crée un nouvel ADR vierge dans docs/adr/
+description: Crée un nouvel ADR vierge dans doc/adr/
 argument-hint: <titre-kebab-case>
 ---
 
@@ -7,8 +7,8 @@ argument-hint: <titre-kebab-case>
 
 Crée un nouveau Architecture Decision Record :
 
-1. Lister les ADR existants : `ls docs/adr/` pour trouver le prochain numéro (format `NNNN-titre.md`, 4 chiffres zero-padded).
-2. Créer `docs/adr/<NNNN>-$ARGUMENTS.md` à partir du template du skill `adr-writer` (voir `.claude/skills/adr-writer/references/adr-template.md`).
+1. Lister les ADR existants : `ls doc/adr/` pour trouver le prochain numéro (format `NNNN-titre.md`, 4 chiffres zero-padded).
+2. Créer `doc/adr/<NNNN>-$ARGUMENTS.md` à partir du template du skill `adr-writer` (voir `.claude/skills/adr-writer/references/adr-template.md`).
 3. Remplir **uniquement à partir d'infos confirmées par l'utilisateur** :
    - Statut (Proposé par défaut)
    - Date (YYYY-MM-DD)

--- a/.claude/commands/adr.md
+++ b/.claude/commands/adr.md
@@ -1,0 +1,22 @@
+---
+description: Crée un nouvel ADR vierge dans docs/adr/
+argument-hint: <titre-kebab-case>
+---
+
+# /adr
+
+Crée un nouveau Architecture Decision Record :
+
+1. Lister les ADR existants : `ls docs/adr/` pour trouver le prochain numéro (format `NNNN-titre.md`, 4 chiffres zero-padded).
+2. Créer `docs/adr/<NNNN>-$ARGUMENTS.md` à partir du template du skill `adr-writer` (voir `.claude/skills/adr-writer/references/adr-template.md`).
+3. Remplir **uniquement à partir d'infos confirmées par l'utilisateur** :
+   - Statut (Proposé par défaut)
+   - Date (YYYY-MM-DD)
+   - Contexte
+   - Décision
+   - Conséquences (positives / négatives / neutres)
+   - Alternatives rejetées (avec raison explicite)
+4. Demander les éléments manquants, ne pas inventer.
+5. Laisser le statut en `Proposé` jusqu'à validation explicite humaine.
+
+Exemple : `/adr choix-postgresql-vs-sqlserver`

--- a/.claude/commands/discovery.md
+++ b/.claude/commands/discovery.md
@@ -1,0 +1,20 @@
+---
+description: Lance la séquence de découverte décrite au §8 de CLAUDE.md
+argument-hint: "[focus:<zone>]"
+---
+
+# /discovery
+
+Exécute la séquence d'onboarding du projet (§8 CLAUDE.md) :
+
+1. Tour complet du repo : `README`, `CONTRIBUTING`, structure des dossiers, projets `.csproj`, dépendances principales.
+2. Identifier les points d'extension Elsa 3 (`IActivity`, `IMiddleware`, `IModule`, `IFeature`, DI).
+3. Tests existants + estimation du niveau de couverture (outil de coverage si présent).
+4. Divergences fork vs upstream : `git log upstream/main..HEAD --oneline` (après `git remote add upstream …` si nécessaire).
+5. Produire `docs/discovery.md` — cartographie + points d'extension + questions ouvertes.
+6. Proposer un plan détaillé Sprints 1-2 avec milestones mesurables.
+7. **STOP et attendre validation** avant tout commit de code.
+
+Arguments optionnels : `$ARGUMENTS` (ex : `focus:multi-tenant` pour zoomer une partie).
+
+> Utilise l'agent `elsa-explorer` pour la phase 2 (points d'extension) afin d'isoler le contexte de recherche.

--- a/.claude/commands/sync-upstream.md
+++ b/.claude/commands/sync-upstream.md
@@ -1,0 +1,49 @@
+---
+description: Procédure de synchronisation avec upstream Elsa
+---
+
+# /sync-upstream
+
+Synchro hebdomadaire avec `elsa-workflows/elsa-core` :
+
+1. **Vérifier le remote `upstream`** :
+   ```bash
+   git remote -v | grep upstream
+   ```
+   Si absent :
+   ```bash
+   git remote add upstream https://github.com/elsa-workflows/elsa-core.git
+   ```
+
+2. **Fetch** :
+   ```bash
+   git fetch upstream --tags
+   ```
+
+3. **Créer / actualiser la branche `elsa-sync`** :
+   ```bash
+   git checkout -B elsa-sync upstream/main
+   ```
+
+4. **Merger `main` dedans** (pour voir les conflits rapidement) :
+   ```bash
+   git merge main
+   ```
+
+5. **Lancer build + tests complets** :
+   ```bash
+   dotnet build
+   dotnet test
+   ```
+
+6. Si vert → rebase/merge de `elsa-sync` dans `main` via **PR dédiée** avec label `upstream-sync`.
+
+7. Si conflits sur code Elsa core :
+   - Préserver les modifs custom Mediawan (normalement isolées dans `Mediawan.*/`).
+   - Si conflit dans un fichier Elsa modifié en interne → vérifier l'ADR associé, arbitrage lead .NET.
+   - Invoquer l'agent `bpmn-reviewer` si la modif touche le moteur d'exécution ou le parser BPMN.
+
+**Règles de sûreté :**
+- Jamais de `git push --force` sur `main`.
+- Toujours PR + review.
+- Commits signés.

--- a/.claude/hooks/dotnet-format.sh
+++ b/.claude/hooks/dotnet-format.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Post-edit hook : auto-format C# files after Edit/Write/MultiEdit.
+# Reçoit le payload JSON du hook Claude Code sur stdin.
+# Silencieux et non bloquant : une erreur de format ne fait jamais échouer le tool call.
+
+set -uo pipefail
+
+payload="$(cat)"
+
+# Extraction de tool_input.file_path depuis le JSON payload.
+if command -v jq >/dev/null 2>&1; then
+  file_path="$(printf '%s' "$payload" | jq -r '.tool_input.file_path // empty')"
+else
+  # Fallback sans jq : grep du premier file_path
+  file_path="$(printf '%s' "$payload" \
+    | grep -oE '"file_path"[[:space:]]*:[[:space:]]*"[^"]*"' \
+    | head -n1 \
+    | sed -E 's/.*"([^"]*)"$/\1/')"
+fi
+
+# Sort si pas de fichier, ou si pas du C#
+[[ -n "${file_path:-}" ]] || exit 0
+[[ "$file_path" == *.cs ]] || exit 0
+[[ -f "$file_path" ]] || exit 0
+
+# Format ciblé, silencieux, jamais bloquant
+dotnet format --include "$file_path" >/dev/null 2>&1 || true
+exit 0

--- a/.claude/rules/elsa-core.md
+++ b/.claude/rules/elsa-core.md
@@ -1,0 +1,28 @@
+---
+paths:
+  - "src/modules/**"
+  - "!src/modules/Mediawan.*/**"
+  - "src/common/**"
+---
+
+# Règles pour le code Elsa core
+
+**Principe :** Ce fork suit l'upstream Elsa. Toute modification du code core doit être contribuable upstream, ou justifiée par ADR.
+
+## Avant d'éditer un fichier ici
+
+1. Vérifier si une extension (`IActivity`, `IMiddleware`, `IModule`, `IFeature`, `IServiceCollection`) résout le besoin sans toucher au core.
+2. Si modif core inévitable :
+   - Créer `docs/adr/NNNN-titre.md` (format Contexte / Décision / Conséquences / Alternatives rejetées).
+   - Ajouter le label `upstream-candidate` au PR.
+   - Inclure un test de non-régression sur le comportement existant.
+
+## Interdictions
+
+- Pas de breaking change sur les API publiques Elsa sans ADR + bump semver.
+- Pas de suppression de code "mort" du core sans vérifier les usages externes (grep cross-modules).
+- Pas de modif du XML BPMN parser sans invoquer l'agent `bpmn-reviewer`.
+
+## Synchro upstream
+
+Merge hebdomadaire de `upstream/main` dans la branche `elsa-sync`, puis intégration dans `main` via PR après validation tests. Voir `/sync-upstream`.

--- a/.claude/rules/mediawan-custom.md
+++ b/.claude/rules/mediawan-custom.md
@@ -1,0 +1,34 @@
+---
+paths:
+  - "**/Mediawan.*/**"
+  - "src/Mediawan.*/**"
+  - "src/modules/Mediawan.*/**"
+---
+
+# Règles pour le code custom Mediawan
+
+Ces modules doivent rester **isolables** : suppression du dossier = fork redevient Elsa upstream pur. Pas de couplage sauvage.
+
+## Conventions
+
+- Namespace : `Mediawan.Workflow.*`
+- Nullable reference types : `enable`
+- Logging : `ILogger<T>` structuré, TraceId OpenTelemetry propagé
+- DI : tout via `IServiceCollection`, jamais de singleton statique
+- Async all the way : pas de `.Result` ni `.Wait()`
+
+## Contraintes archi non-négociables (cf. CLAUDE.md §3)
+
+Tout code ici doit respecter :
+
+1. **BPMN whitelist** au déploiement (refus explicite sinon)
+2. **External Task pattern** par défaut (pas de code métier in-process)
+3. **Idempotence** par `jobKey` (table `idempotency_keys`, TTL ≥ 30 jours)
+4. **Compensation** BPMN, pas de rollback distribué
+5. **Partitionnement** par `correlationKey` métier, jamais cross-tenant
+
+Si une tâche semble les contredire → **stoppe et demande arbitrage**. Invoque l'agent `bpmn-reviewer` en cas de doute.
+
+## Secrets
+
+Jamais en clair. Référence par nom, résolution via coffre (Vault / Azure Key Vault). Aucun secret ne doit apparaître dans le XML BPMN ou dans un fichier de config committé.

--- a/.claude/rules/tests.md
+++ b/.claude/rules/tests.md
@@ -1,0 +1,30 @@
+---
+paths:
+  - "test/**"
+  - "**/*.Tests/**"
+  - "**/*.Tests.csproj"
+  - "**/*Tests.cs"
+---
+
+# Règles de tests
+
+## Stack
+
+- xUnit + FluentAssertions
+- Testcontainers pour l'intégration PostgreSQL / Redis / Azure Service Bus
+- Pas de mock sur les tests d'intégration BD — Testcontainers obligatoire
+
+## Guardrails
+
+- Pas de `Thread.Sleep` ni `Task.Delay` sans commentaire justifiant (timing forcé = smell)
+- Pas de `.Result` ni `.Wait()` — async tout du long
+- Un test = un comportement. Pas de tests "fourre-tout".
+- Nommage : `Methode_Condition_ResultatAttendu` (ex: `ValidateBpmn_WithUnknownElement_ThrowsValidationException`)
+- Arrange / Act / Assert visibles (commentaires `// Arrange` etc. bienvenus sur les tests non triviaux)
+
+## Avant de merger
+
+- Tous les tests passent (unit + integration)
+- Couverture du code custom Mediawan ≥ 80%
+- Pas de test `[Skip]` sans ticket lié dans le message
+- Pas de test flaky toléré : quarantaine immédiate + ticket

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "includeCoAuthoredBy": false,
+  "permissions": {
+    "allow": [
+      "Bash(dotnet build:*)",
+      "Bash(dotnet test:*)",
+      "Bash(dotnet restore:*)",
+      "Bash(dotnet format:*)",
+      "Bash(dotnet run:*)",
+      "Bash(dotnet --version)",
+      "Bash(dotnet --list-sdks)",
+      "Bash(dotnet --info)",
+      "Bash(git status)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git show:*)",
+      "Bash(git branch:*)",
+      "Bash(git remote:*)",
+      "Bash(git fetch:*)",
+      "Bash(git commit:*)",
+      "Bash(git add:*)",
+      "Bash(git stash list)",
+      "Bash(docker compose up:*)",
+      "Bash(docker compose down:*)",
+      "Bash(docker compose ps)",
+      "Bash(docker compose logs:*)",
+      "Bash(docker compose config:*)",
+      "Bash(docker ps)",
+      "Bash(docker logs:*)"
+    ],
+    "deny": [
+      "Bash(git push --force:*)",
+      "Bash(git push -f:*)",
+      "Bash(git reset --hard:*)",
+      "Bash(git clean -fd:*)",
+      "Bash(git branch -D:*)",
+      "Bash(rm -rf:*)",
+      "Bash(docker system prune:*)",
+      "Bash(docker volume rm:*)"
+    ]
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          { "type": "command", "command": "bash .claude/hooks/dotnet-format.sh" }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/adr-writer/SKILL.md
+++ b/.claude/skills/adr-writer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: adr-writer
-description: Utilise ce skill quand tu dois rédiger un Architecture Decision Record pour ce projet. Déclenche sur "ADR", "decision record", "docs/adr", ou toute question architecture structurante (choix de techno, changement de pattern, breaking change, ajout de dépendance externe).
+description: Utilise ce skill quand tu dois rédiger un Architecture Decision Record pour ce projet. Déclenche sur "ADR", "decision record", "doc/adr", ou toute question architecture structurante (choix de techno, changement de pattern, breaking change, ajout de dépendance externe).
 ---
 
 # adr-writer
@@ -13,8 +13,8 @@ description: Utilise ce skill quand tu dois rédiger un Architecture Decision Re
 
 ## Procédure
 
-1. **Numéroter** : `ls docs/adr/` pour trouver le prochain `NNNN` (4 chiffres, zero-padded). Si le dossier n'existe pas, le créer.
-2. **Créer** `docs/adr/NNNN-<titre-kebab>.md` à partir de `references/adr-template.md`.
+1. **Numéroter** : `ls doc/adr/` pour trouver le prochain `NNNN` (4 chiffres, zero-padded). Le fork hérite de 10 ADR Elsa (0001-0010), donc au démarrage du projet **le prochain disponible est 0011**.
+2. **Créer** `doc/adr/NNNN-<titre-kebab>.md` à partir de `references/adr-template.md`.
 3. **Remplir uniquement à partir d'infos confirmées par l'utilisateur.** Ne pas inventer le contexte ou les alternatives.
 4. Laisser le statut en `Proposé` jusqu'à validation humaine explicite.
 

--- a/.claude/skills/adr-writer/SKILL.md
+++ b/.claude/skills/adr-writer/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: adr-writer
+description: Utilise ce skill quand tu dois rédiger un Architecture Decision Record pour ce projet. Déclenche sur "ADR", "decision record", "docs/adr", ou toute question architecture structurante (choix de techno, changement de pattern, breaking change, ajout de dépendance externe).
+---
+
+# adr-writer
+
+## Quand ce skill s'applique
+
+- L'utilisateur demande explicitement un ADR.
+- Tu t'apprêtes à prendre une décision structurante (dépendance nouvelle, pattern d'extension, rupture d'API).
+- Un ADR est **obligatoire** avant toute modif du code Elsa core (voir `.claude/rules/elsa-core.md`).
+
+## Procédure
+
+1. **Numéroter** : `ls docs/adr/` pour trouver le prochain `NNNN` (4 chiffres, zero-padded). Si le dossier n'existe pas, le créer.
+2. **Créer** `docs/adr/NNNN-<titre-kebab>.md` à partir de `references/adr-template.md`.
+3. **Remplir uniquement à partir d'infos confirmées par l'utilisateur.** Ne pas inventer le contexte ou les alternatives.
+4. Laisser le statut en `Proposé` jusqu'à validation humaine explicite.
+
+## Gotchas
+
+- **Ne jamais écraser** un ADR existant : toujours incrémenter le numéro.
+- Un ADR accepté **ne se modifie plus**. S'il devient obsolète, créer un nouvel ADR qui le remplace, et passer l'ancien en statut `Remplacé par ADR-XXXX`.
+- Les **alternatives rejetées ne sont pas optionnelles** — elles documentent *pourquoi* on n'a pas choisi autre chose. C'est le cœur de la valeur d'un ADR.
+- Pas de jargon interne non expliqué : un nouvel arrivant doit pouvoir lire l'ADR isolément.
+
+## Références
+
+- [`references/adr-template.md`](references/adr-template.md) — template à copier tel quel

--- a/.claude/skills/adr-writer/references/adr-template.md
+++ b/.claude/skills/adr-writer/references/adr-template.md
@@ -1,0 +1,53 @@
+# ADR-NNNN : <titre>
+
+- **Statut :** Proposé
+- **Date :** YYYY-MM-DD
+- **Auteur·s :** <nom>
+- **Remplace :** (ADR-XXXX si applicable)
+- **Remplacé par :** (ADR-XXXX si applicable)
+
+## Contexte
+
+Décris la situation et le problème à résoudre. Contraintes techniques, business, deadlines, dette technique existante. 5 à 15 lignes — un lecteur doit comprendre *pourquoi* on doit trancher maintenant.
+
+## Décision
+
+Exprime la décision au présent, en une ou deux phrases directes.
+
+> « Nous choisissons X parce que Y. »
+
+Détaille ensuite la décision en 3 à 10 lignes : périmètre exact, ce qui est inclus, ce qui ne l'est pas.
+
+## Conséquences
+
+### Positives
+
+- …
+
+### Négatives
+
+- …
+
+### Neutres
+
+- …
+
+## Alternatives rejetées
+
+### Alternative A
+
+Description.
+
+**Raison du rejet :** …
+
+### Alternative B
+
+Description.
+
+**Raison du rejet :** …
+
+## Liens
+
+- Issue / ticket : …
+- PR : …
+- Référence externe : …

--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,6 @@ docker/docker-compose-datadog.yml
 # Test results
 TestResults/
 artifacts/
+
+# Claude Code local config (per-dev overrides, never commit)
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ Ces 5 décisions sont verrouillées. Si une tâche semble les contredire, stoppe
 - Retry : backoff exponentiel avec jitter (1s base, factor 2, max 5min, jitter ±25%), max 5 tentatives par défaut configurable
 - Distinguer `RetriableException` (rejouer) de `BusinessException` (parker en incident)
 - Versioning workflow : instances en cours terminent sur leur version d’origine par défaut ; Migration API disponible mais opt-in
-- Secrets connecteurs : référencés par nom, résolus via coffre (Vault ou Azure Key Vault), jamais en clair dans le XML BPMN
+- Secrets connecteurs : référencés par nom, résolus via HashiCorp Vault, jamais en clair dans le XML BPMN
 
 -----
 ## 4. Livrables Phase 1 (J0–J90)
@@ -51,13 +51,13 @@ En ordre de priorité. Chaque livrable = du code mergé + tests + doc courte.
 
 - Cartographier le fork Elsa : modules, points d’extension, tests existants
 - Produire `ARCHITECTURE.md` (décisions acteées) et `CONVENTIONS.md` (code, tests, git)
-- Setup local dev : Docker Compose (Elsa + PostgreSQL 16 + Redis + Angular Designer)
+- Setup local dev : Docker Compose (Elsa + PostgreSQL 16 + Redis + RabbitMQ + Keycloak + Vault + smtp4dev + Angular Designer)
 - CI/CD : build .NET, tests unitaires, tests d’intégration, scan sécurité SAST
 
 **Sprint 3-4 — Multi-tenant & auth**
 
 - Modèle multi-tenant : `tenantId` propagé partout, résolution par subdomain ou header
-- OIDC (Azure AD par défaut, Keycloak en dev)
+- OIDC (Keycloak — dev + prod, tout on-premise)
 - RBAC : rôles `admin`, `designer`, `operator`, `observer` — policies par tenant
 
 **Sprint 5-6 — SDK Worker External Task**
@@ -82,7 +82,7 @@ En ordre de priorité. Chaque livrable = du code mergé + tests + doc courte.
 
 **Sprint 10 — Pilote métier**
 
-- Implémenter 1 process métier Mediawan concret (à définir avec sponsor)
+- Implémenter 1 process métier Mediawan concret — **cible : Ingest média** (sponsor à identifier début Phase 1)
 - Runbook SRE : procédures incident, rollback, escalade
 - Go-live en préprod
 
@@ -92,25 +92,28 @@ En ordre de priorité. Chaque livrable = du code mergé + tests + doc courte.
 ## 5. Stack technique
 
 ```
-Runtime         : .NET 9 / ASP.NET Core
+Runtime         : .NET 10 / ASP.NET Core (source + tests uniformes)
 Moteur          : Elsa Workflows 3 (fork)
-Base de données : PostgreSQL 16 (variables workflow en JSONB)
+Base de données : PostgreSQL 16 (variables workflow en JSONB) — provider unique
 Cache / locks   : Redis 7
-Bus d'événements: Azure Service Bus (prod) / Redis Streams (dev)
-Sidecar         : Dapr (pub/sub, state, secrets) — en évaluation
+Bus d'événements: RabbitMQ (prod + dev)
+Sidecar         : écarté — intégrations natives .NET (pas de Dapr en Phase 1)
 Observabilité   : OpenTelemetry → Prometheus + Grafana + Loki
-Secrets         : HashiCorp Vault OU Azure Key Vault
-Auth            : OIDC — Azure AD (prod) / Keycloak (dev)
+Secrets         : HashiCorp Vault
+Auth            : OIDC — Keycloak (dev + prod)
 API Gateway     : YARP
 Modeleur        : Elsa Designer (Angular) + bpmn-js
-CI/CD           : Azure DevOps ou GitHub Actions (à confirmer avec DSI)
+CI/CD           : GitHub Actions
+Hébergement     : on-premise (VMs Mediawan) — pas de K8s en Phase 1
+Tests           : xUnit + FluentAssertions + Testcontainers (scope Mediawan)
 ```
 
 **Justifications clés :**
 
-- PostgreSQL plutôt que SQL Server : JSONB natif (variables workflow), LISTEN/NOTIFY pour signaling léger, pas de licence. SQL Server reste supporté comme provider alternatif mais PG est la référence de dev.
-- Dapr en sidecar découplable — s’il pose problème en intégration Mediawan, on retire sans réécrire.
-- Pas de Kubernetes imposé en Phase 1. VMs + Docker Compose suffisent pour le pilote. K8s en Phase 2 pour la charge réelle.
+- **PostgreSQL seul** (pas de SQL Server alternatif) : JSONB natif, LISTEN/NOTIFY, pas de licence, RLS pour multi-tenant, une seule suite de migrations EF à maintenir.
+- **`net10.0` uniforme** (source + tests + packages) : LINQ async natif, perfs runtime, alignement direct avec la trajectoire upstream Elsa, zéro matrix CI.
+- **Dapr écarté en Phase 1** : intégrations natives .NET (SDK RabbitMQ, StackExchange.Redis, VaultSharp). Si Phase 2 exige portabilité multi-cloud, évaluation Dapr via `IJobQueue` / `ISecretStore` déjà abstraites.
+- **On-premise VMs Mediawan** : souveraineté des données, OPEX maîtrisé, DSI opère déjà Vault + Keycloak + RabbitMQ ailleurs. Docker Compose pour le dev local, VMs HA pour le pilote, K8s éventuel en Phase 2 si la charge réelle (1000 starts/s) le justifie.
 
 -----
 ## 6. Méthode de travail
@@ -124,7 +127,7 @@ CI/CD           : Azure DevOps ou GitHub Actions (à confirmer avec DSI)
 1. **Confirm** — si ambiguïté, pose la question AVANT de coder. Ne suppose pas.
 1. **Implement** — petits commits atomiques, messages conventionnels (`feat:`, `fix:`, `refactor:`, `test:`, `docs:`)
 1. **Test** — chaque fonctionnalité = tests unitaires + intégration quand possible. Pas de merge sans tests passants.
-1. **Document** — ADR (`docs/adr/NNNN-titre.md`) pour toute décision architecturale non triviale.
+1. **Document** — ADR (`doc/adr/NNNN-titre.md`) pour toute décision architecturale non triviale.
 
 **Git workflow :**
 
@@ -134,7 +137,9 @@ CI/CD           : Azure DevOps ou GitHub Actions (à confirmer avec DSI)
 - Synchro régulière avec upstream Elsa (merge hebdomadaire de la branche stable Elsa dans une branche `elsa-sync`, puis merge dans `main` après validation tests)
 
 **ADR (Architecture Decision Records) :**
-Pour tout choix structurant (ajout d’une dépendance, pattern d’extension, breaking change), crée `docs/adr/NNNN-titre.md` avec format : Contexte / Décision / Conséquences / Alternatives rejetées. C’est le contrat avec les équipes futures.
+Pour tout choix structurant (ajout d’une dépendance, pattern d’extension, breaking change), crée `doc/adr/NNNN-titre.md` avec format : Contexte / Décision / Conséquences / Alternatives rejetées. C’est le contrat avec les équipes futures.
+
+Le fork hérite de 10 ADR Elsa existants (0001–0010). **Prochain numéro disponible : 0011.** Utilise le skill `adr-writer` ou la commande `/adr <titre>` pour générer un squelette.
 
 -----
 ## 7. Conventions de code
@@ -165,24 +170,31 @@ Pour tout choix structurant (ajout d’une dépendance, pattern d’extension, b
 1. Identifie les points d’extension principaux d’Elsa 3 (activities, middleware, modules)
 1. Repère les tests existants et leur niveau de couverture
 1. Note les divergences entre la branche main du fork et l’upstream Elsa (si fork déjà touché)
-1. Produis `docs/discovery.md` : cartographie du repo + points d’extension identifiés + questions ouvertes
+1. Produis `doc/discovery.md` : cartographie du repo + points d’extension identifiés + questions ouvertes
 1. Propose un plan détaillé des Sprints 1-2 (2 semaines) avec milestones mesurables
 1. **Attends validation** avant de créer le premier commit de code
 
 Le but : s’assurer que tu as une vision claire du terrain avant d’y construire.
 
 -----
-## 9. Questions ouvertes (à arbitrer tôt)
+## 9. Décisions de cadrage (arbitrées le 2026-04-20)
 
-Ces points nécessitent une décision humaine. Liste-les dans tes premiers échanges :
+Les 12 arbitrages pris post-`/discovery` sont actés ici. Trace détaillée dans `doc/discovery.md` §8 et dans l'ADR-0011.
 
-- [ ] Nom du produit interne (ex : “MediaFlow”, “Mediawan Workflow Platform”, autre)
-- [ ] Base de données cible production : PostgreSQL seul, ou PG + SQL Server supportés ?
-- [ ] Hébergement cible : on-prem, Azure, hybride ?
-- [ ] Fournisseur CI/CD (Azure DevOps vs GitHub Actions)
-- [ ] Politique de support Elsa : contrat payant avec mainteneurs, ou autonomie complète ?
-- [ ] 1er process métier pilote (à définir avec sponsor — probablement côté production éditoriale)
-- [ ] Dapr : on valide ou on part sur des intégrations natives ?
+- [x] **Nom produit** : Mediawan Workflow Platform (namespace `Mediawan.Workflow.*`)
+- [x] **Runtime .NET** : `net10.0` uniforme (source + tests + packages)
+- [x] **Dossier ADR** : `doc/adr/` (10 ADR existants, prochain = **0011**)
+- [x] **Base de données prod** : PostgreSQL 16 seul
+- [x] **Hébergement** : on-premise VMs Mediawan
+- [x] **CI/CD** : GitHub Actions (déjà en place dans le fork)
+- [x] **Auth** : Keycloak OIDC (dev + prod)
+- [x] **Bus d'événements** : RabbitMQ (dev + prod)
+- [x] **Secrets** : HashiCorp Vault
+- [x] **Sidecar Dapr** : écarté en Phase 1, ré-évaluable en Phase 2
+- [x] **Support Elsa** : autonomie complète (zero contrat externe)
+- [x] **Pilote Sprint 10** : Ingest média (sponsor à identifier)
+- [x] **Global query filter multi-tenant EF** : **Sprint 1-2 urgent** (gap sécurité)
+- [x] **Testcontainers** : scope Mediawan-only, pas d'impact `/sync-upstream`
 
 -----
 ## 10. Contacts & références

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,198 @@
+# Mediawan Workflow Platform — Guide Claude Code
+
+> Ce fichier te donne le contexte projet. Lis-le intégralement avant toute action.
+> Il reste à jour — si une règle ici est ambiguë ou datée, signale-le avant d’agir.
+
+-----
+## 1. Mission
+
+Transformer ce fork d’**Elsa Workflows 3** en plateforme de workflow d’entreprise pour **Mediawan**. Objectif : orchestrer les processus métier du groupe (ingest média, production éditoriale, back-office) avec BPMN 2.0, DMN, External Tasks, sur stack .NET alignée avec nos équipes.
+
+Cible finale : moteur centralisé, multi-tenant, scalable à ~1000 workflow-starts/sec en Phase 2, avec plugins/connecteurs maintenus en interne.
+
+**Nous ne réécrivons pas Elsa.** Nous l’étendons. Chaque modification custom doit pouvoir être contribuée upstream ou isolée dans un dossier `Mediawan.*` séparable.
+
+-----
+## 2. Contexte
+
+- Fork fraîchement créé à partir de la branche stable d’Elsa 3
+- Étude d’architecture de référence : `docs/architecture/workflow-engine-study.html` (à déposer dans le repo)
+- Phase 1 (J0–J90) démarre : fondations techniques + 1er pilote métier
+- Équipe : 4–5 ingénieurs dédiés, lead .NET senior, contexte Mediawan = .NET / Angular / SQL Server historique, tolérant PostgreSQL sur les nouveaux projets
+- Règlement : RGPD + exigences DSI/RSSI Mediawan (audit trail complet, chiffrement des données personnelles, résidence UE)
+
+-----
+## 3. Contraintes architecturales non-négociables
+
+Ces 5 décisions sont verrouillées. Si une tâche semble les contredire, stoppe et demande arbitrage — ne les contourne pas silencieusement.
+
+1. **BPMN 2.0 restreint et validé.** Seul un sous-ensemble whitelisté d’éléments BPMN est exécutable. Validation au déploiement, refus explicite sinon. Palette du modeleur alignée sur cette whitelist.
+1. **External Task pattern par défaut.** Le moteur n’exécute pas de code métier en in-process. Il publie des jobs, les workers externes les poll, remontent le résultat. Les Service Tasks “inline” sont réservés aux connecteurs infrastructure (HTTP, SMTP, log).
+1. **Idempotence par `jobKey` stable.** Le moteur génère un UUID par tâche, les workers l’utilisent comme clé d’idempotence sur tout appel sortant. Table `idempotency_keys` avec TTL 30 jours minimum.
+1. **Compensation, pas rollback.** Implémentation SAGA via Compensation Handlers BPMN. Chaque handler de compensation doit lui-même être idempotent et retriable. Jamais de “rollback transactionnel distribué”.
+1. **Partitionnement par `correlationKey` métier.** Toute instance porte une clé de corrélation métier (ex : `customerId`, `dossierId`). Scaling horizontal par partitions, jamais de cross-tenant.
+
+**Règles opérationnelles complémentaires :**
+
+- Multi-tenant dès le jour 1 : `tenantId` en clé composite dans chaque table, requêtes admin incapables de cross-tenant
+- Audit log append-only : chaque transition d’instance, chaque action opérateur, chaque évaluation DMN → row immuable
+- Variables PII : taggables `@pii` dans le schéma, chiffrement champ-par-champ, purge automatique après N jours post-completion
+- Retry : backoff exponentiel avec jitter (1s base, factor 2, max 5min, jitter ±25%), max 5 tentatives par défaut configurable
+- Distinguer `RetriableException` (rejouer) de `BusinessException` (parker en incident)
+- Versioning workflow : instances en cours terminent sur leur version d’origine par défaut ; Migration API disponible mais opt-in
+- Secrets connecteurs : référencés par nom, résolus via coffre (Vault ou Azure Key Vault), jamais en clair dans le XML BPMN
+
+-----
+## 4. Livrables Phase 1 (J0–J90)
+
+En ordre de priorité. Chaque livrable = du code mergé + tests + doc courte.
+
+**Sprint 1-2 — Exploration & bases**
+
+- Cartographier le fork Elsa : modules, points d’extension, tests existants
+- Produire `ARCHITECTURE.md` (décisions acteées) et `CONVENTIONS.md` (code, tests, git)
+- Setup local dev : Docker Compose (Elsa + PostgreSQL 16 + Redis + Angular Designer)
+- CI/CD : build .NET, tests unitaires, tests d’intégration, scan sécurité SAST
+
+**Sprint 3-4 — Multi-tenant & auth**
+
+- Modèle multi-tenant : `tenantId` propagé partout, résolution par subdomain ou header
+- OIDC (Azure AD par défaut, Keycloak en dev)
+- RBAC : rôles `admin`, `designer`, `operator`, `observer` — policies par tenant
+
+**Sprint 5-6 — SDK Worker External Task**
+
+- Package NuGet `Mediawan.Workflow.Worker.Sdk`
+- API : attribut `[JobHandler]` + injection de variables BPMN
+- Polling long, lock avec TTL renouvelable, heartbeat
+- Retry policies intégrées, distinction Retriable / Business errors
+
+**Sprint 7-8 — Connecteurs built-in v1**
+
+- `Http` (GET/POST/PUT/DELETE avec auth)
+- `Smtp` (templates Razor)
+- `S3` (AWS + Azure Blob derrière la même abstraction)
+- Manifest JSON Schema par connecteur, intégration modeleur
+
+**Sprint 9 — Audit & idempotence**
+
+- Table `audit_log` append-only, Postgres ROW LEVEL SECURITY
+- Table `idempotency_keys` + middleware de déduplication
+- Dashboard Grafana v1 : taux de succès, latence p50/p95/p99 par process
+
+**Sprint 10 — Pilote métier**
+
+- Implémenter 1 process métier Mediawan concret (à définir avec sponsor)
+- Runbook SRE : procédures incident, rollback, escalade
+- Go-live en préprod
+
+**Hors scope Phase 1 :** DMN engine complet, BPMN Migration API, CMMN, Kubernetes production (VMs OK en phase 1), connecteurs Mediawan spécifiques (MAM/DAM/Playout).
+
+-----
+## 5. Stack technique
+
+```
+Runtime         : .NET 9 / ASP.NET Core
+Moteur          : Elsa Workflows 3 (fork)
+Base de données : PostgreSQL 16 (variables workflow en JSONB)
+Cache / locks   : Redis 7
+Bus d'événements: Azure Service Bus (prod) / Redis Streams (dev)
+Sidecar         : Dapr (pub/sub, state, secrets) — en évaluation
+Observabilité   : OpenTelemetry → Prometheus + Grafana + Loki
+Secrets         : HashiCorp Vault OU Azure Key Vault
+Auth            : OIDC — Azure AD (prod) / Keycloak (dev)
+API Gateway     : YARP
+Modeleur        : Elsa Designer (Angular) + bpmn-js
+CI/CD           : Azure DevOps ou GitHub Actions (à confirmer avec DSI)
+```
+
+**Justifications clés :**
+
+- PostgreSQL plutôt que SQL Server : JSONB natif (variables workflow), LISTEN/NOTIFY pour signaling léger, pas de licence. SQL Server reste supporté comme provider alternatif mais PG est la référence de dev.
+- Dapr en sidecar découplable — s’il pose problème en intégration Mediawan, on retire sans réécrire.
+- Pas de Kubernetes imposé en Phase 1. VMs + Docker Compose suffisent pour le pilote. K8s en Phase 2 pour la charge réelle.
+
+-----
+## 6. Méthode de travail
+
+**Principe général : explorer avant d’écrire.** Ne jamais créer une classe sans avoir cherché dans le code Elsa existant si une extension est déjà possible. Les extensions upstream-compatibles sont toujours préférables aux forks internes.
+
+**Boucle standard pour chaque tâche :**
+
+1. **Read** — explore le code concerné, lis les tests existants, cherche les points d’extension (`IActivity`, `IMiddleware`, etc.)
+1. **Plan** — produis un plan écrit avant d’implémenter. Si la tâche fait plus de 2h de code, découpe en sous-tâches explicites.
+1. **Confirm** — si ambiguïté, pose la question AVANT de coder. Ne suppose pas.
+1. **Implement** — petits commits atomiques, messages conventionnels (`feat:`, `fix:`, `refactor:`, `test:`, `docs:`)
+1. **Test** — chaque fonctionnalité = tests unitaires + intégration quand possible. Pas de merge sans tests passants.
+1. **Document** — ADR (`docs/adr/NNNN-titre.md`) pour toute décision architecturale non triviale.
+
+**Git workflow :**
+
+- `main` protégée, PR obligatoires
+- Branches : `feat/...`, `fix/...`, `refactor/...`, `chore/...`
+- Commits signés
+- Synchro régulière avec upstream Elsa (merge hebdomadaire de la branche stable Elsa dans une branche `elsa-sync`, puis merge dans `main` après validation tests)
+
+**ADR (Architecture Decision Records) :**
+Pour tout choix structurant (ajout d’une dépendance, pattern d’extension, breaking change), crée `docs/adr/NNNN-titre.md` avec format : Contexte / Décision / Conséquences / Alternatives rejetées. C’est le contrat avec les équipes futures.
+
+-----
+## 7. Conventions de code
+
+- Style .NET : EditorConfig du fork Elsa respecté
+- Nullable reference types : `enable` partout
+- Tests : xUnit + FluentAssertions + Testcontainers pour l’intégration PostgreSQL
+- Pas de `Thread.Sleep` ni de `Task.Delay` en prod sans justification écrite
+- Async all the way : pas de `.Result` ni `.Wait()`
+- Logging : `ILogger<T>` structuré avec scope, TraceId OpenTelemetry propagé
+- Injection de dépendances : tout via `IServiceCollection`, pas de singletons statiques
+- Nommage custom : `Mediawan.Workflow.*` pour les modules spécifiques
+- XML BPMN : validation schema au déploiement, refus si éléments hors whitelist
+
+**Guardrails stricts :**
+
+- Jamais de secret ni de connection string en clair commité
+- Jamais de modification du code Elsa “core” sans ADR et label `upstream-candidate`
+- Toujours mode opt-in pour les features expérimentales (feature flags)
+- Dépendances nouvelles : justification dans le PR, check licence (pas de GPL)
+
+-----
+## 8. Première action attendue
+
+**Ne commence pas à coder.** Exécute d’abord cette séquence :
+
+1. Fais un tour complet du repo : `README`, `CONTRIBUTING`, structure des dossiers, projets .csproj, dépendances principales
+1. Identifie les points d’extension principaux d’Elsa 3 (activities, middleware, modules)
+1. Repère les tests existants et leur niveau de couverture
+1. Note les divergences entre la branche main du fork et l’upstream Elsa (si fork déjà touché)
+1. Produis `docs/discovery.md` : cartographie du repo + points d’extension identifiés + questions ouvertes
+1. Propose un plan détaillé des Sprints 1-2 (2 semaines) avec milestones mesurables
+1. **Attends validation** avant de créer le premier commit de code
+
+Le but : s’assurer que tu as une vision claire du terrain avant d’y construire.
+
+-----
+## 9. Questions ouvertes (à arbitrer tôt)
+
+Ces points nécessitent une décision humaine. Liste-les dans tes premiers échanges :
+
+- [ ] Nom du produit interne (ex : “MediaFlow”, “Mediawan Workflow Platform”, autre)
+- [ ] Base de données cible production : PostgreSQL seul, ou PG + SQL Server supportés ?
+- [ ] Hébergement cible : on-prem, Azure, hybride ?
+- [ ] Fournisseur CI/CD (Azure DevOps vs GitHub Actions)
+- [ ] Politique de support Elsa : contrat payant avec mainteneurs, ou autonomie complète ?
+- [ ] 1er process métier pilote (à définir avec sponsor — probablement côté production éditoriale)
+- [ ] Dapr : on valide ou on part sur des intégrations natives ?
+
+-----
+## 10. Contacts & références
+
+- Étude d’architecture : `docs/architecture/workflow-engine-study.html`
+- Upstream Elsa : <https://github.com/elsa-workflows/elsa-core>
+- Docs Elsa : <https://v3.elsaworkflows.io>
+- Spec BPMN 2.0 : OMG — <https://www.omg.org/spec/BPMN/2.0/>
+- Spec DMN 1.3 : OMG — <https://www.omg.org/spec/DMN/1.3/>
+
+-----
+
+*Fin de fichier. Si quelque chose ici est flou, demande avant d’agir.*

--- a/doc/adr/0011-strategie-bpmn-external-task-idempotence.md
+++ b/doc/adr/0011-strategie-bpmn-external-task-idempotence.md
@@ -1,0 +1,146 @@
+# ADR-0011 : Stratégie BPMN whitelist + External Task + Idempotence pour Mediawan Workflow Platform
+
+- **Statut :** Proposé
+- **Date :** 2026-04-20
+- **Auteur·s :** O. Yahyaoui (discovery initiale + arbitrages §8)
+- **Remplace :** —
+- **Remplacé par :** —
+
+## Contexte
+
+Le fork `Fatilov/elsa-core-mdw` vise à devenir la **Mediawan Workflow Platform** (MWP). Trois gaps techniques critiques ont été identifiés lors de la phase de découverte (cf. `doc/discovery.md` §7) vis-à-vis des contraintes non-négociables de `CLAUDE.md` §3 :
+
+1. **Pas de parseur BPMN XML natif** dans Elsa 3 — le moteur manipule des workflows en JSON (`.elsa`) via son propre schéma. La contrainte §3.1 « BPMN 2.0 restreint et validé » impose un parseur, une whitelist d'éléments, et une validation au déploiement.
+2. **External Task incomplet** — `RunTask.cs:18` + `ITaskDispatcher` + `ITaskReporter.cs:13` offrent le squelette (bookmark + complétion asynchrone), mais les éléments d'exactly-once promis par §3.2 (worker externe poll/lock/heartbeat, `jobKey` UUID stable exposé, distinction `RetriableException` / `BusinessException`) sont absents.
+3. **Table `idempotency_keys` absente** — la contrainte §3.3 exige une table avec TTL ≥ 30 jours utilisée par les workers comme clé d'idempotence sur tout appel sortant.
+
+Ces trois gaps sont **liés** : la compensation SAGA (contrainte §3.4) dépend du parseur BPMN (elle repose sur les `Compensation Boundary Event` + `Compensation Activity`), et l'External Task s'appuie sur l'idempotence pour garantir l'exactly-once.
+
+Cadrage validé lors des arbitrages §8 de la discovery :
+
+- Runtime cible `net10.0` uniforme
+- Hébergement on-premise Mediawan (Keycloak + RabbitMQ + HashiCorp Vault)
+- Pas de Dapr en Phase 1 — intégrations natives .NET
+- PostgreSQL 16 comme provider unique
+- Pilote métier Sprint 10 : Ingest média (MAM → transcoding → QC → publication) → stress-test direct du pattern External Task + SAGA
+
+## Décision
+
+Nous adoptons une **stratégie en trois couches** isolée dans le namespace `Mediawan.Workflow.*`, implémentée progressivement sur les Sprints 3-9.
+
+### 1. Parseur BPMN XML + whitelist — Sprint 3-4
+
+**Librairie tierce retenue : [`Camunda.Bpmn.Model`](https://www.nuget.org/packages/Camunda.Bpmn.Model) (alt: `SBpmnEngine` / `Bpmn.Net`)** pour le parsing XML (évaluation comparative à finaliser avant la fin du Sprint 3). Le mapping XML → activités Elsa (`IActivity`) et la whitelist sont **écrits en interne** dans `Mediawan.Workflow.Bpmn`.
+
+Éléments BPMN **whitelistés en Phase 1** (sous-ensemble conservateur) :
+
+| Catégorie | Éléments autorisés |
+| --- | --- |
+| Events | `StartEvent` (simple + timer + message), `EndEvent` (simple + terminate), `IntermediateCatchEvent` (timer, signal, message), `CompensationBoundaryEvent` |
+| Activities | `UserTask`, `ServiceTask` (externalTopic uniquement), `ScriptTask` (strictement limité aux connecteurs infra HTTP/SMTP/log), `CompensationActivity`, `CallActivity` |
+| Gateways | `ExclusiveGateway`, `ParallelGateway`, `EventBasedGateway` |
+| Structurels | `SequenceFlow`, `Process`, `Pool`, `Lane` |
+
+Rejetés (erreur explicite au déploiement) : `BusinessRuleTask` (DMN hors scope Phase 1), `InclusiveGateway` (sémantique ambiguë), `ComplexGateway`, `SubProcess` non-embedded, `AdHocSubProcess`, `Transaction`, scripts inline autre que whitelistés.
+
+Validation au déploiement :
+
+- Schema XSD BPMN 2.0 (officiel OMG)
+- Validation whitelist custom `BpmnWhitelistValidator`
+- Palette du modeleur `bpmn-js` côté Angular Designer alignée via un profil MWP
+
+### 2. Pattern External Task + `jobKey` — Sprint 5-6
+
+Un nouveau module `Mediawan.Workflow.Worker.Sdk` (package NuGet public interne) encapsule :
+
+- **`[JobHandler("topic-name")]`** — attribut pour enregistrer un handler
+- **Injection automatique** des variables BPMN typées + `JobContext`
+- **Polling long** sur RabbitMQ (un exchange par topic, queues partitionnées par `correlationKey`)
+- **Lock TTL renouvelable** (Redis, base 5 min, heartbeat toutes les 30 s)
+- **Génération `jobKey` UUID v7** côté moteur (horodaté, partitionné), propagé dans le message AMQP en header `x-mediawan-job-key`
+- **Retry policies** intégrées : backoff exponentiel + jitter (1 s base, factor 2, max 5 min, ±25 %), max 5 tentatives configurables
+- **Distinction typée** `RetriableException` (rejouer) vs `BusinessException` (parker en incident — `IncidentCount` incrémenté sur `WorkflowInstance`)
+
+Le moteur Elsa pousse dans RabbitMQ via un **bridge** implémentant `ITaskDispatcher` → `IJobQueue`. La réponse remonte via `ITaskReporter.ReportCompletionAsync` côté moteur. Aucune modif du code Elsa core — tout est greffé via `IModule`/`IFeature` Mediawan.
+
+### 3. Table `idempotency_keys` + middleware — Sprint 9 (anticipation en Sprint 5-6 pour le SDK)
+
+Schéma PostgreSQL :
+
+```sql
+CREATE TABLE idempotency_keys (
+    key         uuid NOT NULL,
+    tenant_id   text NOT NULL,
+    topic       text NOT NULL,
+    first_seen  timestamptz NOT NULL DEFAULT now(),
+    last_seen   timestamptz NOT NULL DEFAULT now(),
+    response    jsonb,
+    status      smallint NOT NULL,   -- 0=InFlight, 1=Succeeded, 2=Failed
+    expires_at  timestamptz NOT NULL DEFAULT now() + interval '30 days',
+    PRIMARY KEY (tenant_id, key)
+) PARTITION BY HASH (tenant_id);
+
+CREATE INDEX idx_idempotency_keys_expires ON idempotency_keys (expires_at);
+```
+
+Middleware côté SDK Worker intercepte tout appel sortant HTTP/AMQP/DB, insère/vérifie la ligne avant exécution. Purge automatique via un `IHostedService` qui tourne toutes les 6 h.
+
+TTL 30 jours (minimum CLAUDE.md §3.3), configurable par connecteur si nécessaire (ex: S3 multipart upload peut exiger 7 jours supplémentaires).
+
+## Conséquences
+
+### Positives
+
+- **Respect explicite des 3 contraintes §3.1 / §3.2 / §3.3** — traçable, ADR-sourcé.
+- **Isolation Mediawan** : tout vit dans `Mediawan.Workflow.Bpmn` + `Mediawan.Workflow.Worker.Sdk` + `Mediawan.Workflow.Idempotency`. Pas de patch sur le code Elsa core — les PR upstream-candidate restent minimales.
+- **SDK Worker** public en interne → réutilisable par toutes les BU Mediawan (Ingest média, Production éditoriale, Back-office).
+- **Progressivité** : on peut mettre en production Sprint 5-6 sans attendre le parseur BPMN complet (workflows codés directement en C# en interne).
+- **Observabilité** : chaque étape du flow est loggée avec `TraceId` OTel, exportée vers Loki.
+
+### Négatives
+
+- **Charge d'implémentation élevée** : ~30 j·h estimés sur Sprints 3-9 (parseur + SDK + idempotence + tests).
+- **Dépendance à une librairie BPMN tierce** : nécessite un wrapper pour isoler les types et permettre un remplacement ultérieur si nécessaire.
+- **Divergence durable avec Elsa upstream** : les `JobHandler`s Mediawan ne s'interopèrent pas avec les activités C# Elsa traditionnelles. C'est assumé (contrainte §3.2 exige External Task par défaut).
+- **Complexité de debug** : un workflow qui échoue traverse `moteur → RabbitMQ → worker → idempotency → handler → RabbitMQ retour → moteur`. Nécessite des outils de corrélation (TraceId, `jobKey`, `correlationKey`) dès le Sprint 5-6.
+- **PostgreSQL partitionné** : la table `idempotency_keys` en partitioning par `tenant_id` impose une connaissance EF Core avancée ou un recours à `.ExecuteSqlRaw`.
+
+### Neutres
+
+- **Phase 2 possible avec Dapr** : `IJobQueue`/`ISecretStore` sont des abstractions, swap cible si besoin.
+- **Migration API** (contrainte opérationnelle sur le versioning) est hors scope de cet ADR — sera traitée dans un ADR dédié Sprint 8+.
+- **DMN engine complet** explicitement hors scope Phase 1. Si un besoin métier apparaît, évaluer `Camunda.Dmn` ou une grille Excel en fallback.
+
+## Alternatives rejetées
+
+### A. Adopter Camunda Platform 8 / Zeebe à la place d'Elsa
+
+Description : abandonner le fork Elsa et standardiser sur Camunda 8 (BPMN/DMN first-class, External Task natif, parseur XML inclus, compensation SAGA native, clustering multi-tenant).
+
+**Raison du rejet :** la stack Mediawan est .NET-first, l'équipe est dimensionnée pour du C#, et Camunda 8 impose un écosystème Java + Zeebe avec un coût de licence/run. La décision de partir d'Elsa était déjà prise en amont (cf. `CLAUDE.md §1` : « Nous ne réécrivons pas Elsa. Nous l'étendons »). L'investissement pour combler les 3 gaps est modéré (~30 j·h) face au coût de migration.
+
+### B. Implémenter tout en in-process (pas d'External Task)
+
+Description : les workflows exécutent directement des activités C# Elsa (`IActivity`), sans publication RabbitMQ. Plus simple, plus rapide à démarrer.
+
+**Raison du rejet :** viole directement la contrainte §3.2 (External Task par défaut). Sans External Task, le moteur devient un monolithe bloquant, impossible à scaler à 1000 starts/s en Phase 2, et le code métier des BU n'est pas isolé (risque de crash global).
+
+### C. Utiliser Dapr sidecar pour pub/sub + state + secrets
+
+Description : Dapr prend en charge l'abstraction broker/state/secret, évite d'écrire `IJobQueue` / `ISecretStore` à la main.
+
+**Raison du rejet :** décision §8 de la discovery — Dapr est écarté en Phase 1 pour limiter la complexité ops (+1 sidecar par pod, +1 courbe apprentissage équipe, +1 version à suivre). Les abstractions sont conservées (`IJobQueue`) pour permettre une bascule Dapr en Phase 2 si besoin.
+
+### D. Parseur BPMN maison from scratch
+
+Description : écrire nous-mêmes le parseur XML BPMN 2.0 à partir du schéma XSD OMG.
+
+**Raison du rejet :** BPMN 2.0 = ~200 pages de spec, ~100 éléments, nombreux cas limites (sub-process, compensation scope, multi-instance…). Le coût (~10-15 j·h) est trop élevé vs l'utilisation d'une librairie tierce éprouvée (~2-3 j·h pour intégration). Si la librairie tierce pose problème plus tard, on pourra isoler son usage et la remplacer grâce au wrapper MWP.
+
+## Liens
+
+- `doc/discovery.md` — découverte initiale, §7 (gaps) et §8 (arbitrages)
+- `doc/sprint-plan-1-2.md` — plan Sprints 1-2, E2.2 référence cet ADR
+- `CLAUDE.md` §3 — contraintes architecturales non-négociables
+- Référence BPMN 2.0 : [OMG Spec](https://www.omg.org/spec/BPMN/2.0/)
+- Librairie candidate : [`Camunda.Bpmn.Model`](https://www.nuget.org/packages/Camunda.Bpmn.Model)

--- a/doc/discovery.md
+++ b/doc/discovery.md
@@ -1,0 +1,152 @@
+# Discovery — fork Elsa Workflows 3 (Mediawan)
+
+> Livrable §8 CLAUDE.md — cartographie + points d'extension + gaps archi + questions ouvertes.
+> **Date** : 2026-04-20 — **Auteur** : découverte initiale (O. Yahyaoui).
+
+## 1. Résumé exécutif
+
+Le fork `Fatilov/elsa-core-mdw` suit la branche `main` d'`elsa-workflows/elsa-core` (Elsa 3). À date, il ne contient **aucune modification custom du code Elsa** — les seuls commits divergents sont la configuration Claude Code (cf. §6).
+
+Elsa 3 offre les fondations nécessaires à notre cible : pipelines d'exécution extensibles, DI modulaire (`IModule`/`IFeature`), support multi-tenant partiel (`TenantId` propagé), provider PostgreSQL EF Core, squelette External Task via `RunTask`/`ITaskDispatcher`.
+
+**Trois gaps critiques** vis-à-vis des contraintes non-négociables CLAUDE.md §3 :
+
+1. **Pas de parseur BPMN XML natif** → à implémenter entièrement (whitelist + validation).
+2. **External Task incomplet** → `jobKey` UUID stable, `idempotency_keys`, heartbeat, lock TTL absents.
+3. **Multi-tenant sans query filter global** → risque de fuite cross-tenant si non corrigé avant la préprod.
+
+Périmètre Sprint 1-2 recentré : cartographie, setup Docker Compose opérationnel avec les services déjà fournis par le fork (Postgres + Redis), CI/CD initial, et **un ADR cadre** fixant la stratégie BPMN + External Task + multi-tenant.
+
+## 2. Cartographie du repo
+
+```
+elsa-core-mdw/
+├── CLAUDE.md                         ← guide Claude Code (ajouté par nous)
+├── CONTRIBUTING.md
+├── Directory.Build.props             ← props globales (.NET 8/9/10 multi-targeting)
+├── Directory.Packages.props          ← CPM (Central Package Management)
+├── Elsa.sln
+├── build/, build.sh, build.cmd, build.ps1
+├── docker/
+│   ├── docker-compose.yml            ← postgres, sqlserver, mysql, oracle, mongodb,
+│   │                                    rabbitmq, redis, smtp4dev
+│   ├── ElsaServer.Dockerfile, ElsaStudio.Dockerfile, ...
+│   └── init-db-postgres.sh
+├── doc/
+│   ├── adr/                          ← 10 ADRs existants (0001–0010) — convention EN PLACE
+│   ├── changelogs/
+│   ├── qa/, agent-logs/, bounty/
+│   └── discovery.md                  ← CE FICHIER
+├── src/
+│   ├── apps/                         ← Elsa.Server.Web, Elsa.ModularServer.Web,
+│   │                                    Elsa.Server.LoadBalancer, Elsa.SamplePackage
+│   ├── clients/Elsa.Api.Client
+│   ├── common/                       ← Elsa.Features, Elsa.Mediator, Elsa.Api.Common,
+│   │                                    Elsa.Testing.Shared[.Component|.Integration]
+│   ├── extensions/Elsa.Testing.Extensions
+│   └── modules/                      ← 37 modules (cf. §4 pour les points d'extension)
+└── test/
+    ├── unit/ (13 projets)
+    ├── integration/ (8 projets)
+    ├── component/ (1 projet)
+    └── performance/ (1 projet)
+```
+
+## 3. Stack réellement constatée vs CLAUDE.md
+
+| Item | CLAUDE.md déclare | Fork réel | Action |
+| --- | --- | --- | --- |
+| Runtime .NET | .NET 9 | **net8.0 ; net9.0 ; net10.0** multi-target (source) ; **net10.0** (tests) | **Corriger CLAUDE.md §5** (runtime par défaut = 10) ou aligner |
+| EF Core | PG 16 | PG + SQL Server + MySQL + Oracle + SQLite + MongoDB provider | PG reste la cible, garder support SQL Server ouvert comme alternatif |
+| Dossier ADR | `docs/adr/NNNN-*.md` | `doc/adr/NNNN-*.md` (pluriel absent, 10 ADRs déjà présents) | **Aligner CLAUDE.md + `/adr` sur `doc/adr/`** — le numéro à attribuer est **0011** |
+| Docker Compose | à créer | `docker/docker-compose.yml` existe (7 services) | Réutiliser, ajouter Keycloak/Azurite/OTel selon besoin |
+| CI/CD | à confirmer | GitHub Actions actif (`packages.yml`) | Poursuivre sur GitHub Actions |
+
+## 4. Points d'extension Elsa (synthèse)
+
+| Capacité | Verdict | Chemins clés |
+| --- | --- | --- |
+| **Activités (`IActivity`)** | Natif, prêt à étendre | `src/modules/Elsa.Workflows.Core/Contracts/IActivity.cs:8`, `Abstractions/Activity.cs:17` ; provider auto-discovery via `[Activity(...)]` |
+| **Pipelines middleware** | Natif, prêt à étendre | `WorkflowsFeature.cs:82-89` — 2 pipelines : `IWorkflowExecutionPipeline`, `IActivityExecutionPipeline` |
+| **Modules / Features** | Natif, prêt à étendre | `src/common/Elsa.Features/Services/IModule.cs:9`, `FeatureBase.cs:10` — décorateurs `[DependsOn]`/`[DependencyOf]` |
+| **DI** | Natif | Entry point `services.AddElsa(module => module.Configure<MaFeature>())` ; interfaces substituables : `IWorkflowRuntime`, `IWorkflowDispatcher`, `ITaskDispatcher`, `IIdentityGenerator`, `ICommitStateHandler` |
+| **BPMN XML** | **Absent** | Aucun parseur BPMN, aucune whitelist — workflows Elsa stockés en JSON (`.elsa`) |
+| **External Task** | Partiel | `RunTask.cs:18` + `ITaskReporter.cs:13` → bookmark + complétion ; mais **pas** de `jobKey` stable exposé, ni `idempotency_keys`, ni heartbeat/lock TTL |
+| **Multi-tenant** | Partiel | `Elsa.Common/Entities/Entity.cs:16` (`TenantId` propagé) + `Elsa.Tenants` (`ITenantResolver`, `ITenantAccessor`, `TenantsFeature`) ; **pas de RLS ni global query filter EF** |
+| **Persistence PG** | Natif | `Elsa.Persistence.EFCore.PostgreSql` — migrations jusqu'à V3_7 Runtime, JSONB sur `WorkflowState` |
+| **Compensation / SAGA** | Absent | Aucune abstraction ni `CompensationHandler` — à construire via activités + bookmarks |
+| **Retry / Resilience** | Minimal | Module `Elsa.Resilience[.Core]` existe, contenu limité ; `IncidentCount` dispo sur `WorkflowInstance:70` |
+
+**Fichiers prioritaires à relire en Sprint 1-2 :**
+
+- `src/modules/Elsa.Workflows.Core/Features/WorkflowsFeature.cs`
+- `src/modules/Elsa.Workflows.Runtime/Activities/RunTask.cs`
+- `src/modules/Elsa.Tenants/Features/TenantsFeature.cs`
+- `src/modules/Elsa.Persistence.EFCore.Common` (base `ElsaDbContextBase` pour y greffer les global query filters)
+
+## 5. Inventaire des tests
+
+- **22 projets de test** ; **458 fichiers `.cs`** ; stack uniforme **xUnit + Moq + NSubstitute + FluentAssertions-friendly + coverlet**
+- Tous les tests ciblent **`net10.0`** (cf. `test/Directory.Build.props`)
+- Threshold coverage = **10% (ligne, total)** → faible, à durcir pour le code Mediawan custom (≥ 80 % ciblé, cf. `.claude/rules/tests.md`)
+- Output coverlet en `cobertura,lcov,opencover` → consommable par GitHub Actions et Sonar
+- Ventilation :
+  - **Unit** (13) — Activities, Common, Expressions, Http, Mediator, Resilience.Core, Scheduling, Shells.Api, Tenants, Workflows.Core, Workflows.Management, Workflows.Runtime
+  - **Integration** (8) — via `Elsa.Testing.Shared.Integration` (WebApplicationFactory)
+  - **Component** (1) — `Elsa.Workflows.ComponentTests`
+  - **Performance** (1) — `Elsa.Workflows.PerformanceTests`
+- **Testcontainers non présent** dans le fork (mentionné dans CLAUDE.md) — à ajouter comme dépendance pour les tests d'intégration PG/Redis à venir
+
+## 6. Divergences fork vs upstream
+
+`remote add upstream https://github.com/elsa-workflows/elsa-core.git` a été ajouté.
+
+- **Fork en avance de 2 commits** (purement additifs) :
+  - `2673a4364` chore: add Claude Code project configuration
+  - `f393a45d8` Merge PR #1
+- **Upstream en avance de 3 commits** (changements mineurs) :
+  - `9f8423932` Handle null activities in `RunWorkflowResultAssertions`
+  - `632d1a383` Refactor shells setup and clean up NuGet package source mapping
+  - `29d8a64a9` Update package versions: CShells 0.0.14, Nuplane 0.0.1
+
+**Aucune modification custom du code Elsa côté fork** — la procédure `/sync-upstream` peut être exécutée sans conflit anticipé.
+
+## 7. Gaps vs contraintes §3 CLAUDE.md
+
+| # | Contrainte | Gap | Sprint cible |
+| --- | --- | --- | --- |
+| 1 | BPMN whitelist | Parseur XML BPMN + whitelist + validation **à construire** | 3-4 (ADR cadre dès 1-2) |
+| 2 | External Task pattern | Squelette `RunTask` OK, SDK Worker complet à construire | 5-6 |
+| 3 | Idempotence `jobKey` | Table `idempotency_keys`, UUID stable exposé au worker | 5-6 ou 9 |
+| 4 | Compensation SAGA | Abstraction absente, dépendante du parseur BPMN (gap 1) | 7-8 |
+| 5 | Partitionnement `correlationKey` | `TenantId` OK, **global query filter EF manquant**, cross-tenant possible | **1-2 (urgent)** |
+
+## 8. Décisions de cadrage (arbitrées le 2026-04-20)
+
+- [x] **Runtime .NET** : `net10.0` uniforme (source + tests + packages `Mediawan.Workflow.*`). CLAUDE.md §5 corrigé (déclarait .NET 9).
+- [x] **Convention dossier ADR** : `doc/adr/` (aligné Elsa upstream, 10 ADR existants). CLAUDE.md §6, `/adr`, skill `adr-writer` mis à jour. **Prochain numéro = 0011**.
+- [x] **Nom produit interne** : **Mediawan Workflow Platform** (namespace `Mediawan.Workflow.*` conservé).
+- [x] **Base de données prod** : PostgreSQL 16 seul — pas de support SQL Server alternatif.
+- [x] **Hébergement** : **on-premise VMs Mediawan** (Keycloak + RabbitMQ + Vault + PG self-hosted + Prometheus/Grafana/Loki). Pas d'Azure en Phase 1.
+- [x] **CI/CD** : GitHub Actions (déjà en place dans le fork, workflow `packages.yml`).
+- [x] **Auth** : Keycloak OIDC (dev + prod).
+- [x] **Bus d'événements** : RabbitMQ (dev + prod) — pas de Redis Streams, pas de Kafka, pas de Service Bus.
+- [x] **Secrets** : HashiCorp Vault uniquement (pas Azure Key Vault).
+- [x] **Dapr** : **écarté en Phase 1**. Intégrations .NET natives via `IJobQueue`/`ISecretStore` abstraites (refacto Phase 2 si besoin).
+- [x] **Politique support Elsa** : **autonomie complète** (0 contrat externe). Filet de sécurité contrat à reconsidérer si RSSI exige SLA écrit.
+- [x] **Process pilote Sprint 10** : **Ingest média** (MAM/transcoding/QC/publication). Sponsor à identifier Sprint 1.
+- [x] **Testcontainers** : ajout ciblé uniquement sur `Mediawan.*.IntegrationTests`. Zero impact `/sync-upstream`.
+- [x] **Global query filter multi-tenant** : **Sprint 1-2 urgent** (gap sécurité RSSI). Feature Mediawan opt-in, tests Testcontainers PG.
+
+## 8bis. Questions restantes (dépendent du sponsor / DSI)
+
+- [ ] **Sponsor métier Ingest média** : à identifier Sprint 1 (cible production côté BU).
+- [ ] **Accès DSI** : provision Vault, Keycloak realm, runners GH Actions self-hosted on-prem (si requis par DSI réseau).
+- [ ] **Stratégie backup / DR** de la VM PostgreSQL prod — à formaliser en ADR avant go-live préprod (Sprint 10).
+
+## 9. Prochaines étapes proposées
+
+1. **Valider ce document** avec le lead .NET (questions §8).
+2. **Draft plan Sprints 1-2** avec milestones (document séparé : `doc/sprint-plan-1-2.md`) — voir brouillon proposé dans la réponse Claude Code.
+3. **ADR-0011 “Stratégie BPMN whitelist + External Task pour Mediawan”** — cadrage des gaps 1+2+3 avant Sprint 3-4.
+4. **Correction CLAUDE.md** (runtime, dossier ADR, docker-compose existant) une fois les questions §8 arbitrées.

--- a/doc/sprint-plan-1-2.md
+++ b/doc/sprint-plan-1-2.md
@@ -1,0 +1,86 @@
+# Plan Sprints 1-2 — Exploration & bases
+
+> **Durée** : 2 semaines (10 jours ouvrés).
+> **Équipe** : 4-5 ingénieurs (1 lead .NET, 3-4 dev).
+> **Objectif sprint** : fondations techniques opérables + 1 ADR cadre validé.
+> **Statut** : proposition initiale — à valider avec le sponsor et le lead .NET avant lancement.
+
+## Pré-requis (avant J0)
+
+- [x] Arbitrage des questions §8 `doc/discovery.md` (décidé 2026-04-20 — voir ADR-0011 pour la stratégie BPMN + External Task + Idempotence)
+- [ ] Identification du sponsor métier Ingest média (cible Sprint 1)
+- [ ] Validation accès DSI Mediawan : provision Keycloak realm, Vault instance, runners GH Actions (self-hosted si exigé)
+
+## Milestones mesurables
+
+| # | Milestone | Critère d'acceptation | Jour |
+| --- | --- | --- | --- |
+| M1 | `doc/discovery.md` signé | Lead .NET + sponsor ont commenté/validé | **J1** |
+| M2 | Questions §8 arbitrées | Les 11 cases ont une décision écrite dans un ADR ou dans `doc/discovery.md` | **J2** |
+| M3 | Docker Compose `dev` local opérationnel | `docker compose up` → postgres 16 + redis 7 + Elsa.Server.Web joignable ; requête GET `/workflows` répond 200 | **J4** |
+| M4 | CI GitHub Actions build + tests unitaires | Badge vert sur `main`, temps build < 10 min | **J5** |
+| M5 | Global query filter multi-tenant en place | Test d'intégration prouvant qu'une requête cross-tenant retourne 0 row ; ADR-0011 bis publié | **J7** |
+| M6 | `ADR-0011 Stratégie BPMN + External Task + Idempotence` | ADR validé par lead .NET, statut `Accepté` | **J8** |
+| M7 | `ARCHITECTURE.md` + `CONVENTIONS.md` rédigés | PR mergée, référencés depuis `CLAUDE.md` | **J9** |
+| M8 | Scan SAST dans la CI | Au moins 1 run complet (SonarCloud ou équivalent) visible sur une PR | **J10** |
+
+## Découpage par sprint
+
+### Sprint 1 (J1-J5) — Cartographie & infra dev
+
+**Focus** : tout le monde sait lancer le projet localement, la CI tourne, la convention ADR est claire.
+
+| Epic | Tâches | Owner | Estim |
+| --- | --- | --- | --- |
+| **E1.1 Onboarding** | Revue `doc/discovery.md` + `CLAUDE.md`, arbitrages §8, mise à jour CLAUDE.md (runtime réel, `doc/adr/`, docker existant), README onboarding dédié Mediawan | Lead | 0.5j |
+| **E1.2 Docker Compose dev** | Dériver `docker/docker-compose.yml` upstream → `docker/docker-compose.dev.yml` : **PG 16 + Redis 7 + RabbitMQ (management) + Keycloak + Vault (dev mode) + smtp4dev + Elsa.Server.Web**. Realm Keycloak pré-provisionné `mediawan-workflow`. Script `scripts/dev-up.sh` + `scripts/dev-down.sh`. Validation manuelle J4. | Dev #1 | 2.5j |
+| **E1.3 CI GitHub Actions** | Workflow `.github/workflows/ci-mediawan.yml` : build + tests unitaires + upload coverage. Cache NuGet. Badge dans README. | Dev #2 | 1.5j |
+| **E1.4 Pré-checks sécurité** | GitHub Dependabot activé, détection secrets (gitleaks ou TruffleHog), revue des 10 ADR existants | Dev #3 | 1j |
+| **E1.5 Convention docs** | Aligner CLAUDE.md + `.claude/commands/adr.md` + `.claude/skills/adr-writer/` sur `doc/adr/`. Éditer le numéro de départ (0011). | Dev #3 | 0.5j |
+
+**Livrables Sprint 1** : M1, M2, M3, M4 + premier commit convention aligné.
+
+### Sprint 2 (J6-J10) — Multi-tenant, ADR cadre, docs
+
+**Focus** : verrouiller la sécurité multi-tenant avant de produire du code, formaliser la stratégie BPMN / External Task.
+
+| Epic | Tâches | Owner | Estim |
+| --- | --- | --- | --- |
+| **E2.1 Global query filter tenant** | Identifier les `DbContext` Elsa (`ElsaDbContextBase`) ; ajouter `HasQueryFilter(e => e.TenantId == _currentTenant)` via `IEntityTypeConfiguration` custom enregistré dans une feature Mediawan. Tests d'intégration dédiés (Testcontainers PG). | Lead + Dev #1 | 3j |
+| **E2.2 ADR-0011 BPMN + External Task + Idempotence** | Draft ADR : stratégie parseur BPMN (librairie tierce vs maison), format `jobKey` (UUID v7), schéma `idempotency_keys`, positionnement vis-à-vis de `RunTask`/`ITaskDispatcher`. Revue asynchrone. | Lead | 2j |
+| **E2.3 `ARCHITECTURE.md` + `CONVENTIONS.md`** | Vue d'ensemble : modules, pipelines, pattern d'extension. Conventions : branching, commits, nullable, tests, logging structuré, observabilité. | Dev #2 + Dev #3 | 2j |
+| **E2.4 Scan SAST CI** | Intégrer Sonar Cloud (ou GitHub CodeQL) dans le workflow CI — premier run, baseline de dette. | Dev #4 | 1.5j |
+| **E2.5 Synchro upstream N°1** | Exécuter `/sync-upstream` avec les 3 commits Elsa en retard (cf. discovery §6). Valider tests verts, PR `upstream-sync`. | Dev #1 | 1j |
+
+**Livrables Sprint 2** : M5, M6, M7, M8 + branche `elsa-sync` merged.
+
+## Capacité & buffer
+
+- **Capacité brute** : 5 dev × 10j × 0.8 (meetings/imprévus) = **40 jours·homme**
+- **Estimation tâches ci-dessus** : ~18 jours·homme
+- **Buffer** : ~22 j·h → couvre imprévus infra (DSI, accès Vault, droits Azure AD), exploration complémentaire, premier pairing Claude Code <-> dev Mediawan
+
+## Risques identifiés
+
+| Risque | Proba | Impact | Mitigation |
+| --- | --- | --- | --- |
+| Accès DSI (Vault, Azure AD) pas obtenu à temps | Moyenne | Bloque Sprints 3-4 (auth OIDC) | Déposer la demande au J1, escalade sponsor si pas de réponse J5 |
+| Divergence récurrente avec upstream Elsa | Faible aujourd'hui | Croît avec chaque modif custom core | Règle : modifs custom uniquement dans `Mediawan.*` (cf. `.claude/rules/elsa-core.md`), ADR obligatoire sinon |
+| Global query filter casse des features Elsa existantes | Moyenne | Régressions tests intégration | Mettre le filter **opt-in** via une feature flag dans le module Mediawan ; tester sur la suite xUnit complète avant merge |
+| Décision tardive Dapr / SDK Worker | Moyenne | Retarde Sprint 5-6 | Le trancher au plus tard à la revue Sprint 2 (ADR dédié) |
+
+## Hors scope Sprints 1-2
+
+- Implémentation du parseur BPMN (Sprint 3-4 minimum)
+- SDK Worker External Task (Sprint 5-6)
+- Connecteurs built-in (Sprint 7-8)
+- Audit log append-only + Grafana (Sprint 9)
+- Process métier pilote (Sprint 10)
+- Kubernetes (Phase 2)
+
+## Checkpoints
+
+- **Daily** (15 min, 9:30) : tour de table équipe
+- **Mid-sprint review** (J5, 1h) : démo M3/M4, replanif Sprint 2 si dérive
+- **Sprint review** (J10, 1h30) : démo livrables avec sponsor
+- **Retro** (J10, 45 min) : après la review


### PR DESCRIPTION
## Summary

Livrable de la séquence `/discovery` (§8 CLAUDE.md) — cartographie du fork, plan Sprint 1-2, et **12 arbitrages de cadrage** pris le 2026-04-20, matérialisés par un ADR cadre.

### Ce qui est livré

- **`doc/discovery.md`** — cartographie repo, points d'extension Elsa (via agent `elsa-explorer`), tests existants (22 projets, 458 .cs, xUnit+Moq+Coverlet), divergences upstream (fork purement additif), 3 gaps critiques §3, 14 décisions §8 cochées
- **`doc/sprint-plan-1-2.md`** — 8 milestones datés sur 10 j.o, épics par sprint (E1.1-E1.5 / E2.1-E2.5) avec owners et estimations, risques mitigés
- **`doc/adr/0011-strategie-bpmn-external-task-idempotence.md`** — ADR cadre statut `Proposé` pour les 3 gaps : parseur BPMN + whitelist (Sprint 3-4), SDK Worker External Task + `jobKey` UUID v7 (Sprint 5-6), table `idempotency_keys` partitionnée (Sprint 9)
- **`CLAUDE.md`** — §5 stack alignée avec décisions (`net10.0`, on-prem VMs, Keycloak + RabbitMQ + Vault, Dapr écarté, GH Actions, PostgreSQL seul) ; §6 paths ADR corrigés (`doc/adr/`) ; §9 questions cochées
- **`.claude/commands/adr.md`** + **`.claude/skills/adr-writer/SKILL.md`** — alignement `docs/adr/` → `doc/adr/`, prochain numéro = **0011**

### Décisions arbitrées (cf. `doc/discovery.md` §8)

| # | Décision |
| --- | --- |
| 1 | Runtime .NET : **`net10.0` uniforme** |
| 2 | Dossier ADR : **`doc/adr/`** (10 ADR Elsa existants, prochain = 0011) |
| 3 | CI/CD : **GitHub Actions** |
| 4 | Global query filter tenant : **Sprint 1-2 urgent** |
| 5 | Base prod : **PostgreSQL 16 seul** |
| 6 | Hébergement : **on-premise VMs Mediawan** |
| 7 | Sidecar : **Dapr écarté en Phase 1** — intégrations natives |
| 8 | Testcontainers : **Mediawan-only** (pas d'impact upstream) |
| 9 | Nom : **Mediawan Workflow Platform** |
| 10 | Support Elsa : **autonomie complète** |
| 11 | Pilote : **Ingest média** (sponsor à identifier Sprint 1) |
| 12 | Stack on-prem : **Keycloak + RabbitMQ + Vault** |

### Trois gaps critiques identifiés (§3 CLAUDE.md)

1. **Parseur BPMN absent** du fork → à construire (Sprint 3-4, couvert par ADR-0011)
2. **External Task partiel** (`RunTask`/`ITaskDispatcher` OK, mais `jobKey` stable + heartbeat + idempotence absents) → SDK Worker Sprint 5-6
3. **Multi-tenant sans global query filter EF** → **risque sécurité RSSI, traité Sprint 1-2 E2.1**

## Test plan

- [ ] Relecture `doc/discovery.md` — la cartographie correspond à l'état du fork
- [ ] Relecture `doc/sprint-plan-1-2.md` — milestones réalistes pour une équipe de 4-5 dev
- [ ] **Validation ADR-0011** par le lead .NET (choix librairie BPMN, schéma `idempotency_keys` partitionné) — passage au statut `Accepté`
- [ ] Vérifier que CLAUDE.md est cohérent : `net10.0`, `doc/adr/`, on-prem, RabbitMQ, Keycloak, Vault
- [ ] Vérifier que `/adr <titre>` crée bien un fichier dans `doc/adr/0011-...` (ou supérieur si ADR-0011 mergé avant)
- [ ] Identifier le sponsor métier Ingest média avant fin Sprint 1 (bloquant pour Sprint 10)

## Ce qui reste ouvert (§8bis discovery)

- Sponsor métier Ingest média — à identifier Sprint 1
- Accès DSI : provision Vault / Keycloak realm / éventuels runners GH self-hosted
- Stratégie backup/DR PostgreSQL prod — ADR dédié avant go-live préprod