### PR TITLE
[codex] Expose structured log storage diagnostics

### DIFF
--- a/specs/005-structured-log-persistence/quickstart.md
+++ b/specs/005-structured-log-persistence/quickstart.md
@@ -46,6 +46,7 @@ Studio continues to use:
 
 - `/diagnostics/structured-logs/recent`
 - `/diagnostics/structured-logs/sources`
+- `/diagnostics/structured-logs/storage`
 - `/elsa/hubs/diagnostics/structured-logs`
 
 ## Migrations

--- a/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Contracts/IStructuredLogWriteBuffer.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Contracts/IStructuredLogWriteBuffer.cs
@@ -2,9 +2,7 @@ using Elsa.Diagnostics.StructuredLogs.Contracts;
 
 namespace Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Contracts;
 
-public interface IStructuredLogWriteBuffer : IStructuredLogSink
+public interface IStructuredLogWriteBuffer : IStructuredLogSink, IStructuredLogStorageDiagnostics
 {
-    long DroppedWriteCount { get; }
-
     ValueTask FlushAsync(CancellationToken cancellationToken = default);
 }

--- a/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Extensions/RelationalStructuredLogsServiceCollectionExtensions.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Extensions/RelationalStructuredLogsServiceCollectionExtensions.cs
@@ -23,6 +23,7 @@ public static class RelationalStructuredLogsServiceCollectionExtensions
         services.TryAddSingleton<StructuredLogRetentionService>();
         services.AddSingleton<IStructuredLogStore>(sp => sp.GetRequiredService<StructuredLogWriteBuffer>());
         services.AddSingleton<IStructuredLogWriteBuffer>(sp => sp.GetRequiredService<StructuredLogWriteBuffer>());
+        services.AddSingleton<IStructuredLogStorageDiagnostics>(sp => sp.GetRequiredService<StructuredLogWriteBuffer>());
         services.AddHostedService(sp => sp.GetRequiredService<StructuredLogWriteBuffer>());
 
         return services;

--- a/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/README.md
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/README.md
@@ -11,3 +11,5 @@ To add a new relational provider such as SQL Server or PostgreSQL:
 5. Register those services and call `AddRelationalStructuredLogPersistence`.
 
 The core `Elsa.Diagnostics.StructuredLogs` package must remain unaware of provider packages. Provider-specific SQL and migration runner dependencies belong in provider packages.
+
+`StructuredLogWriteBuffer` reports dropped durable writes through the core `IStructuredLogStorageDiagnostics` contract. The core endpoint `GET /diagnostics/structured-logs/storage` returns that provider-neutral count for Studio and other diagnostics clients.

--- a/src/modules/Elsa.Diagnostics.StructuredLogs/Contracts/IStructuredLogStorageDiagnostics.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs/Contracts/IStructuredLogStorageDiagnostics.cs
@@ -1,0 +1,6 @@
+namespace Elsa.Diagnostics.StructuredLogs.Contracts;
+
+public interface IStructuredLogStorageDiagnostics
+{
+    long DroppedWriteCount { get; }
+}

--- a/src/modules/Elsa.Diagnostics.StructuredLogs/Endpoints/StructuredLogs/Storage/Endpoint.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs/Endpoints/StructuredLogs/Storage/Endpoint.cs
@@ -17,7 +17,8 @@ internal class Endpoint(IEnumerable<IStructuredLogStorageDiagnostics> storageDia
     
     public override Task<StructuredLogStorageDiagnostics> ExecuteAsync(CancellationToken cancellationToken)
     {
-        var droppedWriteCount = storageDiagnostics.Sum(x => x.DroppedWriteCount);
-        return Task.FromResult(new StructuredLogStorageDiagnostics(droppedWriteCount));
+        var diagnostics = storageDiagnostics.ToList();
+        var droppedWriteCount = checked(diagnostics.Aggregate(0L, (acc, x) => acc + x.DroppedWriteCount));
+        return Task.FromResult(new StructuredLogStorageDiagnostics(droppedWriteCount, diagnostics.Count > 0));
     }
 }

--- a/src/modules/Elsa.Diagnostics.StructuredLogs/Endpoints/StructuredLogs/Storage/Endpoint.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs/Endpoints/StructuredLogs/Storage/Endpoint.cs
@@ -18,7 +18,7 @@ internal class Endpoint(IEnumerable<IStructuredLogStorageDiagnostics> storageDia
     public override Task<StructuredLogStorageDiagnostics> ExecuteAsync(CancellationToken cancellationToken)
     {
         var diagnostics = storageDiagnostics.ToList();
-        var droppedWriteCount = checked(diagnostics.Aggregate(0L, (acc, x) => acc + x.DroppedWriteCount));
+        var droppedWriteCount = diagnostics.Aggregate(0L, (acc, x) => checked(acc + x.DroppedWriteCount));
         return Task.FromResult(new StructuredLogStorageDiagnostics(droppedWriteCount, diagnostics.Count > 0));
     }
 }

--- a/src/modules/Elsa.Diagnostics.StructuredLogs/Endpoints/StructuredLogs/Storage/Endpoint.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs/Endpoints/StructuredLogs/Storage/Endpoint.cs
@@ -1,0 +1,23 @@
+using Elsa.Abstractions;
+using Elsa.Diagnostics.StructuredLogs.Contracts;
+using Elsa.Diagnostics.StructuredLogs.Models;
+using Elsa.Diagnostics.StructuredLogs.Permissions;
+using JetBrains.Annotations;
+
+namespace Elsa.Diagnostics.StructuredLogs.Endpoints.StructuredLogs.Storage;
+
+[PublicAPI]
+internal class Endpoint(IEnumerable<IStructuredLogStorageDiagnostics> storageDiagnostics) : ElsaEndpointWithoutRequest<StructuredLogStorageDiagnostics>
+{
+    public override void Configure()
+    {
+        Get("/diagnostics/structured-logs/storage");
+        ConfigurePermissions(StructuredLogsPermissions.Read);
+    }
+    
+    public override Task<StructuredLogStorageDiagnostics> ExecuteAsync(CancellationToken cancellationToken)
+    {
+        var droppedWriteCount = storageDiagnostics.Sum(x => x.DroppedWriteCount);
+        return Task.FromResult(new StructuredLogStorageDiagnostics(droppedWriteCount));
+    }
+}

--- a/src/modules/Elsa.Diagnostics.StructuredLogs/Models/StructuredLogStorageDiagnostics.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs/Models/StructuredLogStorageDiagnostics.cs
@@ -1,3 +1,3 @@
 namespace Elsa.Diagnostics.StructuredLogs.Models;
 
-public record StructuredLogStorageDiagnostics(long DroppedWriteCount);
+public record StructuredLogStorageDiagnostics(long DroppedWriteCount, bool HasStorageDiagnosticsProvider);

--- a/src/modules/Elsa.Diagnostics.StructuredLogs/Models/StructuredLogStorageDiagnostics.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs/Models/StructuredLogStorageDiagnostics.cs
@@ -1,0 +1,3 @@
+namespace Elsa.Diagnostics.StructuredLogs.Models;
+
+public record StructuredLogStorageDiagnostics(long DroppedWriteCount);

--- a/src/modules/Elsa.Diagnostics.StructuredLogs/README.md
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs/README.md
@@ -40,7 +40,7 @@ Elsa Studio can use this module to show:
 - Live log events as the server emits them.
 - Level, category, message, tenant, workflow, trace, correlation, source, and time filters.
 - Cluster/source metadata such as source ID, pod name, namespace, container name, node name, machine name, process ID, and source health.
-- Storage pressure metadata such as dropped durable write counts when a configured store reports them.
+- Storage pressure metadata such as dropped durable write counts and whether the active store reports storage diagnostics.
 
 ## Clustered Deployments
 

--- a/src/modules/Elsa.Diagnostics.StructuredLogs/README.md
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs/README.md
@@ -30,7 +30,7 @@ This maps the structured logs hub at `/elsa/hubs/diagnostics/structured-logs` an
 
 ## Authorization
 
-The recent-log endpoint and source-list endpoint require the `read:diagnostics:structured-logs` permission. The SignalR hub requires an authenticated user, matching the existing Elsa workflow hub authorization pattern. Grant `read:diagnostics:structured-logs` only to operators and developers who are allowed to inspect backend logs.
+The recent-log endpoint, source-list endpoint, and storage-diagnostics endpoint require the `read:diagnostics:structured-logs` permission. The SignalR hub requires an authenticated user, matching the existing Elsa workflow hub authorization pattern. Grant `read:diagnostics:structured-logs` only to operators and developers who are allowed to inspect backend logs.
 
 ## Studio Integration
 
@@ -40,6 +40,7 @@ Elsa Studio can use this module to show:
 - Live log events as the server emits them.
 - Level, category, message, tenant, workflow, trace, correlation, source, and time filters.
 - Cluster/source metadata such as source ID, pod name, namespace, container name, node name, machine name, process ID, and source health.
+- Storage pressure metadata such as dropped durable write counts when a configured store reports them.
 
 ## Clustered Deployments
 
@@ -57,7 +58,7 @@ services.AddElsa(elsa =>
 });
 ```
 
-The core module remains storage-provider neutral. Custom stores can replace `IStructuredLogStore` while live updates continue through `IStructuredLogLiveFeed`; Studio continues to use the same REST and SignalR contracts, including source filtering and source-change notifications.
+The core module remains storage-provider neutral. Custom stores can replace `IStructuredLogStore` while live updates continue through `IStructuredLogLiveFeed`; Studio continues to use the same REST and SignalR contracts, including source filtering, source-change notifications, and storage diagnostics.
 
 ## Redaction
 


### PR DESCRIPTION
## Summary

- Adds a storage-provider-neutral diagnostics contract for structured log storage pressure.
- Exposes `GET /diagnostics/structured-logs/storage` with aggregate dropped durable write count.
- Registers the relational SQLite write buffer as the diagnostics source and updates docs/quickstart endpoint lists.

## Why

SQLite persistence can drop newest writes when its bounded queue is full. That count existed in the write buffer, but Studio had no stable REST surface to display it without knowing about SQLite or relational internals.

## Validation

- `dotnet test test/unit/Elsa.Diagnostics.StructuredLogs.UnitTests/Elsa.Diagnostics.StructuredLogs.UnitTests.csproj`
- `dotnet test test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests.csproj`
