### PR TITLE
[codex] Increase structured log relational test coverage

### DIFF
--- a/test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/RelationalStructuredLogMapperTests.cs
+++ b/test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/RelationalStructuredLogMapperTests.cs
@@ -1,4 +1,6 @@
+using System.Data;
 using Elsa.Diagnostics.StructuredLogs.Models;
+using Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Models;
 using Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Services;
 
 namespace Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests;
@@ -32,6 +34,88 @@ public class RelationalStructuredLogMapperTests
     }
 
     [Fact]
+    public void Map_FromReader_DeserializesPersistedFields()
+    {
+        var logEvent = new StructuredLogEvent
+        {
+            Id = "event-a",
+            Sequence = 42,
+            Timestamp = new(2026, 5, 13, 15, 0, 0, TimeSpan.FromHours(2)),
+            ReceivedAt = new(2026, 5, 13, 13, 0, 1, TimeSpan.Zero),
+            Level = StructuredLogLevel.Critical,
+            Category = "Elsa.Tests",
+            EventId = 17,
+            EventName = "Failed",
+            Message = "Failed with scope",
+            MessageTemplate = "Failed with {Scope}",
+            Exception = new("System.InvalidOperationException", "Boom", "Stack"),
+            Scopes = new Dictionary<string, string?> { ["Scope"] = "Value" },
+            Properties = new Dictionary<string, string?> { ["Property"] = null },
+            TraceId = "trace-a",
+            SpanId = "span-a",
+            CorrelationId = "correlation-a",
+            TenantId = "tenant-a",
+            WorkflowDefinitionId = "definition-a",
+            WorkflowInstanceId = "instance-a",
+            SourceId = "source-a"
+        };
+        var record = _mapper.Map(logEvent);
+
+        using var reader = CreateReader(record);
+        Assert.True(reader.Read());
+        var mapped = _mapper.Map(reader);
+
+        Assert.Equal(logEvent.Id, mapped.Id);
+        Assert.Equal(logEvent.Sequence, mapped.Sequence);
+        Assert.Equal(logEvent.Timestamp.ToUniversalTime(), mapped.Timestamp);
+        Assert.Equal(logEvent.ReceivedAt.ToUniversalTime(), mapped.ReceivedAt);
+        Assert.Equal(logEvent.Level, mapped.Level);
+        Assert.Equal(logEvent.Category, mapped.Category);
+        Assert.Equal(logEvent.EventId, mapped.EventId);
+        Assert.Equal(logEvent.EventName, mapped.EventName);
+        Assert.Equal(logEvent.Message, mapped.Message);
+        Assert.Equal(logEvent.MessageTemplate, mapped.MessageTemplate);
+        Assert.Equal(logEvent.Exception, mapped.Exception);
+        Assert.Equal("Value", mapped.Scopes["Scope"]);
+        Assert.True(mapped.Properties.ContainsKey("Property"));
+        Assert.Null(mapped.Properties["Property"]);
+        Assert.Equal(logEvent.TraceId, mapped.TraceId);
+        Assert.Equal(logEvent.SpanId, mapped.SpanId);
+        Assert.Equal(logEvent.CorrelationId, mapped.CorrelationId);
+        Assert.Equal(logEvent.TenantId, mapped.TenantId);
+        Assert.Equal(logEvent.WorkflowDefinitionId, mapped.WorkflowDefinitionId);
+        Assert.Equal(logEvent.WorkflowInstanceId, mapped.WorkflowInstanceId);
+        Assert.Equal(logEvent.SourceId, mapped.SourceId);
+    }
+
+    [Fact]
+    public void Map_FromReader_ReturnsEmptyCollections_WhenJsonFieldsAreNull()
+    {
+        var record = new RelationalStructuredLogRecord
+        {
+            Id = "event-a",
+            Sequence = 1,
+            Timestamp = RelationalStructuredLogMapper.FormatTimestamp(DateTimeOffset.UtcNow),
+            ReceivedAt = RelationalStructuredLogMapper.FormatTimestamp(DateTimeOffset.UtcNow),
+            Level = StructuredLogLevel.Information,
+            Category = "Elsa.Tests",
+            EventId = 0,
+            Message = "Hello",
+            SourceId = "source-a"
+        };
+
+        using var reader = CreateReader(record);
+        Assert.True(reader.Read());
+        var mapped = _mapper.Map(reader);
+
+        Assert.Null(mapped.Exception);
+        Assert.Empty(mapped.Scopes);
+        Assert.Empty(mapped.Properties);
+        Assert.Null(mapped.EventName);
+        Assert.Null(mapped.MessageTemplate);
+    }
+
+    [Fact]
     public void FormatTimestamp_StoresUtcIso8601Text()
     {
         var timestamp = new DateTimeOffset(2026, 5, 13, 15, 0, 0, TimeSpan.FromHours(2));
@@ -40,5 +124,54 @@ public class RelationalStructuredLogMapperTests
 
         Assert.Equal("2026-05-13T13:00:00.0000000+00:00", formatted);
         Assert.Equal(timestamp.ToUniversalTime(), RelationalStructuredLogMapper.ParseTimestamp(formatted));
+    }
+
+    private static DataTableReader CreateReader(RelationalStructuredLogRecord record)
+    {
+        var table = new DataTable();
+        table.Columns.Add("Id", typeof(string));
+        table.Columns.Add("Sequence", typeof(long));
+        table.Columns.Add("Timestamp", typeof(string));
+        table.Columns.Add("ReceivedAt", typeof(string));
+        table.Columns.Add("Level", typeof(int));
+        table.Columns.Add("Category", typeof(string));
+        table.Columns.Add("EventId", typeof(int));
+        table.Columns.Add("EventName", typeof(string));
+        table.Columns.Add("Message", typeof(string));
+        table.Columns.Add("MessageTemplate", typeof(string));
+        table.Columns.Add("ExceptionJson", typeof(string));
+        table.Columns.Add("ScopesJson", typeof(string));
+        table.Columns.Add("PropertiesJson", typeof(string));
+        table.Columns.Add("TraceId", typeof(string));
+        table.Columns.Add("SpanId", typeof(string));
+        table.Columns.Add("CorrelationId", typeof(string));
+        table.Columns.Add("TenantId", typeof(string));
+        table.Columns.Add("WorkflowDefinitionId", typeof(string));
+        table.Columns.Add("WorkflowInstanceId", typeof(string));
+        table.Columns.Add("SourceId", typeof(string));
+
+        table.Rows.Add(
+            record.Id,
+            record.Sequence,
+            record.Timestamp,
+            record.ReceivedAt,
+            (int)record.Level,
+            record.Category,
+            record.EventId,
+            record.EventName ?? (object)DBNull.Value,
+            record.Message,
+            record.MessageTemplate ?? (object)DBNull.Value,
+            record.ExceptionJson ?? (object)DBNull.Value,
+            record.ScopesJson ?? (object)DBNull.Value,
+            record.PropertiesJson ?? (object)DBNull.Value,
+            record.TraceId ?? (object)DBNull.Value,
+            record.SpanId ?? (object)DBNull.Value,
+            record.CorrelationId ?? (object)DBNull.Value,
+            record.TenantId ?? (object)DBNull.Value,
+            record.WorkflowDefinitionId ?? (object)DBNull.Value,
+            record.WorkflowInstanceId ?? (object)DBNull.Value,
+            record.SourceId);
+
+        return table.CreateDataReader();
     }
 }

--- a/test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/RelationalStructuredLogMapperTests.cs
+++ b/test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/RelationalStructuredLogMapperTests.cs
@@ -61,7 +61,9 @@ public class RelationalStructuredLogMapperTests
         };
         var record = _mapper.Map(logEvent);
 
-        using var reader = CreateReader(record);
+        var (table, reader) = CreateReader(record);
+        using var disposableTable = table;
+        using var disposableReader = reader;
         Assert.True(reader.Read());
         var mapped = _mapper.Map(reader);
 
@@ -77,8 +79,8 @@ public class RelationalStructuredLogMapperTests
         Assert.Equal(logEvent.MessageTemplate, mapped.MessageTemplate);
         Assert.Equal(logEvent.Exception, mapped.Exception);
         Assert.Equal("Value", mapped.Scopes["Scope"]);
-        Assert.True(mapped.Properties.ContainsKey("Property"));
-        Assert.Null(mapped.Properties["Property"]);
+        Assert.True(mapped.Properties.TryGetValue("Property", out var propertyValue));
+        Assert.Null(propertyValue);
         Assert.Equal(logEvent.TraceId, mapped.TraceId);
         Assert.Equal(logEvent.SpanId, mapped.SpanId);
         Assert.Equal(logEvent.CorrelationId, mapped.CorrelationId);
@@ -104,7 +106,9 @@ public class RelationalStructuredLogMapperTests
             SourceId = "source-a"
         };
 
-        using var reader = CreateReader(record);
+        var (table, reader) = CreateReader(record, useNullJsonPayloads: true);
+        using var disposableTable = table;
+        using var disposableReader = reader;
         Assert.True(reader.Read());
         var mapped = _mapper.Map(reader);
 
@@ -126,7 +130,7 @@ public class RelationalStructuredLogMapperTests
         Assert.Equal(timestamp.ToUniversalTime(), RelationalStructuredLogMapper.ParseTimestamp(formatted));
     }
 
-    private static DataTableReader CreateReader(RelationalStructuredLogRecord record)
+    private static (DataTable Table, DataTableReader Reader) CreateReader(RelationalStructuredLogRecord record, bool useNullJsonPayloads = false)
     {
         var table = new DataTable();
         table.Columns.Add("Id", typeof(string));
@@ -161,9 +165,9 @@ public class RelationalStructuredLogMapperTests
             record.EventName ?? (object)DBNull.Value,
             record.Message,
             record.MessageTemplate ?? (object)DBNull.Value,
-            record.ExceptionJson ?? (object)DBNull.Value,
-            record.ScopesJson ?? (object)DBNull.Value,
-            record.PropertiesJson ?? (object)DBNull.Value,
+            useNullJsonPayloads ? DBNull.Value : record.ExceptionJson ?? (object)DBNull.Value,
+            useNullJsonPayloads ? DBNull.Value : record.ScopesJson,
+            useNullJsonPayloads ? DBNull.Value : record.PropertiesJson,
             record.TraceId ?? (object)DBNull.Value,
             record.SpanId ?? (object)DBNull.Value,
             record.CorrelationId ?? (object)DBNull.Value,
@@ -172,6 +176,6 @@ public class RelationalStructuredLogMapperTests
             record.WorkflowInstanceId ?? (object)DBNull.Value,
             record.SourceId);
 
-        return table.CreateDataReader();
+        return (table, table.CreateDataReader());
     }
 }

--- a/test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/RelationalStructuredLogSqlBuilderTests.cs
+++ b/test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/RelationalStructuredLogSqlBuilderTests.cs
@@ -29,8 +29,11 @@ public class RelationalStructuredLogSqlBuilderTests
             SourceId = "source-a",
             WorkflowDefinitionId = "definition-a",
             WorkflowInstanceId = "instance-a",
+            TenantId = "tenant-a",
             CorrelationId = "correlation-a",
             TraceId = "trace-a",
+            SpanId = "span-a",
+            Text = "needle",
             From = DateTimeOffset.UtcNow.AddMinutes(-5),
             To = DateTimeOffset.UtcNow,
             Take = 42
@@ -42,14 +45,49 @@ public class RelationalStructuredLogSqlBuilderTests
         Assert.Contains("[SourceId] = @SourceId", query.Sql, StringComparison.Ordinal);
         Assert.Contains("[WorkflowDefinitionId] = @WorkflowDefinitionId", query.Sql, StringComparison.Ordinal);
         Assert.Contains("[WorkflowInstanceId] = @WorkflowInstanceId", query.Sql, StringComparison.Ordinal);
+        Assert.Contains("[TenantId] = @TenantId", query.Sql, StringComparison.Ordinal);
         Assert.Contains("[CorrelationId] = @CorrelationId", query.Sql, StringComparison.Ordinal);
         Assert.Contains("[TraceId] = @TraceId", query.Sql, StringComparison.Ordinal);
+        Assert.Contains("[SpanId] = @SpanId", query.Sql, StringComparison.Ordinal);
+        Assert.Contains("[Message] LIKE @Text", query.Sql, StringComparison.Ordinal);
+        Assert.Contains("[PropertiesJson] LIKE @Text", query.Sql, StringComparison.Ordinal);
         Assert.Contains("[Timestamp] >= @TimestampFrom", query.Sql, StringComparison.Ordinal);
         Assert.Contains("[Timestamp] <= @TimestampTo", query.Sql, StringComparison.Ordinal);
         Assert.Contains("FETCH 42", query.Sql, StringComparison.Ordinal);
         Assert.Equal("Elsa.Workflow%", query.Parameters["Category"]);
+        Assert.Equal("%needle%", query.Parameters["Text"]);
         Assert.Contains("TimestampFrom", query.Parameters.Keys);
         Assert.Contains("TimestampTo", query.Parameters.Keys);
+    }
+
+    [Theory]
+    [InlineData(null, 100)]
+    [InlineData(-1, 0)]
+    [InlineData(2000, 1000)]
+    public void BuildQuery_ClampsTakeToSupportedRange(int? take, int expectedLimit)
+    {
+        var query = _builder.BuildQuery(new() { Take = take });
+
+        Assert.Contains($"FETCH {expectedLimit}", query.Sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildListSources_GroupsBySourceAndLastSeen()
+    {
+        var sql = _builder.BuildListSources();
+
+        Assert.Contains("SELECT [SourceId], MAX([ReceivedAt]) AS [LastSeen]", sql, StringComparison.Ordinal);
+        Assert.Contains("GROUP BY [SourceId]", sql, StringComparison.Ordinal);
+        Assert.Contains("ORDER BY [SourceId]", sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildDeleteOlderThan_UsesReceivedAtCutoff()
+    {
+        var query = _builder.BuildDeleteOlderThan("2026-05-13T13:00:00.0000000+00:00");
+
+        Assert.Equal("2026-05-13T13:00:00.0000000+00:00", query.Parameters["Cutoff"]);
+        Assert.Contains("DELETE FROM [StructuredLogEvents] WHERE [ReceivedAt] < @Cutoff", query.Sql, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/RelationalStructuredLogSqlBuilderTests.cs
+++ b/test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/RelationalStructuredLogSqlBuilderTests.cs
@@ -49,8 +49,8 @@ public class RelationalStructuredLogSqlBuilderTests
         Assert.Contains("[CorrelationId] = @CorrelationId", query.Sql, StringComparison.Ordinal);
         Assert.Contains("[TraceId] = @TraceId", query.Sql, StringComparison.Ordinal);
         Assert.Contains("[SpanId] = @SpanId", query.Sql, StringComparison.Ordinal);
-        Assert.Contains("[Message] LIKE @Text", query.Sql, StringComparison.Ordinal);
-        Assert.Contains("[PropertiesJson] LIKE @Text", query.Sql, StringComparison.Ordinal);
+        foreach (var textColumn in new[] { "Message", "MessageTemplate", "Category", "ExceptionJson", "ScopesJson", "PropertiesJson" })
+            Assert.Contains($"[{textColumn}] LIKE @Text", query.Sql, StringComparison.Ordinal);
         Assert.Contains("[Timestamp] >= @TimestampFrom", query.Sql, StringComparison.Ordinal);
         Assert.Contains("[Timestamp] <= @TimestampTo", query.Sql, StringComparison.Ordinal);
         Assert.Contains("FETCH 42", query.Sql, StringComparison.Ordinal);


### PR DESCRIPTION
## Summary

- Added relational mapper coverage for materializing persisted structured log rows from a `DbDataReader`.
- Added null JSON payload coverage for persisted exception, scope, and property fields.
- Expanded SQL builder assertions for text, tenant, span, list-sources, retention cutoff, and limit-clamping paths.

## Validation

- `dotnet build test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests.csproj --no-restore -m:1 /nr:false` passed.
- `dotnet test test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests.csproj -m:1 /nr:false` compiled the test assembly, but VSTest aborted in the sandbox because local socket binding is blocked with `System.Net.Sockets.SocketException (13): Permission denied`.

## Notes

NuGet vulnerability feed warnings were emitted because the sandbox cannot reach configured package feeds.