### PR TITLE
[codex] Add structured log SQLite persistence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,7 @@ Before handing off changes, verify the following when applicable:
 
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
-shell commands, and other important information, read `specs/004-diagnostics-structured-logs/plan.md`.
+shell commands, and other important information, read `specs/005-structured-log-persistence/plan.md`.
 <!-- SPECKIT END -->
 
 ## Active Technologies
@@ -91,7 +91,10 @@ shell commands, and other important information, read `specs/004-diagnostics-str
 - Bounded in-memory ring buffer for MVP; no EF Core schema changes. Provider abstraction allows external/shared log backends later. (003-live-server-logs)
 - C# latest, nullable reference types enabled, implicit usings enabled. + `Microsoft.Extensions.Logging`, `Microsoft.Extensions.Options`, `Microsoft.AspNetCore.SignalR`, Elsa feature/module infrastructure, FastEndpoints through Elsa API endpoint patterns, CShells shell feature infrastructure. (004-diagnostics-structured-logs)
 - Existing bounded in-memory ring buffer; no EF Core schema changes. Provider abstraction remains available for future shared backends. (004-diagnostics-structured-logs)
+- C# latest, nullable reference types enabled, implicit usings enabled. + Existing `Elsa.Diagnostics.StructuredLogs`, `Microsoft.Extensions.Logging`, `Microsoft.Extensions.Options`, `Microsoft.AspNetCore.SignalR`, Elsa feature/module infrastructure, FastEndpoints through Elsa API endpoint patterns, FluentMigrator runner packages, SQLite ADO.NET provider, and optionally Dapper for relational operations. (005-structured-log-persistence)
+- Bounded in-memory store by default; opt-in SQLite durable store through shared relational persistence. SQLite stores `Timestamp` and `ReceivedAt` as UTC ISO-8601 text and stores exception, scope, and property payloads as JSON text. (005-structured-log-persistence)
 
 ## Recent Changes
+- 005-structured-log-persistence: Plans pluggable structured log storage with in-memory default and opt-in SQLite persistence using FluentMigrator.
 - 004-diagnostics-structured-logs: Refactors the unpublished server logs module into diagnostics structured logs and preserves bounded structured `ILogger` capture.
 - 003-live-server-logs: Added C# latest, nullable reference types enabled, implicit usings enabled. + `Microsoft.Extensions.Logging`, `Microsoft.AspNetCore.SignalR`, Elsa feature/module infrastructure, FastEndpoints through Elsa API endpoint patterns, existing Elsa identity/authorization features.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -113,6 +113,8 @@
         <PackageVersion Include="Elastic.Clients.Elasticsearch" Version="9.2.2"/>
         <PackageVersion Include="FluentStorage" Version="6.0.0"/>
         <PackageVersion Include="FluentStorage.Azure.Blobs" Version="6.0.0"/>
+        <PackageVersion Include="FluentMigrator.Runner" Version="8.0.1"/>
+        <PackageVersion Include="FluentMigrator.Runner.SQLite" Version="8.0.1"/>
         <PackageVersion Include="Fluid.Core" Version="2.31.0"/>
         <PackageVersion Include="Fody" Version="6.9.3" PrivateAssets="All"/>
         <PackageVersion Include="GitHubActionsTestLogger" Version="3.0.1" PrivateAssets="All"/>

--- a/Elsa.sln
+++ b/Elsa.sln
@@ -1,4 +1,4 @@
-
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.7.34003.232
@@ -324,6 +324,14 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Diagnostics.StructuredLogs.IntegrationTests", "test\integration\Elsa.Diagnostics.StructuredLogs.IntegrationTests\Elsa.Diagnostics.StructuredLogs.IntegrationTests.csproj", "{2530E106-A168-4C57-9DFC-AB3F2CBD36AE}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "diagnostics", "diagnostics", "{78FD90A4-90A5-445F-97F2-74BA835AFA5D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Diagnostics.StructuredLogs.Persistence.Relational", "src\modules\Elsa.Diagnostics.StructuredLogs.Persistence.Relational\Elsa.Diagnostics.StructuredLogs.Persistence.Relational.csproj", "{FDABE591-B1A1-4842-9332-04A894D76C05}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite", "src\modules\Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite\Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.csproj", "{A0D906D7-9E4D-4C50-93B4-8720BB0AAFA7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests", "test\unit\Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests\Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests.csproj", "{695814F0-7E8F-469E-9A5A-E46759A4D67C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests", "test\integration\Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests\Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests.csproj", "{FB7836E3-1D05-4123-B4FA-B9E722723603}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -1233,6 +1241,54 @@ Global
 		{2530E106-A168-4C57-9DFC-AB3F2CBD36AE}.Release|x64.Build.0 = Release|Any CPU
 		{2530E106-A168-4C57-9DFC-AB3F2CBD36AE}.Release|x86.ActiveCfg = Release|Any CPU
 		{2530E106-A168-4C57-9DFC-AB3F2CBD36AE}.Release|x86.Build.0 = Release|Any CPU
+		{FDABE591-B1A1-4842-9332-04A894D76C05}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FDABE591-B1A1-4842-9332-04A894D76C05}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FDABE591-B1A1-4842-9332-04A894D76C05}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FDABE591-B1A1-4842-9332-04A894D76C05}.Debug|x64.Build.0 = Debug|Any CPU
+		{FDABE591-B1A1-4842-9332-04A894D76C05}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FDABE591-B1A1-4842-9332-04A894D76C05}.Debug|x86.Build.0 = Debug|Any CPU
+		{FDABE591-B1A1-4842-9332-04A894D76C05}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FDABE591-B1A1-4842-9332-04A894D76C05}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FDABE591-B1A1-4842-9332-04A894D76C05}.Release|x64.ActiveCfg = Release|Any CPU
+		{FDABE591-B1A1-4842-9332-04A894D76C05}.Release|x64.Build.0 = Release|Any CPU
+		{FDABE591-B1A1-4842-9332-04A894D76C05}.Release|x86.ActiveCfg = Release|Any CPU
+		{FDABE591-B1A1-4842-9332-04A894D76C05}.Release|x86.Build.0 = Release|Any CPU
+		{A0D906D7-9E4D-4C50-93B4-8720BB0AAFA7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A0D906D7-9E4D-4C50-93B4-8720BB0AAFA7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A0D906D7-9E4D-4C50-93B4-8720BB0AAFA7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A0D906D7-9E4D-4C50-93B4-8720BB0AAFA7}.Debug|x64.Build.0 = Debug|Any CPU
+		{A0D906D7-9E4D-4C50-93B4-8720BB0AAFA7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A0D906D7-9E4D-4C50-93B4-8720BB0AAFA7}.Debug|x86.Build.0 = Debug|Any CPU
+		{A0D906D7-9E4D-4C50-93B4-8720BB0AAFA7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A0D906D7-9E4D-4C50-93B4-8720BB0AAFA7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A0D906D7-9E4D-4C50-93B4-8720BB0AAFA7}.Release|x64.ActiveCfg = Release|Any CPU
+		{A0D906D7-9E4D-4C50-93B4-8720BB0AAFA7}.Release|x64.Build.0 = Release|Any CPU
+		{A0D906D7-9E4D-4C50-93B4-8720BB0AAFA7}.Release|x86.ActiveCfg = Release|Any CPU
+		{A0D906D7-9E4D-4C50-93B4-8720BB0AAFA7}.Release|x86.Build.0 = Release|Any CPU
+		{695814F0-7E8F-469E-9A5A-E46759A4D67C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{695814F0-7E8F-469E-9A5A-E46759A4D67C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{695814F0-7E8F-469E-9A5A-E46759A4D67C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{695814F0-7E8F-469E-9A5A-E46759A4D67C}.Debug|x64.Build.0 = Debug|Any CPU
+		{695814F0-7E8F-469E-9A5A-E46759A4D67C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{695814F0-7E8F-469E-9A5A-E46759A4D67C}.Debug|x86.Build.0 = Debug|Any CPU
+		{695814F0-7E8F-469E-9A5A-E46759A4D67C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{695814F0-7E8F-469E-9A5A-E46759A4D67C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{695814F0-7E8F-469E-9A5A-E46759A4D67C}.Release|x64.ActiveCfg = Release|Any CPU
+		{695814F0-7E8F-469E-9A5A-E46759A4D67C}.Release|x64.Build.0 = Release|Any CPU
+		{695814F0-7E8F-469E-9A5A-E46759A4D67C}.Release|x86.ActiveCfg = Release|Any CPU
+		{695814F0-7E8F-469E-9A5A-E46759A4D67C}.Release|x86.Build.0 = Release|Any CPU
+		{FB7836E3-1D05-4123-B4FA-B9E722723603}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FB7836E3-1D05-4123-B4FA-B9E722723603}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FB7836E3-1D05-4123-B4FA-B9E722723603}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FB7836E3-1D05-4123-B4FA-B9E722723603}.Debug|x64.Build.0 = Debug|Any CPU
+		{FB7836E3-1D05-4123-B4FA-B9E722723603}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FB7836E3-1D05-4123-B4FA-B9E722723603}.Debug|x86.Build.0 = Debug|Any CPU
+		{FB7836E3-1D05-4123-B4FA-B9E722723603}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FB7836E3-1D05-4123-B4FA-B9E722723603}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FB7836E3-1D05-4123-B4FA-B9E722723603}.Release|x64.ActiveCfg = Release|Any CPU
+		{FB7836E3-1D05-4123-B4FA-B9E722723603}.Release|x64.Build.0 = Release|Any CPU
+		{FB7836E3-1D05-4123-B4FA-B9E722723603}.Release|x86.ActiveCfg = Release|Any CPU
+		{FB7836E3-1D05-4123-B4FA-B9E722723603}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1341,10 +1397,14 @@ Global
 		{85E81AC4-10EF-4A93-A7A3-930087621ACC} = {D92BEAB2-60D6-4BB4-885A-6BA681C6CCF1}
 		{42FFCACD-5A9D-462B-AC84-7E1D14CDBDF0} = {18453B51-25EB-4317-A4B3-B10518252E92}
 		{B314D549-DD53-4D1B-A88E-934A72FA0BCB} = {18453B51-25EB-4317-A4B3-B10518252E92}
+		{72A70AAA-67EA-4454-9AEF-0C08654B8B4E} = {78FD90A4-90A5-445F-97F2-74BA835AFA5D}
 		{96C2CA98-5CFA-4983-A551-CD570CD8CFA7} = {18453B51-25EB-4317-A4B3-B10518252E92}
 		{2530E106-A168-4C57-9DFC-AB3F2CBD36AE} = {1B8D5897-902E-4632-8698-E89CAF3DDF54}
 		{78FD90A4-90A5-445F-97F2-74BA835AFA5D} = {5BA4A8FA-F7F4-45B3-AEC8-8886D35AAC79}
-		{72A70AAA-67EA-4454-9AEF-0C08654B8B4E} = {78FD90A4-90A5-445F-97F2-74BA835AFA5D}
+		{FDABE591-B1A1-4842-9332-04A894D76C05} = {5BA4A8FA-F7F4-45B3-AEC8-8886D35AAC79}
+		{A0D906D7-9E4D-4C50-93B4-8720BB0AAFA7} = {5BA4A8FA-F7F4-45B3-AEC8-8886D35AAC79}
+		{695814F0-7E8F-469E-9A5A-E46759A4D67C} = {18453B51-25EB-4317-A4B3-B10518252E92}
+		{FB7836E3-1D05-4123-B4FA-B9E722723603} = {1B8D5897-902E-4632-8698-E89CAF3DDF54}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D4B5CEAA-7D70-4FCB-A68E-B03FBE5E0E5E}

--- a/specs/005-structured-log-persistence/checklists/requirements.md
+++ b/specs/005-structured-log-persistence/checklists/requirements.md
@@ -1,0 +1,10 @@
+# Requirements Checklist: Structured Log Persistence
+
+- [x] Requirements preserve in-memory behavior as the default.
+- [x] Requirements define SQLite as the only initial durable provider.
+- [x] Requirements separate storage, live feed, and provider facade responsibilities.
+- [x] Requirements keep redaction before all storage and live delivery.
+- [x] Requirements avoid EF Core and specify FluentMigrator for schema management.
+- [x] Requirements make future relational providers possible without changing Studio contracts.
+- [x] Requirements include retention and graceful shutdown flushing.
+- [x] Requirements explicitly defer OpenTelemetry and vendor exporter scope.

--- a/specs/005-structured-log-persistence/contracts/persistence-contract.md
+++ b/specs/005-structured-log-persistence/contracts/persistence-contract.md
@@ -99,6 +99,23 @@ public interface IStructuredLogRetentionService
 }
 ```
 
+## IStructuredLogWriteBuffer
+
+Bounded async write queue used by durable stores.
+
+```csharp
+public interface IStructuredLogWriteBuffer : IAsyncDisposable
+{
+    long DroppedWriteCount { get; }
+
+    ValueTask EnqueueAsync(StructuredLogEvent logEvent, CancellationToken cancellationToken = default);
+
+    ValueTask FlushAsync(CancellationToken cancellationToken = default);
+}
+```
+
+The SQLite implementation drops newly received events when the queue is full and increments `DroppedWriteCount`. It does not block logging calls and does not allocate unbounded memory.
+
 ## Registration Sketch
 
 Default in-memory:
@@ -119,4 +136,4 @@ services.AddElsa(elsa =>
 });
 ```
 
-The exact fluent API may change during implementation to match existing Elsa feature conventions.
+SQLite migrations run on startup by default. Retention deletes no records unless `MaxAge`, `MaxRows`, or both are configured. The exact fluent API may change during implementation to match existing Elsa feature conventions.

--- a/specs/005-structured-log-persistence/contracts/persistence-contract.md
+++ b/specs/005-structured-log-persistence/contracts/persistence-contract.md
@@ -1,0 +1,122 @@
+# Persistence Contract: Structured Log Persistence
+
+## IStructuredLogSink
+
+Append-only destination for redacted structured log events.
+
+```csharp
+public interface IStructuredLogSink
+{
+    ValueTask WriteAsync(StructuredLogEvent logEvent, CancellationToken cancellationToken = default);
+
+    ValueTask WriteManyAsync(IReadOnlyCollection<StructuredLogEvent> logEvents, CancellationToken cancellationToken = default);
+}
+```
+
+## IStructuredLogStore
+
+Queryable storage for redacted structured log events.
+
+```csharp
+public interface IStructuredLogStore : IStructuredLogSink
+{
+    ValueTask<RecentStructuredLogsResult> QueryAsync(StructuredLogFilter filter, CancellationToken cancellationToken = default);
+
+    ValueTask<IReadOnlyCollection<StructuredLogSource>> ListSourcesAsync(CancellationToken cancellationToken = default);
+}
+```
+
+## IStructuredLogLiveFeed
+
+Live subscription source for SignalR.
+
+```csharp
+public interface IStructuredLogLiveFeed
+{
+    ValueTask PublishAsync(StructuredLogEvent logEvent, CancellationToken cancellationToken = default);
+
+    IAsyncEnumerable<StructuredLogStreamItem> SubscribeAsync(StructuredLogFilter filter, CancellationToken cancellationToken = default);
+}
+```
+
+## IStructuredLogStorageProvider
+
+Facade used by existing REST and SignalR code. This can be implemented by composing a store and live feed while preserving `IStructuredLogProvider` compatibility.
+
+```csharp
+public interface IStructuredLogStorageProvider : IStructuredLogStreamProvider
+{
+}
+```
+
+## IRelationalStructuredLogConnectionFactory
+
+Provider-owned connection creation.
+
+```csharp
+public interface IRelationalStructuredLogConnectionFactory
+{
+    ValueTask<DbConnection> OpenConnectionAsync(CancellationToken cancellationToken = default);
+}
+```
+
+## IRelationalStructuredLogDialect
+
+Provider-owned SQL differences.
+
+```csharp
+public interface IRelationalStructuredLogDialect
+{
+    string ProviderName { get; }
+
+    string QuoteIdentifier(string identifier);
+
+    string ApplyLimit(string sql, int take);
+}
+```
+
+Additional methods can be added when implementation reveals provider-specific differences for timestamps, free-text filtering, or JSON handling.
+
+## IStructuredLogSchemaMigrator
+
+FluentMigrator-backed schema setup.
+
+```csharp
+public interface IStructuredLogSchemaMigrator
+{
+    ValueTask MigrateAsync(CancellationToken cancellationToken = default);
+}
+```
+
+## IStructuredLogRetentionService
+
+Durable cleanup boundary.
+
+```csharp
+public interface IStructuredLogRetentionService
+{
+    ValueTask CleanupAsync(CancellationToken cancellationToken = default);
+}
+```
+
+## Registration Sketch
+
+Default in-memory:
+
+```csharp
+services.AddElsa(elsa => elsa.UseStructuredLogs());
+```
+
+SQLite:
+
+```csharp
+services.AddElsa(elsa =>
+{
+    elsa.UseStructuredLogs(structuredLogs =>
+    {
+        structuredLogs.UseSqliteStorage("Data Source=elsa-structured-logs.db");
+    });
+});
+```
+
+The exact fluent API may change during implementation to match existing Elsa feature conventions.

--- a/specs/005-structured-log-persistence/contracts/persistence-contract.md
+++ b/specs/005-structured-log-persistence/contracts/persistence-contract.md
@@ -39,16 +39,6 @@ public interface IStructuredLogLiveFeed
 }
 ```
 
-## IStructuredLogStorageProvider
-
-Facade used by existing REST and SignalR code. This can be implemented by composing a store and live feed while preserving `IStructuredLogProvider` compatibility.
-
-```csharp
-public interface IStructuredLogStorageProvider : IStructuredLogStreamProvider
-{
-}
-```
-
 ## IRelationalStructuredLogConnectionFactory
 
 Provider-owned connection creation.
@@ -114,7 +104,7 @@ public interface IStructuredLogWriteBuffer : IAsyncDisposable
 }
 ```
 
-The SQLite implementation drops newly received events when the queue is full and increments `DroppedWriteCount`. It does not block logging calls and does not allocate unbounded memory.
+The SQLite implementation drops newly received events when the queue is full, increments `DroppedWriteCount`, and logs warning summaries. It does not block logging calls and does not allocate unbounded memory. Existing REST and SignalR code continues to use `IStructuredLogProvider` as the facade.
 
 ## Registration Sketch
 

--- a/specs/005-structured-log-persistence/data-model.md
+++ b/specs/005-structured-log-persistence/data-model.md
@@ -1,0 +1,103 @@
+# Data Model: Structured Log Persistence
+
+## StructuredLogStore
+
+Queryable storage boundary for redacted structured log events.
+
+- Appends redacted `StructuredLogEvent` values.
+- Queries recent events using `StructuredLogFilter`.
+- Lists known `StructuredLogSource` values.
+- Does not own live subscriber backpressure behavior.
+
+## StructuredLogLiveFeed
+
+Runtime live delivery boundary for new events.
+
+- Publishes new redacted events to live subscribers.
+- Applies subscription filters.
+- Reports dropped-event summaries when subscriber queues overflow.
+- Does not guarantee durability.
+
+## StructuredLogSink
+
+Append-only boundary for destinations that receive structured log events.
+
+- Accepts single events or batches.
+- Does not have to support queries.
+- Used internally by stores and later exporter packages.
+
+## RelationalStructuredLogRecord
+
+Relational database representation of `StructuredLogEvent`.
+
+- `Id`: unique event identifier.
+- `Sequence`: monotonic sequence assigned by the logger path.
+- `Timestamp`: original event timestamp.
+- `ReceivedAt`: backend receive timestamp.
+- `Level`: structured log level stored in a queryable representation.
+- `Category`: logger category.
+- `EventId`: numeric Microsoft logging event ID.
+- `EventName`: optional Microsoft logging event name.
+- `Message`: rendered message.
+- `MessageTemplate`: original template from `{OriginalFormat}` when available.
+- `ExceptionJson`: serialized `StructuredLogException`.
+- `ScopesJson`: serialized scope key/value values.
+- `PropertiesJson`: serialized structured property key/value values.
+- `TraceId`, `SpanId`: active `Activity` identifiers.
+- `CorrelationId`: correlation value when available.
+- `TenantId`, `WorkflowDefinitionId`, `WorkflowInstanceId`: Elsa context values when available.
+- `SourceId`: producing source identifier.
+
+Recommended indexes:
+
+- `ReceivedAt`
+- `Timestamp`
+- `Level`
+- `Category`
+- `SourceId`
+- `TenantId`
+- `WorkflowDefinitionId`
+- `WorkflowInstanceId`
+- `CorrelationId`
+- `TraceId`
+- Composite index for recent ordering, such as `ReceivedAt`, `Sequence`, `Id`
+
+## RelationalStructuredLogSourceRecord
+
+Optional relational representation of `StructuredLogSource` when the store persists sources separately.
+
+- `Id`: stable source identifier.
+- `Name`: display name.
+- `MachineName`, `ProcessId`, `ProcessName`: process metadata.
+- `PodName`, `Namespace`, `ContainerName`, `NodeName`: Kubernetes/container metadata.
+- `StartedAt`, `LastSeen`: lifecycle timestamps.
+- `Status`: source status.
+
+## StructuredLogRetentionOptions
+
+Settings controlling durable store growth.
+
+- `MaxAge`: optional maximum event age.
+- `MaxRows`: optional maximum number of retained rows.
+- `CleanupInterval`: background cleanup interval.
+- `RunCleanupOnStartup`: whether to clean immediately after migrations.
+
+## RelationalStructuredLogDialect
+
+Provider-specific SQL behavior.
+
+- Identifier quoting.
+- Parameter prefix behavior when needed.
+- Limit/take syntax.
+- Timestamp storage and comparison behavior.
+- Free-text predicate construction.
+- Provider name for FluentMigrator database branching.
+
+## StructuredLogMigrationRunner
+
+Schema management service.
+
+- Runs FluentMigrator migrations for the configured provider.
+- Creates the structured log schema from an empty database.
+- Applies future upgrades in version order.
+- Documents multi-instance startup locking constraints for shared database providers.

--- a/specs/005-structured-log-persistence/data-model.md
+++ b/specs/005-structured-log-persistence/data-model.md
@@ -32,8 +32,8 @@ Relational database representation of `StructuredLogEvent`.
 
 - `Id`: unique event identifier.
 - `Sequence`: monotonic sequence assigned by the logger path.
-- `Timestamp`: original event timestamp.
-- `ReceivedAt`: backend receive timestamp.
+- `Timestamp`: original event timestamp stored as UTC ISO-8601 text.
+- `ReceivedAt`: backend receive timestamp stored as UTC ISO-8601 text.
 - `Level`: structured log level stored in a queryable representation.
 - `Category`: logger category.
 - `EventId`: numeric Microsoft logging event ID.
@@ -81,6 +81,18 @@ Settings controlling durable store growth.
 - `MaxRows`: optional maximum number of retained rows.
 - `CleanupInterval`: background cleanup interval.
 - `RunCleanupOnStartup`: whether to clean immediately after migrations.
+- Default behavior: delete no records unless `MaxAge`, `MaxRows`, or both are configured.
+
+## StructuredLogWriteQueueOptions
+
+Settings controlling SQLite write buffering.
+
+- `Capacity`: maximum queued events waiting to be written.
+- `BatchSize`: maximum events written in one flush.
+- `FlushInterval`: maximum time between background flushes.
+- `ShutdownFlushTimeout`: maximum graceful shutdown flush duration.
+- `DroppedWriteCount`: reported count of events dropped because the queue was full.
+- Overflow behavior: drop newly received events when the queue is full; never block logging calls or allocate unbounded memory.
 
 ## RelationalStructuredLogDialect
 
@@ -100,4 +112,5 @@ Schema management service.
 - Runs FluentMigrator migrations for the configured provider.
 - Creates the structured log schema from an empty database.
 - Applies future upgrades in version order.
+- Runs on SQLite startup by default and can be disabled.
 - Documents multi-instance startup locking constraints for shared database providers.

--- a/specs/005-structured-log-persistence/plan.md
+++ b/specs/005-structured-log-persistence/plan.md
@@ -70,12 +70,14 @@ src/modules/
 │   ├── Models/
 │   ├── Options/
 │   ├── Services/
+│   ├── ShellFeatures/
 │   └── Stores/
 └── Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/
     ├── Extensions/
     ├── Features/
     ├── Options/
-    └── Services/
+    ├── Services/
+    └── ShellFeatures/
 
 test/unit/
 ├── Elsa.Diagnostics.StructuredLogs.UnitTests/

--- a/specs/005-structured-log-persistence/plan.md
+++ b/specs/005-structured-log-persistence/plan.md
@@ -1,0 +1,136 @@
+# Implementation Plan: Structured Log Persistence
+
+**Branch**: `005-structured-log-persistence` | **Date**: 2026-05-12 | **Spec**: [spec.md](./spec.md)  
+**Input**: Feature specification from `/specs/005-structured-log-persistence/spec.md`
+
+## Summary
+
+Refactor diagnostics structured logs so storage is a replaceable concern. Preserve the existing bounded in-memory behavior as the default, introduce shared relational persistence abstractions, and add an opt-in SQLite durable store. Use FluentMigrator for schema creation and upgrades while keeping the append/query hot path explicit through Dapper or raw ADO.NET. Defer OTLP and vendor sink/exporter work.
+
+## Technical Context
+
+**Language/Version**: C# latest, nullable reference types enabled, implicit usings enabled.  
+**Primary Dependencies**: Existing `Elsa.Diagnostics.StructuredLogs`, `Microsoft.Extensions.Logging`, `Microsoft.Extensions.Options`, `Microsoft.AspNetCore.SignalR`, Elsa feature/module infrastructure, FastEndpoints through Elsa API endpoint patterns, FluentMigrator runner packages, SQLite ADO.NET provider, and optionally Dapper for relational operations.  
+**Storage**: Bounded in-memory store by default; opt-in SQLite durable store through shared relational persistence.  
+**Testing**: Existing xUnit unit/integration projects for structured logs plus new unit/integration coverage for storage abstraction, SQLite persistence, migrations, filtering, and retention.  
+**Target Platform**: ASP.NET Core Elsa Server on the repository's supported .NET target frameworks.  
+**Project Type**: Modular .NET libraries inside the existing Elsa solution.  
+**Performance Goals**: Preserve non-blocking logging behavior; avoid synchronous disk writes on `ILogger` call paths; keep recent queries indexed for common filters.  
+**Constraints**: No EF Core persistence for this feature. OpenTelemetry, vendor exporters, raw console capture, and trace/metric exploration remain out of scope. Redaction must run before persistence.  
+**Scale/Scope**: Core structured logs refactor, shared relational package, SQLite provider package, tests, docs, and Speckit artifacts.
+
+## Constitution Check
+
+Evaluated against `.specify/memory/constitution.md` v1.1.0:
+
+| Principle | Verdict | Evidence |
+|-----------|---------|----------|
+| I. Modular Architecture | PASS | Core contracts stay in `Elsa.Diagnostics.StructuredLogs`; relational and SQLite persistence live in focused provider packages. |
+| II. Composition & Extensibility | PASS | Store, live feed, dialect, migration runner, and retention services are replaceable. |
+| III. Convention-Driven Design | PASS | Public APIs continue the `StructuredLog`/`StructuredLogs` naming established by feature 004. |
+| IV. Async & Pipeline Execution | PASS | Append, query, migration, cleanup, and shutdown paths are async/cancellation-aware. |
+| V. Testing Discipline | PASS | Tasks include targeted unit/integration tests for in-memory compatibility and SQLite durability. |
+| VI. Trunk-Based Development | PASS | SQLite persistence can ship independently from future OTLP or vendor sink work. |
+| VII. Simplicity, SRP, DRY & KISS | PASS | EF Core and broad vendor exporter support are intentionally excluded from this slice. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/005-structured-log-persistence/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── persistence-contract.md
+├── checklists/
+│   └── requirements.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+src/modules/
+├── Elsa.Diagnostics.StructuredLogs/
+│   ├── Contracts/
+│   │   ├── IStructuredLogProvider.cs
+│   │   ├── IStructuredLogStore.cs
+│   │   ├── IStructuredLogLiveFeed.cs
+│   │   └── IStructuredLogSink.cs
+│   ├── Providers/
+│   │   └── InMemory/
+│   └── Services/
+│       └── DefaultStructuredLogProvider.cs
+├── Elsa.Diagnostics.StructuredLogs.Persistence.Relational/
+│   ├── Contracts/
+│   ├── Features/
+│   ├── Migrations/
+│   ├── Models/
+│   ├── Options/
+│   ├── Services/
+│   └── Stores/
+└── Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/
+    ├── Extensions/
+    ├── Features/
+    ├── Options/
+    └── Services/
+
+test/unit/
+├── Elsa.Diagnostics.StructuredLogs.UnitTests/
+└── Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/
+
+test/integration/
+└── Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/
+```
+
+**Structure Decision**: Keep runtime capture, API, hub, and Studio-facing contracts in the existing structured logs module. Add relational and SQLite packages only for durable persistence. Do not create OTLP or vendor sink packages in this feature.
+
+## Phase 0 Output
+
+See [research.md](./research.md).
+
+Resolved decisions:
+
+- Keep in-memory storage as the default.
+- Split storage/live-feed responsibilities from the existing provider facade.
+- Add SQLite as the first durable provider.
+- Build SQLite on a shared relational persistence package.
+- Use FluentMigrator for schema management.
+- Use explicit SQL/Dapper-style operations for appending, querying, and retention.
+- Defer OpenTelemetry and vendor sink/exporter packages.
+
+## Phase 1 Output
+
+- [data-model.md](./data-model.md)
+- [contracts/persistence-contract.md](./contracts/persistence-contract.md)
+- [quickstart.md](./quickstart.md)
+
+## Post-Design Constitution Re-Check
+
+| Principle | Verdict | Post-design evidence |
+|-----------|---------|----------------------|
+| I. Modular Architecture | PASS | Persistence packages are separate from the core diagnostics structured logs module. |
+| II. Composition & Extensibility | PASS | Future relational providers can reuse the relational store and provide provider-specific services. |
+| III. Convention-Driven Design | PASS | Configuration and package names follow Elsa module conventions. |
+| IV. Async & Pipeline Execution | PASS | Contracts use async append/query/migration/cleanup methods. |
+| V. Testing Discipline | PASS | Story tasks include independent tests for each deliverable slice. |
+| VI. Trunk-Based Development | PASS | The SQLite slice is independently releasable. |
+| VII. Simplicity, SRP, DRY & KISS | PASS | The design avoids EF Core and skips exporter scope. |
+
+## Phase 2 Handoff
+
+Use [tasks.md](./tasks.md) as the implementation backlog. Suggested order:
+
+1. Introduce storage/live-feed contracts while preserving current behavior.
+2. Convert the in-memory provider into reusable in-memory store/live-feed pieces behind the existing facade.
+3. Add shared relational persistence contracts, record model, dialect, migration runner, retention service, and store implementation.
+4. Add SQLite provider registration, dialect, migration runner configuration, and tests.
+5. Update README/quickstart and run targeted builds/tests.
+
+## Complexity Tracking
+
+No constitution violations identified.

--- a/specs/005-structured-log-persistence/plan.md
+++ b/specs/005-structured-log-persistence/plan.md
@@ -1,37 +1,37 @@
 # Implementation Plan: Structured Log Persistence
 
-**Branch**: `005-structured-log-persistence` | **Date**: 2026-05-12 | **Spec**: [spec.md](./spec.md)  
+**Branch**: `005-structured-log-persistence` | **Date**: 2026-05-13 | **Spec**: [spec.md](./spec.md)
 **Input**: Feature specification from `/specs/005-structured-log-persistence/spec.md`
 
 ## Summary
 
-Refactor diagnostics structured logs so storage is a replaceable concern. Preserve the existing bounded in-memory behavior as the default, introduce shared relational persistence abstractions, and add an opt-in SQLite durable store. Use FluentMigrator for schema creation and upgrades while keeping the append/query hot path explicit through Dapper or raw ADO.NET. Defer OTLP and vendor sink/exporter work.
+Refactor diagnostics structured logs so queryable storage is replaceable while the existing `IStructuredLogProvider` remains the REST/SignalR facade. Keep bounded in-memory storage as the default and add opt-in SQLite durable storage backed by shared relational persistence. Use FluentMigrator for schema management, explicit SQL/Dapper-style runtime operations, async batched writes, a bounded drop-newest write queue, startup migrations enabled by default, UTC ISO-8601 timestamp text, and opt-in retention.
 
 ## Technical Context
 
-**Language/Version**: C# latest, nullable reference types enabled, implicit usings enabled.  
-**Primary Dependencies**: Existing `Elsa.Diagnostics.StructuredLogs`, `Microsoft.Extensions.Logging`, `Microsoft.Extensions.Options`, `Microsoft.AspNetCore.SignalR`, Elsa feature/module infrastructure, FastEndpoints through Elsa API endpoint patterns, FluentMigrator runner packages, SQLite ADO.NET provider, and optionally Dapper for relational operations.  
-**Storage**: Bounded in-memory store by default; opt-in SQLite durable store through shared relational persistence.  
-**Testing**: Existing xUnit unit/integration projects for structured logs plus new unit/integration coverage for storage abstraction, SQLite persistence, migrations, filtering, and retention.  
-**Target Platform**: ASP.NET Core Elsa Server on the repository's supported .NET target frameworks.  
-**Project Type**: Modular .NET libraries inside the existing Elsa solution.  
-**Performance Goals**: Preserve non-blocking logging behavior; avoid synchronous disk writes on `ILogger` call paths; keep recent queries indexed for common filters.  
-**Constraints**: No EF Core persistence for this feature. OpenTelemetry, vendor exporters, raw console capture, and trace/metric exploration remain out of scope. Redaction must run before persistence.  
-**Scale/Scope**: Core structured logs refactor, shared relational package, SQLite provider package, tests, docs, and Speckit artifacts.
+**Language/Version**: C# latest, nullable reference types enabled, implicit usings enabled.
+**Primary Dependencies**: Existing `Elsa.Diagnostics.StructuredLogs`, `Microsoft.Extensions.Logging`, `Microsoft.Extensions.Options`, `Microsoft.AspNetCore.SignalR`, Elsa feature/module infrastructure, FastEndpoints through Elsa API endpoint patterns, FluentMigrator runner packages, SQLite ADO.NET provider, and optionally Dapper for relational operations.
+**Storage**: Bounded in-memory store by default; opt-in SQLite durable store through shared relational persistence. SQLite stores `Timestamp` and `ReceivedAt` as UTC ISO-8601 text and stores exception, scope, and property payloads as JSON text.
+**Testing**: xUnit unit and integration tests under existing structured logs projects plus new relational unit tests and SQLite integration tests.
+**Target Platform**: ASP.NET Core Elsa Server on the repository's supported .NET target frameworks.
+**Project Type**: Modular .NET libraries inside the existing Elsa solution.
+**Performance Goals**: Preserve non-blocking `ILogger` capture. SQLite writes use async batching and a bounded queue; full queues drop newly received events and report dropped-write counts.
+**Constraints**: No EF Core persistence for this feature. OpenTelemetry, vendor exporters, raw console capture, and trace/metric exploration remain out of scope. Redaction must run before persistence. SQLite may lose queued-but-unflushed events after an ungraceful process crash.
+**Scale/Scope**: Core structured logs storage refactor, shared relational package, SQLite provider package, tests, docs, and Speckit artifacts.
 
 ## Constitution Check
 
-Evaluated against `.specify/memory/constitution.md` v1.1.0:
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
 
 | Principle | Verdict | Evidence |
 |-----------|---------|----------|
-| I. Modular Architecture | PASS | Core contracts stay in `Elsa.Diagnostics.StructuredLogs`; relational and SQLite persistence live in focused provider packages. |
-| II. Composition & Extensibility | PASS | Store, live feed, dialect, migration runner, and retention services are replaceable. |
-| III. Convention-Driven Design | PASS | Public APIs continue the `StructuredLog`/`StructuredLogs` naming established by feature 004. |
-| IV. Async & Pipeline Execution | PASS | Append, query, migration, cleanup, and shutdown paths are async/cancellation-aware. |
-| V. Testing Discipline | PASS | Tasks include targeted unit/integration tests for in-memory compatibility and SQLite durability. |
+| I. Modular Architecture | PASS | Core contracts stay in `Elsa.Diagnostics.StructuredLogs`; relational and SQLite persistence live in focused provider packages under `src/modules/`. |
+| II. Composition & Extensibility | PASS | Store, live feed, dialect, migration runner, write queue, and retention services are replaceable. |
+| III. Convention-Driven Design | PASS | Public APIs continue the `StructuredLog`/`StructuredLogs` naming established by feature 004 and use American English. |
+| IV. Async & Pipeline Execution | PASS | Append, query, migration, cleanup, flush, and shutdown paths are async/cancellation-aware. |
+| V. Testing Discipline | PASS | Plan includes unit/integration coverage for in-memory compatibility, SQLite durability, migrations, queue overflow, timestamp storage, and retention. |
 | VI. Trunk-Based Development | PASS | SQLite persistence can ship independently from future OTLP or vendor sink work. |
-| VII. Simplicity, SRP, DRY & KISS | PASS | EF Core and broad vendor exporter support are intentionally excluded from this slice. |
+| VII. Simplicity, SRP, DRY & KISS | PASS | EF Core and broad vendor exporter support are intentionally excluded; abstractions serve documented persistence extensibility. |
 
 ## Project Structure
 
@@ -61,10 +61,8 @@ src/modules/
 │   │   ├── IStructuredLogStore.cs
 │   │   ├── IStructuredLogLiveFeed.cs
 │   │   └── IStructuredLogSink.cs
-│   ├── Providers/
-│   │   └── InMemory/
-│   └── Services/
-│       └── DefaultStructuredLogProvider.cs
+│   ├── Providers/InMemory/
+│   └── Services/DefaultStructuredLogProvider.cs
 ├── Elsa.Diagnostics.StructuredLogs.Persistence.Relational/
 │   ├── Contracts/
 │   ├── Features/
@@ -99,8 +97,12 @@ Resolved decisions:
 - Split storage/live-feed responsibilities from the existing provider facade.
 - Add SQLite as the first durable provider.
 - Build SQLite on a shared relational persistence package.
-- Use FluentMigrator for schema management.
+- Use FluentMigrator for schema management and run SQLite migrations on startup by default with opt-out.
 - Use explicit SQL/Dapper-style operations for appending, querying, and retention.
+- Use async batched SQLite writes with graceful-shutdown flush.
+- Use a bounded write queue that drops newest events when full and reports dropped-write counts.
+- Store SQLite timestamps as UTC ISO-8601 text.
+- Make retention opt-in; delete no records unless max age or max rows is configured.
 - Defer OpenTelemetry and vendor sink/exporter packages.
 
 ## Phase 1 Output
@@ -115,11 +117,11 @@ Resolved decisions:
 |-----------|---------|----------------------|
 | I. Modular Architecture | PASS | Persistence packages are separate from the core diagnostics structured logs module. |
 | II. Composition & Extensibility | PASS | Future relational providers can reuse the relational store and provide provider-specific services. |
-| III. Convention-Driven Design | PASS | Configuration and package names follow Elsa module conventions. |
-| IV. Async & Pipeline Execution | PASS | Contracts use async append/query/migration/cleanup methods. |
-| V. Testing Discipline | PASS | Story tasks include independent tests for each deliverable slice. |
+| III. Convention-Driven Design | PASS | Configuration and package names follow Elsa module conventions and American English. |
+| IV. Async & Pipeline Execution | PASS | Contracts and planned services use async append/query/migration/cleanup/flush methods. |
+| V. Testing Discipline | PASS | Story tasks include independent tests for each deliverable slice and clarified edge behavior. |
 | VI. Trunk-Based Development | PASS | The SQLite slice is independently releasable. |
-| VII. Simplicity, SRP, DRY & KISS | PASS | The design avoids EF Core and skips exporter scope. |
+| VII. Simplicity, SRP, DRY & KISS | PASS | The design avoids EF Core and skips exporter scope while keeping relational extensibility focused. |
 
 ## Phase 2 Handoff
 
@@ -127,8 +129,8 @@ Use [tasks.md](./tasks.md) as the implementation backlog. Suggested order:
 
 1. Introduce storage/live-feed contracts while preserving current behavior.
 2. Convert the in-memory provider into reusable in-memory store/live-feed pieces behind the existing facade.
-3. Add shared relational persistence contracts, record model, dialect, migration runner, retention service, and store implementation.
-4. Add SQLite provider registration, dialect, migration runner configuration, and tests.
+3. Add shared relational persistence contracts, record model, dialect, migration runner, retention service, write queue, and store implementation.
+4. Add SQLite provider registration, dialect, migration runner configuration, startup migration option, and tests.
 5. Update README/quickstart and run targeted builds/tests.
 
 ## Complexity Tracking

--- a/specs/005-structured-log-persistence/quickstart.md
+++ b/specs/005-structured-log-persistence/quickstart.md
@@ -28,9 +28,8 @@ services.AddElsa(elsa =>
     {
         structuredLogs.UseSqliteStorage("Data Source=elsa-structured-logs.db", sqlite =>
         {
-            sqlite.Retention.MaxAge = TimeSpan.FromDays(14);
-            sqlite.Retention.MaxRows = 250_000;
             sqlite.RunMigrationsOnStartup = true;
+            sqlite.WriteQueueCapacity = 10_000;
         });
     });
 });
@@ -54,6 +53,19 @@ SQLite storage runs FluentMigrator migrations when `RunMigrationsOnStartup` is e
 
 For future shared relational providers such as SQL Server or PostgreSQL, production deployments may choose to run migrations once during deployment instead of from every application instance. Multi-instance startup locking must be documented by each provider.
 
+## Retention
+
+SQLite storage does not delete persisted log entries by default. Configure `Retention.MaxAge`, `Retention.MaxRows`, or both to bound durable storage growth:
+
+```csharp
+sqlite.Retention.MaxAge = TimeSpan.FromDays(14);
+sqlite.Retention.MaxRows = 250_000;
+```
+
+## Write buffering
+
+SQLite writes are batched through a bounded background queue. Graceful shutdown flushes queued events where possible. If the process crashes, queued-but-unflushed events can be lost. If the queue is full, newly received events are dropped and dropped-write counts are reported.
+
 ## Validation
 
 Run targeted checks after implementation:
@@ -72,7 +84,9 @@ Manual validation:
 3. Query recent logs from Studio and verify filters work.
 4. Restart the host using the same SQLite database file.
 5. Query recent logs again and verify events from before the restart are still available.
-6. Lower retention settings in a test environment and verify cleanup removes old or excess rows.
+6. Verify timestamps are stored and filtered as UTC ISO-8601 values.
+7. Lower retention settings in a test environment and verify cleanup removes old or excess rows.
+8. Saturate the write queue in a test environment and verify newest events are dropped with visible dropped-write counts.
 
 ## Out of scope
 

--- a/specs/005-structured-log-persistence/quickstart.md
+++ b/specs/005-structured-log-persistence/quickstart.md
@@ -29,7 +29,8 @@ services.AddElsa(elsa =>
         structuredLogs.UseSqliteStorage("Data Source=elsa-structured-logs.db", sqlite =>
         {
             sqlite.RunMigrationsOnStartup = true;
-            sqlite.WriteQueueCapacity = 10_000;
+            sqlite.Relational.WriteQueue.Capacity = 10_000;
+            sqlite.Relational.WriteQueue.BatchSize = 100;
         });
     });
 });
@@ -58,8 +59,9 @@ For future shared relational providers such as SQL Server or PostgreSQL, product
 SQLite storage does not delete persisted log entries by default. Configure `Retention.MaxAge`, `Retention.MaxRows`, or both to bound durable storage growth:
 
 ```csharp
-sqlite.Retention.MaxAge = TimeSpan.FromDays(14);
-sqlite.Retention.MaxRows = 250_000;
+sqlite.Relational.Retention.MaxAge = TimeSpan.FromDays(14);
+sqlite.Relational.Retention.MaxRows = 250_000;
+sqlite.Relational.Retention.CleanupOnStartup = true;
 ```
 
 ## Write buffering

--- a/specs/005-structured-log-persistence/quickstart.md
+++ b/specs/005-structured-log-persistence/quickstart.md
@@ -1,0 +1,79 @@
+# Quickstart: Structured Log Persistence
+
+## Default in-memory storage
+
+No durable storage configuration is required:
+
+```csharp
+services.AddElsa(elsa =>
+{
+    elsa.UseStructuredLogs(options =>
+    {
+        options.RecentLogCapacity = 5_000;
+        options.MaxRecentLogQuerySize = 1_000;
+    });
+});
+```
+
+This keeps the current bounded in-memory recent history and live SignalR streaming behavior.
+
+## SQLite durable storage
+
+Add the SQLite persistence package and configure a database file:
+
+```csharp
+services.AddElsa(elsa =>
+{
+    elsa.UseStructuredLogs(structuredLogs =>
+    {
+        structuredLogs.UseSqliteStorage("Data Source=elsa-structured-logs.db", sqlite =>
+        {
+            sqlite.Retention.MaxAge = TimeSpan.FromDays(14);
+            sqlite.Retention.MaxRows = 250_000;
+            sqlite.RunMigrationsOnStartup = true;
+        });
+    });
+});
+```
+
+Then map the existing structured logs endpoints and hub:
+
+```csharp
+app.UseStructuredLogs();
+```
+
+Studio continues to use:
+
+- `/diagnostics/structured-logs/recent`
+- `/diagnostics/structured-logs/sources`
+- `/elsa/hubs/diagnostics/structured-logs`
+
+## Migrations
+
+SQLite storage runs FluentMigrator migrations when `RunMigrationsOnStartup` is enabled. For SQLite this is the recommended default.
+
+For future shared relational providers such as SQL Server or PostgreSQL, production deployments may choose to run migrations once during deployment instead of from every application instance. Multi-instance startup locking must be documented by each provider.
+
+## Validation
+
+Run targeted checks after implementation:
+
+```bash
+dotnet build src/modules/Elsa.Diagnostics.StructuredLogs/Elsa.Diagnostics.StructuredLogs.csproj
+dotnet build src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.csproj
+dotnet test test/unit/Elsa.Diagnostics.StructuredLogs.UnitTests/Elsa.Diagnostics.StructuredLogs.UnitTests.csproj
+dotnet test test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests.csproj
+```
+
+Manual validation:
+
+1. Start Elsa Server with SQLite structured log storage enabled.
+2. Emit several `ILogger` records with different levels, categories, workflow IDs, and correlation IDs.
+3. Query recent logs from Studio and verify filters work.
+4. Restart the host using the same SQLite database file.
+5. Query recent logs again and verify events from before the restart are still available.
+6. Lower retention settings in a test environment and verify cleanup removes old or excess rows.
+
+## Out of scope
+
+This feature does not add OTLP, Logstash, Datadog, Splunk, Loki, Seq, or Parquet exporters. Those can be added later as sinks/exporters after persistence is stable.

--- a/specs/005-structured-log-persistence/research.md
+++ b/specs/005-structured-log-persistence/research.md
@@ -1,0 +1,66 @@
+# Research: Structured Log Persistence
+
+## Decision: Preserve in-memory storage as the default
+
+**Rationale**: The existing bounded in-memory provider is the current structured logs behavior and has the lowest operational burden. It should remain the zero-configuration path for development, tests, and hosts that only need live diagnostics.
+
+**Alternatives considered**:
+
+- Make SQLite the default: rejected because it adds disk, migration, and retention behavior to hosts that did not ask for durability.
+- Remove in-memory storage: rejected because it would break the existing feature and complicate local development.
+
+## Decision: Split store and live-feed responsibilities from the provider facade
+
+**Rationale**: `IStructuredLogProvider` currently combines append, recent query, source listing, and live subscription behavior. Durable persistence needs queryable storage, while SignalR needs live delivery. Splitting these concerns makes storage replaceable without forcing every store to implement subscriber queue behavior.
+
+**Alternatives considered**:
+
+- Keep only `IStructuredLogProvider`: rejected because durable stores and vendor sinks would inherit unrelated live streaming responsibilities.
+- Replace `IStructuredLogProvider` entirely: rejected because endpoints and SignalR already depend on it and the existing contract is a useful facade.
+
+## Decision: Add SQLite as the first durable store
+
+**Rationale**: SQLite gives customers an easy persistence story with no external database service. It is a good first step for single-node Elsa hosts and a useful proving ground for a relational store contract.
+
+**Alternatives considered**:
+
+- Add OTLP first: rejected because OpenTelemetry scope should be handled deliberately by a later diagnostics/observability feature.
+- Add SQL Server or PostgreSQL first: rejected because they raise deployment requirements for the first persistence story.
+- Use Parquet as the default durable format: rejected because Parquet is better suited to archive and analytics exports than hot append/query/live operational diagnostics.
+
+## Decision: Build SQLite on shared relational persistence
+
+**Rationale**: Customers are likely to ask for SQL Server, PostgreSQL, MySQL, or other relational providers later. Shared relational store logic keeps the SQLite provider from becoming a one-off and reduces future provider work.
+
+**Alternatives considered**:
+
+- SQLite-only implementation: rejected because it would create duplicate work when the next relational provider is requested.
+- Fully generic provider with no dialect abstraction: rejected because limit syntax, identifiers, JSON behavior, date handling, and migration details vary by database.
+
+## Decision: Use FluentMigrator for schema management
+
+**Rationale**: FluentMigrator provides versioned migrations without adopting EF Core as the persistence layer. It supports several database providers and allows shared migrations with provider-specific branches when needed.
+
+**Alternatives considered**:
+
+- EF Core migrations: rejected because maintaining migrations per provider is a burden and EF runtime features are not needed for append/query/delete log storage.
+- Hand-rolled `CREATE TABLE IF NOT EXISTS`: rejected because it lacks a clean schema upgrade path once fields or indexes evolve.
+- External SQL scripts only: rejected because hosts need an easy in-process migration story, especially for SQLite.
+
+## Decision: Use explicit SQL/Dapper-style data access for runtime operations
+
+**Rationale**: Structured log storage needs append, filtered query, source list, and retention delete operations. These are predictable SQL operations and do not need change tracking, navigation properties, or LINQ translation. Dapper can reduce mapping boilerplate while keeping SQL explicit.
+
+**Alternatives considered**:
+
+- EF Core runtime access: rejected for the same reasons as EF migrations.
+- A generic query-builder library: deferred because current filters are simple enough to compose directly with a small dialect service.
+
+## Decision: Defer exporter/sink packages
+
+**Rationale**: Vendor sinks and OTLP export are useful, but they are not required for the first customer persistence story. Keeping them out of this slice prevents the storage abstraction from being distorted by outbound shipping concerns.
+
+**Alternatives considered**:
+
+- Add OTLP logs exporter now: rejected until the future `Elsa.Diagnostics.OpenTelemetry` boundary is clearer.
+- Add Logstash, Datadog, Splunk, Loki, or Seq now: rejected because they are better represented as sinks/exporters after the core store abstraction is stable.

--- a/specs/005-structured-log-persistence/research.md
+++ b/specs/005-structured-log-persistence/research.md
@@ -56,6 +56,52 @@
 - EF Core runtime access: rejected for the same reasons as EF migrations.
 - A generic query-builder library: deferred because current filters are simple enough to compose directly with a small dialect service.
 
+## Decision: Use async batched SQLite writes with graceful-shutdown flush
+
+**Rationale**: Structured log capture must not make `ILogger` callers wait on disk I/O. A background writer preserves the diagnostics feature's low-latency capture path while graceful shutdown flushes queued events where possible.
+
+**Alternatives considered**:
+
+- Synchronous durable writes per event: rejected because slow disk I/O would directly affect application logging paths.
+- Configurable synchronous durability mode: deferred because the first persistence story prioritizes simple operational diagnostics over no-loss audit logging.
+
+## Decision: Use a bounded drop-newest SQLite write queue
+
+**Rationale**: The write queue must not grow without bound during logging spikes or disk stalls. Dropping newly received events keeps already queued events stable, keeps memory bounded, and makes loss visible through dropped-write counts.
+
+**Alternatives considered**:
+
+- Block logging when the queue is full: rejected because persistence backpressure would slow application code.
+- Drop oldest queued events: rejected because it makes the batch already accepted for persistence less predictable.
+- Use an unbounded queue: rejected because it can turn a logging spike into process memory pressure.
+
+## Decision: Run SQLite migrations on startup by default
+
+**Rationale**: The SQLite provider should provide an easy durable logging story. Startup migrations make first-run setup simple, while an opt-out lets advanced hosts prepare schemas separately.
+
+**Alternatives considered**:
+
+- Require explicit migration calls: rejected because it weakens the easy persistence story.
+- Run migrations only in development: rejected because SQLite is expected to be useful in small production hosts too.
+
+## Decision: Store SQLite timestamps as UTC ISO-8601 text
+
+**Rationale**: UTC ISO-8601 text is SQLite-friendly, human-readable, sortable when normalized, and avoids provider-specific date/time behavior in the first durable provider.
+
+**Alternatives considered**:
+
+- Unix epoch milliseconds: rejected because it is less inspectable and loses sub-millisecond detail.
+- Unix epoch ticks or nanoseconds: rejected because it is less readable and still requires conversion for most manual inspection.
+
+## Decision: Make retention opt-in
+
+**Rationale**: Durable storage should not delete customer logs unexpectedly. Hosts can configure maximum age, maximum rows, or both when they want bounded durable storage.
+
+**Alternatives considered**:
+
+- Default 14-day and 250,000-row retention: rejected because default deletion can surprise operators.
+- Default maximum rows only: rejected because any default deletion policy still needs explicit customer intent.
+
 ## Decision: Defer exporter/sink packages
 
 **Rationale**: Vendor sinks and OTLP export are useful, but they are not required for the first customer persistence story. Keeping them out of this slice prevents the storage abstraction from being distorted by outbound shipping concerns.

--- a/specs/005-structured-log-persistence/spec.md
+++ b/specs/005-structured-log-persistence/spec.md
@@ -16,6 +16,14 @@
 - Q: Should EF Core be used for persistence? -> A: No. Avoid EF Core and per-provider EF migrations for this feature.
 - Q: Should FluentMigrator manage schema creation and upgrades? -> A: Yes. Use FluentMigrator for schema versioning and migration execution; use explicit SQL/Dapper-style access for the hot storage path.
 
+### Session 2026-05-13
+
+- Q: What durability guarantee should SQLite writes provide on the logging hot path? -> A: Async batched writes with graceful-shutdown flush; a crash may lose queued events.
+- Q: What should happen when the SQLite write queue is full? -> A: Drop newest queued events and report dropped counts/metrics.
+- Q: Should SQLite migrations run automatically on startup? -> A: Run migrations on startup by default, with opt-out.
+- Q: How should SQLite persist timestamps? -> A: Store timestamps as UTC ISO-8601 text.
+- Q: What default retention policy should SQLite use? -> A: No default deletion; retention runs only when max age or max rows is configured.
+
 ## User Scenarios & Testing *(mandatory)*
 
 ### User Story 1 - Preserve the existing in-memory structured logs behavior (Priority: P1)
@@ -48,6 +56,8 @@ An Elsa host developer opts into SQLite persistence so structured log entries su
 2. **Given** the host restarts with the same SQLite database, **When** recent structured logs are queried, **Then** persisted events are returned according to the filter.
 3. **Given** retention settings are configured, **When** cleanup runs, **Then** old or excess records are deleted without breaking recent queries.
 4. **Given** schema migrations have not run, **When** the SQLite provider starts, **Then** FluentMigrator creates or upgrades the structured log schema.
+5. **Given** an operator disables startup migrations, **When** the SQLite provider starts, **Then** it does not run migrations and requires the schema to be prepared separately.
+6. **Given** no SQLite retention settings are configured, **When** cleanup runs, **Then** no persisted log entries are deleted by default.
 
 ---
 
@@ -67,7 +77,8 @@ An Elsa maintainer can add SQL Server, PostgreSQL, MySQL, or another relational 
 
 ### Edge Cases
 
-- Durable writes must not block `ILogger` callers on slow disk I/O.
+- Durable writes must not block `ILogger` callers on slow disk I/O; SQLite persistence accepts possible loss of queued-but-unflushed events after process crashes.
+- If the SQLite write queue reaches capacity, newest events are dropped and loss counts are reported instead of blocking logging calls or growing memory without bound.
 - A host can emit logs before migrations complete if startup ordering is wrong.
 - Multiple app instances can start against a shared future relational database and attempt migrations concurrently.
 - SQLite file paths can be missing, relative, or point to directories without write permissions.
@@ -100,28 +111,36 @@ An Elsa maintainer can add SQL Server, PostgreSQL, MySQL, or another relational 
 - **FR-010**: SQLite storage MUST support the existing `StructuredLogFilter` fields used by the REST recent-log endpoint.
 - **FR-011**: SQLite storage MUST persist scalar filter fields as queryable columns and persist exception, scopes, and properties as serialized JSON.
 - **FR-012**: SQLite storage MUST provide configurable retention by maximum age and/or maximum row count.
-- **FR-013**: SQLite writes SHOULD be batched or queued so logging calls do not synchronously wait on disk I/O.
-- **FR-014**: SQLite storage MUST flush queued events during graceful shutdown where possible.
+- **FR-013**: SQLite storage MUST persist `Timestamp` and `ReceivedAt` as UTC ISO-8601 text values.
+- **FR-014**: SQLite writes MUST be batched or queued so logging calls do not synchronously wait on disk I/O.
+- **FR-015**: SQLite storage MUST flush queued events during graceful shutdown where possible.
+- **FR-016**: SQLite storage MAY lose events that were queued but not flushed before an ungraceful process crash.
+- **FR-017**: SQLite storage MUST use a bounded write queue.
+- **FR-018**: When the SQLite write queue is full, SQLite storage MUST drop newly received events instead of blocking logging calls or using unbounded memory.
+- **FR-019**: SQLite storage MUST expose dropped-write counts through logs, metrics, or the structured log provider result surface.
+- **FR-020**: SQLite retention MUST delete no records by default unless `MaxAge`, `MaxRows`, or both are configured.
 
 **Relational extensibility**
 
-- **FR-015**: Shared relational persistence code MUST be reusable by future SQL Server, PostgreSQL, MySQL, and similar providers.
-- **FR-016**: Provider-specific SQL syntax MUST be isolated behind dialect or provider services.
-- **FR-017**: The first SQLite provider MUST not introduce SQLite-only assumptions into the core structured logs module.
-- **FR-018**: Future relational providers MUST be able to supply their own connection factory, dialect, and migration runner configuration without changing REST, SignalR, or Studio contracts.
+- **FR-021**: Shared relational persistence code MUST be reusable by future SQL Server, PostgreSQL, MySQL, and similar providers.
+- **FR-022**: Provider-specific SQL syntax MUST be isolated behind dialect or provider services.
+- **FR-023**: The first SQLite provider MUST not introduce SQLite-only assumptions into the core structured logs module.
+- **FR-024**: Future relational providers MUST be able to supply their own connection factory, dialect, and migration runner configuration without changing REST, SignalR, or Studio contracts.
 
 **Schema management**
 
-- **FR-019**: Relational schema creation and upgrades MUST use FluentMigrator.
-- **FR-020**: Migrations MUST be versioned and idempotently executable by the host.
-- **FR-021**: Provider packages MUST register only the FluentMigrator runner dependencies they need.
-- **FR-022**: The feature MUST document startup migration behavior and the multi-instance locking consideration for future shared database providers.
+- **FR-025**: Relational schema creation and upgrades MUST use FluentMigrator.
+- **FR-026**: Migrations MUST be versioned and idempotently executable by the host.
+- **FR-027**: Provider packages MUST register only the FluentMigrator runner dependencies they need.
+- **FR-028**: SQLite storage MUST run migrations on startup by default.
+- **FR-029**: SQLite storage MUST provide an option to disable startup migrations for hosts that prepare schemas separately.
+- **FR-030**: The feature MUST document startup migration behavior and the multi-instance locking consideration for future shared database providers.
 
 **Configuration and safety**
 
-- **FR-023**: Host configuration MUST make the active storage mode explicit when SQLite is selected.
-- **FR-024**: The existing no-configuration in-memory setup MUST continue to work.
-- **FR-025**: The feature MUST document that OpenTelemetry/exporter sinks are deferred and out of scope for this persistence slice.
+- **FR-031**: Host configuration MUST make the active storage mode explicit when SQLite is selected.
+- **FR-032**: The existing no-configuration in-memory setup MUST continue to work.
+- **FR-033**: The feature MUST document that OpenTelemetry/exporter sinks are deferred and out of scope for this persistence slice.
 
 ### Key Entities *(include if feature involves data)*
 
@@ -140,9 +159,14 @@ An Elsa maintainer can add SQL Server, PostgreSQL, MySQL, or another relational 
 - **SC-002**: New tests verify SQLite persistence survives service-provider or process recreation with the same database file.
 - **SC-003**: New tests verify SQLite recent queries honor level, category, source, workflow, correlation, trace/span, time range, and limit filters.
 - **SC-004**: New tests verify FluentMigrator creates the SQLite schema from an empty database.
-- **SC-005**: New tests verify retention cleanup removes expired or excess records.
-- **SC-006**: Documentation shows both zero-configuration in-memory setup and opt-in SQLite setup.
-- **SC-007**: The core structured logs module does not reference SQLite-specific types.
+- **SC-005**: New tests verify retention cleanup removes expired or excess records only when retention settings are configured.
+- **SC-006**: New tests verify queued SQLite writes are flushed during graceful shutdown.
+- **SC-007**: New tests verify a full SQLite write queue drops newest events and reports dropped-write counts.
+- **SC-008**: New tests verify SQLite startup migrations run by default and can be disabled.
+- **SC-009**: New tests verify SQLite stores and filters UTC ISO-8601 timestamp text values consistently.
+- **SC-010**: New tests verify SQLite retention deletes no records by default.
+- **SC-011**: Documentation shows both zero-configuration in-memory setup and opt-in SQLite setup.
+- **SC-012**: The core structured logs module does not reference SQLite-specific types.
 
 ## Assumptions
 

--- a/specs/005-structured-log-persistence/spec.md
+++ b/specs/005-structured-log-persistence/spec.md
@@ -117,7 +117,7 @@ An Elsa maintainer can add SQL Server, PostgreSQL, MySQL, or another relational 
 - **FR-016**: SQLite storage MAY lose events that were queued but not flushed before an ungraceful process crash.
 - **FR-017**: SQLite storage MUST use a bounded write queue.
 - **FR-018**: When the SQLite write queue is full, SQLite storage MUST drop newly received events instead of blocking logging calls or using unbounded memory.
-- **FR-019**: SQLite storage MUST expose dropped-write counts through logs, metrics, or the structured log provider result surface.
+- **FR-019**: SQLite storage MUST expose dropped-write counts through `IStructuredLogWriteBuffer.DroppedWriteCount` and log warning summaries.
 - **FR-020**: SQLite retention MUST delete no records by default unless `MaxAge`, `MaxRows`, or both are configured.
 
 **Relational extensibility**

--- a/specs/005-structured-log-persistence/spec.md
+++ b/specs/005-structured-log-persistence/spec.md
@@ -1,0 +1,153 @@
+# Feature Specification: Structured Log Persistence
+
+**Feature Branch**: `005-structured-log-persistence`  
+**Created**: 2026-05-12  
+**Status**: Draft  
+**Input**: User description: "Make structured log storage a pluggable concern. Keep in-memory support, add an easy durable SQLite storage story first, use FluentMigrator for schema management, and defer OpenTelemetry/exporter scope."
+
+## Clarifications
+
+### Session 2026-05-12
+
+- Q: Should this feature add vendor sinks such as Logstash, Datadog, Splunk, Loki, or Seq now? -> A: No. Keep the first slice small.
+- Q: Should this feature add an OTLP logs exporter now? -> A: No. Defer OpenTelemetry until the diagnostics OpenTelemetry boundary is clearer.
+- Q: What storage providers should exist initially? -> A: Preserve in-memory storage and add opt-in SQLite durable storage.
+- Q: Should SQLite be implemented as a one-off store? -> A: No. Implement it as the first relational provider so SQL Server, PostgreSQL, MySQL, and similar providers can be added later.
+- Q: Should EF Core be used for persistence? -> A: No. Avoid EF Core and per-provider EF migrations for this feature.
+- Q: Should FluentMigrator manage schema creation and upgrades? -> A: Yes. Use FluentMigrator for schema versioning and migration execution; use explicit SQL/Dapper-style access for the hot storage path.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Preserve the existing in-memory structured logs behavior (Priority: P1)
+
+An Elsa host developer enables structured logs without configuring durable persistence and gets the same bounded in-memory recent history and live streaming behavior as today.
+
+**Why this priority**: The storage refactor must not regress the current module. In-memory remains the zero-configuration default and the fastest validation path.
+
+**Independent Test**: Enable `UseStructuredLogs` with no persistence options, emit several `ILogger` events, and verify recent queries, filtering, source listing, live subscriptions, redaction, and dropped-event summaries continue to work.
+
+**Acceptance Scenarios**:
+
+1. **Given** no durable store is configured, **When** structured logs are enabled, **Then** the module uses bounded in-memory storage by default.
+2. **Given** recent logs are queried through the existing REST endpoint, **When** events have been captured, **Then** the endpoint returns filtered recent events using the same contract as before.
+3. **Given** Studio subscribes over SignalR, **When** new matching events are emitted, **Then** live events and dropped-event summaries continue to stream.
+
+---
+
+### User Story 2 - Enable durable SQLite structured log storage (Priority: P2)
+
+An Elsa host developer opts into SQLite persistence so structured log entries survive process restarts and can be queried by Studio after restart.
+
+**Why this priority**: Customers need an easy persistence story without standing up a separate database service or observability stack.
+
+**Independent Test**: Configure SQLite storage, emit structured log entries, restart or recreate the service provider with the same database file, and verify recent queries return the previously written events.
+
+**Acceptance Scenarios**:
+
+1. **Given** SQLite storage is configured with a database file, **When** structured log events are captured, **Then** the events are written durably to SQLite.
+2. **Given** the host restarts with the same SQLite database, **When** recent structured logs are queried, **Then** persisted events are returned according to the filter.
+3. **Given** retention settings are configured, **When** cleanup runs, **Then** old or excess records are deleted without breaking recent queries.
+4. **Given** schema migrations have not run, **When** the SQLite provider starts, **Then** FluentMigrator creates or upgrades the structured log schema.
+
+---
+
+### User Story 3 - Keep relational persistence extensible for future databases (Priority: P3)
+
+An Elsa maintainer can add SQL Server, PostgreSQL, MySQL, or another relational provider later without rewriting the structured logs module or changing Studio contracts.
+
+**Why this priority**: SQLite should prove the relational persistence model, not become a dead-end implementation.
+
+**Independent Test**: Review the relational contracts, dialect hooks, migrations, and SQLite package to confirm provider-specific behavior is isolated from the core structured logs module.
+
+**Acceptance Scenarios**:
+
+1. **Given** a future database provider is added, **When** it supplies a connection factory, SQL dialect, and FluentMigrator runner registration, **Then** it can reuse the shared relational store implementation.
+2. **Given** a provider needs database-specific DDL, **When** migrations run, **Then** the migration can branch by database while keeping a shared migration version.
+3. **Given** Studio uses existing structured logs REST and SignalR contracts, **When** storage changes from in-memory to SQLite, **Then** Studio requires no API changes.
+
+### Edge Cases
+
+- Durable writes must not block `ILogger` callers on slow disk I/O.
+- A host can emit logs before migrations complete if startup ordering is wrong.
+- Multiple app instances can start against a shared future relational database and attempt migrations concurrently.
+- SQLite file paths can be missing, relative, or point to directories without write permissions.
+- A process can crash after events enter a background queue but before they are flushed.
+- Free-text filtering over JSON fields can be provider-specific and initially approximate.
+- Retention cleanup can race with recent queries or live subscriptions.
+- Schema changes must preserve already persisted log events where practical.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Storage abstraction**
+
+- **FR-001**: The structured logs module MUST separate queryable storage from live streaming and capture/provider facade responsibilities.
+- **FR-002**: The existing `IStructuredLogProvider` contract MAY remain as the facade used by REST endpoints and SignalR, but storage-specific responsibilities MUST be represented by a replaceable store abstraction.
+- **FR-003**: The storage abstraction MUST support appending redacted `StructuredLogEvent` values, querying recent events by `StructuredLogFilter`, and listing structured log sources.
+- **FR-004**: Live streaming MUST remain available when durable storage is configured.
+- **FR-005**: Redaction MUST continue to happen before any event reaches in-memory storage, SQLite storage, or live subscribers.
+
+**In-memory default**
+
+- **FR-006**: The module MUST keep bounded in-memory storage as the default when no durable storage provider is configured.
+- **FR-007**: The in-memory implementation MUST preserve existing recent query, source listing, subscription, dropped-event summary, capacity, and filtering behavior.
+
+**SQLite durable storage**
+
+- **FR-008**: The feature MUST add an opt-in SQLite structured log persistence provider.
+- **FR-009**: SQLite storage MUST persist structured log events across process restarts.
+- **FR-010**: SQLite storage MUST support the existing `StructuredLogFilter` fields used by the REST recent-log endpoint.
+- **FR-011**: SQLite storage MUST persist scalar filter fields as queryable columns and persist exception, scopes, and properties as serialized JSON.
+- **FR-012**: SQLite storage MUST provide configurable retention by maximum age and/or maximum row count.
+- **FR-013**: SQLite writes SHOULD be batched or queued so logging calls do not synchronously wait on disk I/O.
+- **FR-014**: SQLite storage MUST flush queued events during graceful shutdown where possible.
+
+**Relational extensibility**
+
+- **FR-015**: Shared relational persistence code MUST be reusable by future SQL Server, PostgreSQL, MySQL, and similar providers.
+- **FR-016**: Provider-specific SQL syntax MUST be isolated behind dialect or provider services.
+- **FR-017**: The first SQLite provider MUST not introduce SQLite-only assumptions into the core structured logs module.
+- **FR-018**: Future relational providers MUST be able to supply their own connection factory, dialect, and migration runner configuration without changing REST, SignalR, or Studio contracts.
+
+**Schema management**
+
+- **FR-019**: Relational schema creation and upgrades MUST use FluentMigrator.
+- **FR-020**: Migrations MUST be versioned and idempotently executable by the host.
+- **FR-021**: Provider packages MUST register only the FluentMigrator runner dependencies they need.
+- **FR-022**: The feature MUST document startup migration behavior and the multi-instance locking consideration for future shared database providers.
+
+**Configuration and safety**
+
+- **FR-023**: Host configuration MUST make the active storage mode explicit when SQLite is selected.
+- **FR-024**: The existing no-configuration in-memory setup MUST continue to work.
+- **FR-025**: The feature MUST document that OpenTelemetry/exporter sinks are deferred and out of scope for this persistence slice.
+
+### Key Entities *(include if feature involves data)*
+
+- **Structured Log Store**: Queryable storage for redacted structured log events and sources.
+- **Structured Log Live Feed**: Runtime stream of new events and dropped-event summaries for SignalR subscribers.
+- **Relational Structured Log Record**: Database representation of a `StructuredLogEvent` with indexed scalar columns and JSON payload columns.
+- **Relational Storage Dialect**: Provider-specific SQL and parameter behavior needed by the shared relational store.
+- **Structured Log Migration Runner**: FluentMigrator-based schema creation and upgrade service.
+- **Structured Log Retention Policy**: Settings and cleanup behavior that bound durable storage growth.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Existing structured logs unit and integration tests continue to pass with the in-memory default.
+- **SC-002**: New tests verify SQLite persistence survives service-provider or process recreation with the same database file.
+- **SC-003**: New tests verify SQLite recent queries honor level, category, source, workflow, correlation, trace/span, time range, and limit filters.
+- **SC-004**: New tests verify FluentMigrator creates the SQLite schema from an empty database.
+- **SC-005**: New tests verify retention cleanup removes expired or excess records.
+- **SC-006**: Documentation shows both zero-configuration in-memory setup and opt-in SQLite setup.
+- **SC-007**: The core structured logs module does not reference SQLite-specific types.
+
+## Assumptions
+
+- The structured logs module from `004-diagnostics-structured-logs` is available and remains the owning diagnostics module.
+- SQLite is the only durable provider implemented in this feature.
+- Future relational providers can be added in separate specs and packages.
+- OpenTelemetry logs export, vendor sinks, raw console streaming, and trace/metric exploration remain out of scope.
+- The implementation can introduce new package dependencies such as FluentMigrator and Dapper where appropriate, with versions managed centrally.

--- a/specs/005-structured-log-persistence/tasks.md
+++ b/specs/005-structured-log-persistence/tasks.md
@@ -1,0 +1,196 @@
+# Tasks: Structured Log Persistence
+
+**Input**: Design documents from `/specs/005-structured-log-persistence/`  
+**Prerequisites**: [plan.md](./plan.md), [spec.md](./spec.md), [research.md](./research.md), [data-model.md](./data-model.md), [contracts/](./contracts), [quickstart.md](./quickstart.md)
+
+**Tests**: Included because the specification defines independent tests for in-memory compatibility, SQLite durability, filtering, migrations, and retention.
+
+**Organization**: Tasks are grouped by user story so each increment can be validated independently.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel with other marked tasks after prerequisites are satisfied.
+- **[Story]**: User story label from [spec.md](./spec.md).
+- Every task includes the primary file path to edit or create.
+
+## Phase 1: Setup
+
+**Purpose**: Add package skeletons, package references, and solution entries for relational and SQLite persistence.
+
+- [ ] T001 Create `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.csproj`.
+- [ ] T002 Create `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.csproj`.
+- [ ] T003 Create `test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests.csproj`.
+- [ ] T004 Create `test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests.csproj`.
+- [ ] T005 Add new projects to `Elsa.sln`.
+- [ ] T006 Add centrally managed package versions for FluentMigrator, SQLite provider, and Dapper if used in `Directory.Packages.props`.
+
+---
+
+## Phase 2: Foundational Storage Refactor
+
+**Purpose**: Split store/live-feed concerns while preserving existing `IStructuredLogProvider` behavior.
+
+**Critical**: No SQLite work should begin until in-memory behavior is preserved behind the new boundaries.
+
+- [ ] T007 Add `IStructuredLogSink` in `src/modules/Elsa.Diagnostics.StructuredLogs/Contracts/IStructuredLogSink.cs`.
+- [ ] T008 Add `IStructuredLogStore` in `src/modules/Elsa.Diagnostics.StructuredLogs/Contracts/IStructuredLogStore.cs`.
+- [ ] T009 Add `IStructuredLogLiveFeed` in `src/modules/Elsa.Diagnostics.StructuredLogs/Contracts/IStructuredLogLiveFeed.cs`.
+- [ ] T010 Refactor `InMemoryStructuredLogProvider` storage behavior into in-memory store/live-feed components under `src/modules/Elsa.Diagnostics.StructuredLogs/Providers/InMemory`.
+- [ ] T011 Add a composed provider facade in `src/modules/Elsa.Diagnostics.StructuredLogs/Services/DefaultStructuredLogProvider.cs`.
+- [ ] T012 Update service registration in `src/modules/Elsa.Diagnostics.StructuredLogs/Extensions/ServiceCollectionExtensions.cs`.
+- [ ] T013 Update existing unit tests in `test/unit/Elsa.Diagnostics.StructuredLogs.UnitTests` for the new in-memory component names.
+
+**Checkpoint**: Existing structured logs tests pass with the default in-memory storage.
+
+---
+
+## Phase 3: User Story 1 - Preserve existing in-memory behavior (Priority: P1) MVP
+
+**Goal**: No-configuration structured logs behave exactly as before from the host, REST, SignalR, and Studio perspective.
+
+**Independent Test**: Enable structured logs without durable storage and verify capture, recent query, filtering, sources, live streaming, and dropped summaries.
+
+### Tests for User Story 1
+
+- [ ] T014 [P] [US1] Add compatibility tests for default store registration in `test/unit/Elsa.Diagnostics.StructuredLogs.UnitTests`.
+- [ ] T015 [P] [US1] Preserve or update in-memory recent query tests in `test/unit/Elsa.Diagnostics.StructuredLogs.UnitTests/InMemory`.
+- [ ] T016 [P] [US1] Preserve or update live dropped-event tests in `test/unit/Elsa.Diagnostics.StructuredLogs.UnitTests/InMemory`.
+
+### Implementation for User Story 1
+
+- [ ] T017 [US1] Ensure `UseStructuredLogs` defaults to bounded in-memory store/live feed in `src/modules/Elsa.Diagnostics.StructuredLogs/Extensions/ServiceCollectionExtensions.cs`.
+- [ ] T018 [US1] Ensure REST endpoints continue to depend on `IStructuredLogProvider` in `src/modules/Elsa.Diagnostics.StructuredLogs/Endpoints/StructuredLogs`.
+- [ ] T019 [US1] Ensure `StructuredLogSubscriptionManager` can stream from the composed provider in `src/modules/Elsa.Diagnostics.StructuredLogs/RealTime/StructuredLogSubscriptionManager.cs`.
+
+**Checkpoint**: User Story 1 is releasable by itself.
+
+---
+
+## Phase 4: User Story 2 - Enable durable SQLite structured log storage (Priority: P2)
+
+**Goal**: Hosts can opt into SQLite storage and retain structured log events across restarts.
+
+**Independent Test**: Configure SQLite, emit events, recreate the service provider with the same database, and query persisted events.
+
+### Tests for User Story 2
+
+- [ ] T020 [P] [US2] Add SQLite migration-from-empty-database test in `test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests`.
+- [ ] T021 [P] [US2] Add SQLite persistence-across-provider-recreation test in `test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests`.
+- [ ] T022 [P] [US2] Add SQLite filter coverage for level/category/source/workflow/correlation/trace/time/limit in `test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests`.
+- [ ] T023 [P] [US2] Add SQLite retention cleanup tests in `test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests`.
+
+### Implementation for User Story 2
+
+- [ ] T024 [US2] Add relational record model in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Models/RelationalStructuredLogRecord.cs`.
+- [ ] T025 [US2] Add relational connection factory contract in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Contracts`.
+- [ ] T026 [US2] Add relational dialect contract and base SQL builder in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Services`.
+- [ ] T027 [US2] Add FluentMigrator migration for structured log tables/indexes in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Migrations`.
+- [ ] T028 [US2] Add relational structured log store implementation in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Stores`.
+- [ ] T029 [US2] Add retention options and cleanup service in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational`.
+- [ ] T030 [US2] Add SQLite connection factory in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Services`.
+- [ ] T031 [US2] Add SQLite dialect in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Services`.
+- [ ] T032 [US2] Add SQLite FluentMigrator runner registration in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite`.
+- [ ] T033 [US2] Add SQLite fluent configuration extension in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Extensions`.
+- [ ] T034 [US2] Ensure queued/batched writes flush during shutdown in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Services`.
+
+**Checkpoint**: User Stories 1 and 2 work together with durable SQLite storage.
+
+---
+
+## Phase 5: User Story 3 - Keep relational persistence extensible (Priority: P3)
+
+**Goal**: Future relational providers can be added by supplying provider services, not by rewriting structured log capture or Studio contracts.
+
+**Independent Test**: Review code boundaries and tests that use fake dialect/connection services where practical.
+
+### Tests for User Story 3
+
+- [ ] T035 [P] [US3] Add relational SQL builder tests with a fake dialect in `test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests`.
+- [ ] T036 [P] [US3] Add registration boundary tests proving core module has no SQLite dependency in `test/unit/Elsa.Diagnostics.StructuredLogs.UnitTests`.
+- [ ] T037 [P] [US3] Add migration metadata/version tests in `test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests`.
+
+### Implementation for User Story 3
+
+- [ ] T038 [US3] Keep provider-specific SQL out of `src/modules/Elsa.Diagnostics.StructuredLogs`.
+- [ ] T039 [US3] Keep SQLite-specific services inside `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite`.
+- [ ] T040 [US3] Document future SQL Server/PostgreSQL provider requirements in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/README.md`.
+
+**Checkpoint**: SQLite is the first relational provider, not a one-off persistence path.
+
+---
+
+## Phase 6: Documentation & Polish
+
+**Purpose**: Update public docs, sample guidance, and validation.
+
+- [ ] T041 Update structured logs README with storage mode guidance in `src/modules/Elsa.Diagnostics.StructuredLogs/README.md`.
+- [ ] T042 Add relational persistence README in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/README.md`.
+- [ ] T043 Add SQLite persistence README in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/README.md`.
+- [ ] T044 Update sample host wiring only if a sample explicitly opts into SQLite in `src/apps/Elsa.Server.Web/Program.cs`.
+- [ ] T045 Run `dotnet build src/modules/Elsa.Diagnostics.StructuredLogs/Elsa.Diagnostics.StructuredLogs.csproj`.
+- [ ] T046 Run `dotnet build src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.csproj`.
+- [ ] T047 Run `dotnet test test/unit/Elsa.Diagnostics.StructuredLogs.UnitTests/Elsa.Diagnostics.StructuredLogs.UnitTests.csproj`.
+- [ ] T048 Run `dotnet test test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests.csproj`.
+- [ ] T049 Run `dotnet test test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests.csproj`.
+- [ ] T050 Run `rg "OpenTelemetry|OTLP|Datadog|Logstash|Splunk|Loki|Seq" src/modules/Elsa.Diagnostics.StructuredLogs* specs/005-structured-log-persistence` and confirm only out-of-scope documentation references remain.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 Setup**: No dependencies.
+- **Phase 2 Foundational**: Depends on Phase 1 and blocks SQLite work.
+- **Phase 3 US1**: Depends on Phase 2; MVP.
+- **Phase 4 US2**: Depends on Phase 2 and should follow US1 validation.
+- **Phase 5 US3**: Depends on relational code from US2.
+- **Phase 6 Polish**: Depends on selected story implementation.
+
+### User Story Dependencies
+
+- **US1 (P1)**: First executable slice; preserves current behavior.
+- **US2 (P2)**: Adds durable SQLite storage using the new storage boundary.
+- **US3 (P3)**: Hardens provider boundaries for future relational stores.
+
+### Parallel Opportunities
+
+- T001 through T004 can run in parallel.
+- T007 through T009 can run in parallel.
+- US1 tests T014 through T016 can run in parallel after Phase 2.
+- US2 tests T020 through T023 can run in parallel after SQLite skeleton exists.
+- US3 tests T035 through T037 can run in parallel after relational contracts exist.
+- Documentation tasks T041 through T043 can run in parallel after implementation APIs settle.
+
+## Parallel Example: User Story 2
+
+```text
+Task: "Add SQLite migration-from-empty-database test in test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests"
+Task: "Add SQLite persistence-across-provider-recreation test in test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests"
+Task: "Add SQLite filter coverage for level/category/source/workflow/correlation/trace/time/limit in test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests"
+Task: "Add SQLite retention cleanup tests in test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests"
+```
+
+## Implementation Strategy
+
+### MVP First
+
+1. Complete Phase 1 and Phase 2.
+2. Complete Phase 3 only.
+3. Run existing structured logs tests and ensure no behavior changed.
+4. Continue to SQLite persistence after the storage boundary is stable.
+
+### Incremental Delivery
+
+1. US1: in-memory compatibility after storage refactor.
+2. US2: durable SQLite persistence with migrations and retention.
+3. US3: relational provider extensibility.
+4. Polish: documentation, sample guidance, builds, and tests.
+
+## Notes
+
+- Do not implement OTLP or vendor sinks in this feature.
+- Do not introduce EF Core for structured log persistence.
+- Preserve redaction-before-storage.
+- Keep Studio REST and SignalR contracts unchanged.
+- Prefer small, boring SQL over clever generic query abstraction unless implementation pressure proves otherwise.

--- a/specs/005-structured-log-persistence/tasks.md
+++ b/specs/005-structured-log-persistence/tasks.md
@@ -3,9 +3,9 @@
 **Input**: Design documents from `/specs/005-structured-log-persistence/`  
 **Prerequisites**: [plan.md](./plan.md), [spec.md](./spec.md), [research.md](./research.md), [data-model.md](./data-model.md), [contracts/](./contracts), [quickstart.md](./quickstart.md)
 
-**Tests**: Included because the specification defines independent tests for in-memory compatibility, SQLite durability, filtering, migrations, and retention.
+**Tests**: Included because the specification defines independent tests for in-memory compatibility, SQLite durability, filtering, migrations, queue overflow, timestamp storage, graceful shutdown flushing, and retention.
 
-**Organization**: Tasks are grouped by user story so each increment can be validated independently.
+**Organization**: Tasks are grouped by user story so each increment can be implemented and tested independently.
 
 ## Format: `[ID] [P?] [Story] Description`
 
@@ -17,81 +17,95 @@
 
 **Purpose**: Add package skeletons, package references, and solution entries for relational and SQLite persistence.
 
-- [ ] T001 Create `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.csproj`.
-- [ ] T002 Create `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.csproj`.
-- [ ] T003 Create `test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests.csproj`.
-- [ ] T004 Create `test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests.csproj`.
+- [ ] T001 [P] Create relational persistence project in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.csproj`.
+- [ ] T002 [P] Create SQLite persistence project in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.csproj`.
+- [ ] T003 [P] Create relational unit test project in `test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests.csproj`.
+- [ ] T004 [P] Create SQLite integration test project in `test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests.csproj`.
 - [ ] T005 Add new projects to `Elsa.sln`.
-- [ ] T006 Add centrally managed package versions for FluentMigrator, SQLite provider, and Dapper if used in `Directory.Packages.props`.
+- [ ] T006 Add centrally managed package versions for FluentMigrator and SQLite dependencies in `Directory.Packages.props`.
 
 ---
 
 ## Phase 2: Foundational Storage Refactor
 
-**Purpose**: Split store/live-feed concerns while preserving existing `IStructuredLogProvider` behavior.
+**Purpose**: Split store and live-feed concerns while preserving the current `IStructuredLogProvider` facade.
 
-**Critical**: No SQLite work should begin until in-memory behavior is preserved behind the new boundaries.
+**Critical**: No SQLite story work should begin until the in-memory default still passes existing structured log tests.
 
-- [ ] T007 Add `IStructuredLogSink` in `src/modules/Elsa.Diagnostics.StructuredLogs/Contracts/IStructuredLogSink.cs`.
-- [ ] T008 Add `IStructuredLogStore` in `src/modules/Elsa.Diagnostics.StructuredLogs/Contracts/IStructuredLogStore.cs`.
-- [ ] T009 Add `IStructuredLogLiveFeed` in `src/modules/Elsa.Diagnostics.StructuredLogs/Contracts/IStructuredLogLiveFeed.cs`.
-- [ ] T010 Refactor `InMemoryStructuredLogProvider` storage behavior into in-memory store/live-feed components under `src/modules/Elsa.Diagnostics.StructuredLogs/Providers/InMemory`.
-- [ ] T011 Add a composed provider facade in `src/modules/Elsa.Diagnostics.StructuredLogs/Services/DefaultStructuredLogProvider.cs`.
-- [ ] T012 Update service registration in `src/modules/Elsa.Diagnostics.StructuredLogs/Extensions/ServiceCollectionExtensions.cs`.
-- [ ] T013 Update existing unit tests in `test/unit/Elsa.Diagnostics.StructuredLogs.UnitTests` for the new in-memory component names.
+- [ ] T007 [P] Add append-only sink contract in `src/modules/Elsa.Diagnostics.StructuredLogs/Contracts/IStructuredLogSink.cs`.
+- [ ] T008 [P] Add queryable store contract in `src/modules/Elsa.Diagnostics.StructuredLogs/Contracts/IStructuredLogStore.cs`.
+- [ ] T009 [P] Add live feed contract in `src/modules/Elsa.Diagnostics.StructuredLogs/Contracts/IStructuredLogLiveFeed.cs`.
+- [ ] T010 Refactor in-memory recent-history behavior into `src/modules/Elsa.Diagnostics.StructuredLogs/Providers/InMemory/InMemoryStructuredLogStore.cs`.
+- [ ] T011 Refactor in-memory subscriber behavior into `src/modules/Elsa.Diagnostics.StructuredLogs/Providers/InMemory/InMemoryStructuredLogLiveFeed.cs`.
+- [ ] T012 Preserve `InMemoryStructuredLogProvider` compatibility facade in `src/modules/Elsa.Diagnostics.StructuredLogs/Providers/InMemory/InMemoryStructuredLogProvider.cs`.
+- [ ] T013 Add composed provider facade in `src/modules/Elsa.Diagnostics.StructuredLogs/Services/DefaultStructuredLogProvider.cs`.
+- [ ] T014 Update default DI registration in `src/modules/Elsa.Diagnostics.StructuredLogs/Extensions/ServiceCollectionExtensions.cs`.
 
-**Checkpoint**: Existing structured logs tests pass with the default in-memory storage.
+**Checkpoint**: Existing structured logs behavior is preserved behind the new abstractions.
 
 ---
 
 ## Phase 3: User Story 1 - Preserve existing in-memory behavior (Priority: P1) MVP
 
-**Goal**: No-configuration structured logs behave exactly as before from the host, REST, SignalR, and Studio perspective.
+**Goal**: Hosts that configure only `UseStructuredLogs` get the same bounded in-memory recent query, source listing, live streaming, redaction, and dropped-event behavior as before.
 
-**Independent Test**: Enable structured logs without durable storage and verify capture, recent query, filtering, sources, live streaming, and dropped summaries.
+**Independent Test**: Enable structured logs without durable persistence, emit `ILogger` records, and verify recent queries, filters, source listing, live subscriptions, and dropped summaries.
 
 ### Tests for User Story 1
 
-- [ ] T014 [P] [US1] Add compatibility tests for default store registration in `test/unit/Elsa.Diagnostics.StructuredLogs.UnitTests`.
-- [ ] T015 [P] [US1] Preserve or update in-memory recent query tests in `test/unit/Elsa.Diagnostics.StructuredLogs.UnitTests/InMemory`.
-- [ ] T016 [P] [US1] Preserve or update live dropped-event tests in `test/unit/Elsa.Diagnostics.StructuredLogs.UnitTests/InMemory`.
+- [ ] T015 [P] [US1] Add default registration compatibility tests in `test/unit/Elsa.Diagnostics.StructuredLogs.UnitTests/StructuredLogsStorageRegistrationTests.cs`.
+- [ ] T016 [P] [US1] Update in-memory recent query tests in `test/unit/Elsa.Diagnostics.StructuredLogs.UnitTests/InMemory/InMemoryStructuredLogProviderTests.cs`.
+- [ ] T017 [P] [US1] Update in-memory source listing tests in `test/unit/Elsa.Diagnostics.StructuredLogs.UnitTests/InMemory/InMemoryStructuredLogProviderSourceTests.cs`.
+- [ ] T018 [P] [US1] Update live dropped-event tests in `test/unit/Elsa.Diagnostics.StructuredLogs.UnitTests/InMemory/InMemoryStructuredLogProviderTests.cs`.
 
 ### Implementation for User Story 1
 
-- [ ] T017 [US1] Ensure `UseStructuredLogs` defaults to bounded in-memory store/live feed in `src/modules/Elsa.Diagnostics.StructuredLogs/Extensions/ServiceCollectionExtensions.cs`.
-- [ ] T018 [US1] Ensure REST endpoints continue to depend on `IStructuredLogProvider` in `src/modules/Elsa.Diagnostics.StructuredLogs/Endpoints/StructuredLogs`.
-- [ ] T019 [US1] Ensure `StructuredLogSubscriptionManager` can stream from the composed provider in `src/modules/Elsa.Diagnostics.StructuredLogs/RealTime/StructuredLogSubscriptionManager.cs`.
+- [ ] T019 [US1] Ensure REST endpoints continue using `IStructuredLogProvider` in `src/modules/Elsa.Diagnostics.StructuredLogs/Endpoints/StructuredLogs/Recent/Endpoint.cs`.
+- [ ] T020 [US1] Ensure source endpoint continues using `IStructuredLogProvider` in `src/modules/Elsa.Diagnostics.StructuredLogs/Endpoints/StructuredLogs/Sources/Endpoint.cs`.
+- [ ] T021 [US1] Ensure SignalR subscriptions stream through the composed provider in `src/modules/Elsa.Diagnostics.StructuredLogs/RealTime/StructuredLogSubscriptionManager.cs`.
+- [ ] T022 [US1] Run `dotnet test test/unit/Elsa.Diagnostics.StructuredLogs.UnitTests/Elsa.Diagnostics.StructuredLogs.UnitTests.csproj`.
 
-**Checkpoint**: User Story 1 is releasable by itself.
+**Checkpoint**: User Story 1 is fully functional and independently testable.
 
 ---
 
 ## Phase 4: User Story 2 - Enable durable SQLite structured log storage (Priority: P2)
 
-**Goal**: Hosts can opt into SQLite storage and retain structured log events across restarts.
+**Goal**: Hosts can opt into SQLite storage, run migrations by default, persist redacted structured logs across restarts, query persisted records, flush queued writes on graceful shutdown, and configure retention explicitly.
 
-**Independent Test**: Configure SQLite, emit events, recreate the service provider with the same database, and query persisted events.
+**Independent Test**: Configure SQLite storage, emit events, flush or recreate services with the same database file, and verify persisted recent queries, filters, migration behavior, queue overflow behavior, timestamp storage, and retention behavior.
 
 ### Tests for User Story 2
 
-- [ ] T020 [P] [US2] Add SQLite migration-from-empty-database test in `test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests`.
-- [ ] T021 [P] [US2] Add SQLite persistence-across-provider-recreation test in `test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests`.
-- [ ] T022 [P] [US2] Add SQLite filter coverage for level/category/source/workflow/correlation/trace/time/limit in `test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests`.
-- [ ] T023 [P] [US2] Add SQLite retention cleanup tests in `test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests`.
+- [ ] T023 [P] [US2] Add SQLite migration-from-empty-database test in `test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogMigrationTests.cs`.
+- [ ] T024 [P] [US2] Add SQLite persistence-across-provider-recreation test in `test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogStoreTests.cs`.
+- [ ] T025 [P] [US2] Add SQLite filter coverage for level, category, source, workflow, correlation, trace, time, and limit in `test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogFilterTests.cs`.
+- [ ] T026 [P] [US2] Add SQLite write queue flush and overflow tests in `test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogWriteQueueTests.cs`.
+- [ ] T027 [P] [US2] Add SQLite startup migration opt-out tests in `test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogMigrationTests.cs`.
+- [ ] T028 [P] [US2] Add SQLite ISO-8601 timestamp storage tests in `test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogTimestampTests.cs`.
+- [ ] T029 [P] [US2] Add SQLite retention tests for opt-in cleanup and default no-delete behavior in `test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogRetentionTests.cs`.
 
 ### Implementation for User Story 2
 
-- [ ] T024 [US2] Add relational record model in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Models/RelationalStructuredLogRecord.cs`.
-- [ ] T025 [US2] Add relational connection factory contract in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Contracts`.
-- [ ] T026 [US2] Add relational dialect contract and base SQL builder in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Services`.
-- [ ] T027 [US2] Add FluentMigrator migration for structured log tables/indexes in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Migrations`.
-- [ ] T028 [US2] Add relational structured log store implementation in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Stores`.
-- [ ] T029 [US2] Add retention options and cleanup service in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational`.
-- [ ] T030 [US2] Add SQLite connection factory in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Services`.
-- [ ] T031 [US2] Add SQLite dialect in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Services`.
-- [ ] T032 [US2] Add SQLite FluentMigrator runner registration in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite`.
-- [ ] T033 [US2] Add SQLite fluent configuration extension in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Extensions`.
-- [ ] T034 [US2] Ensure queued/batched writes flush during shutdown in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Services`.
+- [ ] T030 [US2] Add relational record model in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Models/RelationalStructuredLogRecord.cs`.
+- [ ] T031 [US2] Add relational persistence options in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Options/RelationalStructuredLogOptions.cs`.
+- [ ] T032 [US2] Add relational connection factory contract in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Contracts/IRelationalStructuredLogConnectionFactory.cs`.
+- [ ] T033 [US2] Add relational dialect contract in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Contracts/IRelationalStructuredLogDialect.cs`.
+- [ ] T034 [US2] Add schema migrator contract in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Contracts/IStructuredLogSchemaMigrator.cs`.
+- [ ] T035 [US2] Add SQL builder for inserts, filters, sources, and retention in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Services/RelationalStructuredLogSqlBuilder.cs`.
+- [ ] T036 [US2] Add JSON/timestamp mapper in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Services/RelationalStructuredLogMapper.cs`.
+- [ ] T037 [US2] Add FluentMigrator migration for structured log tables and indexes in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Migrations/M001_CreateStructuredLogTables.cs`.
+- [ ] T038 [US2] Add relational structured log store in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Stores/RelationalStructuredLogStore.cs`.
+- [ ] T039 [US2] Add bounded write buffer with graceful shutdown flush in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Services/StructuredLogWriteBuffer.cs`.
+- [ ] T040 [US2] Add retention cleanup service in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Services/StructuredLogRetentionService.cs`.
+- [ ] T041 [US2] Add relational service registration extensions in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Extensions/RelationalStructuredLogsServiceCollectionExtensions.cs`.
+- [ ] T042 [US2] Add SQLite options in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Options/SqliteStructuredLogOptions.cs`.
+- [ ] T043 [US2] Add SQLite connection factory in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Services/SqliteStructuredLogConnectionFactory.cs`.
+- [ ] T044 [US2] Add SQLite dialect in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Services/SqliteStructuredLogDialect.cs`.
+- [ ] T045 [US2] Add FluentMigrator runner integration in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Services/SqliteStructuredLogSchemaMigrator.cs`.
+- [ ] T046 [US2] Add SQLite hosted startup service for migrations and cleanup in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Services/SqliteStructuredLogStartupService.cs`.
+- [ ] T047 [US2] Add SQLite fluent configuration extension in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Extensions/SqliteStructuredLogsModuleExtensions.cs`.
+- [ ] T048 [US2] Run `dotnet test test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests.csproj`.
 
 **Checkpoint**: User Stories 1 and 2 work together with durable SQLite storage.
 
@@ -99,21 +113,23 @@
 
 ## Phase 5: User Story 3 - Keep relational persistence extensible (Priority: P3)
 
-**Goal**: Future relational providers can be added by supplying provider services, not by rewriting structured log capture or Studio contracts.
+**Goal**: Future relational providers can reuse the relational store by supplying a connection factory, dialect, and FluentMigrator runner configuration without changing core structured logs or Studio contracts.
 
-**Independent Test**: Review code boundaries and tests that use fake dialect/connection services where practical.
+**Independent Test**: Review code boundaries and run relational tests that use fake dialect or connection services where practical.
 
 ### Tests for User Story 3
 
-- [ ] T035 [P] [US3] Add relational SQL builder tests with a fake dialect in `test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests`.
-- [ ] T036 [P] [US3] Add registration boundary tests proving core module has no SQLite dependency in `test/unit/Elsa.Diagnostics.StructuredLogs.UnitTests`.
-- [ ] T037 [P] [US3] Add migration metadata/version tests in `test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests`.
+- [ ] T049 [P] [US3] Add relational SQL builder tests with a fake dialect in `test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/RelationalStructuredLogSqlBuilderTests.cs`.
+- [ ] T050 [P] [US3] Add relational mapper tests for JSON and UTC ISO-8601 timestamps in `test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/RelationalStructuredLogMapperTests.cs`.
+- [ ] T051 [P] [US3] Add migration metadata/version tests in `test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/StructuredLogMigrationTests.cs`.
+- [ ] T052 [P] [US3] Add core boundary test proving `Elsa.Diagnostics.StructuredLogs` has no SQLite dependency in `test/unit/Elsa.Diagnostics.StructuredLogs.UnitTests/StructuredLogsStorageRegistrationTests.cs`.
 
 ### Implementation for User Story 3
 
-- [ ] T038 [US3] Keep provider-specific SQL out of `src/modules/Elsa.Diagnostics.StructuredLogs`.
-- [ ] T039 [US3] Keep SQLite-specific services inside `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite`.
-- [ ] T040 [US3] Document future SQL Server/PostgreSQL provider requirements in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/README.md`.
+- [ ] T053 [US3] Keep provider-specific SQL outside core module in `src/modules/Elsa.Diagnostics.StructuredLogs`.
+- [ ] T054 [US3] Keep SQLite-specific services inside `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite`.
+- [ ] T055 [US3] Add relational provider guidance in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/README.md`.
+- [ ] T056 [US3] Run `dotnet test test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests.csproj`.
 
 **Checkpoint**: SQLite is the first relational provider, not a one-off persistence path.
 
@@ -123,16 +139,16 @@
 
 **Purpose**: Update public docs, sample guidance, and validation.
 
-- [ ] T041 Update structured logs README with storage mode guidance in `src/modules/Elsa.Diagnostics.StructuredLogs/README.md`.
-- [ ] T042 Add relational persistence README in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/README.md`.
-- [ ] T043 Add SQLite persistence README in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/README.md`.
-- [ ] T044 Update sample host wiring only if a sample explicitly opts into SQLite in `src/apps/Elsa.Server.Web/Program.cs`.
-- [ ] T045 Run `dotnet build src/modules/Elsa.Diagnostics.StructuredLogs/Elsa.Diagnostics.StructuredLogs.csproj`.
-- [ ] T046 Run `dotnet build src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.csproj`.
-- [ ] T047 Run `dotnet test test/unit/Elsa.Diagnostics.StructuredLogs.UnitTests/Elsa.Diagnostics.StructuredLogs.UnitTests.csproj`.
-- [ ] T048 Run `dotnet test test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests.csproj`.
-- [ ] T049 Run `dotnet test test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests.csproj`.
-- [ ] T050 Run `rg "OpenTelemetry|OTLP|Datadog|Logstash|Splunk|Loki|Seq" src/modules/Elsa.Diagnostics.StructuredLogs* specs/005-structured-log-persistence` and confirm only out-of-scope documentation references remain.
+- [ ] T057 [P] Update structured logs README with storage mode guidance in `src/modules/Elsa.Diagnostics.StructuredLogs/README.md`.
+- [ ] T058 [P] Add SQLite persistence README in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/README.md`.
+- [ ] T059 [P] Update Speckit quickstart implementation notes in `specs/005-structured-log-persistence/quickstart.md`.
+- [ ] T060 Update sample host wiring only if a sample explicitly opts into SQLite in `src/apps/Elsa.Server.Web/Program.cs`.
+- [ ] T061 Run `dotnet build src/modules/Elsa.Diagnostics.StructuredLogs/Elsa.Diagnostics.StructuredLogs.csproj`.
+- [ ] T062 Run `dotnet build src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.csproj`.
+- [ ] T063 Run `dotnet test test/unit/Elsa.Diagnostics.StructuredLogs.UnitTests/Elsa.Diagnostics.StructuredLogs.UnitTests.csproj`.
+- [ ] T064 Run `dotnet test test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests.csproj`.
+- [ ] T065 Run `dotnet test test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests.csproj`.
+- [ ] T066 Run `rg "OpenTelemetry|OTLP|Datadog|Logstash|Splunk|Loki|Seq" src/modules/Elsa.Diagnostics.StructuredLogs* specs/005-structured-log-persistence` and confirm only out-of-scope documentation references remain.
 
 ---
 
@@ -141,15 +157,15 @@
 ### Phase Dependencies
 
 - **Phase 1 Setup**: No dependencies.
-- **Phase 2 Foundational**: Depends on Phase 1 and blocks SQLite work.
+- **Phase 2 Foundational**: Depends on Phase 1 and blocks all user stories.
 - **Phase 3 US1**: Depends on Phase 2; MVP.
 - **Phase 4 US2**: Depends on Phase 2 and should follow US1 validation.
-- **Phase 5 US3**: Depends on relational code from US2.
+- **Phase 5 US3**: Depends on relational and SQLite code from US2.
 - **Phase 6 Polish**: Depends on selected story implementation.
 
 ### User Story Dependencies
 
-- **US1 (P1)**: First executable slice; preserves current behavior.
+- **US1 (P1)**: First executable slice; preserves current behavior after storage refactor.
 - **US2 (P2)**: Adds durable SQLite storage using the new storage boundary.
 - **US3 (P3)**: Hardens provider boundaries for future relational stores.
 
@@ -157,18 +173,18 @@
 
 - T001 through T004 can run in parallel.
 - T007 through T009 can run in parallel.
-- US1 tests T014 through T016 can run in parallel after Phase 2.
-- US2 tests T020 through T023 can run in parallel after SQLite skeleton exists.
-- US3 tests T035 through T037 can run in parallel after relational contracts exist.
-- Documentation tasks T041 through T043 can run in parallel after implementation APIs settle.
+- US1 tests T015 through T018 can run in parallel after Phase 2.
+- US2 tests T023 through T029 can run in parallel after project skeleton exists.
+- US3 tests T049 through T052 can run in parallel after relational contracts exist.
+- Documentation tasks T057 through T059 can run in parallel after implementation APIs settle.
 
 ## Parallel Example: User Story 2
 
 ```text
-Task: "Add SQLite migration-from-empty-database test in test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests"
-Task: "Add SQLite persistence-across-provider-recreation test in test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests"
-Task: "Add SQLite filter coverage for level/category/source/workflow/correlation/trace/time/limit in test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests"
-Task: "Add SQLite retention cleanup tests in test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests"
+Task: "Add SQLite migration-from-empty-database test in test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogMigrationTests.cs"
+Task: "Add SQLite persistence-across-provider-recreation test in test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogStoreTests.cs"
+Task: "Add SQLite filter coverage for level, category, source, workflow, correlation, trace, time, and limit in test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogFilterTests.cs"
+Task: "Add SQLite retention tests for opt-in cleanup and default no-delete behavior in test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogRetentionTests.cs"
 ```
 
 ## Implementation Strategy
@@ -183,7 +199,7 @@ Task: "Add SQLite retention cleanup tests in test/integration/Elsa.Diagnostics.S
 ### Incremental Delivery
 
 1. US1: in-memory compatibility after storage refactor.
-2. US2: durable SQLite persistence with migrations and retention.
+2. US2: durable SQLite persistence with migrations, queue behavior, timestamp storage, and retention.
 3. US3: relational provider extensibility.
 4. Polish: documentation, sample guidance, builds, and tests.
 
@@ -193,4 +209,4 @@ Task: "Add SQLite retention cleanup tests in test/integration/Elsa.Diagnostics.S
 - Do not introduce EF Core for structured log persistence.
 - Preserve redaction-before-storage.
 - Keep Studio REST and SignalR contracts unchanged.
-- Prefer small, boring SQL over clever generic query abstraction unless implementation pressure proves otherwise.
+- Prefer small, explicit SQL over clever generic query abstraction unless implementation pressure proves otherwise.

--- a/specs/005-structured-log-persistence/tasks.md
+++ b/specs/005-structured-log-persistence/tasks.md
@@ -17,14 +17,14 @@
 
 **Purpose**: Add package skeletons, package references, and solution entries for relational and SQLite persistence.
 
-- [ ] T001 [P] Create relational persistence project in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.csproj`.
-- [ ] T002 [P] Create SQLite persistence project in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.csproj`.
-- [ ] T003 [P] Create relational unit test project in `test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests.csproj`.
-- [ ] T004 [P] Create SQLite integration test project in `test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests.csproj`.
-- [ ] T005 [P] Create relational module shell feature skeleton in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/ShellFeatures/StructuredLogRelationalPersistenceFeature.cs`.
-- [ ] T006 [P] Create SQLite module shell feature skeleton in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/ShellFeatures/SqliteStructuredLogPersistenceFeature.cs`.
-- [ ] T007 Add new projects to `Elsa.sln`.
-- [ ] T008 Add centrally managed package versions for FluentMigrator and SQLite dependencies in `Directory.Packages.props`.
+- [X] T001 [P] Create relational persistence project in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.csproj`.
+- [X] T002 [P] Create SQLite persistence project in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.csproj`.
+- [X] T003 [P] Create relational unit test project in `test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests.csproj`.
+- [X] T004 [P] Create SQLite integration test project in `test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests.csproj`.
+- [X] T005 [P] Create relational module shell feature skeleton in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/ShellFeatures/StructuredLogRelationalPersistenceFeature.cs`.
+- [X] T006 [P] Create SQLite module shell feature skeleton in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/ShellFeatures/SqliteStructuredLogPersistenceFeature.cs`.
+- [X] T007 Add new projects to `Elsa.sln`.
+- [X] T008 Add centrally managed package versions for FluentMigrator and SQLite dependencies in `Directory.Packages.props`.
 
 ---
 
@@ -34,14 +34,14 @@
 
 **Critical**: No SQLite story work should begin until the in-memory default still passes existing structured log tests.
 
-- [ ] T009 [P] Add append-only sink contract in `src/modules/Elsa.Diagnostics.StructuredLogs/Contracts/IStructuredLogSink.cs`.
-- [ ] T010 [P] Add queryable store contract in `src/modules/Elsa.Diagnostics.StructuredLogs/Contracts/IStructuredLogStore.cs`.
-- [ ] T011 [P] Add live feed contract in `src/modules/Elsa.Diagnostics.StructuredLogs/Contracts/IStructuredLogLiveFeed.cs`.
-- [ ] T012 Refactor in-memory recent-history behavior into `src/modules/Elsa.Diagnostics.StructuredLogs/Providers/InMemory/InMemoryStructuredLogStore.cs`.
-- [ ] T013 Refactor in-memory subscriber behavior into `src/modules/Elsa.Diagnostics.StructuredLogs/Providers/InMemory/InMemoryStructuredLogLiveFeed.cs`.
-- [ ] T014 Preserve `InMemoryStructuredLogProvider` compatibility facade in `src/modules/Elsa.Diagnostics.StructuredLogs/Providers/InMemory/InMemoryStructuredLogProvider.cs`.
-- [ ] T015 Add composed provider facade in `src/modules/Elsa.Diagnostics.StructuredLogs/Services/DefaultStructuredLogProvider.cs`.
-- [ ] T016 Update default DI registration in `src/modules/Elsa.Diagnostics.StructuredLogs/Extensions/ServiceCollectionExtensions.cs`.
+- [X] T009 [P] Add append-only sink contract in `src/modules/Elsa.Diagnostics.StructuredLogs/Contracts/IStructuredLogSink.cs`.
+- [X] T010 [P] Add queryable store contract in `src/modules/Elsa.Diagnostics.StructuredLogs/Contracts/IStructuredLogStore.cs`.
+- [X] T011 [P] Add live feed contract in `src/modules/Elsa.Diagnostics.StructuredLogs/Contracts/IStructuredLogLiveFeed.cs`.
+- [X] T012 Refactor in-memory recent-history behavior into `src/modules/Elsa.Diagnostics.StructuredLogs/Providers/InMemory/InMemoryStructuredLogStore.cs`.
+- [X] T013 Refactor in-memory subscriber behavior into `src/modules/Elsa.Diagnostics.StructuredLogs/Providers/InMemory/InMemoryStructuredLogLiveFeed.cs`.
+- [X] T014 Preserve `InMemoryStructuredLogProvider` compatibility facade in `src/modules/Elsa.Diagnostics.StructuredLogs/Providers/InMemory/InMemoryStructuredLogProvider.cs`.
+- [X] T015 Add composed provider facade in `src/modules/Elsa.Diagnostics.StructuredLogs/Services/DefaultStructuredLogProvider.cs`.
+- [X] T016 Update default DI registration in `src/modules/Elsa.Diagnostics.StructuredLogs/Extensions/ServiceCollectionExtensions.cs`.
 
 **Checkpoint**: Existing structured logs behavior is preserved behind the new abstractions.
 
@@ -55,17 +55,17 @@
 
 ### Tests for User Story 1
 
-- [ ] T017 [P] [US1] Add default registration compatibility tests in `test/unit/Elsa.Diagnostics.StructuredLogs.UnitTests/StructuredLogsStorageRegistrationTests.cs`.
-- [ ] T018 [P] [US1] Update in-memory recent query tests in `test/unit/Elsa.Diagnostics.StructuredLogs.UnitTests/InMemory/InMemoryStructuredLogProviderTests.cs`.
-- [ ] T019 [P] [US1] Update in-memory source listing tests in `test/unit/Elsa.Diagnostics.StructuredLogs.UnitTests/InMemory/InMemoryStructuredLogProviderSourceTests.cs`.
-- [ ] T020 [P] [US1] Update live dropped-event tests in `test/unit/Elsa.Diagnostics.StructuredLogs.UnitTests/InMemory/InMemoryStructuredLogProviderTests.cs`.
+- [X] T017 [P] [US1] Add default registration compatibility tests in `test/unit/Elsa.Diagnostics.StructuredLogs.UnitTests/StructuredLogsStorageRegistrationTests.cs`.
+- [X] T018 [P] [US1] Update in-memory recent query tests in `test/unit/Elsa.Diagnostics.StructuredLogs.UnitTests/InMemory/InMemoryStructuredLogProviderTests.cs`.
+- [X] T019 [P] [US1] Update in-memory source listing tests in `test/unit/Elsa.Diagnostics.StructuredLogs.UnitTests/InMemory/InMemoryStructuredLogProviderSourceTests.cs`.
+- [X] T020 [P] [US1] Update live dropped-event tests in `test/unit/Elsa.Diagnostics.StructuredLogs.UnitTests/InMemory/InMemoryStructuredLogProviderTests.cs`.
 
 ### Implementation for User Story 1
 
-- [ ] T021 [US1] Ensure REST endpoints continue using `IStructuredLogProvider` in `src/modules/Elsa.Diagnostics.StructuredLogs/Endpoints/StructuredLogs/Recent/Endpoint.cs`.
-- [ ] T022 [US1] Ensure source endpoint continues using `IStructuredLogProvider` in `src/modules/Elsa.Diagnostics.StructuredLogs/Endpoints/StructuredLogs/Sources/Endpoint.cs`.
-- [ ] T023 [US1] Ensure SignalR subscriptions stream through the composed provider in `src/modules/Elsa.Diagnostics.StructuredLogs/RealTime/StructuredLogSubscriptionManager.cs`.
-- [ ] T024 [US1] Run `dotnet test test/unit/Elsa.Diagnostics.StructuredLogs.UnitTests/Elsa.Diagnostics.StructuredLogs.UnitTests.csproj`.
+- [X] T021 [US1] Ensure REST endpoints continue using `IStructuredLogProvider` in `src/modules/Elsa.Diagnostics.StructuredLogs/Endpoints/StructuredLogs/Recent/Endpoint.cs`.
+- [X] T022 [US1] Ensure source endpoint continues using `IStructuredLogProvider` in `src/modules/Elsa.Diagnostics.StructuredLogs/Endpoints/StructuredLogs/Sources/Endpoint.cs`.
+- [X] T023 [US1] Ensure SignalR subscriptions stream through the composed provider in `src/modules/Elsa.Diagnostics.StructuredLogs/RealTime/StructuredLogSubscriptionManager.cs`.
+- [X] T024 [US1] Run `dotnet test test/unit/Elsa.Diagnostics.StructuredLogs.UnitTests/Elsa.Diagnostics.StructuredLogs.UnitTests.csproj`.
 
 **Checkpoint**: User Story 1 is fully functional and independently testable.
 
@@ -79,40 +79,40 @@
 
 ### Tests for User Story 2
 
-- [ ] T025 [P] [US2] Add SQLite migration-from-empty-database test in `test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogMigrationTests.cs`.
-- [ ] T026 [P] [US2] Add SQLite persistence-across-provider-recreation test in `test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogStoreTests.cs`.
-- [ ] T027 [P] [US2] Add SQLite persisted redaction test in `test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogStoreTests.cs`.
-- [ ] T028 [P] [US2] Add SQLite filter coverage for level, category, source, workflow, correlation, trace, time, and limit in `test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogFilterTests.cs`.
-- [ ] T029 [P] [US2] Add SQLite write queue flush and overflow tests for `DroppedWriteCount` in `test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogWriteQueueTests.cs`.
-- [ ] T030 [P] [US2] Add SQLite startup migration opt-out tests in `test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogMigrationTests.cs`.
-- [ ] T031 [P] [US2] Add SQLite ISO-8601 timestamp storage tests in `test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogTimestampTests.cs`.
-- [ ] T032 [P] [US2] Add SQLite retention tests for opt-in cleanup and default no-delete behavior in `test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogRetentionTests.cs`.
+- [X] T025 [P] [US2] Add SQLite migration-from-empty-database test in `test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogMigrationTests.cs`.
+- [X] T026 [P] [US2] Add SQLite persistence-across-provider-recreation test in `test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogStoreTests.cs`.
+- [X] T027 [P] [US2] Add SQLite persisted redaction test in `test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogStoreTests.cs`.
+- [X] T028 [P] [US2] Add SQLite filter coverage for level, category, source, workflow, correlation, trace, time, and limit in `test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogFilterTests.cs`.
+- [X] T029 [P] [US2] Add SQLite write queue flush and overflow tests for `DroppedWriteCount` in `test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogWriteQueueTests.cs`.
+- [X] T030 [P] [US2] Add SQLite startup migration opt-out tests in `test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogMigrationTests.cs`.
+- [X] T031 [P] [US2] Add SQLite ISO-8601 timestamp storage tests in `test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogTimestampTests.cs`.
+- [X] T032 [P] [US2] Add SQLite retention tests for opt-in cleanup and default no-delete behavior in `test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogRetentionTests.cs`.
 
 ### Implementation for User Story 2
 
-- [ ] T033 [US2] Add relational record model in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Models/RelationalStructuredLogRecord.cs`.
-- [ ] T034 [US2] Add relational persistence options in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Options/RelationalStructuredLogOptions.cs`.
-- [ ] T035 [US2] Add relational connection factory contract in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Contracts/IRelationalStructuredLogConnectionFactory.cs`.
-- [ ] T036 [US2] Add relational dialect contract in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Contracts/IRelationalStructuredLogDialect.cs`.
-- [ ] T037 [US2] Add schema migrator contract in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Contracts/IStructuredLogSchemaMigrator.cs`.
-- [ ] T038 [US2] Add SQL builder for inserts, filters, sources, and retention in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Services/RelationalStructuredLogSqlBuilder.cs`.
-- [ ] T039 [US2] Add JSON/timestamp mapper in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Services/RelationalStructuredLogMapper.cs`.
-- [ ] T040 [US2] Add FluentMigrator migration for structured log tables and indexes in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Migrations/M001_CreateStructuredLogTables.cs`.
-- [ ] T041 [US2] Add relational structured log store in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Stores/RelationalStructuredLogStore.cs`.
-- [ ] T042 [US2] Add bounded write buffer with graceful shutdown flush and dropped-write warning summaries in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Services/StructuredLogWriteBuffer.cs`.
-- [ ] T043 [US2] Add retention cleanup service in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Services/StructuredLogRetentionService.cs`.
-- [ ] T044 [US2] Add relational service registration extensions in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Extensions/RelationalStructuredLogsServiceCollectionExtensions.cs`.
-- [ ] T045 [US2] Add relational persistence feature registration in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Features/StructuredLogRelationalPersistenceFeature.cs`.
-- [ ] T046 [US2] Complete relational module shell feature in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/ShellFeatures/StructuredLogRelationalPersistenceFeature.cs`.
-- [ ] T047 [US2] Add SQLite options in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Options/SqliteStructuredLogOptions.cs`.
-- [ ] T048 [US2] Add SQLite connection factory in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Services/SqliteStructuredLogConnectionFactory.cs`.
-- [ ] T049 [US2] Add SQLite dialect in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Services/SqliteStructuredLogDialect.cs`.
-- [ ] T050 [US2] Add FluentMigrator runner integration in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Services/SqliteStructuredLogSchemaMigrator.cs`.
-- [ ] T051 [US2] Add SQLite hosted startup service for migrations and cleanup in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Services/SqliteStructuredLogStartupService.cs`.
-- [ ] T052 [US2] Add SQLite fluent configuration extension in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Extensions/SqliteStructuredLogsModuleExtensions.cs`.
-- [ ] T053 [US2] Add SQLite persistence feature registration in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Features/SqliteStructuredLogPersistenceFeature.cs`.
-- [ ] T054 [US2] Complete SQLite module shell feature in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/ShellFeatures/SqliteStructuredLogPersistenceFeature.cs`.
-- [ ] T055 [US2] Run `dotnet test test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests.csproj`.
+- [X] T033 [US2] Add relational record model in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Models/RelationalStructuredLogRecord.cs`.
+- [X] T034 [US2] Add relational persistence options in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Options/RelationalStructuredLogOptions.cs`.
+- [X] T035 [US2] Add relational connection factory contract in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Contracts/IRelationalStructuredLogConnectionFactory.cs`.
+- [X] T036 [US2] Add relational dialect contract in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Contracts/IRelationalStructuredLogDialect.cs`.
+- [X] T037 [US2] Add schema migrator contract in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Contracts/IStructuredLogSchemaMigrator.cs`.
+- [X] T038 [US2] Add SQL builder for inserts, filters, sources, and retention in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Services/RelationalStructuredLogSqlBuilder.cs`.
+- [X] T039 [US2] Add JSON/timestamp mapper in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Services/RelationalStructuredLogMapper.cs`.
+- [X] T040 [US2] Add FluentMigrator migration for structured log tables and indexes in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Migrations/M001_CreateStructuredLogTables.cs`.
+- [X] T041 [US2] Add relational structured log store in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Stores/RelationalStructuredLogStore.cs`.
+- [X] T042 [US2] Add bounded write buffer with graceful shutdown flush and dropped-write warning summaries in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Services/StructuredLogWriteBuffer.cs`.
+- [X] T043 [US2] Add retention cleanup service in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Services/StructuredLogRetentionService.cs`.
+- [X] T044 [US2] Add relational service registration extensions in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Extensions/RelationalStructuredLogsServiceCollectionExtensions.cs`.
+- [X] T045 [US2] Add relational persistence feature registration in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Features/StructuredLogRelationalPersistenceFeature.cs`.
+- [X] T046 [US2] Complete relational module shell feature in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/ShellFeatures/StructuredLogRelationalPersistenceFeature.cs`.
+- [X] T047 [US2] Add SQLite options in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Options/SqliteStructuredLogOptions.cs`.
+- [X] T048 [US2] Add SQLite connection factory in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Services/SqliteStructuredLogConnectionFactory.cs`.
+- [X] T049 [US2] Add SQLite dialect in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Services/SqliteStructuredLogDialect.cs`.
+- [X] T050 [US2] Add FluentMigrator runner integration in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Services/SqliteStructuredLogSchemaMigrator.cs`.
+- [X] T051 [US2] Add SQLite hosted startup service for migrations and cleanup in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Services/SqliteStructuredLogStartupService.cs`.
+- [X] T052 [US2] Add SQLite fluent configuration extension in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Extensions/SqliteStructuredLogsModuleExtensions.cs`.
+- [X] T053 [US2] Add SQLite persistence feature registration in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Features/SqliteStructuredLogPersistenceFeature.cs`.
+- [X] T054 [US2] Complete SQLite module shell feature in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/ShellFeatures/SqliteStructuredLogPersistenceFeature.cs`.
+- [X] T055 [US2] Run `dotnet test test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests.csproj`.
 
 **Checkpoint**: User Stories 1 and 2 work together with durable SQLite storage.
 
@@ -126,17 +126,17 @@
 
 ### Tests for User Story 3
 
-- [ ] T056 [P] [US3] Add relational SQL builder tests with a fake dialect in `test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/RelationalStructuredLogSqlBuilderTests.cs`.
-- [ ] T057 [P] [US3] Add relational mapper tests for JSON and UTC ISO-8601 timestamps in `test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/RelationalStructuredLogMapperTests.cs`.
-- [ ] T058 [P] [US3] Add migration metadata/version tests in `test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/StructuredLogMigrationTests.cs`.
-- [ ] T059 [P] [US3] Add core boundary test proving `Elsa.Diagnostics.StructuredLogs` has no SQLite dependency in `test/unit/Elsa.Diagnostics.StructuredLogs.UnitTests/StructuredLogsStorageRegistrationTests.cs`.
+- [X] T056 [P] [US3] Add relational SQL builder tests with a fake dialect in `test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/RelationalStructuredLogSqlBuilderTests.cs`.
+- [X] T057 [P] [US3] Add relational mapper tests for JSON and UTC ISO-8601 timestamps in `test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/RelationalStructuredLogMapperTests.cs`.
+- [X] T058 [P] [US3] Add migration metadata/version tests in `test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/StructuredLogMigrationTests.cs`.
+- [X] T059 [P] [US3] Add core boundary test proving `Elsa.Diagnostics.StructuredLogs` has no SQLite dependency in `test/unit/Elsa.Diagnostics.StructuredLogs.UnitTests/StructuredLogsStorageRegistrationTests.cs`.
 
 ### Implementation for User Story 3
 
-- [ ] T060 [US3] Keep provider-specific SQL outside core module in `src/modules/Elsa.Diagnostics.StructuredLogs`.
-- [ ] T061 [US3] Keep SQLite-specific services inside `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite`.
-- [ ] T062 [US3] Add relational provider guidance in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/README.md`.
-- [ ] T063 [US3] Run `dotnet test test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests.csproj`.
+- [X] T060 [US3] Keep provider-specific SQL outside core module in `src/modules/Elsa.Diagnostics.StructuredLogs`.
+- [X] T061 [US3] Keep SQLite-specific services inside `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite`.
+- [X] T062 [US3] Add relational provider guidance in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/README.md`.
+- [X] T063 [US3] Run `dotnet test test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests.csproj`.
 
 **Checkpoint**: SQLite is the first relational provider, not a one-off persistence path.
 
@@ -146,16 +146,16 @@
 
 **Purpose**: Update public docs, sample guidance, and validation.
 
-- [ ] T064 [P] Update structured logs README with storage mode guidance in `src/modules/Elsa.Diagnostics.StructuredLogs/README.md`.
-- [ ] T065 [P] Add SQLite persistence README in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/README.md`.
-- [ ] T066 [P] Update Speckit quickstart implementation notes in `specs/005-structured-log-persistence/quickstart.md`.
-- [ ] T067 Update sample host wiring only if a sample explicitly opts into SQLite in `src/apps/Elsa.Server.Web/Program.cs`.
-- [ ] T068 Run `dotnet build src/modules/Elsa.Diagnostics.StructuredLogs/Elsa.Diagnostics.StructuredLogs.csproj`.
-- [ ] T069 Run `dotnet build src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.csproj`.
-- [ ] T070 Run `dotnet test test/unit/Elsa.Diagnostics.StructuredLogs.UnitTests/Elsa.Diagnostics.StructuredLogs.UnitTests.csproj`.
-- [ ] T071 Run `dotnet test test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests.csproj`.
-- [ ] T072 Run `dotnet test test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests.csproj`.
-- [ ] T073 Run `rg "OpenTelemetry|OTLP|Datadog|Logstash|Splunk|Loki|Seq" src/modules/Elsa.Diagnostics.StructuredLogs* specs/005-structured-log-persistence` and confirm only out-of-scope documentation references remain.
+- [X] T064 [P] Update structured logs README with storage mode guidance in `src/modules/Elsa.Diagnostics.StructuredLogs/README.md`.
+- [X] T065 [P] Add SQLite persistence README in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/README.md`.
+- [X] T066 [P] Update Speckit quickstart implementation notes in `specs/005-structured-log-persistence/quickstart.md`.
+- [X] T067 Update sample host wiring only if a sample explicitly opts into SQLite in `src/apps/Elsa.Server.Web/Program.cs`.
+- [X] T068 Run `dotnet build src/modules/Elsa.Diagnostics.StructuredLogs/Elsa.Diagnostics.StructuredLogs.csproj`.
+- [X] T069 Run `dotnet build src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.csproj`.
+- [X] T070 Run `dotnet test test/unit/Elsa.Diagnostics.StructuredLogs.UnitTests/Elsa.Diagnostics.StructuredLogs.UnitTests.csproj`.
+- [X] T071 Run `dotnet test test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests.csproj`.
+- [X] T072 Run `dotnet test test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests.csproj`.
+- [X] T073 Run `rg "OpenTelemetry|OTLP|Datadog|Logstash|Splunk|Loki|Seq" src/modules/Elsa.Diagnostics.StructuredLogs* specs/005-structured-log-persistence` and confirm only out-of-scope documentation references remain.
 
 ---
 

--- a/specs/005-structured-log-persistence/tasks.md
+++ b/specs/005-structured-log-persistence/tasks.md
@@ -21,8 +21,10 @@
 - [ ] T002 [P] Create SQLite persistence project in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.csproj`.
 - [ ] T003 [P] Create relational unit test project in `test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests.csproj`.
 - [ ] T004 [P] Create SQLite integration test project in `test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests.csproj`.
-- [ ] T005 Add new projects to `Elsa.sln`.
-- [ ] T006 Add centrally managed package versions for FluentMigrator and SQLite dependencies in `Directory.Packages.props`.
+- [ ] T005 [P] Create relational module shell feature skeleton in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/ShellFeatures/StructuredLogRelationalPersistenceFeature.cs`.
+- [ ] T006 [P] Create SQLite module shell feature skeleton in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/ShellFeatures/SqliteStructuredLogPersistenceFeature.cs`.
+- [ ] T007 Add new projects to `Elsa.sln`.
+- [ ] T008 Add centrally managed package versions for FluentMigrator and SQLite dependencies in `Directory.Packages.props`.
 
 ---
 
@@ -32,14 +34,14 @@
 
 **Critical**: No SQLite story work should begin until the in-memory default still passes existing structured log tests.
 
-- [ ] T007 [P] Add append-only sink contract in `src/modules/Elsa.Diagnostics.StructuredLogs/Contracts/IStructuredLogSink.cs`.
-- [ ] T008 [P] Add queryable store contract in `src/modules/Elsa.Diagnostics.StructuredLogs/Contracts/IStructuredLogStore.cs`.
-- [ ] T009 [P] Add live feed contract in `src/modules/Elsa.Diagnostics.StructuredLogs/Contracts/IStructuredLogLiveFeed.cs`.
-- [ ] T010 Refactor in-memory recent-history behavior into `src/modules/Elsa.Diagnostics.StructuredLogs/Providers/InMemory/InMemoryStructuredLogStore.cs`.
-- [ ] T011 Refactor in-memory subscriber behavior into `src/modules/Elsa.Diagnostics.StructuredLogs/Providers/InMemory/InMemoryStructuredLogLiveFeed.cs`.
-- [ ] T012 Preserve `InMemoryStructuredLogProvider` compatibility facade in `src/modules/Elsa.Diagnostics.StructuredLogs/Providers/InMemory/InMemoryStructuredLogProvider.cs`.
-- [ ] T013 Add composed provider facade in `src/modules/Elsa.Diagnostics.StructuredLogs/Services/DefaultStructuredLogProvider.cs`.
-- [ ] T014 Update default DI registration in `src/modules/Elsa.Diagnostics.StructuredLogs/Extensions/ServiceCollectionExtensions.cs`.
+- [ ] T009 [P] Add append-only sink contract in `src/modules/Elsa.Diagnostics.StructuredLogs/Contracts/IStructuredLogSink.cs`.
+- [ ] T010 [P] Add queryable store contract in `src/modules/Elsa.Diagnostics.StructuredLogs/Contracts/IStructuredLogStore.cs`.
+- [ ] T011 [P] Add live feed contract in `src/modules/Elsa.Diagnostics.StructuredLogs/Contracts/IStructuredLogLiveFeed.cs`.
+- [ ] T012 Refactor in-memory recent-history behavior into `src/modules/Elsa.Diagnostics.StructuredLogs/Providers/InMemory/InMemoryStructuredLogStore.cs`.
+- [ ] T013 Refactor in-memory subscriber behavior into `src/modules/Elsa.Diagnostics.StructuredLogs/Providers/InMemory/InMemoryStructuredLogLiveFeed.cs`.
+- [ ] T014 Preserve `InMemoryStructuredLogProvider` compatibility facade in `src/modules/Elsa.Diagnostics.StructuredLogs/Providers/InMemory/InMemoryStructuredLogProvider.cs`.
+- [ ] T015 Add composed provider facade in `src/modules/Elsa.Diagnostics.StructuredLogs/Services/DefaultStructuredLogProvider.cs`.
+- [ ] T016 Update default DI registration in `src/modules/Elsa.Diagnostics.StructuredLogs/Extensions/ServiceCollectionExtensions.cs`.
 
 **Checkpoint**: Existing structured logs behavior is preserved behind the new abstractions.
 
@@ -53,17 +55,17 @@
 
 ### Tests for User Story 1
 
-- [ ] T015 [P] [US1] Add default registration compatibility tests in `test/unit/Elsa.Diagnostics.StructuredLogs.UnitTests/StructuredLogsStorageRegistrationTests.cs`.
-- [ ] T016 [P] [US1] Update in-memory recent query tests in `test/unit/Elsa.Diagnostics.StructuredLogs.UnitTests/InMemory/InMemoryStructuredLogProviderTests.cs`.
-- [ ] T017 [P] [US1] Update in-memory source listing tests in `test/unit/Elsa.Diagnostics.StructuredLogs.UnitTests/InMemory/InMemoryStructuredLogProviderSourceTests.cs`.
-- [ ] T018 [P] [US1] Update live dropped-event tests in `test/unit/Elsa.Diagnostics.StructuredLogs.UnitTests/InMemory/InMemoryStructuredLogProviderTests.cs`.
+- [ ] T017 [P] [US1] Add default registration compatibility tests in `test/unit/Elsa.Diagnostics.StructuredLogs.UnitTests/StructuredLogsStorageRegistrationTests.cs`.
+- [ ] T018 [P] [US1] Update in-memory recent query tests in `test/unit/Elsa.Diagnostics.StructuredLogs.UnitTests/InMemory/InMemoryStructuredLogProviderTests.cs`.
+- [ ] T019 [P] [US1] Update in-memory source listing tests in `test/unit/Elsa.Diagnostics.StructuredLogs.UnitTests/InMemory/InMemoryStructuredLogProviderSourceTests.cs`.
+- [ ] T020 [P] [US1] Update live dropped-event tests in `test/unit/Elsa.Diagnostics.StructuredLogs.UnitTests/InMemory/InMemoryStructuredLogProviderTests.cs`.
 
 ### Implementation for User Story 1
 
-- [ ] T019 [US1] Ensure REST endpoints continue using `IStructuredLogProvider` in `src/modules/Elsa.Diagnostics.StructuredLogs/Endpoints/StructuredLogs/Recent/Endpoint.cs`.
-- [ ] T020 [US1] Ensure source endpoint continues using `IStructuredLogProvider` in `src/modules/Elsa.Diagnostics.StructuredLogs/Endpoints/StructuredLogs/Sources/Endpoint.cs`.
-- [ ] T021 [US1] Ensure SignalR subscriptions stream through the composed provider in `src/modules/Elsa.Diagnostics.StructuredLogs/RealTime/StructuredLogSubscriptionManager.cs`.
-- [ ] T022 [US1] Run `dotnet test test/unit/Elsa.Diagnostics.StructuredLogs.UnitTests/Elsa.Diagnostics.StructuredLogs.UnitTests.csproj`.
+- [ ] T021 [US1] Ensure REST endpoints continue using `IStructuredLogProvider` in `src/modules/Elsa.Diagnostics.StructuredLogs/Endpoints/StructuredLogs/Recent/Endpoint.cs`.
+- [ ] T022 [US1] Ensure source endpoint continues using `IStructuredLogProvider` in `src/modules/Elsa.Diagnostics.StructuredLogs/Endpoints/StructuredLogs/Sources/Endpoint.cs`.
+- [ ] T023 [US1] Ensure SignalR subscriptions stream through the composed provider in `src/modules/Elsa.Diagnostics.StructuredLogs/RealTime/StructuredLogSubscriptionManager.cs`.
+- [ ] T024 [US1] Run `dotnet test test/unit/Elsa.Diagnostics.StructuredLogs.UnitTests/Elsa.Diagnostics.StructuredLogs.UnitTests.csproj`.
 
 **Checkpoint**: User Story 1 is fully functional and independently testable.
 
@@ -77,35 +79,40 @@
 
 ### Tests for User Story 2
 
-- [ ] T023 [P] [US2] Add SQLite migration-from-empty-database test in `test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogMigrationTests.cs`.
-- [ ] T024 [P] [US2] Add SQLite persistence-across-provider-recreation test in `test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogStoreTests.cs`.
-- [ ] T025 [P] [US2] Add SQLite filter coverage for level, category, source, workflow, correlation, trace, time, and limit in `test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogFilterTests.cs`.
-- [ ] T026 [P] [US2] Add SQLite write queue flush and overflow tests in `test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogWriteQueueTests.cs`.
-- [ ] T027 [P] [US2] Add SQLite startup migration opt-out tests in `test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogMigrationTests.cs`.
-- [ ] T028 [P] [US2] Add SQLite ISO-8601 timestamp storage tests in `test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogTimestampTests.cs`.
-- [ ] T029 [P] [US2] Add SQLite retention tests for opt-in cleanup and default no-delete behavior in `test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogRetentionTests.cs`.
+- [ ] T025 [P] [US2] Add SQLite migration-from-empty-database test in `test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogMigrationTests.cs`.
+- [ ] T026 [P] [US2] Add SQLite persistence-across-provider-recreation test in `test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogStoreTests.cs`.
+- [ ] T027 [P] [US2] Add SQLite persisted redaction test in `test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogStoreTests.cs`.
+- [ ] T028 [P] [US2] Add SQLite filter coverage for level, category, source, workflow, correlation, trace, time, and limit in `test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogFilterTests.cs`.
+- [ ] T029 [P] [US2] Add SQLite write queue flush and overflow tests for `DroppedWriteCount` in `test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogWriteQueueTests.cs`.
+- [ ] T030 [P] [US2] Add SQLite startup migration opt-out tests in `test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogMigrationTests.cs`.
+- [ ] T031 [P] [US2] Add SQLite ISO-8601 timestamp storage tests in `test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogTimestampTests.cs`.
+- [ ] T032 [P] [US2] Add SQLite retention tests for opt-in cleanup and default no-delete behavior in `test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogRetentionTests.cs`.
 
 ### Implementation for User Story 2
 
-- [ ] T030 [US2] Add relational record model in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Models/RelationalStructuredLogRecord.cs`.
-- [ ] T031 [US2] Add relational persistence options in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Options/RelationalStructuredLogOptions.cs`.
-- [ ] T032 [US2] Add relational connection factory contract in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Contracts/IRelationalStructuredLogConnectionFactory.cs`.
-- [ ] T033 [US2] Add relational dialect contract in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Contracts/IRelationalStructuredLogDialect.cs`.
-- [ ] T034 [US2] Add schema migrator contract in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Contracts/IStructuredLogSchemaMigrator.cs`.
-- [ ] T035 [US2] Add SQL builder for inserts, filters, sources, and retention in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Services/RelationalStructuredLogSqlBuilder.cs`.
-- [ ] T036 [US2] Add JSON/timestamp mapper in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Services/RelationalStructuredLogMapper.cs`.
-- [ ] T037 [US2] Add FluentMigrator migration for structured log tables and indexes in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Migrations/M001_CreateStructuredLogTables.cs`.
-- [ ] T038 [US2] Add relational structured log store in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Stores/RelationalStructuredLogStore.cs`.
-- [ ] T039 [US2] Add bounded write buffer with graceful shutdown flush in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Services/StructuredLogWriteBuffer.cs`.
-- [ ] T040 [US2] Add retention cleanup service in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Services/StructuredLogRetentionService.cs`.
-- [ ] T041 [US2] Add relational service registration extensions in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Extensions/RelationalStructuredLogsServiceCollectionExtensions.cs`.
-- [ ] T042 [US2] Add SQLite options in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Options/SqliteStructuredLogOptions.cs`.
-- [ ] T043 [US2] Add SQLite connection factory in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Services/SqliteStructuredLogConnectionFactory.cs`.
-- [ ] T044 [US2] Add SQLite dialect in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Services/SqliteStructuredLogDialect.cs`.
-- [ ] T045 [US2] Add FluentMigrator runner integration in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Services/SqliteStructuredLogSchemaMigrator.cs`.
-- [ ] T046 [US2] Add SQLite hosted startup service for migrations and cleanup in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Services/SqliteStructuredLogStartupService.cs`.
-- [ ] T047 [US2] Add SQLite fluent configuration extension in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Extensions/SqliteStructuredLogsModuleExtensions.cs`.
-- [ ] T048 [US2] Run `dotnet test test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests.csproj`.
+- [ ] T033 [US2] Add relational record model in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Models/RelationalStructuredLogRecord.cs`.
+- [ ] T034 [US2] Add relational persistence options in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Options/RelationalStructuredLogOptions.cs`.
+- [ ] T035 [US2] Add relational connection factory contract in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Contracts/IRelationalStructuredLogConnectionFactory.cs`.
+- [ ] T036 [US2] Add relational dialect contract in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Contracts/IRelationalStructuredLogDialect.cs`.
+- [ ] T037 [US2] Add schema migrator contract in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Contracts/IStructuredLogSchemaMigrator.cs`.
+- [ ] T038 [US2] Add SQL builder for inserts, filters, sources, and retention in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Services/RelationalStructuredLogSqlBuilder.cs`.
+- [ ] T039 [US2] Add JSON/timestamp mapper in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Services/RelationalStructuredLogMapper.cs`.
+- [ ] T040 [US2] Add FluentMigrator migration for structured log tables and indexes in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Migrations/M001_CreateStructuredLogTables.cs`.
+- [ ] T041 [US2] Add relational structured log store in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Stores/RelationalStructuredLogStore.cs`.
+- [ ] T042 [US2] Add bounded write buffer with graceful shutdown flush and dropped-write warning summaries in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Services/StructuredLogWriteBuffer.cs`.
+- [ ] T043 [US2] Add retention cleanup service in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Services/StructuredLogRetentionService.cs`.
+- [ ] T044 [US2] Add relational service registration extensions in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Extensions/RelationalStructuredLogsServiceCollectionExtensions.cs`.
+- [ ] T045 [US2] Add relational persistence feature registration in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Features/StructuredLogRelationalPersistenceFeature.cs`.
+- [ ] T046 [US2] Complete relational module shell feature in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/ShellFeatures/StructuredLogRelationalPersistenceFeature.cs`.
+- [ ] T047 [US2] Add SQLite options in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Options/SqliteStructuredLogOptions.cs`.
+- [ ] T048 [US2] Add SQLite connection factory in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Services/SqliteStructuredLogConnectionFactory.cs`.
+- [ ] T049 [US2] Add SQLite dialect in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Services/SqliteStructuredLogDialect.cs`.
+- [ ] T050 [US2] Add FluentMigrator runner integration in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Services/SqliteStructuredLogSchemaMigrator.cs`.
+- [ ] T051 [US2] Add SQLite hosted startup service for migrations and cleanup in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Services/SqliteStructuredLogStartupService.cs`.
+- [ ] T052 [US2] Add SQLite fluent configuration extension in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Extensions/SqliteStructuredLogsModuleExtensions.cs`.
+- [ ] T053 [US2] Add SQLite persistence feature registration in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Features/SqliteStructuredLogPersistenceFeature.cs`.
+- [ ] T054 [US2] Complete SQLite module shell feature in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/ShellFeatures/SqliteStructuredLogPersistenceFeature.cs`.
+- [ ] T055 [US2] Run `dotnet test test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests.csproj`.
 
 **Checkpoint**: User Stories 1 and 2 work together with durable SQLite storage.
 
@@ -119,17 +126,17 @@
 
 ### Tests for User Story 3
 
-- [ ] T049 [P] [US3] Add relational SQL builder tests with a fake dialect in `test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/RelationalStructuredLogSqlBuilderTests.cs`.
-- [ ] T050 [P] [US3] Add relational mapper tests for JSON and UTC ISO-8601 timestamps in `test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/RelationalStructuredLogMapperTests.cs`.
-- [ ] T051 [P] [US3] Add migration metadata/version tests in `test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/StructuredLogMigrationTests.cs`.
-- [ ] T052 [P] [US3] Add core boundary test proving `Elsa.Diagnostics.StructuredLogs` has no SQLite dependency in `test/unit/Elsa.Diagnostics.StructuredLogs.UnitTests/StructuredLogsStorageRegistrationTests.cs`.
+- [ ] T056 [P] [US3] Add relational SQL builder tests with a fake dialect in `test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/RelationalStructuredLogSqlBuilderTests.cs`.
+- [ ] T057 [P] [US3] Add relational mapper tests for JSON and UTC ISO-8601 timestamps in `test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/RelationalStructuredLogMapperTests.cs`.
+- [ ] T058 [P] [US3] Add migration metadata/version tests in `test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/StructuredLogMigrationTests.cs`.
+- [ ] T059 [P] [US3] Add core boundary test proving `Elsa.Diagnostics.StructuredLogs` has no SQLite dependency in `test/unit/Elsa.Diagnostics.StructuredLogs.UnitTests/StructuredLogsStorageRegistrationTests.cs`.
 
 ### Implementation for User Story 3
 
-- [ ] T053 [US3] Keep provider-specific SQL outside core module in `src/modules/Elsa.Diagnostics.StructuredLogs`.
-- [ ] T054 [US3] Keep SQLite-specific services inside `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite`.
-- [ ] T055 [US3] Add relational provider guidance in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/README.md`.
-- [ ] T056 [US3] Run `dotnet test test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests.csproj`.
+- [ ] T060 [US3] Keep provider-specific SQL outside core module in `src/modules/Elsa.Diagnostics.StructuredLogs`.
+- [ ] T061 [US3] Keep SQLite-specific services inside `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite`.
+- [ ] T062 [US3] Add relational provider guidance in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/README.md`.
+- [ ] T063 [US3] Run `dotnet test test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests.csproj`.
 
 **Checkpoint**: SQLite is the first relational provider, not a one-off persistence path.
 
@@ -139,16 +146,16 @@
 
 **Purpose**: Update public docs, sample guidance, and validation.
 
-- [ ] T057 [P] Update structured logs README with storage mode guidance in `src/modules/Elsa.Diagnostics.StructuredLogs/README.md`.
-- [ ] T058 [P] Add SQLite persistence README in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/README.md`.
-- [ ] T059 [P] Update Speckit quickstart implementation notes in `specs/005-structured-log-persistence/quickstart.md`.
-- [ ] T060 Update sample host wiring only if a sample explicitly opts into SQLite in `src/apps/Elsa.Server.Web/Program.cs`.
-- [ ] T061 Run `dotnet build src/modules/Elsa.Diagnostics.StructuredLogs/Elsa.Diagnostics.StructuredLogs.csproj`.
-- [ ] T062 Run `dotnet build src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.csproj`.
-- [ ] T063 Run `dotnet test test/unit/Elsa.Diagnostics.StructuredLogs.UnitTests/Elsa.Diagnostics.StructuredLogs.UnitTests.csproj`.
-- [ ] T064 Run `dotnet test test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests.csproj`.
-- [ ] T065 Run `dotnet test test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests.csproj`.
-- [ ] T066 Run `rg "OpenTelemetry|OTLP|Datadog|Logstash|Splunk|Loki|Seq" src/modules/Elsa.Diagnostics.StructuredLogs* specs/005-structured-log-persistence` and confirm only out-of-scope documentation references remain.
+- [ ] T064 [P] Update structured logs README with storage mode guidance in `src/modules/Elsa.Diagnostics.StructuredLogs/README.md`.
+- [ ] T065 [P] Add SQLite persistence README in `src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/README.md`.
+- [ ] T066 [P] Update Speckit quickstart implementation notes in `specs/005-structured-log-persistence/quickstart.md`.
+- [ ] T067 Update sample host wiring only if a sample explicitly opts into SQLite in `src/apps/Elsa.Server.Web/Program.cs`.
+- [ ] T068 Run `dotnet build src/modules/Elsa.Diagnostics.StructuredLogs/Elsa.Diagnostics.StructuredLogs.csproj`.
+- [ ] T069 Run `dotnet build src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.csproj`.
+- [ ] T070 Run `dotnet test test/unit/Elsa.Diagnostics.StructuredLogs.UnitTests/Elsa.Diagnostics.StructuredLogs.UnitTests.csproj`.
+- [ ] T071 Run `dotnet test test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests.csproj`.
+- [ ] T072 Run `dotnet test test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests.csproj`.
+- [ ] T073 Run `rg "OpenTelemetry|OTLP|Datadog|Logstash|Splunk|Loki|Seq" src/modules/Elsa.Diagnostics.StructuredLogs* specs/005-structured-log-persistence` and confirm only out-of-scope documentation references remain.
 
 ---
 
@@ -171,12 +178,12 @@
 
 ### Parallel Opportunities
 
-- T001 through T004 can run in parallel.
-- T007 through T009 can run in parallel.
-- US1 tests T015 through T018 can run in parallel after Phase 2.
-- US2 tests T023 through T029 can run in parallel after project skeleton exists.
-- US3 tests T049 through T052 can run in parallel after relational contracts exist.
-- Documentation tasks T057 through T059 can run in parallel after implementation APIs settle.
+- T001 through T006 can run in parallel.
+- T009 through T011 can run in parallel.
+- US1 tests T017 through T020 can run in parallel after Phase 2.
+- US2 tests T025 through T032 can run in parallel after project skeleton exists.
+- US3 tests T056 through T059 can run in parallel after relational contracts exist.
+- Documentation tasks T064 through T066 can run in parallel after implementation APIs settle.
 
 ## Parallel Example: User Story 2
 

--- a/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Contracts/IRelationalStructuredLogConnectionFactory.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Contracts/IRelationalStructuredLogConnectionFactory.cs
@@ -1,0 +1,8 @@
+using System.Data.Common;
+
+namespace Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Contracts;
+
+public interface IRelationalStructuredLogConnectionFactory
+{
+    ValueTask<DbConnection> OpenConnectionAsync(CancellationToken cancellationToken = default);
+}

--- a/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Contracts/IRelationalStructuredLogDialect.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Contracts/IRelationalStructuredLogDialect.cs
@@ -9,4 +9,6 @@ public interface IRelationalStructuredLogDialect
     string QuoteIdentifier(string identifier);
 
     string ApplyLimit(string sql, int limit);
+
+    string ApplyOffset(string sql, int offset);
 }

--- a/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Contracts/IRelationalStructuredLogDialect.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Contracts/IRelationalStructuredLogDialect.cs
@@ -1,0 +1,12 @@
+namespace Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Contracts;
+
+public interface IRelationalStructuredLogDialect
+{
+    string ProviderName { get; }
+
+    string ParameterPrefix { get; }
+
+    string QuoteIdentifier(string identifier);
+
+    string ApplyLimit(string sql, int limit);
+}

--- a/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Contracts/IStructuredLogSchemaMigrator.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Contracts/IStructuredLogSchemaMigrator.cs
@@ -1,0 +1,6 @@
+namespace Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Contracts;
+
+public interface IStructuredLogSchemaMigrator
+{
+    ValueTask MigrateAsync(CancellationToken cancellationToken = default);
+}

--- a/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Contracts/IStructuredLogWriteBuffer.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Contracts/IStructuredLogWriteBuffer.cs
@@ -1,0 +1,10 @@
+using Elsa.Diagnostics.StructuredLogs.Contracts;
+
+namespace Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Contracts;
+
+public interface IStructuredLogWriteBuffer : IStructuredLogSink
+{
+    long DroppedWriteCount { get; }
+
+    ValueTask FlushAsync(CancellationToken cancellationToken = default);
+}

--- a/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.csproj
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <Description>
+            Provides shared relational persistence services for diagnostics structured logs.
+        </Description>
+        <PackageTags>elsa module diagnostics structured-logs persistence relational logging</PackageTags>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="CShells" />
+        <PackageReference Include="FluentMigrator.Runner" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+        <PackageReference Include="Microsoft.Extensions.Options" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Elsa.Diagnostics.StructuredLogs\Elsa.Diagnostics.StructuredLogs.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Extensions/RelationalStructuredLogsServiceCollectionExtensions.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Extensions/RelationalStructuredLogsServiceCollectionExtensions.cs
@@ -1,0 +1,30 @@
+using Elsa.Diagnostics.StructuredLogs.Contracts;
+using Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Contracts;
+using Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Options;
+using Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Services;
+using Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Stores;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Extensions;
+
+public static class RelationalStructuredLogsServiceCollectionExtensions
+{
+    public static IServiceCollection AddRelationalStructuredLogPersistence(this IServiceCollection services, Action<RelationalStructuredLogOptions>? configureOptions = null)
+    {
+        if (configureOptions != null)
+            services.Configure(configureOptions);
+
+        services.AddOptions<RelationalStructuredLogOptions>();
+        services.TryAddSingleton<RelationalStructuredLogMapper>();
+        services.TryAddSingleton<RelationalStructuredLogSqlBuilder>();
+        services.TryAddSingleton<RelationalStructuredLogStore>();
+        services.TryAddSingleton<StructuredLogWriteBuffer>();
+        services.TryAddSingleton<StructuredLogRetentionService>();
+        services.AddSingleton<IStructuredLogStore>(sp => sp.GetRequiredService<StructuredLogWriteBuffer>());
+        services.AddSingleton<IStructuredLogWriteBuffer>(sp => sp.GetRequiredService<StructuredLogWriteBuffer>());
+        services.AddHostedService(sp => sp.GetRequiredService<StructuredLogWriteBuffer>());
+
+        return services;
+    }
+}

--- a/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Features/StructuredLogRelationalPersistenceFeature.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Features/StructuredLogRelationalPersistenceFeature.cs
@@ -1,0 +1,16 @@
+using Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Extensions;
+using Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Options;
+using Elsa.Features.Abstractions;
+using Elsa.Features.Services;
+
+namespace Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Features;
+
+public class StructuredLogRelationalPersistenceFeature(IModule module) : FeatureBase(module)
+{
+    public Action<RelationalStructuredLogOptions>? ConfigureOptions { get; set; }
+
+    public override void Apply()
+    {
+        Services.AddRelationalStructuredLogPersistence(ConfigureOptions);
+    }
+}

--- a/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/FodyWeavers.xml
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/FodyWeavers.xml
@@ -1,0 +1,3 @@
+﻿<Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
+  <ConfigureAwait />
+</Weavers>

--- a/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Migrations/M001_CreateStructuredLogTables.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Migrations/M001_CreateStructuredLogTables.cs
@@ -1,0 +1,50 @@
+using FluentMigrator;
+
+namespace Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Migrations;
+
+[Migration(2026051301)]
+public class M001CreateStructuredLogTables : Migration
+{
+    private const string TableName = "StructuredLogEvents";
+
+    public override void Up()
+    {
+        Create.Table(TableName)
+            .WithColumn("Id").AsString(64).PrimaryKey()
+            .WithColumn("Sequence").AsInt64().NotNullable()
+            .WithColumn("Timestamp").AsString(40).NotNullable()
+            .WithColumn("ReceivedAt").AsString(40).NotNullable()
+            .WithColumn("Level").AsInt32().NotNullable()
+            .WithColumn("Category").AsString(512).NotNullable()
+            .WithColumn("EventId").AsInt32().NotNullable()
+            .WithColumn("EventName").AsString(512).Nullable()
+            .WithColumn("Message").AsString(int.MaxValue).NotNullable()
+            .WithColumn("MessageTemplate").AsString(int.MaxValue).Nullable()
+            .WithColumn("ExceptionJson").AsString(int.MaxValue).Nullable()
+            .WithColumn("ScopesJson").AsString(int.MaxValue).NotNullable()
+            .WithColumn("PropertiesJson").AsString(int.MaxValue).NotNullable()
+            .WithColumn("TraceId").AsString(64).Nullable()
+            .WithColumn("SpanId").AsString(64).Nullable()
+            .WithColumn("CorrelationId").AsString(256).Nullable()
+            .WithColumn("TenantId").AsString(256).Nullable()
+            .WithColumn("WorkflowDefinitionId").AsString(256).Nullable()
+            .WithColumn("WorkflowInstanceId").AsString(256).Nullable()
+            .WithColumn("SourceId").AsString(512).NotNullable();
+
+        Create.Index("IX_StructuredLogEvents_Timestamp").OnTable(TableName).OnColumn("Timestamp").Descending();
+        Create.Index("IX_StructuredLogEvents_ReceivedAt").OnTable(TableName).OnColumn("ReceivedAt").Descending();
+        Create.Index("IX_StructuredLogEvents_Level").OnTable(TableName).OnColumn("Level").Ascending();
+        Create.Index("IX_StructuredLogEvents_Category").OnTable(TableName).OnColumn("Category").Ascending();
+        Create.Index("IX_StructuredLogEvents_SourceId").OnTable(TableName).OnColumn("SourceId").Ascending();
+        Create.Index("IX_StructuredLogEvents_TenantId").OnTable(TableName).OnColumn("TenantId").Ascending();
+        Create.Index("IX_StructuredLogEvents_WorkflowDefinitionId").OnTable(TableName).OnColumn("WorkflowDefinitionId").Ascending();
+        Create.Index("IX_StructuredLogEvents_WorkflowInstanceId").OnTable(TableName).OnColumn("WorkflowInstanceId").Ascending();
+        Create.Index("IX_StructuredLogEvents_CorrelationId").OnTable(TableName).OnColumn("CorrelationId").Ascending();
+        Create.Index("IX_StructuredLogEvents_TraceId").OnTable(TableName).OnColumn("TraceId").Ascending();
+    }
+
+    public override void Down()
+    {
+        Delete.Table(TableName);
+    }
+}

--- a/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Models/RelationalStructuredLogRecord.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Models/RelationalStructuredLogRecord.cs
@@ -1,0 +1,27 @@
+using Elsa.Diagnostics.StructuredLogs.Models;
+
+namespace Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Models;
+
+public record RelationalStructuredLogRecord
+{
+    public string Id { get; init; } = default!;
+    public long Sequence { get; init; }
+    public string Timestamp { get; init; } = default!;
+    public string ReceivedAt { get; init; } = default!;
+    public StructuredLogLevel Level { get; init; }
+    public string Category { get; init; } = default!;
+    public int EventId { get; init; }
+    public string? EventName { get; init; }
+    public string Message { get; init; } = string.Empty;
+    public string? MessageTemplate { get; init; }
+    public string? ExceptionJson { get; init; }
+    public string ScopesJson { get; init; } = "{}";
+    public string PropertiesJson { get; init; } = "{}";
+    public string? TraceId { get; init; }
+    public string? SpanId { get; init; }
+    public string? CorrelationId { get; init; }
+    public string? TenantId { get; init; }
+    public string? WorkflowDefinitionId { get; init; }
+    public string? WorkflowInstanceId { get; init; }
+    public string SourceId { get; init; } = default!;
+}

--- a/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Options/RelationalStructuredLogOptions.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Options/RelationalStructuredLogOptions.cs
@@ -1,0 +1,22 @@
+namespace Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Options;
+
+public class RelationalStructuredLogOptions
+{
+    public StructuredLogWriteQueueOptions WriteQueue { get; set; } = new();
+    public StructuredLogRetentionOptions Retention { get; set; } = new();
+}
+
+public class StructuredLogWriteQueueOptions
+{
+    public int Capacity { get; set; } = 10_000;
+    public int BatchSize { get; set; } = 100;
+    public TimeSpan FlushInterval { get; set; } = TimeSpan.FromSeconds(1);
+    public TimeSpan ShutdownFlushTimeout { get; set; } = TimeSpan.FromSeconds(10);
+}
+
+public class StructuredLogRetentionOptions
+{
+    public TimeSpan? MaxAge { get; set; }
+    public int? MaxRows { get; set; }
+    public bool CleanupOnStartup { get; set; }
+}

--- a/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/README.md
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/README.md
@@ -1,0 +1,13 @@
+# Elsa Diagnostics Structured Logs Relational Persistence
+
+This package contains the reusable relational storage layer for diagnostics structured logs. It is provider-neutral: concrete packages supply the connection factory, SQL dialect, and FluentMigrator runner wiring.
+
+To add a new relational provider such as SQL Server or PostgreSQL:
+
+1. Reference this package from the provider package.
+2. Implement `IRelationalStructuredLogConnectionFactory`.
+3. Implement `IRelationalStructuredLogDialect` for identifier quoting, parameter prefixing, and result limiting.
+4. Implement `IStructuredLogSchemaMigrator` using FluentMigrator with the provider-specific runner.
+5. Register those services and call `AddRelationalStructuredLogPersistence`.
+
+The core `Elsa.Diagnostics.StructuredLogs` package must remain unaware of provider packages. Provider-specific SQL and migration runner dependencies belong in provider packages.

--- a/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Services/RelationalStructuredLogMapper.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Services/RelationalStructuredLogMapper.cs
@@ -1,0 +1,95 @@
+using System.Data.Common;
+using System.Globalization;
+using System.Text.Json;
+using Elsa.Diagnostics.StructuredLogs.Models;
+using Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Models;
+
+namespace Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Services;
+
+public class RelationalStructuredLogMapper
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    public RelationalStructuredLogRecord Map(StructuredLogEvent logEvent)
+    {
+        return new()
+        {
+            Id = logEvent.Id,
+            Sequence = logEvent.Sequence,
+            Timestamp = FormatTimestamp(logEvent.Timestamp),
+            ReceivedAt = FormatTimestamp(logEvent.ReceivedAt),
+            Level = logEvent.Level,
+            Category = logEvent.Category,
+            EventId = logEvent.EventId,
+            EventName = logEvent.EventName,
+            Message = logEvent.Message,
+            MessageTemplate = logEvent.MessageTemplate,
+            ExceptionJson = logEvent.Exception == null ? null : JsonSerializer.Serialize(logEvent.Exception, JsonOptions),
+            ScopesJson = JsonSerializer.Serialize(logEvent.Scopes, JsonOptions),
+            PropertiesJson = JsonSerializer.Serialize(logEvent.Properties, JsonOptions),
+            TraceId = logEvent.TraceId,
+            SpanId = logEvent.SpanId,
+            CorrelationId = logEvent.CorrelationId,
+            TenantId = logEvent.TenantId,
+            WorkflowDefinitionId = logEvent.WorkflowDefinitionId,
+            WorkflowInstanceId = logEvent.WorkflowInstanceId,
+            SourceId = logEvent.SourceId
+        };
+    }
+
+    public StructuredLogEvent Map(DbDataReader reader)
+    {
+        return new()
+        {
+            Id = reader.GetString(reader.GetOrdinal("Id")),
+            Sequence = reader.GetInt64(reader.GetOrdinal("Sequence")),
+            Timestamp = ParseTimestamp(reader.GetString(reader.GetOrdinal("Timestamp"))),
+            ReceivedAt = ParseTimestamp(reader.GetString(reader.GetOrdinal("ReceivedAt"))),
+            Level = (StructuredLogLevel)reader.GetInt32(reader.GetOrdinal("Level")),
+            Category = reader.GetString(reader.GetOrdinal("Category")),
+            EventId = reader.GetInt32(reader.GetOrdinal("EventId")),
+            EventName = ReadNullableString(reader, "EventName"),
+            Message = reader.GetString(reader.GetOrdinal("Message")),
+            MessageTemplate = ReadNullableString(reader, "MessageTemplate"),
+            Exception = Deserialize<StructuredLogException>(ReadNullableString(reader, "ExceptionJson")),
+            Scopes = DeserializeDictionary(ReadNullableString(reader, "ScopesJson")),
+            Properties = DeserializeDictionary(ReadNullableString(reader, "PropertiesJson")),
+            TraceId = ReadNullableString(reader, "TraceId"),
+            SpanId = ReadNullableString(reader, "SpanId"),
+            CorrelationId = ReadNullableString(reader, "CorrelationId"),
+            TenantId = ReadNullableString(reader, "TenantId"),
+            WorkflowDefinitionId = ReadNullableString(reader, "WorkflowDefinitionId"),
+            WorkflowInstanceId = ReadNullableString(reader, "WorkflowInstanceId"),
+            SourceId = reader.GetString(reader.GetOrdinal("SourceId"))
+        };
+    }
+
+    public static string FormatTimestamp(DateTimeOffset timestamp)
+    {
+        return timestamp.ToUniversalTime().ToString("O", CultureInfo.InvariantCulture);
+    }
+
+    public static DateTimeOffset ParseTimestamp(string timestamp)
+    {
+        return DateTimeOffset.Parse(timestamp, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
+    }
+
+    private static string? ReadNullableString(DbDataReader reader, string name)
+    {
+        var ordinal = reader.GetOrdinal(name);
+        return reader.IsDBNull(ordinal) ? null : reader.GetString(ordinal);
+    }
+
+    private static IDictionary<string, string?> DeserializeDictionary(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+            return new Dictionary<string, string?>();
+
+        return JsonSerializer.Deserialize<Dictionary<string, string?>>(json, JsonOptions) ?? new Dictionary<string, string?>();
+    }
+
+    private static T? Deserialize<T>(string? json)
+    {
+        return string.IsNullOrWhiteSpace(json) ? default : JsonSerializer.Deserialize<T>(json, JsonOptions);
+    }
+}

--- a/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Services/RelationalStructuredLogSqlBuilder.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Services/RelationalStructuredLogSqlBuilder.cs
@@ -43,8 +43,9 @@ public class RelationalStructuredLogSqlBuilder(IRelationalStructuredLogDialect d
         var id = dialect.QuoteIdentifier("Id");
         var receivedAt = dialect.QuoteIdentifier("ReceivedAt");
         var sequence = dialect.QuoteIdentifier("Sequence");
-        var sql = $"DELETE FROM {_table} WHERE {id} IN (SELECT {id} FROM {_table} ORDER BY {receivedAt} DESC, {sequence} DESC, {id} DESC LIMIT -1 OFFSET {dialect.ParameterPrefix}MaxRows)";
-        return new(sql, new Dictionary<string, object?> { ["MaxRows"] = maxRows });
+        var selectSql = $"SELECT {id} FROM {_table} ORDER BY {receivedAt} DESC, {sequence} DESC, {id} DESC";
+        var sql = $"DELETE FROM {_table} WHERE {id} IN ({dialect.ApplyOffset(selectSql, maxRows)})";
+        return new(sql, new Dictionary<string, object?>());
     }
 
     private List<string> BuildFilterPredicates(StructuredLogFilter filter, IDictionary<string, object?> parameters)
@@ -84,10 +85,10 @@ public class RelationalStructuredLogSqlBuilder(IRelationalStructuredLogDialect d
         AddStringPredicate(predicates, parameters, "SourceId", filter.SourceId);
 
         if (filter.From is { } from)
-            AddPredicate(predicates, parameters, "Timestamp", ">=", RelationalStructuredLogMapper.FormatTimestamp(from));
+            AddPredicate(predicates, parameters, "Timestamp", ">=", RelationalStructuredLogMapper.FormatTimestamp(from), "TimestampFrom");
 
         if (filter.To is { } to)
-            AddPredicate(predicates, parameters, "Timestamp", "<=", RelationalStructuredLogMapper.FormatTimestamp(to));
+            AddPredicate(predicates, parameters, "Timestamp", "<=", RelationalStructuredLogMapper.FormatTimestamp(to), "TimestampTo");
 
         return predicates;
     }
@@ -100,10 +101,11 @@ public class RelationalStructuredLogSqlBuilder(IRelationalStructuredLogDialect d
         AddPredicate(predicates, parameters, column, "=", value);
     }
 
-    private void AddPredicate(ICollection<string> predicates, IDictionary<string, object?> parameters, string column, string op, object value)
+    private void AddPredicate(ICollection<string> predicates, IDictionary<string, object?> parameters, string column, string op, object value, string? parameterName = null)
     {
-        predicates.Add($"{dialect.QuoteIdentifier(column)} {op} {dialect.ParameterPrefix}{column}");
-        parameters[column] = value;
+        var name = parameterName ?? column;
+        predicates.Add($"{dialect.QuoteIdentifier(column)} {op} {dialect.ParameterPrefix}{name}");
+        parameters[name] = value;
     }
 
     private static readonly string[] Columns =

--- a/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Services/RelationalStructuredLogSqlBuilder.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Services/RelationalStructuredLogSqlBuilder.cs
@@ -1,0 +1,134 @@
+using Elsa.Diagnostics.StructuredLogs.Models;
+using Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Contracts;
+
+namespace Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Services;
+
+public class RelationalStructuredLogSqlBuilder(IRelationalStructuredLogDialect dialect)
+{
+    private readonly string _table = dialect.QuoteIdentifier("StructuredLogEvents");
+
+    public string BuildInsert()
+    {
+        var columns = Columns;
+        var columnList = string.Join(", ", columns.Select(dialect.QuoteIdentifier));
+        var parameterList = string.Join(", ", columns.Select(x => $"{dialect.ParameterPrefix}{x}"));
+        return $"INSERT INTO {_table} ({columnList}) VALUES ({parameterList})";
+    }
+
+    public QueryDefinition BuildQuery(StructuredLogFilter filter)
+    {
+        var parameters = new Dictionary<string, object?>();
+        var predicates = BuildFilterPredicates(filter, parameters);
+        var where = predicates.Count == 0 ? "" : $" WHERE {string.Join(" AND ", predicates)}";
+        var limit = Math.Clamp(filter.Take ?? 100, 0, 1000);
+        var sql = $"SELECT {string.Join(", ", Columns.Select(dialect.QuoteIdentifier))} FROM {_table}{where} ORDER BY {dialect.QuoteIdentifier("Timestamp")} DESC, {dialect.QuoteIdentifier("ReceivedAt")} DESC, {dialect.QuoteIdentifier("Sequence")} DESC, {dialect.QuoteIdentifier("Id")} DESC";
+        sql = dialect.ApplyLimit(sql, limit);
+        return new(sql, parameters);
+    }
+
+    public string BuildListSources()
+    {
+        var sourceId = dialect.QuoteIdentifier("SourceId");
+        var receivedAt = dialect.QuoteIdentifier("ReceivedAt");
+        return $"SELECT {sourceId}, MAX({receivedAt}) AS {dialect.QuoteIdentifier("LastSeen")} FROM {_table} GROUP BY {sourceId} ORDER BY {sourceId}";
+    }
+
+    public QueryDefinition BuildDeleteOlderThan(string cutoff)
+    {
+        return new($"DELETE FROM {_table} WHERE {dialect.QuoteIdentifier("ReceivedAt")} < {dialect.ParameterPrefix}Cutoff", new Dictionary<string, object?> { ["Cutoff"] = cutoff });
+    }
+
+    public QueryDefinition BuildDeleteRowsBeyondMax(int maxRows)
+    {
+        var id = dialect.QuoteIdentifier("Id");
+        var receivedAt = dialect.QuoteIdentifier("ReceivedAt");
+        var sequence = dialect.QuoteIdentifier("Sequence");
+        var sql = $"DELETE FROM {_table} WHERE {id} IN (SELECT {id} FROM {_table} ORDER BY {receivedAt} DESC, {sequence} DESC, {id} DESC LIMIT -1 OFFSET {dialect.ParameterPrefix}MaxRows)";
+        return new(sql, new Dictionary<string, object?> { ["MaxRows"] = maxRows });
+    }
+
+    private List<string> BuildFilterPredicates(StructuredLogFilter filter, IDictionary<string, object?> parameters)
+    {
+        var predicates = new List<string>();
+
+        if (filter.MinimumLevel is { } minimumLevel)
+            AddPredicate(predicates, parameters, "Level", ">=", (int)minimumLevel);
+
+        if (filter.Levels is { Count: > 0 })
+        {
+            var names = filter.Levels.Select((level, index) =>
+            {
+                var name = $"Level{index}";
+                parameters[name] = (int)level;
+                return $"{dialect.ParameterPrefix}{name}";
+            });
+            predicates.Add($"{dialect.QuoteIdentifier("Level")} IN ({string.Join(", ", names)})");
+        }
+
+        if (!string.IsNullOrWhiteSpace(filter.CategoryPrefix))
+            AddPredicate(predicates, parameters, "Category", "LIKE", $"{filter.CategoryPrefix}%");
+
+        if (!string.IsNullOrWhiteSpace(filter.Text))
+        {
+            parameters["Text"] = $"%{filter.Text}%";
+            var textParameter = $"{dialect.ParameterPrefix}Text";
+            predicates.Add($"({dialect.QuoteIdentifier("Message")} LIKE {textParameter} OR {dialect.QuoteIdentifier("MessageTemplate")} LIKE {textParameter} OR {dialect.QuoteIdentifier("Category")} LIKE {textParameter} OR {dialect.QuoteIdentifier("ExceptionJson")} LIKE {textParameter} OR {dialect.QuoteIdentifier("ScopesJson")} LIKE {textParameter} OR {dialect.QuoteIdentifier("PropertiesJson")} LIKE {textParameter})");
+        }
+
+        AddStringPredicate(predicates, parameters, "TenantId", filter.TenantId);
+        AddStringPredicate(predicates, parameters, "WorkflowDefinitionId", filter.WorkflowDefinitionId);
+        AddStringPredicate(predicates, parameters, "WorkflowInstanceId", filter.WorkflowInstanceId);
+        AddStringPredicate(predicates, parameters, "TraceId", filter.TraceId);
+        AddStringPredicate(predicates, parameters, "SpanId", filter.SpanId);
+        AddStringPredicate(predicates, parameters, "CorrelationId", filter.CorrelationId);
+        AddStringPredicate(predicates, parameters, "SourceId", filter.SourceId);
+
+        if (filter.From is { } from)
+            AddPredicate(predicates, parameters, "Timestamp", ">=", RelationalStructuredLogMapper.FormatTimestamp(from));
+
+        if (filter.To is { } to)
+            AddPredicate(predicates, parameters, "Timestamp", "<=", RelationalStructuredLogMapper.FormatTimestamp(to));
+
+        return predicates;
+    }
+
+    private void AddStringPredicate(ICollection<string> predicates, IDictionary<string, object?> parameters, string column, string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return;
+
+        AddPredicate(predicates, parameters, column, "=", value);
+    }
+
+    private void AddPredicate(ICollection<string> predicates, IDictionary<string, object?> parameters, string column, string op, object value)
+    {
+        predicates.Add($"{dialect.QuoteIdentifier(column)} {op} {dialect.ParameterPrefix}{column}");
+        parameters[column] = value;
+    }
+
+    private static readonly string[] Columns =
+    [
+        "Id",
+        "Sequence",
+        "Timestamp",
+        "ReceivedAt",
+        "Level",
+        "Category",
+        "EventId",
+        "EventName",
+        "Message",
+        "MessageTemplate",
+        "ExceptionJson",
+        "ScopesJson",
+        "PropertiesJson",
+        "TraceId",
+        "SpanId",
+        "CorrelationId",
+        "TenantId",
+        "WorkflowDefinitionId",
+        "WorkflowInstanceId",
+        "SourceId"
+    ];
+}
+
+public record QueryDefinition(string Sql, IReadOnlyDictionary<string, object?> Parameters);

--- a/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Services/StructuredLogRetentionService.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Services/StructuredLogRetentionService.cs
@@ -1,0 +1,48 @@
+using System.Data.Common;
+using Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Contracts;
+using Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Options;
+using Microsoft.Extensions.Options;
+
+namespace Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Services;
+
+public class StructuredLogRetentionService(
+    IRelationalStructuredLogConnectionFactory connectionFactory,
+    IRelationalStructuredLogDialect dialect,
+    RelationalStructuredLogSqlBuilder sqlBuilder,
+    IOptions<RelationalStructuredLogOptions> options)
+{
+    public async ValueTask CleanupAsync(CancellationToken cancellationToken = default)
+    {
+        var retention = options.Value.Retention;
+
+        if (retention.MaxAge == null && retention.MaxRows == null)
+            return;
+
+        await using var connection = await connectionFactory.OpenConnectionAsync(cancellationToken);
+
+        if (retention.MaxAge is { } maxAge)
+        {
+            var cutoff = RelationalStructuredLogMapper.FormatTimestamp(DateTimeOffset.UtcNow.Subtract(maxAge));
+            await ExecuteAsync(connection, sqlBuilder.BuildDeleteOlderThan(cutoff), cancellationToken);
+        }
+
+        if (retention.MaxRows is { } maxRows and >= 0)
+            await ExecuteAsync(connection, sqlBuilder.BuildDeleteRowsBeyondMax(maxRows), cancellationToken);
+    }
+
+    private async ValueTask ExecuteAsync(DbConnection connection, QueryDefinition query, CancellationToken cancellationToken)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = query.Sql;
+
+        foreach (var (name, value) in query.Parameters)
+        {
+            var parameter = command.CreateParameter();
+            parameter.ParameterName = name.StartsWith(dialect.ParameterPrefix, StringComparison.Ordinal) ? name : $"{dialect.ParameterPrefix}{name}";
+            parameter.Value = value ?? DBNull.Value;
+            command.Parameters.Add(parameter);
+        }
+
+        await command.ExecuteNonQueryAsync(cancellationToken);
+    }
+}

--- a/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Services/StructuredLogWriteBuffer.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Services/StructuredLogWriteBuffer.cs
@@ -1,0 +1,149 @@
+using Elsa.Diagnostics.StructuredLogs.Contracts;
+using Elsa.Diagnostics.StructuredLogs.Models;
+using Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Contracts;
+using Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Options;
+using Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Stores;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Services;
+
+public class StructuredLogWriteBuffer(
+    RelationalStructuredLogStore store,
+    IOptions<RelationalStructuredLogOptions> options) : IStructuredLogStore, IStructuredLogWriteBuffer, IHostedService, IAsyncDisposable
+{
+    private readonly Queue<StructuredLogEvent> _queue = new();
+    private readonly SemaphoreSlim _signal = new(0);
+    private readonly CancellationTokenSource _stopTokenSource = new();
+    private Task? _backgroundTask;
+    private long _droppedWriteCount;
+    private int _disposed;
+
+    public long DroppedWriteCount => Interlocked.Read(ref _droppedWriteCount);
+
+    public ValueTask WriteAsync(StructuredLogEvent logEvent, CancellationToken cancellationToken = default)
+    {
+        lock (_queue)
+        {
+            if (_queue.Count >= Math.Max(1, options.Value.WriteQueue.Capacity))
+            {
+                Interlocked.Increment(ref _droppedWriteCount);
+                return ValueTask.CompletedTask;
+            }
+
+            _queue.Enqueue(logEvent);
+        }
+
+        _signal.Release();
+        return ValueTask.CompletedTask;
+    }
+
+    public async ValueTask WriteManyAsync(IReadOnlyCollection<StructuredLogEvent> logEvents, CancellationToken cancellationToken = default)
+    {
+        foreach (var logEvent in logEvents)
+            await WriteAsync(logEvent, cancellationToken);
+    }
+
+    public ValueTask<RecentStructuredLogsResult> QueryAsync(StructuredLogFilter filter, CancellationToken cancellationToken = default)
+    {
+        return store.QueryAsync(filter, cancellationToken);
+    }
+
+    public ValueTask<IReadOnlyCollection<StructuredLogSource>> ListSourcesAsync(CancellationToken cancellationToken = default)
+    {
+        return store.ListSourcesAsync(cancellationToken);
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _backgroundTask ??= Task.Run(ProcessQueueAsync, CancellationToken.None);
+        return Task.CompletedTask;
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        await _stopTokenSource.CancelAsync();
+
+        if (_backgroundTask != null)
+        {
+            try
+            {
+                await _backgroundTask.WaitAsync(cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+            }
+        }
+
+        using var timeoutTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutTokenSource.CancelAfter(options.Value.WriteQueue.ShutdownFlushTimeout);
+        try
+        {
+            await FlushAsync(timeoutTokenSource.Token);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+    }
+
+    public async ValueTask FlushAsync(CancellationToken cancellationToken = default)
+    {
+        while (true)
+        {
+            var batch = DequeueBatch();
+            if (batch.Count == 0)
+                return;
+
+            await store.WriteManyAsync(batch, cancellationToken);
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) == 1)
+            return;
+
+        await _stopTokenSource.CancelAsync();
+        _signal.Dispose();
+        _stopTokenSource.Dispose();
+    }
+
+    private async Task ProcessQueueAsync()
+    {
+        using var timer = new PeriodicTimer(options.Value.WriteQueue.FlushInterval);
+        var cancellationToken = _stopTokenSource.Token;
+
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            try
+            {
+                var signalTask = _signal.WaitAsync(cancellationToken);
+                var timerTask = timer.WaitForNextTickAsync(cancellationToken).AsTask();
+                await Task.WhenAny(signalTask, timerTask);
+                await FlushAsync(CancellationToken.None);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+            catch (Exception e)
+            {
+                _ = e;
+            }
+        }
+    }
+
+    private IReadOnlyCollection<StructuredLogEvent> DequeueBatch()
+    {
+        var batchSize = Math.Max(1, options.Value.WriteQueue.BatchSize);
+        var batch = new List<StructuredLogEvent>(batchSize);
+
+        lock (_queue)
+        {
+            while (_queue.Count > 0 && batch.Count < batchSize)
+                batch.Add(_queue.Dequeue());
+        }
+
+        return batch;
+    }
+}

--- a/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Services/StructuredLogWriteBuffer.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Services/StructuredLogWriteBuffer.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Elsa.Diagnostics.StructuredLogs.Contracts;
 using Elsa.Diagnostics.StructuredLogs.Models;
 using Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Contracts;
@@ -119,10 +120,10 @@ public class StructuredLogWriteBuffer(
             return;
 
         await _stopTokenSource.CancelAsync();
+        using var timeoutTokenSource = new CancellationTokenSource(options.Value.WriteQueue.ShutdownFlushTimeout);
 
         if (_backgroundTask != null)
         {
-            using var timeoutTokenSource = new CancellationTokenSource(options.Value.WriteQueue.ShutdownFlushTimeout);
             try
             {
                 await _backgroundTask.WaitAsync(timeoutTokenSource.Token);
@@ -131,6 +132,15 @@ public class StructuredLogWriteBuffer(
             {
                 CountPendingWritesAsDropped();
             }
+        }
+
+        try
+        {
+            await FlushAsync(timeoutTokenSource.Token);
+        }
+        catch (OperationCanceledException) when (timeoutTokenSource.IsCancellationRequested)
+        {
+            CountPendingWritesAsDropped();
         }
 
         _signal.Dispose();
@@ -158,6 +168,10 @@ public class StructuredLogWriteBuffer(
             catch (ObjectDisposedException) when (cancellationToken.IsCancellationRequested)
             {
                 return;
+            }
+            catch (Exception e) when (!cancellationToken.IsCancellationRequested)
+            {
+                Trace.TraceError("Failed to flush structured log writes: {0}", e);
             }
         }
     }

--- a/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Services/StructuredLogWriteBuffer.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Services/StructuredLogWriteBuffer.cs
@@ -23,6 +23,8 @@ public class StructuredLogWriteBuffer(
 
     public ValueTask WriteAsync(StructuredLogEvent logEvent, CancellationToken cancellationToken = default)
     {
+        var shouldSignal = false;
+
         lock (_queue)
         {
             if (_queue.Count >= Math.Max(1, options.Value.WriteQueue.Capacity))
@@ -31,10 +33,13 @@ public class StructuredLogWriteBuffer(
                 return ValueTask.CompletedTask;
             }
 
+            shouldSignal = _queue.Count == 0;
             _queue.Enqueue(logEvent);
         }
 
-        _signal.Release();
+        if (shouldSignal)
+            _signal.Release();
+
         return ValueTask.CompletedTask;
     }
 
@@ -70,8 +75,9 @@ public class StructuredLogWriteBuffer(
             {
                 await _backgroundTask.WaitAsync(cancellationToken);
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested || _stopTokenSource.IsCancellationRequested)
             {
+                // Expected during shutdown; remaining queued writes are flushed below.
             }
         }
 
@@ -81,8 +87,9 @@ public class StructuredLogWriteBuffer(
         {
             await FlushAsync(timeoutTokenSource.Token);
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (timeoutTokenSource.IsCancellationRequested)
         {
+            CountPendingWritesAsDropped();
         }
     }
 
@@ -94,7 +101,15 @@ public class StructuredLogWriteBuffer(
             if (batch.Count == 0)
                 return;
 
-            await store.WriteManyAsync(batch, cancellationToken);
+            try
+            {
+                await store.WriteManyAsync(batch, cancellationToken);
+            }
+            catch
+            {
+                Interlocked.Add(ref _droppedWriteCount, batch.Count);
+                throw;
+            }
         }
     }
 
@@ -104,6 +119,20 @@ public class StructuredLogWriteBuffer(
             return;
 
         await _stopTokenSource.CancelAsync();
+
+        if (_backgroundTask != null)
+        {
+            using var timeoutTokenSource = new CancellationTokenSource(options.Value.WriteQueue.ShutdownFlushTimeout);
+            try
+            {
+                await _backgroundTask.WaitAsync(timeoutTokenSource.Token);
+            }
+            catch (OperationCanceledException) when (timeoutTokenSource.IsCancellationRequested || _stopTokenSource.IsCancellationRequested)
+            {
+                CountPendingWritesAsDropped();
+            }
+        }
+
         _signal.Dispose();
         _stopTokenSource.Dispose();
     }
@@ -120,15 +149,15 @@ public class StructuredLogWriteBuffer(
                 var signalTask = _signal.WaitAsync(cancellationToken);
                 var timerTask = timer.WaitForNextTickAsync(cancellationToken).AsTask();
                 await Task.WhenAny(signalTask, timerTask);
-                await FlushAsync(CancellationToken.None);
+                await FlushAsync(cancellationToken);
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
                 return;
             }
-            catch (Exception e)
+            catch (ObjectDisposedException) when (cancellationToken.IsCancellationRequested)
             {
-                _ = e;
+                return;
             }
         }
     }
@@ -145,5 +174,17 @@ public class StructuredLogWriteBuffer(
         }
 
         return batch;
+    }
+
+    private void CountPendingWritesAsDropped()
+    {
+        lock (_queue)
+        {
+            if (_queue.Count == 0)
+                return;
+
+            Interlocked.Add(ref _droppedWriteCount, _queue.Count);
+            _queue.Clear();
+        }
     }
 }

--- a/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/ShellFeatures/StructuredLogRelationalPersistenceFeature.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/ShellFeatures/StructuredLogRelationalPersistenceFeature.cs
@@ -1,0 +1,20 @@
+using CShells.Features;
+using JetBrains.Annotations;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Elsa.Diagnostics.StructuredLogs.Persistence.Relational.ShellFeatures;
+
+/// <summary>
+/// Provides shared relational persistence services for diagnostics structured logs.
+/// </summary>
+[ShellFeature(
+    DisplayName = "Structured Log Relational Persistence",
+    Description = "Provides shared relational persistence services for diagnostics structured logs",
+    DependsOn = ["Structured Logs"])]
+[UsedImplicitly]
+public class StructuredLogRelationalPersistenceFeature : IShellFeature
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+    }
+}

--- a/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Stores/RelationalStructuredLogStore.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Stores/RelationalStructuredLogStore.cs
@@ -5,7 +5,6 @@ using Elsa.Diagnostics.StructuredLogs.Models;
 using Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Contracts;
 using Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Models;
 using Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Services;
-using Elsa.Diagnostics.StructuredLogs.Services;
 
 namespace Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Stores;
 
@@ -37,8 +36,7 @@ public class RelationalStructuredLogStore(
 
     public async ValueTask<RecentStructuredLogsResult> QueryAsync(StructuredLogFilter filter, CancellationToken cancellationToken = default)
     {
-        var queryFilter = filter with { From = null, To = null, Take = filter.From != null || filter.To != null ? 1000 : filter.Take };
-        var query = sqlBuilder.BuildQuery(queryFilter);
+        var query = sqlBuilder.BuildQuery(filter);
         await using var connection = await connectionFactory.OpenConnectionAsync(cancellationToken);
         await using var command = CreateCommand(connection, query.Sql, query.Parameters);
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
@@ -48,11 +46,6 @@ public class RelationalStructuredLogStore(
             items.Add(mapper.Map(reader));
 
         items.Reverse();
-        items = items
-            .Where(x => StructuredLogFilterEvaluator.Matches(x, filter))
-            .TakeLast(Math.Clamp(filter.Take ?? 100, 0, 1000))
-            .ToList();
-
         return new(items, 0);
     }
 

--- a/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Stores/RelationalStructuredLogStore.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Stores/RelationalStructuredLogStore.cs
@@ -1,0 +1,137 @@
+using System.Data;
+using System.Data.Common;
+using Elsa.Diagnostics.StructuredLogs.Contracts;
+using Elsa.Diagnostics.StructuredLogs.Models;
+using Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Contracts;
+using Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Models;
+using Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Services;
+using Elsa.Diagnostics.StructuredLogs.Services;
+
+namespace Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Stores;
+
+public class RelationalStructuredLogStore(
+    IRelationalStructuredLogConnectionFactory connectionFactory,
+    IRelationalStructuredLogDialect dialect,
+    RelationalStructuredLogSqlBuilder sqlBuilder,
+    RelationalStructuredLogMapper mapper) : IStructuredLogStore
+{
+    public async ValueTask WriteAsync(StructuredLogEvent logEvent, CancellationToken cancellationToken = default)
+    {
+        await using var connection = await connectionFactory.OpenConnectionAsync(cancellationToken);
+        await InsertAsync(connection, mapper.Map(logEvent), null, cancellationToken);
+    }
+
+    public async ValueTask WriteManyAsync(IReadOnlyCollection<StructuredLogEvent> logEvents, CancellationToken cancellationToken = default)
+    {
+        if (logEvents.Count == 0)
+            return;
+
+        await using var connection = await connectionFactory.OpenConnectionAsync(cancellationToken);
+        await using var transaction = await connection.BeginTransactionAsync(cancellationToken);
+
+        foreach (var logEvent in logEvents)
+            await InsertAsync(connection, mapper.Map(logEvent), transaction, cancellationToken);
+
+        await transaction.CommitAsync(cancellationToken);
+    }
+
+    public async ValueTask<RecentStructuredLogsResult> QueryAsync(StructuredLogFilter filter, CancellationToken cancellationToken = default)
+    {
+        var queryFilter = filter with { From = null, To = null, Take = filter.From != null || filter.To != null ? 1000 : filter.Take };
+        var query = sqlBuilder.BuildQuery(queryFilter);
+        await using var connection = await connectionFactory.OpenConnectionAsync(cancellationToken);
+        await using var command = CreateCommand(connection, query.Sql, query.Parameters);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        var items = new List<StructuredLogEvent>();
+
+        while (await reader.ReadAsync(cancellationToken))
+            items.Add(mapper.Map(reader));
+
+        items.Reverse();
+        items = items
+            .Where(x => StructuredLogFilterEvaluator.Matches(x, filter))
+            .TakeLast(Math.Clamp(filter.Take ?? 100, 0, 1000))
+            .ToList();
+
+        return new(items, 0);
+    }
+
+    public async ValueTask<IReadOnlyCollection<StructuredLogSource>> ListSourcesAsync(CancellationToken cancellationToken = default)
+    {
+        await using var connection = await connectionFactory.OpenConnectionAsync(cancellationToken);
+        await using var command = CreateCommand(connection, sqlBuilder.BuildListSources());
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        var sources = new List<StructuredLogSource>();
+
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            var sourceId = reader.GetString(reader.GetOrdinal("SourceId"));
+            var lastSeen = RelationalStructuredLogMapper.ParseTimestamp(reader.GetString(reader.GetOrdinal("LastSeen")));
+            sources.Add(new()
+            {
+                Id = sourceId,
+                DisplayName = sourceId,
+                MachineName = sourceId,
+                ProcessId = 0,
+                LastSeen = lastSeen,
+                Status = StructuredLogSourceStatus.Connected
+            });
+        }
+
+        return sources;
+    }
+
+    private async ValueTask InsertAsync(DbConnection connection, RelationalStructuredLogRecord record, DbTransaction? transaction, CancellationToken cancellationToken)
+    {
+        await using var command = CreateCommand(connection, sqlBuilder.BuildInsert(), CreateParameters(record));
+        command.Transaction = transaction;
+        await command.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    private DbCommand CreateCommand(DbConnection connection, string sql, IReadOnlyDictionary<string, object?>? parameters = null)
+    {
+        var command = connection.CreateCommand();
+        command.CommandText = sql;
+        command.CommandType = CommandType.Text;
+
+        if (parameters == null)
+            return command;
+
+        foreach (var (name, value) in parameters)
+        {
+            var parameter = command.CreateParameter();
+            parameter.ParameterName = name.StartsWith(dialect.ParameterPrefix, StringComparison.Ordinal) ? name : $"{dialect.ParameterPrefix}{name}";
+            parameter.Value = value ?? DBNull.Value;
+            command.Parameters.Add(parameter);
+        }
+
+        return command;
+    }
+
+    private static IReadOnlyDictionary<string, object?> CreateParameters(RelationalStructuredLogRecord record)
+    {
+        return new Dictionary<string, object?>
+        {
+            ["Id"] = record.Id,
+            ["Sequence"] = record.Sequence,
+            ["Timestamp"] = record.Timestamp,
+            ["ReceivedAt"] = record.ReceivedAt,
+            ["Level"] = (int)record.Level,
+            ["Category"] = record.Category,
+            ["EventId"] = record.EventId,
+            ["EventName"] = record.EventName,
+            ["Message"] = record.Message,
+            ["MessageTemplate"] = record.MessageTemplate,
+            ["ExceptionJson"] = record.ExceptionJson,
+            ["ScopesJson"] = record.ScopesJson,
+            ["PropertiesJson"] = record.PropertiesJson,
+            ["TraceId"] = record.TraceId,
+            ["SpanId"] = record.SpanId,
+            ["CorrelationId"] = record.CorrelationId,
+            ["TenantId"] = record.TenantId,
+            ["WorkflowDefinitionId"] = record.WorkflowDefinitionId,
+            ["WorkflowInstanceId"] = record.WorkflowInstanceId,
+            ["SourceId"] = record.SourceId
+        };
+    }
+}

--- a/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.csproj
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <Description>
+            Provides SQLite persistence for diagnostics structured logs.
+        </Description>
+        <PackageTags>elsa module diagnostics structured-logs persistence sqlite logging</PackageTags>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="CShells" />
+        <PackageReference Include="FluentMigrator.Runner.SQLite" />
+        <PackageReference Include="Microsoft.Data.Sqlite" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+        <PackageReference Include="Microsoft.Extensions.Options" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Elsa.Diagnostics.StructuredLogs.Persistence.Relational\Elsa.Diagnostics.StructuredLogs.Persistence.Relational.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Extensions/SqliteStructuredLogsModuleExtensions.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Extensions/SqliteStructuredLogsModuleExtensions.cs
@@ -1,0 +1,64 @@
+using Elsa.Diagnostics.StructuredLogs.Features;
+using Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Contracts;
+using Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Extensions;
+using Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Options;
+using Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.Features;
+using Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.Options;
+using Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.Services;
+using Elsa.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+
+namespace Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.Extensions;
+
+public static class SqliteStructuredLogsModuleExtensions
+{
+    public static StructuredLogsFeature UseSqliteStorage(this StructuredLogsFeature feature, string connectionString, Action<SqliteStructuredLogOptions>? configure = null)
+    {
+        feature.Module.Use<SqliteStructuredLogPersistenceFeature>(sqlite =>
+        {
+            sqlite.ConfigureOptions = options =>
+            {
+                options.ConnectionString = connectionString;
+                configure?.Invoke(options);
+            };
+        });
+
+        return feature;
+    }
+
+    public static StructuredLogsFeature UseSqliteStorage(this StructuredLogsFeature feature, Action<SqliteStructuredLogOptions>? configure = null)
+    {
+        feature.Module.Use<SqliteStructuredLogPersistenceFeature>(sqlite => sqlite.ConfigureOptions = configure);
+        return feature;
+    }
+
+    public static IServiceCollection AddSqliteStructuredLogPersistence(this IServiceCollection services, Action<SqliteStructuredLogOptions>? configure = null)
+    {
+        if (configure != null)
+            services.Configure(configure);
+
+        services.AddOptions<SqliteStructuredLogOptions>();
+        services.AddOptions<RelationalStructuredLogOptions>().Configure<IOptions<SqliteStructuredLogOptions>>((relational, sqlite) => Copy(sqlite.Value.Relational, relational));
+
+        services.AddRelationalStructuredLogPersistence();
+        services.TryAddSingleton<IRelationalStructuredLogConnectionFactory, SqliteStructuredLogConnectionFactory>();
+        services.TryAddSingleton<IRelationalStructuredLogDialect, SqliteStructuredLogDialect>();
+        services.TryAddSingleton<IStructuredLogSchemaMigrator, SqliteStructuredLogSchemaMigrator>();
+        services.AddHostedService<SqliteStructuredLogStartupService>();
+
+        return services;
+    }
+
+    private static void Copy(RelationalStructuredLogOptions source, RelationalStructuredLogOptions target)
+    {
+        target.WriteQueue.Capacity = source.WriteQueue.Capacity;
+        target.WriteQueue.BatchSize = source.WriteQueue.BatchSize;
+        target.WriteQueue.FlushInterval = source.WriteQueue.FlushInterval;
+        target.WriteQueue.ShutdownFlushTimeout = source.WriteQueue.ShutdownFlushTimeout;
+        target.Retention.MaxAge = source.Retention.MaxAge;
+        target.Retention.MaxRows = source.Retention.MaxRows;
+        target.Retention.CleanupOnStartup = source.Retention.CleanupOnStartup;
+    }
+}

--- a/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Extensions/SqliteStructuredLogsModuleExtensions.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Extensions/SqliteStructuredLogsModuleExtensions.cs
@@ -42,11 +42,11 @@ public static class SqliteStructuredLogsModuleExtensions
         services.AddOptions<SqliteStructuredLogOptions>();
         services.AddOptions<RelationalStructuredLogOptions>().Configure<IOptions<SqliteStructuredLogOptions>>((relational, sqlite) => Copy(sqlite.Value.Relational, relational));
 
-        services.AddRelationalStructuredLogPersistence();
         services.TryAddSingleton<IRelationalStructuredLogConnectionFactory, SqliteStructuredLogConnectionFactory>();
         services.TryAddSingleton<IRelationalStructuredLogDialect, SqliteStructuredLogDialect>();
         services.TryAddSingleton<IStructuredLogSchemaMigrator, SqliteStructuredLogSchemaMigrator>();
         services.AddHostedService<SqliteStructuredLogStartupService>();
+        services.AddRelationalStructuredLogPersistence();
 
         return services;
     }

--- a/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Features/SqliteStructuredLogPersistenceFeature.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Features/SqliteStructuredLogPersistenceFeature.cs
@@ -1,0 +1,16 @@
+using Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.Extensions;
+using Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.Options;
+using Elsa.Features.Abstractions;
+using Elsa.Features.Services;
+
+namespace Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.Features;
+
+public class SqliteStructuredLogPersistenceFeature(IModule module) : FeatureBase(module)
+{
+    public Action<SqliteStructuredLogOptions>? ConfigureOptions { get; set; }
+
+    public override void Apply()
+    {
+        Services.AddSqliteStructuredLogPersistence(ConfigureOptions);
+    }
+}

--- a/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/FodyWeavers.xml
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/FodyWeavers.xml
@@ -1,0 +1,3 @@
+﻿<Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
+  <ConfigureAwait />
+</Weavers>

--- a/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Options/SqliteStructuredLogOptions.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Options/SqliteStructuredLogOptions.cs
@@ -1,0 +1,10 @@
+using Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Options;
+
+namespace Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.Options;
+
+public class SqliteStructuredLogOptions
+{
+    public string ConnectionString { get; set; } = "Data Source=elsa-structured-logs.db";
+    public bool RunMigrationsOnStartup { get; set; } = true;
+    public RelationalStructuredLogOptions Relational { get; set; } = new();
+}

--- a/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/README.md
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/README.md
@@ -1,0 +1,40 @@
+# Elsa Diagnostics Structured Logs SQLite Persistence
+
+This package persists diagnostics structured log events to SQLite using the shared relational structured log store.
+
+## Configure
+
+```csharp
+services.AddElsa(elsa =>
+{
+    elsa.UseStructuredLogs(structuredLogs =>
+    {
+        structuredLogs.UseSqliteStorage("Data Source=elsa-structured-logs.db", sqlite =>
+        {
+            sqlite.RunMigrationsOnStartup = true;
+            sqlite.Relational.WriteQueue.Capacity = 10_000;
+            sqlite.Relational.WriteQueue.BatchSize = 100;
+        });
+    });
+});
+```
+
+SQLite migrations run on startup by default. Set `RunMigrationsOnStartup` to `false` when migrations are handled by deployment tooling.
+
+## Retention
+
+SQLite storage does not delete persisted log entries by default. Configure retention explicitly:
+
+```csharp
+sqlite.Relational.Retention.MaxAge = TimeSpan.FromDays(14);
+sqlite.Relational.Retention.MaxRows = 250_000;
+sqlite.Relational.Retention.CleanupOnStartup = true;
+```
+
+## Write Queue
+
+Writes are buffered through a bounded queue. Graceful shutdown flushes queued events where possible. If the queue is full, newest writes are dropped and `IStructuredLogWriteBuffer.DroppedWriteCount` reports the dropped-write count.
+
+## Provider Boundary
+
+SQLite-specific services live in this package: connection factory, SQL dialect, FluentMigrator runner wiring, and startup migration/cleanup service. Shared relational behavior lives in `Elsa.Diagnostics.StructuredLogs.Persistence.Relational`.

--- a/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Services/SqliteStructuredLogConnectionFactory.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Services/SqliteStructuredLogConnectionFactory.cs
@@ -1,0 +1,17 @@
+using System.Data.Common;
+using Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Contracts;
+using Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.Options;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Options;
+
+namespace Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.Services;
+
+public class SqliteStructuredLogConnectionFactory(IOptions<SqliteStructuredLogOptions> options) : IRelationalStructuredLogConnectionFactory
+{
+    public async ValueTask<DbConnection> OpenConnectionAsync(CancellationToken cancellationToken = default)
+    {
+        var connection = new SqliteConnection(options.Value.ConnectionString);
+        await connection.OpenAsync(cancellationToken);
+        return connection;
+    }
+}

--- a/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Services/SqliteStructuredLogDialect.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Services/SqliteStructuredLogDialect.cs
@@ -1,0 +1,19 @@
+using Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Contracts;
+
+namespace Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.Services;
+
+public class SqliteStructuredLogDialect : IRelationalStructuredLogDialect
+{
+    public string ProviderName => "SQLite";
+    public string ParameterPrefix => "@";
+
+    public string QuoteIdentifier(string identifier)
+    {
+        return $"\"{identifier.Replace("\"", "\"\"", StringComparison.Ordinal)}\"";
+    }
+
+    public string ApplyLimit(string sql, int limit)
+    {
+        return $"{sql} LIMIT {limit}";
+    }
+}

--- a/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Services/SqliteStructuredLogDialect.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Services/SqliteStructuredLogDialect.cs
@@ -16,4 +16,9 @@ public class SqliteStructuredLogDialect : IRelationalStructuredLogDialect
     {
         return $"{sql} LIMIT {limit}";
     }
+
+    public string ApplyOffset(string sql, int offset)
+    {
+        return $"{sql} LIMIT -1 OFFSET {offset}";
+    }
 }

--- a/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Services/SqliteStructuredLogSchemaMigrator.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Services/SqliteStructuredLogSchemaMigrator.cs
@@ -1,0 +1,29 @@
+using Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Contracts;
+using Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Migrations;
+using Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.Options;
+using FluentMigrator.Runner;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.Services;
+
+public class SqliteStructuredLogSchemaMigrator(IOptions<SqliteStructuredLogOptions> options) : IStructuredLogSchemaMigrator
+{
+    public ValueTask MigrateAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        using var services = new ServiceCollection()
+            .AddLogging()
+            .AddFluentMigratorCore()
+            .ConfigureRunner(builder => builder
+                .AddSQLite()
+                .WithGlobalConnectionString(options.Value.ConnectionString)
+                .ScanIn(typeof(M001CreateStructuredLogTables).Assembly).For.Migrations())
+            .BuildServiceProvider(false);
+
+        using var scope = services.CreateScope();
+        scope.ServiceProvider.GetRequiredService<IMigrationRunner>().MigrateUp();
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Services/SqliteStructuredLogStartupService.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Services/SqliteStructuredLogStartupService.cs
@@ -1,0 +1,24 @@
+using Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Contracts;
+using Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Services;
+using Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.Options;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.Services;
+
+public class SqliteStructuredLogStartupService(
+    IStructuredLogSchemaMigrator schemaMigrator,
+    StructuredLogRetentionService retentionService,
+    IOptions<SqliteStructuredLogOptions> options) : IHostedService
+{
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (options.Value.RunMigrationsOnStartup)
+            await schemaMigrator.MigrateAsync(cancellationToken);
+
+        if (options.Value.Relational.Retention.CleanupOnStartup)
+            await retentionService.CleanupAsync(cancellationToken);
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/ShellFeatures/SqliteStructuredLogPersistenceFeature.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/ShellFeatures/SqliteStructuredLogPersistenceFeature.cs
@@ -1,0 +1,29 @@
+using CShells.Features;
+using Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.Extensions;
+using JetBrains.Annotations;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.ShellFeatures;
+
+/// <summary>
+/// Provides SQLite persistence for diagnostics structured logs.
+/// </summary>
+[ShellFeature(
+    DisplayName = "SQLite Structured Log Persistence",
+    Description = "Provides SQLite persistence for diagnostics structured logs",
+    DependsOn = ["Structured Log Relational Persistence"])]
+[UsedImplicitly]
+public class SqliteStructuredLogPersistenceFeature : IShellFeature
+{
+    public string ConnectionString { get; set; } = "Data Source=elsa-structured-logs.db";
+    public bool RunMigrationsOnStartup { get; set; } = true;
+
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.AddSqliteStructuredLogPersistence(options =>
+        {
+            options.ConnectionString = ConnectionString;
+            options.RunMigrationsOnStartup = RunMigrationsOnStartup;
+        });
+    }
+}

--- a/src/modules/Elsa.Diagnostics.StructuredLogs/Contracts/IStructuredLogLiveFeed.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs/Contracts/IStructuredLogLiveFeed.cs
@@ -1,0 +1,10 @@
+using Elsa.Diagnostics.StructuredLogs.Models;
+
+namespace Elsa.Diagnostics.StructuredLogs.Contracts;
+
+public interface IStructuredLogLiveFeed
+{
+    ValueTask PublishAsync(StructuredLogEvent logEvent, CancellationToken cancellationToken = default);
+
+    IAsyncEnumerable<StructuredLogStreamItem> SubscribeAsync(StructuredLogFilter filter, CancellationToken cancellationToken = default);
+}

--- a/src/modules/Elsa.Diagnostics.StructuredLogs/Contracts/IStructuredLogSink.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs/Contracts/IStructuredLogSink.cs
@@ -1,0 +1,14 @@
+using Elsa.Diagnostics.StructuredLogs.Models;
+
+namespace Elsa.Diagnostics.StructuredLogs.Contracts;
+
+public interface IStructuredLogSink
+{
+    ValueTask WriteAsync(StructuredLogEvent logEvent, CancellationToken cancellationToken = default);
+
+    async ValueTask WriteManyAsync(IReadOnlyCollection<StructuredLogEvent> logEvents, CancellationToken cancellationToken = default)
+    {
+        foreach (var logEvent in logEvents)
+            await WriteAsync(logEvent, cancellationToken);
+    }
+}

--- a/src/modules/Elsa.Diagnostics.StructuredLogs/Contracts/IStructuredLogStore.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs/Contracts/IStructuredLogStore.cs
@@ -1,0 +1,10 @@
+using Elsa.Diagnostics.StructuredLogs.Models;
+
+namespace Elsa.Diagnostics.StructuredLogs.Contracts;
+
+public interface IStructuredLogStore : IStructuredLogSink
+{
+    ValueTask<RecentStructuredLogsResult> QueryAsync(StructuredLogFilter filter, CancellationToken cancellationToken = default);
+
+    ValueTask<IReadOnlyCollection<StructuredLogSource>> ListSourcesAsync(CancellationToken cancellationToken = default);
+}

--- a/src/modules/Elsa.Diagnostics.StructuredLogs/Extensions/ServiceCollectionExtensions.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs/Extensions/ServiceCollectionExtensions.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Elsa.Diagnostics.StructuredLogs.Extensions;
 
-internal static class ServiceCollectionExtensions
+public static class ServiceCollectionExtensions
 {
     public static IServiceCollection AddStructuredLogsServices(this IServiceCollection services, Action<StructuredLogsOptions>? configureOptions = null)
     {
@@ -21,7 +21,11 @@ internal static class ServiceCollectionExtensions
         services.AddOptions<StructuredLogsOptions>();
         services.TryAddSingleton<IStructuredLogSourceRegistry, StructuredLogSourceRegistry>();
         services.TryAddSingleton<IStructuredLogRedactor, StructuredLogRedactor>();
-        services.TryAddSingleton<IStructuredLogProvider, InMemoryStructuredLogProvider>();
+        services.TryAddSingleton<InMemoryStructuredLogStore>();
+        services.TryAddSingleton<IStructuredLogStore>(sp => sp.GetRequiredService<InMemoryStructuredLogStore>());
+        services.TryAddSingleton<InMemoryStructuredLogLiveFeed>();
+        services.TryAddSingleton<IStructuredLogLiveFeed>(sp => sp.GetRequiredService<InMemoryStructuredLogLiveFeed>());
+        services.TryAddSingleton<IStructuredLogProvider, DefaultStructuredLogProvider>();
         services.TryAddSingleton<StructuredLogSubscriptionManager>();
         services.TryAddEnumerable(ServiceDescriptor.Singleton<ILoggerProvider, StructuredLogLoggerProvider>());
 

--- a/src/modules/Elsa.Diagnostics.StructuredLogs/Providers/InMemory/InMemoryStructuredLogLiveFeed.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs/Providers/InMemory/InMemoryStructuredLogLiveFeed.cs
@@ -1,0 +1,110 @@
+using System.Runtime.CompilerServices;
+using System.Threading.Channels;
+using Elsa.Diagnostics.StructuredLogs.Contracts;
+using Elsa.Diagnostics.StructuredLogs.Models;
+using Elsa.Diagnostics.StructuredLogs.Options;
+using Elsa.Diagnostics.StructuredLogs.Services;
+using Microsoft.Extensions.Options;
+
+namespace Elsa.Diagnostics.StructuredLogs.Providers.InMemory;
+
+public class InMemoryStructuredLogLiveFeed(IOptions<StructuredLogsOptions> options) : IStructuredLogLiveFeed
+{
+    private readonly StructuredLogsOptions _options = options.Value;
+    private readonly object _subscribersLock = new();
+    private readonly Dictionary<Guid, StructuredLogSubscriber> _subscribers = new();
+
+    public ValueTask PublishAsync(StructuredLogEvent logEvent, CancellationToken cancellationToken = default)
+    {
+        List<StructuredLogSubscriber> subscribers;
+        lock (_subscribersLock)
+            subscribers = _subscribers.Values.ToList();
+
+        foreach (var subscriber in subscribers)
+            subscriber.TryWrite(logEvent, _options.SubscriberChannelCapacity);
+
+        return ValueTask.CompletedTask;
+    }
+
+    public async IAsyncEnumerable<StructuredLogStreamItem> SubscribeAsync(StructuredLogFilter filter, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var subscriberId = Guid.NewGuid();
+        var subscriber = new StructuredLogSubscriber(filter);
+
+        lock (_subscribersLock)
+            _subscribers[subscriberId] = subscriber;
+
+        try
+        {
+            await foreach (var item in subscriber.Channel.Reader.ReadAllAsync(cancellationToken))
+            {
+                subscriber.MarkConsumed(item);
+                yield return item;
+            }
+        }
+        finally
+        {
+            lock (_subscribersLock)
+                _subscribers.Remove(subscriberId);
+        }
+    }
+
+    private sealed class StructuredLogSubscriber(StructuredLogFilter filter)
+    {
+        private readonly object _lock = new();
+        private int _pendingItemCount;
+        private long _droppedSinceLastSummary;
+        private bool _summaryQueued;
+
+        public Channel<StructuredLogStreamItem> Channel { get; } = System.Threading.Channels.Channel.CreateUnbounded<StructuredLogStreamItem>(new UnboundedChannelOptions
+        {
+            SingleReader = true,
+            SingleWriter = false
+        });
+
+        public void TryWrite(StructuredLogEvent logEvent, int capacity)
+        {
+            if (!StructuredLogFilterEvaluator.Matches(logEvent, filter))
+                return;
+
+            lock (_lock)
+            {
+                if (_pendingItemCount >= capacity)
+                {
+                    _droppedSinceLastSummary++;
+                    QueueDroppedSummaryIfNeeded();
+                    return;
+                }
+
+                Channel.Writer.TryWrite(StructuredLogStreamItem.FromLogEvent(logEvent));
+                _pendingItemCount++;
+            }
+        }
+
+        public void MarkConsumed(StructuredLogStreamItem item)
+        {
+            lock (_lock)
+            {
+                _pendingItemCount = Math.Max(0, _pendingItemCount - 1);
+
+                if (item.DroppedEvents != null)
+                {
+                    _summaryQueued = false;
+                    QueueDroppedSummaryIfNeeded();
+                }
+            }
+        }
+
+        private void QueueDroppedSummaryIfNeeded()
+        {
+            if (_summaryQueued || _droppedSinceLastSummary == 0)
+                return;
+
+            var summary = new StructuredLogDroppedEventSummary(null, _droppedSinceLastSummary, "SubscriberChannelFull");
+            _droppedSinceLastSummary = 0;
+            _summaryQueued = true;
+            _pendingItemCount++;
+            Channel.Writer.TryWrite(StructuredLogStreamItem.FromDroppedEvents(summary));
+        }
+    }
+}

--- a/src/modules/Elsa.Diagnostics.StructuredLogs/Providers/InMemory/InMemoryStructuredLogStore.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs/Providers/InMemory/InMemoryStructuredLogStore.cs
@@ -1,0 +1,50 @@
+using Elsa.Diagnostics.StructuredLogs.Contracts;
+using Elsa.Diagnostics.StructuredLogs.Models;
+using Elsa.Diagnostics.StructuredLogs.Options;
+using Elsa.Diagnostics.StructuredLogs.Services;
+using Microsoft.Extensions.Options;
+
+namespace Elsa.Diagnostics.StructuredLogs.Providers.InMemory;
+
+public class InMemoryStructuredLogStore : IStructuredLogStore
+{
+    private readonly RingBuffer<StructuredLogEvent> _recentLogs;
+    private readonly IStructuredLogSourceRegistry _sourceRegistry;
+    private readonly StructuredLogsOptions _options;
+
+    public InMemoryStructuredLogStore(IOptions<StructuredLogsOptions> options, IStructuredLogSourceRegistry sourceRegistry)
+    {
+        _options = options.Value;
+        _sourceRegistry = sourceRegistry;
+        _recentLogs = new(_options.RecentLogCapacity);
+    }
+
+    public ValueTask WriteAsync(StructuredLogEvent logEvent, CancellationToken cancellationToken = default)
+    {
+        _recentLogs.Add(logEvent);
+        _sourceRegistry.MarkSeen(logEvent.SourceId, logEvent.ReceivedAt);
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask<RecentStructuredLogsResult> QueryAsync(StructuredLogFilter filter, CancellationToken cancellationToken = default)
+    {
+        var take = Math.Clamp(filter.Take ?? _options.MaxRecentLogQuerySize, 0, _options.MaxRecentLogQuerySize);
+        var items = _recentLogs
+            .Snapshot()
+            .Where(x => StructuredLogFilterEvaluator.Matches(x, filter))
+            .OrderBy(x => x.Timestamp)
+            .ThenBy(x => x.ReceivedAt)
+            .ThenBy(x => x.SourceId, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(x => x.Sequence)
+            .ThenBy(x => x.Id, StringComparer.Ordinal)
+            .TakeLast(take)
+            .ToList();
+
+        return ValueTask.FromResult(new RecentStructuredLogsResult(items, _recentLogs.DroppedCount));
+    }
+
+    public ValueTask<IReadOnlyCollection<StructuredLogSource>> ListSourcesAsync(CancellationToken cancellationToken = default)
+    {
+        return ValueTask.FromResult(_sourceRegistry.List());
+    }
+}

--- a/src/modules/Elsa.Diagnostics.StructuredLogs/README.md
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs/README.md
@@ -45,7 +45,19 @@ Elsa Studio can use this module to show:
 
 The default in-memory provider captures logs for the current process only. It still includes source identity and Kubernetes/container metadata so Studio can filter and display the active source.
 
-For merged multi-pod logs, provide an implementation of `IStructuredLogProvider` backed by shared infrastructure such as a log broker, distributed stream, or platform log API. Studio continues to use the same REST and SignalR contracts, including source filtering and source-change notifications.
+For persisted logs, add a storage package such as `Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite` and opt in from the structured logs feature:
+
+```csharp
+services.AddElsa(elsa =>
+{
+    elsa.UseStructuredLogs(structuredLogs =>
+    {
+        structuredLogs.UseSqliteStorage("Data Source=elsa-structured-logs.db");
+    });
+});
+```
+
+The core module remains storage-provider neutral. Custom stores can replace `IStructuredLogStore` while live updates continue through `IStructuredLogLiveFeed`; Studio continues to use the same REST and SignalR contracts, including source filtering and source-change notifications.
 
 ## Redaction
 

--- a/src/modules/Elsa.Diagnostics.StructuredLogs/Services/DefaultStructuredLogProvider.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs/Services/DefaultStructuredLogProvider.cs
@@ -1,37 +1,20 @@
 using System.Runtime.CompilerServices;
 using Elsa.Diagnostics.StructuredLogs.Contracts;
 using Elsa.Diagnostics.StructuredLogs.Models;
-using Elsa.Diagnostics.StructuredLogs.Options;
-using Microsoft.Extensions.Options;
 
-namespace Elsa.Diagnostics.StructuredLogs.Providers.InMemory;
+namespace Elsa.Diagnostics.StructuredLogs.Services;
 
-public class InMemoryStructuredLogProvider : IStructuredLogStreamProvider
+public class DefaultStructuredLogProvider(IStructuredLogStore store, IStructuredLogLiveFeed liveFeed) : IStructuredLogStreamProvider
 {
-    private readonly InMemoryStructuredLogStore _store;
-    private readonly InMemoryStructuredLogLiveFeed _liveFeed;
-
-    public InMemoryStructuredLogProvider(IOptions<StructuredLogsOptions> options, IStructuredLogSourceRegistry sourceRegistry)
-    {
-        _store = new(options, sourceRegistry);
-        _liveFeed = new(options);
-    }
-
-    public InMemoryStructuredLogProvider(InMemoryStructuredLogStore store, InMemoryStructuredLogLiveFeed liveFeed)
-    {
-        _store = store;
-        _liveFeed = liveFeed;
-    }
-
     public async ValueTask PublishAsync(StructuredLogEvent logEvent, CancellationToken cancellationToken = default)
     {
-        await _store.WriteAsync(logEvent, cancellationToken);
-        await _liveFeed.PublishAsync(logEvent, cancellationToken);
+        await store.WriteAsync(logEvent, cancellationToken);
+        await liveFeed.PublishAsync(logEvent, cancellationToken);
     }
 
     public ValueTask<RecentStructuredLogsResult> GetRecentAsync(StructuredLogFilter filter, CancellationToken cancellationToken = default)
     {
-        return _store.QueryAsync(filter, cancellationToken);
+        return store.QueryAsync(filter, cancellationToken);
     }
 
     public async IAsyncEnumerable<StructuredLogEvent> SubscribeAsync(StructuredLogFilter filter, [EnumeratorCancellation] CancellationToken cancellationToken = default)
@@ -45,11 +28,11 @@ public class InMemoryStructuredLogProvider : IStructuredLogStreamProvider
 
     public IAsyncEnumerable<StructuredLogStreamItem> SubscribeWithDroppedEventsAsync(StructuredLogFilter filter, CancellationToken cancellationToken = default)
     {
-        return _liveFeed.SubscribeAsync(filter, cancellationToken);
+        return liveFeed.SubscribeAsync(filter, cancellationToken);
     }
 
     public ValueTask<IReadOnlyCollection<StructuredLogSource>> ListSourcesAsync(CancellationToken cancellationToken = default)
     {
-        return _store.ListSourcesAsync(cancellationToken);
+        return store.ListSourcesAsync(cancellationToken);
     }
 }

--- a/test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests.csproj
+++ b/test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <Include>[Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite]*</Include>
+        <Threshold>0</Threshold>
+        <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\src\modules\Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite\Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogFilterTests.cs
+++ b/test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogFilterTests.cs
@@ -1,0 +1,57 @@
+using Elsa.Diagnostics.StructuredLogs.Models;
+
+namespace Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests;
+
+public class SqliteStructuredLogFilterTests
+{
+    private readonly DateTimeOffset _baseTime = new(2026, 5, 13, 10, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public async Task QueryAsync_AppliesStructuredLogFilters()
+    {
+        await using var host = new SqliteStructuredLogTestHost();
+        var target = StructuredLogTestEvents.Create(
+            "filter-target",
+            _baseTime.AddMinutes(2),
+            StructuredLogLevel.Warning,
+            "Elsa.Workflow.Target",
+            "source-target",
+            "wf-def",
+            "wf-inst",
+            "corr-target",
+            "trace-target",
+            "needle");
+        await host.WriteAsync(target);
+
+        await AssertMatchesAsync(host, new() { Levels = [StructuredLogLevel.Warning] });
+        await AssertMatchesAsync(host, new() { CategoryPrefix = "Elsa.Workflow" });
+        await AssertMatchesAsync(host, new() { SourceId = "source-target" });
+        await AssertMatchesAsync(host, new() { WorkflowDefinitionId = "wf-def" });
+        await AssertMatchesAsync(host, new() { WorkflowInstanceId = "wf-inst" });
+        await AssertMatchesAsync(host, new() { CorrelationId = "corr-target" });
+        await AssertMatchesAsync(host, new() { TraceId = "trace-target" });
+        await AssertMatchesAsync(host, new() { From = _baseTime, To = _baseTime.AddMinutes(10) });
+    }
+
+    private static async Task AssertMatchesAsync(SqliteStructuredLogTestHost host, StructuredLogFilter filter)
+    {
+        var result = await host.Store.QueryAsync(filter with { Take = 1 });
+        var item = Assert.Single(result.Items);
+        Assert.Equal("filter-target", item.Id);
+    }
+
+    [Fact]
+    public async Task QueryAsync_AppliesMinimumLevelAndLimit()
+    {
+        await using var host = new SqliteStructuredLogTestHost();
+        await host.WriteAsync(
+            StructuredLogTestEvents.Create("debug", _baseTime, StructuredLogLevel.Debug),
+            StructuredLogTestEvents.Create("warning", _baseTime.AddMinutes(1), StructuredLogLevel.Warning),
+            StructuredLogTestEvents.Create("error", _baseTime.AddMinutes(2), StructuredLogLevel.Error));
+
+        var result = await host.Store.QueryAsync(new() { MinimumLevel = StructuredLogLevel.Warning, Take = 1 });
+
+        var item = Assert.Single(result.Items);
+        Assert.Equal("error", item.Id);
+    }
+}

--- a/test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogFilterTests.cs
+++ b/test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogFilterTests.cs
@@ -54,4 +54,27 @@ public class SqliteStructuredLogFilterTests
         var item = Assert.Single(result.Items);
         Assert.Equal("error", item.Id);
     }
+
+    [Fact]
+    public async Task QueryAsync_AppliesTimeRangeInSqlBeforeLimiting()
+    {
+        await using var host = new SqliteStructuredLogTestHost();
+        var target = StructuredLogTestEvents.Create("old-target", _baseTime);
+        var recentEvents = Enumerable
+            .Range(0, 1005)
+            .Select(i => StructuredLogTestEvents.Create($"recent-{i}", _baseTime.AddDays(1).AddMinutes(i)))
+            .ToArray();
+
+        await host.WriteAsync([target, .. recentEvents]);
+
+        var result = await host.Store.QueryAsync(new()
+        {
+            From = _baseTime.AddMinutes(-1),
+            To = _baseTime.AddMinutes(1),
+            Take = 10
+        });
+
+        var item = Assert.Single(result.Items);
+        Assert.Equal("old-target", item.Id);
+    }
 }

--- a/test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogMigrationTests.cs
+++ b/test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogMigrationTests.cs
@@ -1,0 +1,30 @@
+using Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.Options;
+using Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests;
+
+public class SqliteStructuredLogMigrationTests
+{
+    [Fact]
+    public async Task MigrateAsync_CreatesStructuredLogTableInEmptyDatabase()
+    {
+        await using var host = new SqliteStructuredLogTestHost(migrate: false);
+
+        await host.Migrator.MigrateAsync();
+
+        Assert.True(await host.TableExistsAsync("StructuredLogEvents"));
+    }
+
+    [Fact]
+    public async Task Startup_DoesNotRunMigrations_WhenOptedOut()
+    {
+        await using var host = new SqliteStructuredLogTestHost(options => options.RunMigrationsOnStartup = false, migrate: false);
+        var startup = host.Services.GetServices<IHostedService>().OfType<SqliteStructuredLogStartupService>().Single();
+
+        await startup.StartAsync(CancellationToken.None);
+
+        Assert.False(await host.TableExistsAsync("StructuredLogEvents"));
+    }
+}

--- a/test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogMigrationTests.cs
+++ b/test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogMigrationTests.cs
@@ -1,5 +1,6 @@
 using Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.Options;
 using Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.Services;
+using Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
@@ -26,5 +27,17 @@ public class SqliteStructuredLogMigrationTests
         await startup.StartAsync(CancellationToken.None);
 
         Assert.False(await host.TableExistsAsync("StructuredLogEvents"));
+    }
+
+    [Fact]
+    public async Task HostedServices_StartMigrationBeforeWriteBuffer()
+    {
+        await using var host = new SqliteStructuredLogTestHost(migrate: false);
+
+        var hostedServiceTypes = host.Services.GetServices<IHostedService>().Select(x => x.GetType()).ToList();
+
+        Assert.True(
+            hostedServiceTypes.IndexOf(typeof(SqliteStructuredLogStartupService)) < hostedServiceTypes.IndexOf(typeof(StructuredLogWriteBuffer)),
+            "SQLite migrations must run before the durable write buffer starts flushing queued logs.");
     }
 }

--- a/test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogRetentionTests.cs
+++ b/test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogRetentionTests.cs
@@ -1,0 +1,37 @@
+namespace Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests;
+
+public class SqliteStructuredLogRetentionTests
+{
+    [Fact]
+    public async Task CleanupAsync_DoesNotDeleteRows_WhenRetentionIsNotConfigured()
+    {
+        await using var host = new SqliteStructuredLogTestHost();
+        await host.WriteAsync(
+            StructuredLogTestEvents.Create("old", DateTimeOffset.UtcNow.AddDays(-30)),
+            StructuredLogTestEvents.Create("new", DateTimeOffset.UtcNow));
+
+        await host.Retention.CleanupAsync();
+
+        Assert.Equal(2, await host.CountRowsAsync("StructuredLogEvents"));
+    }
+
+    [Fact]
+    public async Task CleanupAsync_AppliesMaxAgeAndMaxRows_WhenConfigured()
+    {
+        await using var host = new SqliteStructuredLogTestHost(options =>
+        {
+            options.Relational.Retention.MaxAge = TimeSpan.FromDays(7);
+            options.Relational.Retention.MaxRows = 1;
+        });
+        await host.WriteAsync(
+            StructuredLogTestEvents.Create("old", DateTimeOffset.UtcNow.AddDays(-30)),
+            StructuredLogTestEvents.Create("middle", DateTimeOffset.UtcNow.AddMinutes(-10)),
+            StructuredLogTestEvents.Create("new", DateTimeOffset.UtcNow));
+
+        await host.Retention.CleanupAsync();
+
+        var result = await host.Store.QueryAsync(new() { Take = 10 });
+        var item = Assert.Single(result.Items);
+        Assert.Equal("new", item.Id);
+    }
+}

--- a/test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogStoreTests.cs
+++ b/test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogStoreTests.cs
@@ -1,0 +1,37 @@
+using Elsa.Diagnostics.StructuredLogs.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests;
+
+public class SqliteStructuredLogStoreTests
+{
+    [Fact]
+    public async Task QueryAsync_ReturnsLogsWrittenByPreviousProviderInstance()
+    {
+        await using var firstHost = new SqliteStructuredLogTestHost();
+        var written = StructuredLogTestEvents.Create("persisted-1", message: "persist me");
+        await firstHost.WriteAsync(written);
+        var connectionString = firstHost.ConnectionString;
+
+        await using var secondHost = new SqliteStructuredLogTestHost(options => options.ConnectionString = connectionString);
+
+        var result = await secondHost.Store.QueryAsync(new StructuredLogFilter { Take = 10 });
+
+        Assert.Contains(result.Items, x => x.Id == written.Id && x.Message == "persist me");
+    }
+
+    [Fact]
+    public async Task Logger_RedactsSensitiveValuesBeforePersisting()
+    {
+        await using var host = new SqliteStructuredLogTestHost();
+        var logger = host.Services.GetRequiredService<ILoggerFactory>().CreateLogger("Elsa.Tests.Redaction");
+
+        logger.LogInformation("Authorization bearer abc123");
+        await host.Buffer.FlushAsync();
+
+        var result = await host.Store.QueryAsync(new StructuredLogFilter { Take = 10, Text = "[Redacted]" });
+        var item = Assert.Single(result.Items);
+        Assert.Equal("Authorization [Redacted]", item.Message);
+    }
+}

--- a/test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogTestHost.cs
+++ b/test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogTestHost.cs
@@ -18,9 +18,9 @@ internal sealed class SqliteStructuredLogTestHost : IAsyncDisposable
 
     public SqliteStructuredLogTestHost(Action<SqliteStructuredLogOptions>? configure = null, bool migrate = true)
     {
-        _directory = Path.Combine(Path.GetTempPath(), $"elsa-structured-logs-{Guid.NewGuid():N}");
+        _directory = Path.Join(Path.GetTempPath(), $"elsa-structured-logs-{Guid.NewGuid():N}");
         Directory.CreateDirectory(_directory);
-        DatabasePath = Path.Combine(_directory, "structured-logs.db");
+        DatabasePath = Path.Join(_directory, "structured-logs.db");
         ConnectionString = $"Data Source={DatabasePath}";
 
         var services = new ServiceCollection();

--- a/test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogTestHost.cs
+++ b/test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogTestHost.cs
@@ -1,0 +1,145 @@
+using Elsa.Diagnostics.StructuredLogs.Contracts;
+using Elsa.Diagnostics.StructuredLogs.Extensions;
+using Elsa.Diagnostics.StructuredLogs.Models;
+using Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Contracts;
+using Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Services;
+using Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.Extensions;
+using Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.Options;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests;
+
+internal sealed class SqliteStructuredLogTestHost : IAsyncDisposable
+{
+    private readonly string _directory;
+
+    public SqliteStructuredLogTestHost(Action<SqliteStructuredLogOptions>? configure = null, bool migrate = true)
+    {
+        _directory = Path.Combine(Path.GetTempPath(), $"elsa-structured-logs-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_directory);
+        DatabasePath = Path.Combine(_directory, "structured-logs.db");
+        ConnectionString = $"Data Source={DatabasePath}";
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddStructuredLogsServices();
+        services.AddSqliteStructuredLogPersistence(options =>
+        {
+            options.ConnectionString = ConnectionString;
+            configure?.Invoke(options);
+        });
+
+        Services = services.BuildServiceProvider(new ServiceProviderOptions { ValidateScopes = true });
+
+        if (migrate)
+            Migrator.MigrateAsync().AsTask().GetAwaiter().GetResult();
+    }
+
+    public string DatabasePath { get; }
+    public string ConnectionString { get; }
+    public ServiceProvider Services { get; }
+    public IStructuredLogStore Store => Services.GetRequiredService<IStructuredLogStore>();
+    public IStructuredLogProvider Provider => Services.GetRequiredService<IStructuredLogProvider>();
+    public IStructuredLogWriteBuffer Buffer => Services.GetRequiredService<IStructuredLogWriteBuffer>();
+    public IStructuredLogSchemaMigrator Migrator => Services.GetRequiredService<IStructuredLogSchemaMigrator>();
+    public StructuredLogRetentionService Retention => Services.GetRequiredService<StructuredLogRetentionService>();
+
+    public async ValueTask WriteAsync(params StructuredLogEvent[] events)
+    {
+        await Buffer.WriteManyAsync(events);
+        await Buffer.FlushAsync();
+    }
+
+    public async ValueTask StartHostedServicesAsync()
+    {
+        foreach (var hostedService in Services.GetServices<IHostedService>())
+            await hostedService.StartAsync(CancellationToken.None);
+    }
+
+    public async ValueTask StopHostedServicesAsync()
+    {
+        foreach (var hostedService in Services.GetServices<IHostedService>().Reverse())
+            await hostedService.StopAsync(CancellationToken.None);
+    }
+
+    public async ValueTask<int> CountRowsAsync(string tableName)
+    {
+        await using var connection = new SqliteConnection(ConnectionString);
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = $"SELECT COUNT(*) FROM {tableName}";
+        return Convert.ToInt32(await command.ExecuteScalarAsync());
+    }
+
+    public async ValueTask<bool> TableExistsAsync(string tableName)
+    {
+        await using var connection = new SqliteConnection(ConnectionString);
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = @Name";
+        command.Parameters.AddWithValue("@Name", tableName);
+        return Convert.ToInt32(await command.ExecuteScalarAsync()) > 0;
+    }
+
+    public async ValueTask<IReadOnlyCollection<string>> ReadRawTimestampsAsync()
+    {
+        await using var connection = new SqliteConnection(ConnectionString);
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT Timestamp FROM StructuredLogEvents ORDER BY Timestamp";
+        await using var reader = await command.ExecuteReaderAsync();
+        var values = new List<string>();
+
+        while (await reader.ReadAsync())
+            values.Add(reader.GetString(0));
+
+        return values;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await Services.DisposeAsync();
+
+        if (Directory.Exists(_directory))
+            Directory.Delete(_directory, true);
+    }
+}
+
+internal static class StructuredLogTestEvents
+{
+    public static StructuredLogEvent Create(
+        string id,
+        DateTimeOffset? timestamp = null,
+        StructuredLogLevel level = StructuredLogLevel.Information,
+        string category = "Elsa.Tests",
+        string sourceId = "source-a",
+        string? workflowDefinitionId = null,
+        string? workflowInstanceId = null,
+        string? correlationId = null,
+        string? traceId = null,
+        string message = "Test event")
+    {
+        var now = timestamp ?? DateTimeOffset.UtcNow;
+        return new()
+        {
+            Id = id,
+            Sequence = Math.Abs(id.GetHashCode(StringComparison.Ordinal)),
+            Timestamp = now,
+            ReceivedAt = now,
+            Level = level,
+            Category = category,
+            EventId = 1,
+            Message = message,
+            MessageTemplate = "Test event",
+            SourceId = sourceId,
+            WorkflowDefinitionId = workflowDefinitionId,
+            WorkflowInstanceId = workflowInstanceId,
+            CorrelationId = correlationId,
+            TraceId = traceId,
+            Properties = new Dictionary<string, string?> { ["Property"] = message }
+        };
+    }
+}

--- a/test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogTimestampTests.cs
+++ b/test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogTimestampTests.cs
@@ -1,0 +1,19 @@
+using System.Globalization;
+
+namespace Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests;
+
+public class SqliteStructuredLogTimestampTests
+{
+    [Fact]
+    public async Task WriteAsync_StoresTimestampsAsUtcIso8601()
+    {
+        await using var host = new SqliteStructuredLogTestHost();
+        var timestamp = new DateTimeOffset(2026, 5, 13, 12, 30, 45, TimeSpan.FromHours(2));
+
+        await host.WriteAsync(StructuredLogTestEvents.Create("timestamp", timestamp));
+
+        var rawTimestamp = Assert.Single(await host.ReadRawTimestampsAsync());
+        Assert.EndsWith("+00:00", rawTimestamp, StringComparison.Ordinal);
+        Assert.Equal(timestamp.ToUniversalTime(), DateTimeOffset.Parse(rawTimestamp, CultureInfo.InvariantCulture));
+    }
+}

--- a/test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogWriteQueueTests.cs
+++ b/test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/SqliteStructuredLogWriteQueueTests.cs
@@ -1,0 +1,46 @@
+using Elsa.Diagnostics.StructuredLogs.Models;
+
+namespace Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests;
+
+public class SqliteStructuredLogWriteQueueTests
+{
+    [Fact]
+    public async Task FlushAsync_PersistsQueuedWrites()
+    {
+        await using var host = new SqliteStructuredLogTestHost();
+
+        await host.Buffer.WriteAsync(StructuredLogTestEvents.Create("queued"));
+        await host.Buffer.FlushAsync();
+
+        Assert.Equal(1, await host.CountRowsAsync("StructuredLogEvents"));
+    }
+
+    [Fact]
+    public async Task WriteAsync_DropsWrites_WhenQueueIsFull()
+    {
+        await using var host = new SqliteStructuredLogTestHost(options =>
+        {
+            options.Relational.WriteQueue.Capacity = 1;
+            options.Relational.WriteQueue.BatchSize = 10;
+        });
+
+        await host.Buffer.WriteAsync(StructuredLogTestEvents.Create("kept"));
+        await host.Buffer.WriteAsync(StructuredLogTestEvents.Create("dropped"));
+        await host.Buffer.FlushAsync();
+
+        Assert.Equal(1, host.Buffer.DroppedWriteCount);
+        Assert.Equal(1, await host.CountRowsAsync("StructuredLogEvents"));
+    }
+
+    [Fact]
+    public async Task StopAsync_FlushesQueuedWrites()
+    {
+        await using var host = new SqliteStructuredLogTestHost();
+        await host.StartHostedServicesAsync();
+
+        await host.Buffer.WriteAsync(StructuredLogTestEvents.Create("shutdown"));
+        await host.StopHostedServicesAsync();
+
+        Assert.Equal(1, await host.CountRowsAsync("StructuredLogEvents"));
+    }
+}

--- a/test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests.csproj
+++ b/test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <Include>[Elsa.Diagnostics.StructuredLogs.Persistence.Relational]*</Include>
+        <Threshold>0</Threshold>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\src\modules\Elsa.Diagnostics.StructuredLogs.Persistence.Relational\Elsa.Diagnostics.StructuredLogs.Persistence.Relational.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/RelationalStructuredLogMapperTests.cs
+++ b/test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/RelationalStructuredLogMapperTests.cs
@@ -1,0 +1,44 @@
+using Elsa.Diagnostics.StructuredLogs.Models;
+using Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Services;
+
+namespace Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests;
+
+public class RelationalStructuredLogMapperTests
+{
+    private readonly RelationalStructuredLogMapper _mapper = new();
+
+    [Fact]
+    public void Map_SerializesJsonFields()
+    {
+        var logEvent = new StructuredLogEvent
+        {
+            Id = "event-a",
+            Timestamp = DateTimeOffset.UtcNow,
+            ReceivedAt = DateTimeOffset.UtcNow,
+            Level = StructuredLogLevel.Error,
+            Category = "Elsa.Tests",
+            Message = "Failed",
+            Exception = new("System.Exception", "Boom", "Stack"),
+            SourceId = "source-a",
+            Scopes = new Dictionary<string, string?> { ["Scope"] = "Value" },
+            Properties = new Dictionary<string, string?> { ["Property"] = "Value" }
+        };
+
+        var record = _mapper.Map(logEvent);
+
+        Assert.Contains("Boom", record.ExceptionJson, StringComparison.Ordinal);
+        Assert.Contains("Scope", record.ScopesJson, StringComparison.Ordinal);
+        Assert.Contains("Property", record.PropertiesJson, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FormatTimestamp_StoresUtcIso8601Text()
+    {
+        var timestamp = new DateTimeOffset(2026, 5, 13, 15, 0, 0, TimeSpan.FromHours(2));
+
+        var formatted = RelationalStructuredLogMapper.FormatTimestamp(timestamp);
+
+        Assert.Equal("2026-05-13T13:00:00.0000000+00:00", formatted);
+        Assert.Equal(timestamp.ToUniversalTime(), RelationalStructuredLogMapper.ParseTimestamp(formatted));
+    }
+}

--- a/test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/RelationalStructuredLogSqlBuilderTests.cs
+++ b/test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/RelationalStructuredLogSqlBuilderTests.cs
@@ -44,8 +44,21 @@ public class RelationalStructuredLogSqlBuilderTests
         Assert.Contains("[WorkflowInstanceId] = @WorkflowInstanceId", query.Sql, StringComparison.Ordinal);
         Assert.Contains("[CorrelationId] = @CorrelationId", query.Sql, StringComparison.Ordinal);
         Assert.Contains("[TraceId] = @TraceId", query.Sql, StringComparison.Ordinal);
+        Assert.Contains("[Timestamp] >= @TimestampFrom", query.Sql, StringComparison.Ordinal);
+        Assert.Contains("[Timestamp] <= @TimestampTo", query.Sql, StringComparison.Ordinal);
         Assert.Contains("FETCH 42", query.Sql, StringComparison.Ordinal);
         Assert.Equal("Elsa.Workflow%", query.Parameters["Category"]);
+        Assert.Contains("TimestampFrom", query.Parameters.Keys);
+        Assert.Contains("TimestampTo", query.Parameters.Keys);
+    }
+
+    [Fact]
+    public void BuildDeleteRowsBeyondMax_DelegatesOffsetSyntaxToDialect()
+    {
+        var query = _builder.BuildDeleteRowsBeyondMax(250);
+
+        Assert.Contains("SKIP 250", query.Sql, StringComparison.Ordinal);
+        Assert.DoesNotContain("LIMIT -1", query.Sql, StringComparison.Ordinal);
     }
 
     private class FakeDialect : IRelationalStructuredLogDialect
@@ -54,5 +67,6 @@ public class RelationalStructuredLogSqlBuilderTests
         public string ParameterPrefix => "@";
         public string QuoteIdentifier(string identifier) => $"[{identifier}]";
         public string ApplyLimit(string sql, int limit) => $"{sql} FETCH {limit}";
+        public string ApplyOffset(string sql, int offset) => $"{sql} SKIP {offset}";
     }
 }

--- a/test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/RelationalStructuredLogSqlBuilderTests.cs
+++ b/test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/RelationalStructuredLogSqlBuilderTests.cs
@@ -1,0 +1,58 @@
+using Elsa.Diagnostics.StructuredLogs.Models;
+using Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Contracts;
+using Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Services;
+
+namespace Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests;
+
+public class RelationalStructuredLogSqlBuilderTests
+{
+    private readonly RelationalStructuredLogSqlBuilder _builder = new(new FakeDialect());
+
+    [Fact]
+    public void BuildInsert_UsesDialectQuotingAndParameters()
+    {
+        var sql = _builder.BuildInsert();
+
+        Assert.StartsWith("INSERT INTO [StructuredLogEvents]", sql, StringComparison.Ordinal);
+        Assert.Contains("[TraceId]", sql, StringComparison.Ordinal);
+        Assert.Contains("@TraceId", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildQuery_AddsReusableFilterPredicates()
+    {
+        var query = _builder.BuildQuery(new()
+        {
+            MinimumLevel = StructuredLogLevel.Warning,
+            Levels = [StructuredLogLevel.Warning, StructuredLogLevel.Error],
+            CategoryPrefix = "Elsa.Workflow",
+            SourceId = "source-a",
+            WorkflowDefinitionId = "definition-a",
+            WorkflowInstanceId = "instance-a",
+            CorrelationId = "correlation-a",
+            TraceId = "trace-a",
+            From = DateTimeOffset.UtcNow.AddMinutes(-5),
+            To = DateTimeOffset.UtcNow,
+            Take = 42
+        });
+
+        Assert.Contains("[Level] >=", query.Sql, StringComparison.Ordinal);
+        Assert.Contains("[Level] IN (@Level0, @Level1)", query.Sql, StringComparison.Ordinal);
+        Assert.Contains("[Category] LIKE @Category", query.Sql, StringComparison.Ordinal);
+        Assert.Contains("[SourceId] = @SourceId", query.Sql, StringComparison.Ordinal);
+        Assert.Contains("[WorkflowDefinitionId] = @WorkflowDefinitionId", query.Sql, StringComparison.Ordinal);
+        Assert.Contains("[WorkflowInstanceId] = @WorkflowInstanceId", query.Sql, StringComparison.Ordinal);
+        Assert.Contains("[CorrelationId] = @CorrelationId", query.Sql, StringComparison.Ordinal);
+        Assert.Contains("[TraceId] = @TraceId", query.Sql, StringComparison.Ordinal);
+        Assert.Contains("FETCH 42", query.Sql, StringComparison.Ordinal);
+        Assert.Equal("Elsa.Workflow%", query.Parameters["Category"]);
+    }
+
+    private class FakeDialect : IRelationalStructuredLogDialect
+    {
+        public string ProviderName => "Fake";
+        public string ParameterPrefix => "@";
+        public string QuoteIdentifier(string identifier) => $"[{identifier}]";
+        public string ApplyLimit(string sql, int limit) => $"{sql} FETCH {limit}";
+    }
+}

--- a/test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/StructuredLogMigrationTests.cs
+++ b/test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/StructuredLogMigrationTests.cs
@@ -1,0 +1,18 @@
+using Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Migrations;
+using FluentMigrator;
+
+namespace Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests;
+
+public class StructuredLogMigrationTests
+{
+    [Fact]
+    public void CreateStructuredLogTablesMigration_HasStableVersion()
+    {
+        var attribute = typeof(M001CreateStructuredLogTables)
+            .GetCustomAttributes(typeof(MigrationAttribute), false)
+            .Cast<MigrationAttribute>()
+            .Single();
+
+        Assert.Equal(2026051301, attribute.Version);
+    }
+}

--- a/test/unit/Elsa.Diagnostics.StructuredLogs.UnitTests/StructuredLogsStorageRegistrationTests.cs
+++ b/test/unit/Elsa.Diagnostics.StructuredLogs.UnitTests/StructuredLogsStorageRegistrationTests.cs
@@ -1,0 +1,47 @@
+using Elsa.Diagnostics.StructuredLogs.Contracts;
+using Elsa.Diagnostics.StructuredLogs.Extensions;
+using Elsa.Diagnostics.StructuredLogs.Providers.InMemory;
+using Elsa.Diagnostics.StructuredLogs.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Elsa.Diagnostics.StructuredLogs.UnitTests;
+
+public class StructuredLogsStorageRegistrationTests
+{
+    [Fact]
+    public void AddStructuredLogsServices_WhenNoStoreIsConfigured_UsesInMemoryStorageAndComposedProvider()
+    {
+        var services = new ServiceCollection();
+
+        services.AddStructuredLogsServices();
+
+        using var serviceProvider = services.BuildServiceProvider();
+        Assert.IsType<InMemoryStructuredLogStore>(serviceProvider.GetRequiredService<IStructuredLogStore>());
+        Assert.IsType<InMemoryStructuredLogLiveFeed>(serviceProvider.GetRequiredService<IStructuredLogLiveFeed>());
+        Assert.IsType<DefaultStructuredLogProvider>(serviceProvider.GetRequiredService<IStructuredLogProvider>());
+    }
+
+    [Fact]
+    public void StructuredLogsAssembly_DoesNotReferenceSqlitePersistence()
+    {
+        var references = typeof(IStructuredLogProvider)
+            .Assembly
+            .GetReferencedAssemblies()
+            .Select(x => x.Name)
+            .ToList();
+
+        Assert.DoesNotContain("Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite", references);
+    }
+
+    [Fact]
+    public void AddStructuredLogsServices_RegistersLoggerProvider()
+    {
+        var services = new ServiceCollection();
+
+        services.AddStructuredLogsServices();
+
+        using var serviceProvider = services.BuildServiceProvider();
+        Assert.Contains(serviceProvider.GetServices<ILoggerProvider>(), x => x.GetType().Name == "StructuredLogLoggerProvider");
+    }
+}


### PR DESCRIPTION
## Summary

Adds pluggable structured log storage and an initial durable SQLite implementation.

- Splits structured log capture into sink, store, and live-feed abstractions while preserving the existing provider facade.
- Keeps the default in-memory behavior for hosts that only enable structured logs.
- Adds reusable relational persistence contracts, SQL builder, mapper, FluentMigrator migration, retention cleanup, and bounded write buffer.
- Adds SQLite persistence with connection factory, dialect, FluentMigrator runner integration, startup migration/cleanup, shell feature registration, and fluent `UseSqliteStorage` configuration.
- Adds documentation and Spec Kit task updates for the storage model and deferred exporter scope.

## Validation

- `dotnet build src/modules/Elsa.Diagnostics.StructuredLogs/Elsa.Diagnostics.StructuredLogs.csproj`
- `dotnet build src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.csproj`
- `dotnet test test/unit/Elsa.Diagnostics.StructuredLogs.UnitTests/Elsa.Diagnostics.StructuredLogs.UnitTests.csproj`
- `dotnet test test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests.csproj`
- `dotnet test test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests.csproj`
- `rg "OpenTelemetry|OTLP|Datadog|Logstash|Splunk|Loki|Seq" src/modules/Elsa.Diagnostics.StructuredLogs* specs/005-structured-log-persistence` confirmed only out-of-scope documentation references remain.