### PR TITLE
fixed outcome issue when subclassing FlowSendHttpRequest #7407

### DIFF
--- a/src/modules/Elsa.Http/Activities/FlowSendHttpRequest.cs
+++ b/src/modules/Elsa.Http/Activities/FlowSendHttpRequest.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using Elsa.Extensions;
 using Elsa.Workflows;
+using Elsa.Workflows.Activities.Flowchart.Attributes;
 using Elsa.Workflows.Attributes;
 using Elsa.Workflows.UIHints;
 using Elsa.Workflows.Models;
@@ -12,6 +13,7 @@ namespace Elsa.Http;
 /// Send an HTTP request.
 /// </summary>
 [Activity("Elsa", "HTTP", "Send an HTTP request.", DisplayName = "HTTP Request (flow)", Kind = ActivityKind.Task)]
+[FlowNode("Done", "Unmatched status code", "Failed to connect", "Timeout")]
 public class FlowSendHttpRequest : SendHttpRequestBase, IActivityPropertyDefaultValueProvider
 {
     /// <inheritdoc />

--- a/src/modules/Elsa.Http/Features/HttpFeature.cs
+++ b/src/modules/Elsa.Http/Features/HttpFeature.cs
@@ -197,6 +197,9 @@ public class HttpFeature(IModule module) : FeatureBase(module)
             // Port resolvers.
             .AddScoped<IActivityResolver, SendHttpRequestActivityResolver>()
 
+            // Activity descriptor modifiers.
+            .AddScoped<IActivityDescriptorModifier, FlowSendHttpRequestDescriptorModifier>()
+
             // HTTP endpoint handlers.
             .AddScoped<AuthenticationBasedHttpEndpointAuthorizationHandler>()
             .AddScoped<AllowAnonymousHttpEndpointAuthorizationHandler>()

--- a/src/modules/Elsa.Http/Modifiers/FlowSendHttpRequestDescriptorModifier.cs
+++ b/src/modules/Elsa.Http/Modifiers/FlowSendHttpRequestDescriptorModifier.cs
@@ -14,7 +14,7 @@ public class FlowSendHttpRequestDescriptorModifier : IActivityDescriptorModifier
     /// <inheritdoc />
     public void Modify(ActivityDescriptor descriptor)
     {
-        if (!typeof(FlowSendHttpRequest).IsAssignableFrom(descriptor.ClrType))
+        if (!descriptor.ClrType.IsAssignableTo(typeof(FlowSendHttpRequest)))
             return;
 
         var statusCodesInput = descriptor.Inputs.FirstOrDefault(x => x.Name == nameof(FlowSendHttpRequest.ExpectedStatusCodes));

--- a/src/modules/Elsa.Http/Modifiers/FlowSendHttpRequestDescriptorModifier.cs
+++ b/src/modules/Elsa.Http/Modifiers/FlowSendHttpRequestDescriptorModifier.cs
@@ -1,0 +1,38 @@
+using Elsa.Workflows;
+using Elsa.Workflows.Models;
+
+namespace Elsa.Http;
+
+/// <summary>
+/// Adds dynamic flow ports for each configured <see cref="FlowSendHttpRequest.ExpectedStatusCodes"/> default value.
+/// Static ports (Done, Unmatched status code, Failed to connect, Timeout) are already declared via <see cref="Elsa.Workflows.Activities.Flowchart.Attributes.FlowNodeAttribute"/>.
+/// This modifier ensures that the default status-code ports (e.g. "200") are visible in the designer for
+/// <see cref="FlowSendHttpRequest"/> and any subclass.
+/// </summary>
+public class FlowSendHttpRequestDescriptorModifier : IActivityDescriptorModifier
+{
+    /// <inheritdoc />
+    public void Modify(ActivityDescriptor descriptor)
+    {
+        if (!typeof(FlowSendHttpRequest).IsAssignableFrom(descriptor.ClrType))
+            return;
+
+        var statusCodesInput = descriptor.Inputs.FirstOrDefault(x => x.Name == nameof(FlowSendHttpRequest.ExpectedStatusCodes));
+        if (statusCodesInput?.DefaultValue is not IEnumerable<int> defaultCodes)
+            return;
+
+        foreach (var statusCode in defaultCodes)
+        {
+            var portName = statusCode.ToString();
+            if (descriptor.Ports.All(p => p.Name != portName))
+            {
+                descriptor.Ports.Add(new Port
+                {
+                    Type = PortType.Flow,
+                    Name = portName,
+                    DisplayName = portName
+                });
+            }
+        }
+    }
+}

--- a/src/modules/Elsa.Http/ShellFeatures/HttpFeature.cs
+++ b/src/modules/Elsa.Http/ShellFeatures/HttpFeature.cs
@@ -174,6 +174,9 @@ public class HttpFeature : IMiddlewareShellFeature
             // Port resolvers.
             .AddScoped<IActivityResolver, SendHttpRequestActivityResolver>()
 
+            // Activity descriptor modifiers.
+            .AddScoped<IActivityDescriptorModifier, FlowSendHttpRequestDescriptorModifier>()
+
             // HTTP endpoint handlers.
             .AddScoped<AuthenticationBasedHttpEndpointAuthorizationHandler>()
             .AddScoped<AllowAnonymousHttpEndpointAuthorizationHandler>()

--- a/test/unit/Elsa.Http.UnitTests/Activities/FlowSendHttpRequestTests.cs
+++ b/test/unit/Elsa.Http.UnitTests/Activities/FlowSendHttpRequestTests.cs
@@ -1,0 +1,158 @@
+using System.Reflection;
+using Elsa.Workflows;
+using Elsa.Workflows.Activities.Flowchart.Attributes;
+using Elsa.Workflows.Models;
+
+namespace Elsa.Http.UnitTests.Activities;
+
+/// <summary>
+/// Tests for <see cref="FlowSendHttpRequest"/> port/outcome declaration and descriptor modification.
+/// Regression coverage for https://github.com/elsa-workflows/elsa-core/issues/7407 — subclassing
+/// FlowSendHttpRequest should expose the same outcomes as the base class.
+/// </summary>
+public class FlowSendHttpRequestTests
+{
+    private static readonly string[] ExpectedStaticOutcomes =
+    [
+        "Done",
+        "Unmatched status code",
+        "Failed to connect",
+        "Timeout"
+    ];
+
+    [Fact]
+    public void FlowSendHttpRequest_HasFlowNodeAttribute_WithExpectedOutcomes()
+    {
+        var attr = typeof(FlowSendHttpRequest).GetCustomAttribute<FlowNodeAttribute>(inherit: false);
+
+        Assert.NotNull(attr);
+        foreach (var outcome in ExpectedStaticOutcomes)
+            Assert.Contains(outcome, attr.Outcomes);
+    }
+
+    [Fact]
+    public void SubclassOfFlowSendHttpRequest_InheritsFlowNodeAttribute()
+    {
+        // The attribute must be discoverable on the subclass type without the subclass
+        // redeclaring it, so that ActivityDescriber (which calls GetCustomAttribute with
+        // inherit:true) picks it up automatically.
+        var attr = typeof(CustomFlowSendHttpRequest).GetCustomAttribute<FlowNodeAttribute>(inherit: true);
+
+        Assert.NotNull(attr);
+        foreach (var outcome in ExpectedStaticOutcomes)
+            Assert.Contains(outcome, attr.Outcomes);
+    }
+
+    [Fact]
+    public void SubclassOfFlowSendHttpRequest_HasNoOwnFlowNodeAttribute()
+    {
+        // The subclass should NOT re-declare [FlowNode] — it inherits it from the base class.
+        // This test guards against accidentally hiding the base attribute.
+        var ownAttr = typeof(CustomFlowSendHttpRequest).GetCustomAttribute<FlowNodeAttribute>(inherit: false);
+        Assert.Null(ownAttr);
+    }
+
+    [Fact]
+    public void Modifier_AddsDefaultStatusCodePort_ForFlowSendHttpRequest()
+    {
+        var descriptor = BuildDescriptor(typeof(FlowSendHttpRequest), new List<int> { 200 });
+        var modifier = new FlowSendHttpRequestDescriptorModifier();
+
+        modifier.Modify(descriptor);
+
+        Assert.Contains(descriptor.Ports, p => p.Name == "200" && p.Type == PortType.Flow);
+    }
+
+    [Fact]
+    public void Modifier_AddsMultipleStatusCodePorts_WhenMultipleDefaultsConfigured()
+    {
+        var descriptor = BuildDescriptor(typeof(FlowSendHttpRequest), new List<int> { 200, 404, 500 });
+        var modifier = new FlowSendHttpRequestDescriptorModifier();
+
+        modifier.Modify(descriptor);
+
+        Assert.Contains(descriptor.Ports, p => p.Name == "200" && p.Type == PortType.Flow);
+        Assert.Contains(descriptor.Ports, p => p.Name == "404" && p.Type == PortType.Flow);
+        Assert.Contains(descriptor.Ports, p => p.Name == "500" && p.Type == PortType.Flow);
+    }
+
+    [Fact]
+    public void Modifier_DoesNotAddDuplicatePort_WhenStatusCodePortAlreadyExists()
+    {
+        var descriptor = BuildDescriptor(typeof(FlowSendHttpRequest), new List<int> { 200 });
+        descriptor.Ports.Add(new Port { Name = "200", Type = PortType.Flow });
+        var modifier = new FlowSendHttpRequestDescriptorModifier();
+
+        modifier.Modify(descriptor);
+
+        Assert.Single(descriptor.Ports, p => p.Name == "200");
+    }
+
+    [Fact]
+    public void Modifier_AddsStatusCodePort_ForSubclassOfFlowSendHttpRequest()
+    {
+        var descriptor = BuildDescriptor(typeof(CustomFlowSendHttpRequest), new List<int> { 201 });
+        var modifier = new FlowSendHttpRequestDescriptorModifier();
+
+        modifier.Modify(descriptor);
+
+        Assert.Contains(descriptor.Ports, p => p.Name == "201" && p.Type == PortType.Flow);
+    }
+
+    [Fact]
+    public void Modifier_DoesNotModify_WhenActivityIsNotFlowSendHttpRequest()
+    {
+        var descriptor = BuildDescriptor(typeof(UnrelatedActivity), null);
+        var originalPortCount = descriptor.Ports.Count;
+        var modifier = new FlowSendHttpRequestDescriptorModifier();
+
+        modifier.Modify(descriptor);
+
+        Assert.Equal(originalPortCount, descriptor.Ports.Count);
+    }
+
+    [Fact]
+    public void Modifier_DoesNotModify_WhenExpectedStatusCodesInputMissing()
+    {
+        var descriptor = new ActivityDescriptor { ClrType = typeof(FlowSendHttpRequest) };
+        var modifier = new FlowSendHttpRequestDescriptorModifier();
+
+        modifier.Modify(descriptor);
+
+        Assert.Empty(descriptor.Ports);
+    }
+
+    [Fact]
+    public void Modifier_DoesNotModify_WhenDefaultValueIsNull()
+    {
+        var descriptor = BuildDescriptor(typeof(FlowSendHttpRequest), null);
+        var modifier = new FlowSendHttpRequestDescriptorModifier();
+
+        modifier.Modify(descriptor);
+
+        Assert.Empty(descriptor.Ports);
+    }
+
+    // ---- helpers ----
+
+    private static ActivityDescriptor BuildDescriptor(Type activityType, ICollection<int>? defaultStatusCodes)
+    {
+        var descriptor = new ActivityDescriptor { ClrType = activityType };
+
+        descriptor.Inputs.Add(new InputDescriptor
+        {
+            Name = nameof(FlowSendHttpRequest.ExpectedStatusCodes),
+            DefaultValue = defaultStatusCodes
+        });
+
+        return descriptor;
+    }
+
+    // Minimal subclass — no [FlowNode] redeclaration, replicating what a user would write.
+    private class CustomFlowSendHttpRequest : FlowSendHttpRequest;
+
+    private class UnrelatedActivity : Activity
+    {
+        protected override ValueTask ExecuteAsync(ActivityExecutionContext context) => ValueTask.CompletedTask;
+    }
+}


### PR DESCRIPTION
## Purpose

Fixes subclasses of FlowSendHttpRequest showing only the "Done" outcome in the Studio designer by declaring flow ports on the base class so they are inherited automatically.
---

## Scope

Select one primary concern:

- [x] Bug fix (behavior change)
- [ ] Refactor (no behavior change)
- [ ] Documentation update
- [ ] Formatting / code cleanup
- [ ] Dependency / build update
- [ ] New feature

> If this PR includes multiple unrelated concerns, please split it before requesting review.

---

## Description

### Problem
When subclassing FlowSendHttpRequest (e.g. class MyFlowSendHttpRequest : FlowSendHttpRequest), the Elsa Studio designer only showed a single "Done" outcome port. The expected ports — "Done", "Unmatched status code", "Failed to connect", "Timeout", and the configured status-code ports (e.g. "200") — were all missing.

The root cause is that FlowSendHttpRequest had no [FlowNode] attribute. ActivityDescriber.DescribeActivityAsync uses GetCustomAttribute<FlowNodeAttribute>(inherit: true) to build the Ports collection in the activity descriptor. Without the attribute on the base class, every subclass registered under its own type name received zero flow ports. The Studio hardcodes "Done" as a fallback, which is why only that one outcome appeared.

### Solution
Solution
Added [FlowNode("Done", "Unmatched status code", "Failed to connect", "Timeout")] to FlowSendHttpRequest. Because FlowNodeAttribute has Inherited = true (the default) and ActivityDescriber calls GetCustomAttribute with inherit: true, all subclasses automatically inherit these ports without needing to redeclare the attribute.

Added FlowSendHttpRequestDescriptorModifier (IActivityDescriptorModifier) that detects any type assignable to FlowSendHttpRequest and appends flow ports for each status code present in the ExpectedStatusCodes input's default value. This ensures the default "200" port (and any other default codes a subclass declares) is visible at design time.

Registered the modifier in both HttpFeature and ShellFeatures/HttpFeature.

## Verification
Steps:

Create a subclass of FlowSendHttpRequest in your project: public class MyFlowSendHttpRequest : FlowSendHttpRequest { }
Register it and open Elsa Studio.
Add the custom activity to a Flowchart workflow.
Expected outcome: The activity node shows "Done", "Unmatched status code", "Failed to connect", "Timeout", and "200" outcome ports — identical to the built-in FlowSendHttpRequest.


## Screenshots / Recordings (if applicable)

<!-- Required for UI changes -->

---

## Commit Convention

We recommend using conventional commit prefixes:

- `fix:` – Bug fixes (behavior change)
- `feat:` – New features
- `refactor:` – Code changes without behavior change
- `docs:` – Documentation updates
- `chore:` – Maintenance, tooling, or dependency updates
- `test:` – Test additions or modifications

Clear commit messages make reviews easier and history more meaningful.

---

## Checklist

- [x] The PR is focused on a single concern
- [x] Commit messages follow the recommended convention
- [x] Tests added or updated (if applicable)
- [ ] Documentation updated (if applicable)
- [x] No unrelated cleanup included
- [x] All tests pass
