### PR TITLE
fix: do not resume interrupted workflows that are already finished

### DIFF
--- a/src/modules/Elsa.Workflows.Runtime/Tasks/RestartInterruptedWorkflowsTask.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Tasks/RestartInterruptedWorkflowsTask.cs
@@ -63,7 +63,8 @@ public class RestartInterruptedWorkflowsTask(
         return new()
         {
             IsExecuting = true,
-            BeforeLastUpdated = cutoffTimestamp
+            BeforeLastUpdated = cutoffTimestamp,
+            WorkflowStatus = WorkflowStatus.Running,
         };
     }
 }

--- a/test/integration/Elsa.Workflows.IntegrationTests/GracefulShutdown/RestartInterruptedWorkflowsTests.cs
+++ b/test/integration/Elsa.Workflows.IntegrationTests/GracefulShutdown/RestartInterruptedWorkflowsTests.cs
@@ -1,0 +1,82 @@
+﻿using Elsa.Extensions;
+using Elsa.Testing.Shared;
+using Elsa.Workflows.Management;
+using Elsa.Workflows.Management.Entities;
+using Elsa.Workflows.Runtime;
+using Elsa.Workflows.Runtime.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit.Abstractions;
+
+namespace Elsa.Workflows.IntegrationTests.GracefulShutdown;
+
+/// <summary>
+/// Integration tests for the <see cref="RestartInterruptedWorkflowsTask" />
+/// </summary>
+public class RestartInterruptedWorkflowsTests
+{
+    private readonly IServiceProvider _services;
+
+    public RestartInterruptedWorkflowsTests(ITestOutputHelper testOutputHelper)
+    {
+        _services = new TestApplicationBuilder(testOutputHelper)
+            .ConfigureElsa(elsa => elsa.UseWorkflowRuntime())
+            .Build();
+    }
+
+    [Fact(DisplayName = "Task ignores instances NOT Interrupted")]
+    public async Task Filter()
+    {
+        var fakeRestarter = new RecordingRestarter();
+        using var scope = _services.CreateScope();
+        var instanceStore = scope.ServiceProvider.GetRequiredService<IWorkflowInstanceStore>();
+
+        await SeedInstancesAsync(instanceStore, 3, WorkflowStatus.Running, WorkflowSubStatus.Executing, isExecuting: true, idPrefix: "stale-");
+        await SeedInstancesAsync(instanceStore, 2, WorkflowStatus.Finished, WorkflowSubStatus.Executing, isExecuting: true, idPrefix: "finished-stale-");
+        await SeedInstancesAsync(instanceStore, 1, WorkflowStatus.Finished, WorkflowSubStatus.Executing, isExecuting: false, idPrefix: "finished-");
+
+        var scanner = ActivatorUtilities.CreateInstance<RestartInterruptedWorkflowsTask>(scope.ServiceProvider, fakeRestarter);
+        await scanner.ExecuteAsync(CancellationToken.None);
+
+        Assert.Equal(3, fakeRestarter.RestartedIds.Count);
+        Assert.All(fakeRestarter.RestartedIds, id => Assert.StartsWith("stale-", id));
+    }
+
+    private static async Task SeedInstancesAsync(IWorkflowInstanceStore store, int count, WorkflowStatus status, WorkflowSubStatus subStatus, bool isExecuting, string idPrefix = "instance-")
+    {
+        for (var i = 0; i < count; i++)
+        {
+            await store.SaveAsync(new WorkflowInstance
+            {
+                Id = $"{idPrefix}{i}",
+                DefinitionId = "def-1",
+                DefinitionVersionId = "ver-1",
+                Version = 1,
+                Status = status,
+                SubStatus = subStatus,
+                IsExecuting = isExecuting,
+                CreatedAt = DateTimeOffset.Parse("2026-04-13T12:00:00Z"),
+                UpdatedAt = DateTimeOffset.Parse("2026-04-13T12:00:00Z"),
+                WorkflowState = new State.WorkflowState
+                {
+                    Id = $"{idPrefix}{i}",
+                    DefinitionId = "def-1",
+                    DefinitionVersionId = "ver-1",
+                    Status = status,
+                    SubStatus = subStatus,
+                },
+            }, CancellationToken.None);
+        }
+    }
+
+    /// <summary>Captures restart calls without actually invoking the workflow runtime — keeps the integration test focused.</summary>
+    private sealed class RecordingRestarter : IWorkflowRestarter
+    {
+        public List<string> RestartedIds { get; } = [];
+
+        public Task RestartWorkflowAsync(string workflowInstanceId, CancellationToken cancellationToken = default)
+        {
+            RestartedIds.Add(workflowInstanceId);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/test/integration/Elsa.Workflows.IntegrationTests/GracefulShutdown/RestartInterruptedWorkflowsTests.cs
+++ b/test/integration/Elsa.Workflows.IntegrationTests/GracefulShutdown/RestartInterruptedWorkflowsTests.cs
@@ -1,10 +1,13 @@
-﻿using Elsa.Extensions;
+﻿using Elsa.Common;
+using Elsa.Extensions;
 using Elsa.Testing.Shared;
 using Elsa.Workflows.Management;
 using Elsa.Workflows.Management.Entities;
 using Elsa.Workflows.Runtime;
+using Elsa.Workflows.Runtime.Options;
 using Elsa.Workflows.Runtime.Tasks;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Xunit.Abstractions;
 
 namespace Elsa.Workflows.IntegrationTests.GracefulShutdown;
@@ -29,10 +32,11 @@ public class RestartInterruptedWorkflowsTests
         var fakeRestarter = new RecordingRestarter();
         using var scope = _services.CreateScope();
         var instanceStore = scope.ServiceProvider.GetRequiredService<IWorkflowInstanceStore>();
+        var staleTimestamp = GetStaleTimestamp(scope.ServiceProvider);
 
-        await SeedInstancesAsync(instanceStore, 3, WorkflowStatus.Running, WorkflowSubStatus.Executing, isExecuting: true, idPrefix: "stale-");
-        await SeedInstancesAsync(instanceStore, 2, WorkflowStatus.Finished, WorkflowSubStatus.Executing, isExecuting: true, idPrefix: "finished-stale-");
-        await SeedInstancesAsync(instanceStore, 1, WorkflowStatus.Finished, WorkflowSubStatus.Executing, isExecuting: false, idPrefix: "finished-");
+        await SeedInstancesAsync(instanceStore, 3, WorkflowStatus.Running, WorkflowSubStatus.Executing, isExecuting: true, idPrefix: "stale-", timestamp: staleTimestamp);
+        await SeedInstancesAsync(instanceStore, 2, WorkflowStatus.Finished, WorkflowSubStatus.Executing, isExecuting: true, idPrefix: "finished-stale-", timestamp: staleTimestamp);
+        await SeedInstancesAsync(instanceStore, 1, WorkflowStatus.Finished, WorkflowSubStatus.Executing, isExecuting: false, idPrefix: "finished-", timestamp: staleTimestamp);
 
         var scanner = ActivatorUtilities.CreateInstance<RestartInterruptedWorkflowsTask>(scope.ServiceProvider, fakeRestarter);
         await scanner.ExecuteAsync(CancellationToken.None);
@@ -41,8 +45,17 @@ public class RestartInterruptedWorkflowsTests
         Assert.All(fakeRestarter.RestartedIds, id => Assert.StartsWith("stale-", id));
     }
 
-    private static async Task SeedInstancesAsync(IWorkflowInstanceStore store, int count, WorkflowStatus status, WorkflowSubStatus subStatus, bool isExecuting, string idPrefix = "instance-")
+    private static DateTimeOffset GetStaleTimestamp(IServiceProvider serviceProvider)
     {
+        var clock = serviceProvider.GetRequiredService<ISystemClock>();
+        var options = serviceProvider.GetRequiredService<IOptions<RuntimeOptions>>().Value;
+        return clock.UtcNow - options.InactivityThreshold - TimeSpan.FromMinutes(1);
+    }
+
+    private static async Task SeedInstancesAsync(IWorkflowInstanceStore store, int count, WorkflowStatus status, WorkflowSubStatus subStatus, bool isExecuting, string idPrefix = "instance-", DateTimeOffset? timestamp = null)
+    {
+        var createdAt = timestamp ?? DateTimeOffset.UtcNow;
+
         for (var i = 0; i < count; i++)
         {
             await store.SaveAsync(new WorkflowInstance
@@ -54,8 +67,8 @@ public class RestartInterruptedWorkflowsTests
                 Status = status,
                 SubStatus = subStatus,
                 IsExecuting = isExecuting,
-                CreatedAt = DateTimeOffset.Parse("2026-04-13T12:00:00Z"),
-                UpdatedAt = DateTimeOffset.Parse("2026-04-13T12:00:00Z"),
+                CreatedAt = createdAt,
+                UpdatedAt = createdAt,
                 WorkflowState = new State.WorkflowState
                 {
                     Id = $"{idPrefix}{i}",


### PR DESCRIPTION
## Purpose

Prevent restarting interrupted but finished workflows that have IsExecuting = 1 but WorkflowStatus = Finished. Currently these end up in a infinite restart cycle.

---

## Scope

Select one primary concern:

- [x] Bug fix (behavior change)
- [ ] Refactor (no behavior change)
- [ ] Documentation update
- [ ] Formatting / code cleanup
- [ ] Dependency / build update
- [ ] New feature

> If this PR includes multiple unrelated concerns, please split it before requesting review.

---

## Description

### Problem
This solves an infinite restart of interrupted workflows that ended up in a semi-invalid state.

### Solution
Extend the filter for the restart to ignore finished workflows

---

## Commit Convention

We recommend using conventional commit prefixes:

- `fix:` – Bug fixes (behavior change)
- `feat:` – New features
- `refactor:` – Code changes without behavior change
- `docs:` – Documentation updates
- `chore:` – Maintenance, tooling, or dependency updates
- `test:` – Test additions or modifications

Clear commit messages make reviews easier and history more meaningful.

---

## Checklist

- [x] The PR is focused on a single concern
- [x] Commit messages follow the recommended convention
- [x] Tests added or updated (if applicable)
- [x] Documentation updated (if applicable)
- [x] No unrelated cleanup included
- [x] All tests pass
