### PR TITLE
[codex] Increase structured log persistence test coverage

### DIFF
--- a/test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/RelationalStructuredLogMapperTests.cs
+++ b/test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/RelationalStructuredLogMapperTests.cs
@@ -217,6 +217,7 @@ public class RelationalStructuredLogMapperTests
         public override decimal GetDecimal(int ordinal) => reader.GetDecimal(ordinal);
         public override double GetDouble(int ordinal) => reader.GetDouble(ordinal);
         public override IEnumerator GetEnumerator() => reader.GetEnumerator();
+
         [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicProperties)]
         public override Type GetFieldType(int ordinal) => ordinal switch
         {
@@ -224,6 +225,7 @@ public class RelationalStructuredLogMapperTests
             4 or 6 => typeof(int),
             _ => typeof(string)
         };
+
         public override float GetFloat(int ordinal) => reader.GetFloat(ordinal);
         public override Guid GetGuid(int ordinal) => reader.GetGuid(ordinal);
         public override short GetInt16(int ordinal) => reader.GetInt16(ordinal);
@@ -231,6 +233,7 @@ public class RelationalStructuredLogMapperTests
         public override long GetInt64(int ordinal) => reader.GetInt64(ordinal);
         public override string GetName(int ordinal) => reader.GetName(ordinal);
         public override int GetOrdinal(string name) => reader.GetOrdinal(name);
+        public override DataTable? GetSchemaTable() => reader.GetSchemaTable();
         public override string GetString(int ordinal) => reader.GetString(ordinal);
         public override object GetValue(int ordinal) => reader.GetValue(ordinal);
         public override int GetValues(object[] values) => reader.GetValues(values);

--- a/test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/RelationalStructuredLogMapperTests.cs
+++ b/test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/RelationalStructuredLogMapperTests.cs
@@ -1,4 +1,6 @@
+using System.Data;
 using Elsa.Diagnostics.StructuredLogs.Models;
+using Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Models;
 using Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Services;
 
 namespace Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests;
@@ -40,5 +42,155 @@ public class RelationalStructuredLogMapperTests
 
         Assert.Equal("2026-05-13T13:00:00.0000000+00:00", formatted);
         Assert.Equal(timestamp.ToUniversalTime(), RelationalStructuredLogMapper.ParseTimestamp(formatted));
+    }
+
+    [Fact]
+    public void MapReader_DeserializesStoredJsonAndNullableFields()
+    {
+        var timestamp = new DateTimeOffset(2026, 5, 13, 15, 0, 0, TimeSpan.FromHours(2));
+        var logEvent = new StructuredLogEvent
+        {
+            Id = "event-a",
+            Sequence = 123,
+            Timestamp = timestamp,
+            ReceivedAt = timestamp.AddSeconds(1),
+            Level = StructuredLogLevel.Warning,
+            Category = "Elsa.Tests",
+            EventId = 42,
+            EventName = "TestEvent",
+            Message = "Message",
+            MessageTemplate = "Message {Value}",
+            Exception = new("System.InvalidOperationException", "Boom", "Stack"),
+            Scopes = new Dictionary<string, string?> { ["Scope"] = "Value" },
+            Properties = new Dictionary<string, string?> { ["Property"] = "Value" },
+            TraceId = "trace-a",
+            SpanId = "span-a",
+            CorrelationId = "correlation-a",
+            TenantId = "tenant-a",
+            WorkflowDefinitionId = "definition-a",
+            WorkflowInstanceId = "instance-a",
+            SourceId = "source-a"
+        };
+
+        using var reader = CreateReader(_mapper.Map(logEvent));
+        Assert.True(reader.Read());
+
+        var mapped = _mapper.Map(reader);
+
+        Assert.Equal(logEvent.Id, mapped.Id);
+        Assert.Equal(logEvent.Sequence, mapped.Sequence);
+        Assert.Equal(logEvent.Timestamp.ToUniversalTime(), mapped.Timestamp);
+        Assert.Equal(logEvent.ReceivedAt.ToUniversalTime(), mapped.ReceivedAt);
+        Assert.Equal(logEvent.Level, mapped.Level);
+        Assert.Equal(logEvent.Category, mapped.Category);
+        Assert.Equal(logEvent.EventId, mapped.EventId);
+        Assert.Equal(logEvent.EventName, mapped.EventName);
+        Assert.Equal(logEvent.Message, mapped.Message);
+        Assert.Equal(logEvent.MessageTemplate, mapped.MessageTemplate);
+        Assert.Equal(logEvent.Exception.Type, mapped.Exception!.Type);
+        Assert.Equal(logEvent.Exception.Message, mapped.Exception.Message);
+        Assert.Equal(logEvent.Scopes, mapped.Scopes);
+        Assert.Equal(logEvent.Properties, mapped.Properties);
+        Assert.Equal(logEvent.TraceId, mapped.TraceId);
+        Assert.Equal(logEvent.SpanId, mapped.SpanId);
+        Assert.Equal(logEvent.CorrelationId, mapped.CorrelationId);
+        Assert.Equal(logEvent.TenantId, mapped.TenantId);
+        Assert.Equal(logEvent.WorkflowDefinitionId, mapped.WorkflowDefinitionId);
+        Assert.Equal(logEvent.WorkflowInstanceId, mapped.WorkflowInstanceId);
+        Assert.Equal(logEvent.SourceId, mapped.SourceId);
+    }
+
+    [Fact]
+    public void MapReader_TreatsNullAndWhitespaceJsonAsEmptyValues()
+    {
+        var record = new RelationalStructuredLogRecord
+        {
+            Id = "event-a",
+            Sequence = 123,
+            Timestamp = RelationalStructuredLogMapper.FormatTimestamp(DateTimeOffset.UtcNow),
+            ReceivedAt = RelationalStructuredLogMapper.FormatTimestamp(DateTimeOffset.UtcNow),
+            Level = StructuredLogLevel.Information,
+            Category = "Elsa.Tests",
+            EventId = 42,
+            EventName = null,
+            Message = "Message",
+            MessageTemplate = null,
+            ExceptionJson = null,
+            ScopesJson = " ",
+            PropertiesJson = "",
+            TraceId = null,
+            SpanId = null,
+            CorrelationId = null,
+            TenantId = null,
+            WorkflowDefinitionId = null,
+            WorkflowInstanceId = null,
+            SourceId = "source-a"
+        };
+
+        using var reader = CreateReader(record);
+        Assert.True(reader.Read());
+
+        var mapped = _mapper.Map(reader);
+
+        Assert.Null(mapped.EventName);
+        Assert.Null(mapped.MessageTemplate);
+        Assert.Null(mapped.Exception);
+        Assert.Empty(mapped.Scopes);
+        Assert.Empty(mapped.Properties);
+        Assert.Null(mapped.TraceId);
+        Assert.Null(mapped.SpanId);
+        Assert.Null(mapped.CorrelationId);
+        Assert.Null(mapped.TenantId);
+        Assert.Null(mapped.WorkflowDefinitionId);
+        Assert.Null(mapped.WorkflowInstanceId);
+    }
+
+    private static DataTableReader CreateReader(RelationalStructuredLogRecord record)
+    {
+        var table = new DataTable();
+        table.Columns.Add("Id", typeof(string));
+        table.Columns.Add("Sequence", typeof(long));
+        table.Columns.Add("Timestamp", typeof(string));
+        table.Columns.Add("ReceivedAt", typeof(string));
+        table.Columns.Add("Level", typeof(int));
+        table.Columns.Add("Category", typeof(string));
+        table.Columns.Add("EventId", typeof(int));
+        table.Columns.Add("EventName", typeof(string));
+        table.Columns.Add("Message", typeof(string));
+        table.Columns.Add("MessageTemplate", typeof(string));
+        table.Columns.Add("ExceptionJson", typeof(string));
+        table.Columns.Add("ScopesJson", typeof(string));
+        table.Columns.Add("PropertiesJson", typeof(string));
+        table.Columns.Add("TraceId", typeof(string));
+        table.Columns.Add("SpanId", typeof(string));
+        table.Columns.Add("CorrelationId", typeof(string));
+        table.Columns.Add("TenantId", typeof(string));
+        table.Columns.Add("WorkflowDefinitionId", typeof(string));
+        table.Columns.Add("WorkflowInstanceId", typeof(string));
+        table.Columns.Add("SourceId", typeof(string));
+
+        table.Rows.Add(
+            record.Id,
+            record.Sequence,
+            record.Timestamp,
+            record.ReceivedAt,
+            (int)record.Level,
+            record.Category,
+            record.EventId,
+            record.EventName ?? (object)DBNull.Value,
+            record.Message,
+            record.MessageTemplate ?? (object)DBNull.Value,
+            record.ExceptionJson ?? (object)DBNull.Value,
+            record.ScopesJson,
+            record.PropertiesJson,
+            record.TraceId ?? (object)DBNull.Value,
+            record.SpanId ?? (object)DBNull.Value,
+            record.CorrelationId ?? (object)DBNull.Value,
+            record.TenantId ?? (object)DBNull.Value,
+            record.WorkflowDefinitionId ?? (object)DBNull.Value,
+            record.WorkflowInstanceId ?? (object)DBNull.Value,
+            record.SourceId);
+
+        return table.CreateDataReader();
     }
 }

--- a/test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/RelationalStructuredLogMapperTests.cs
+++ b/test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/RelationalStructuredLogMapperTests.cs
@@ -1,4 +1,7 @@
+using System.Collections;
 using System.Data;
+using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
 using Elsa.Diagnostics.StructuredLogs.Models;
 using Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Models;
 using Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Services;
@@ -89,6 +92,7 @@ public class RelationalStructuredLogMapperTests
         Assert.Equal(logEvent.MessageTemplate, mapped.MessageTemplate);
         Assert.Equal(logEvent.Exception.Type, mapped.Exception!.Type);
         Assert.Equal(logEvent.Exception.Message, mapped.Exception.Message);
+        Assert.Equal(logEvent.Exception.StackTrace, mapped.Exception.StackTrace);
         Assert.Equal(logEvent.Scopes, mapped.Scopes);
         Assert.Equal(logEvent.Properties, mapped.Properties);
         Assert.Equal(logEvent.TraceId, mapped.TraceId);
@@ -145,7 +149,7 @@ public class RelationalStructuredLogMapperTests
         Assert.Null(mapped.WorkflowInstanceId);
     }
 
-    private static DataTableReader CreateReader(RelationalStructuredLogRecord record)
+    private static DbDataReader CreateReader(RelationalStructuredLogRecord record)
     {
         var table = new DataTable();
         table.Columns.Add("Id", typeof(string));
@@ -181,8 +185,8 @@ public class RelationalStructuredLogMapperTests
             record.Message,
             record.MessageTemplate ?? (object)DBNull.Value,
             record.ExceptionJson ?? (object)DBNull.Value,
-            record.ScopesJson,
-            record.PropertiesJson,
+            record.ScopesJson ?? (object)DBNull.Value,
+            record.PropertiesJson ?? (object)DBNull.Value,
             record.TraceId ?? (object)DBNull.Value,
             record.SpanId ?? (object)DBNull.Value,
             record.CorrelationId ?? (object)DBNull.Value,
@@ -191,6 +195,58 @@ public class RelationalStructuredLogMapperTests
             record.WorkflowInstanceId ?? (object)DBNull.Value,
             record.SourceId);
 
-        return table.CreateDataReader();
+        return new DisposingDataReader(table, table.CreateDataReader());
+    }
+
+    private sealed class DisposingDataReader(DataTable table, DataTableReader reader) : DbDataReader
+    {
+        public override object this[int ordinal] => reader[ordinal];
+        public override object this[string name] => reader[name];
+        public override int Depth => reader.Depth;
+        public override int FieldCount => reader.FieldCount;
+        public override bool HasRows => reader.HasRows;
+        public override bool IsClosed => reader.IsClosed;
+        public override int RecordsAffected => reader.RecordsAffected;
+        public override bool GetBoolean(int ordinal) => reader.GetBoolean(ordinal);
+        public override byte GetByte(int ordinal) => reader.GetByte(ordinal);
+        public override long GetBytes(int ordinal, long dataOffset, byte[]? buffer, int bufferOffset, int length) => reader.GetBytes(ordinal, dataOffset, buffer, bufferOffset, length);
+        public override char GetChar(int ordinal) => reader.GetChar(ordinal);
+        public override long GetChars(int ordinal, long dataOffset, char[]? buffer, int bufferOffset, int length) => reader.GetChars(ordinal, dataOffset, buffer, bufferOffset, length);
+        public override string GetDataTypeName(int ordinal) => reader.GetDataTypeName(ordinal);
+        public override DateTime GetDateTime(int ordinal) => reader.GetDateTime(ordinal);
+        public override decimal GetDecimal(int ordinal) => reader.GetDecimal(ordinal);
+        public override double GetDouble(int ordinal) => reader.GetDouble(ordinal);
+        public override IEnumerator GetEnumerator() => reader.GetEnumerator();
+        [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicProperties)]
+        public override Type GetFieldType(int ordinal) => ordinal switch
+        {
+            1 => typeof(long),
+            4 or 6 => typeof(int),
+            _ => typeof(string)
+        };
+        public override float GetFloat(int ordinal) => reader.GetFloat(ordinal);
+        public override Guid GetGuid(int ordinal) => reader.GetGuid(ordinal);
+        public override short GetInt16(int ordinal) => reader.GetInt16(ordinal);
+        public override int GetInt32(int ordinal) => reader.GetInt32(ordinal);
+        public override long GetInt64(int ordinal) => reader.GetInt64(ordinal);
+        public override string GetName(int ordinal) => reader.GetName(ordinal);
+        public override int GetOrdinal(string name) => reader.GetOrdinal(name);
+        public override string GetString(int ordinal) => reader.GetString(ordinal);
+        public override object GetValue(int ordinal) => reader.GetValue(ordinal);
+        public override int GetValues(object[] values) => reader.GetValues(values);
+        public override bool IsDBNull(int ordinal) => reader.IsDBNull(ordinal);
+        public override bool NextResult() => reader.NextResult();
+        public override bool Read() => reader.Read();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                reader.Dispose();
+                table.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
     }
 }

--- a/test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/RelationalStructuredLogSqlBuilderTests.cs
+++ b/test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/RelationalStructuredLogSqlBuilderTests.cs
@@ -63,12 +63,7 @@ public class RelationalStructuredLogSqlBuilderTests
             Take = 25
         });
 
-        Assert.Contains("[Message] LIKE @Text", query.Sql, StringComparison.Ordinal);
-        Assert.Contains("[MessageTemplate] LIKE @Text", query.Sql, StringComparison.Ordinal);
-        Assert.Contains("[Category] LIKE @Text", query.Sql, StringComparison.Ordinal);
-        Assert.Contains("[ExceptionJson] LIKE @Text", query.Sql, StringComparison.Ordinal);
-        Assert.Contains("[ScopesJson] LIKE @Text", query.Sql, StringComparison.Ordinal);
-        Assert.Contains("[PropertiesJson] LIKE @Text", query.Sql, StringComparison.Ordinal);
+        Assert.Contains("([Message] LIKE @Text OR [MessageTemplate] LIKE @Text OR [Category] LIKE @Text OR [ExceptionJson] LIKE @Text OR [ScopesJson] LIKE @Text OR [PropertiesJson] LIKE @Text)", query.Sql, StringComparison.Ordinal);
         Assert.Contains("[TenantId] = @TenantId", query.Sql, StringComparison.Ordinal);
         Assert.Contains("[SpanId] = @SpanId", query.Sql, StringComparison.Ordinal);
         Assert.Equal("%failure%", query.Parameters["Text"]);

--- a/test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/RelationalStructuredLogSqlBuilderTests.cs
+++ b/test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/RelationalStructuredLogSqlBuilderTests.cs
@@ -63,7 +63,9 @@ public class RelationalStructuredLogSqlBuilderTests
             Take = 25
         });
 
-        Assert.Contains("([Message] LIKE @Text OR [MessageTemplate] LIKE @Text OR [Category] LIKE @Text OR [ExceptionJson] LIKE @Text OR [ScopesJson] LIKE @Text OR [PropertiesJson] LIKE @Text)", query.Sql, StringComparison.Ordinal);
+        const string expectedTextPredicate = "([Message] LIKE @Text OR [MessageTemplate] LIKE @Text OR [Category] LIKE @Text OR [ExceptionJson] LIKE @Text OR [ScopesJson] LIKE @Text OR [PropertiesJson] LIKE @Text)";
+
+        Assert.Contains(expectedTextPredicate, query.Sql, StringComparison.Ordinal);
         Assert.Contains("[TenantId] = @TenantId", query.Sql, StringComparison.Ordinal);
         Assert.Contains("[SpanId] = @SpanId", query.Sql, StringComparison.Ordinal);
         Assert.Equal("%failure%", query.Parameters["Text"]);

--- a/test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/RelationalStructuredLogSqlBuilderTests.cs
+++ b/test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/RelationalStructuredLogSqlBuilderTests.cs
@@ -53,6 +53,58 @@ public class RelationalStructuredLogSqlBuilderTests
     }
 
     [Fact]
+    public void BuildQuery_AddsTextPredicateAcrossSearchableColumns()
+    {
+        var query = _builder.BuildQuery(new()
+        {
+            Text = "failure",
+            TenantId = "tenant-a",
+            SpanId = "span-a",
+            Take = 25
+        });
+
+        Assert.Contains("[Message] LIKE @Text", query.Sql, StringComparison.Ordinal);
+        Assert.Contains("[MessageTemplate] LIKE @Text", query.Sql, StringComparison.Ordinal);
+        Assert.Contains("[Category] LIKE @Text", query.Sql, StringComparison.Ordinal);
+        Assert.Contains("[ExceptionJson] LIKE @Text", query.Sql, StringComparison.Ordinal);
+        Assert.Contains("[ScopesJson] LIKE @Text", query.Sql, StringComparison.Ordinal);
+        Assert.Contains("[PropertiesJson] LIKE @Text", query.Sql, StringComparison.Ordinal);
+        Assert.Contains("[TenantId] = @TenantId", query.Sql, StringComparison.Ordinal);
+        Assert.Contains("[SpanId] = @SpanId", query.Sql, StringComparison.Ordinal);
+        Assert.Equal("%failure%", query.Parameters["Text"]);
+    }
+
+    [Theory]
+    [InlineData(-5, "FETCH 0")]
+    [InlineData(5000, "FETCH 1000")]
+    public void BuildQuery_ClampsTakeToSupportedRange(int take, string expectedLimit)
+    {
+        var query = _builder.BuildQuery(new()
+        {
+            Take = take
+        });
+
+        Assert.Contains(expectedLimit, query.Sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildListSources_GroupsBySourceAndOrdersBySource()
+    {
+        var sql = _builder.BuildListSources();
+
+        Assert.Equal("SELECT [SourceId], MAX([ReceivedAt]) AS [LastSeen] FROM [StructuredLogEvents] GROUP BY [SourceId] ORDER BY [SourceId]", sql);
+    }
+
+    [Fact]
+    public void BuildDeleteOlderThan_UsesReceivedAtCutoffParameter()
+    {
+        var query = _builder.BuildDeleteOlderThan("2026-05-13T13:00:00.0000000+00:00");
+
+        Assert.Equal("DELETE FROM [StructuredLogEvents] WHERE [ReceivedAt] < @Cutoff", query.Sql);
+        Assert.Equal("2026-05-13T13:00:00.0000000+00:00", query.Parameters["Cutoff"]);
+    }
+
+    [Fact]
     public void BuildDeleteRowsBeyondMax_DelegatesOffsetSyntaxToDialect()
     {
         var query = _builder.BuildDeleteRowsBeyondMax(250);


### PR DESCRIPTION
## Summary

- Adds relational mapper tests for DbDataReader deserialization, nullable columns, and empty JSON payload handling.
- Adds relational SQL builder tests for text search predicates, take clamping, source listing SQL, and age-based retention deletion SQL.

## Validation

- `dotnet build test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests.csproj -m:1 /nodeReuse:false --no-restore`

## Notes

`dotnet test` compiled the project but VSTest was unable to start its localhost socket in the sandbox (`SocketException (13): Permission denied`), so local test execution could not complete in this environment.