### PR TITLE
[codex] Avoid duplicate structured log storage diagnostics

### DIFF
--- a/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Extensions/RelationalStructuredLogsServiceCollectionExtensions.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Extensions/RelationalStructuredLogsServiceCollectionExtensions.cs
@@ -21,8 +21,8 @@ public static class RelationalStructuredLogsServiceCollectionExtensions
         services.TryAddSingleton<RelationalStructuredLogStore>();
         services.TryAddSingleton<StructuredLogWriteBuffer>();
         services.TryAddSingleton<StructuredLogRetentionService>();
-        services.AddSingleton<IStructuredLogStore>(sp => sp.GetRequiredService<StructuredLogWriteBuffer>());
-        services.AddSingleton<IStructuredLogWriteBuffer>(sp => sp.GetRequiredService<StructuredLogWriteBuffer>());
+        services.Replace(ServiceDescriptor.Singleton<IStructuredLogStore>(sp => sp.GetRequiredService<StructuredLogWriteBuffer>()));
+        services.Replace(ServiceDescriptor.Singleton<IStructuredLogWriteBuffer>(sp => sp.GetRequiredService<StructuredLogWriteBuffer>()));
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IStructuredLogStorageDiagnostics, StructuredLogWriteBufferStorageDiagnostics>());
         services.AddHostedService(sp => sp.GetRequiredService<StructuredLogWriteBuffer>());
 

--- a/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Extensions/RelationalStructuredLogsServiceCollectionExtensions.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Extensions/RelationalStructuredLogsServiceCollectionExtensions.cs
@@ -23,7 +23,7 @@ public static class RelationalStructuredLogsServiceCollectionExtensions
         services.TryAddSingleton<StructuredLogRetentionService>();
         services.AddSingleton<IStructuredLogStore>(sp => sp.GetRequiredService<StructuredLogWriteBuffer>());
         services.AddSingleton<IStructuredLogWriteBuffer>(sp => sp.GetRequiredService<StructuredLogWriteBuffer>());
-        services.AddSingleton<IStructuredLogStorageDiagnostics>(sp => sp.GetRequiredService<StructuredLogWriteBuffer>());
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IStructuredLogStorageDiagnostics, StructuredLogWriteBufferStorageDiagnostics>());
         services.AddHostedService(sp => sp.GetRequiredService<StructuredLogWriteBuffer>());
 
         return services;

--- a/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Services/StructuredLogWriteBufferStorageDiagnostics.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Services/StructuredLogWriteBufferStorageDiagnostics.cs
@@ -1,0 +1,9 @@
+using Elsa.Diagnostics.StructuredLogs.Contracts;
+using Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Contracts;
+
+namespace Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Services;
+
+public class StructuredLogWriteBufferStorageDiagnostics(IStructuredLogWriteBuffer writeBuffer) : IStructuredLogStorageDiagnostics
+{
+    public long DroppedWriteCount => writeBuffer.DroppedWriteCount;
+}

--- a/test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/RelationalStructuredLogServiceCollectionExtensionsTests.cs
+++ b/test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/RelationalStructuredLogServiceCollectionExtensionsTests.cs
@@ -1,0 +1,21 @@
+using Elsa.Diagnostics.StructuredLogs.Contracts;
+using Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests;
+
+public class RelationalStructuredLogServiceCollectionExtensionsTests
+{
+    [Fact]
+    public void AddRelationalStructuredLogPersistence_WhenCalledTwice_RegistersStorageDiagnosticsOnce()
+    {
+        var services = new ServiceCollection();
+
+        services.AddRelationalStructuredLogPersistence();
+        services.AddRelationalStructuredLogPersistence();
+
+        var descriptors = services.Where(x => x.ServiceType == typeof(IStructuredLogStorageDiagnostics)).ToList();
+
+        Assert.Single(descriptors);
+    }
+}

--- a/test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/RelationalStructuredLogServiceCollectionExtensionsTests.cs
+++ b/test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/RelationalStructuredLogServiceCollectionExtensionsTests.cs
@@ -1,4 +1,6 @@
+using System.Data.Common;
 using Elsa.Diagnostics.StructuredLogs.Contracts;
+using Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Contracts;
 using Elsa.Diagnostics.StructuredLogs.Persistence.Relational.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -7,15 +9,43 @@ namespace Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests;
 public class RelationalStructuredLogServiceCollectionExtensionsTests
 {
     [Fact]
-    public void AddRelationalStructuredLogPersistence_WhenCalledTwice_RegistersStorageDiagnosticsOnce()
+    public async Task AddRelationalStructuredLogPersistence_WhenCalledTwice_DoesNotDuplicateRelationalRegistrations()
     {
         var services = new ServiceCollection();
+        services.AddSingleton<IRelationalStructuredLogConnectionFactory, FakeConnectionFactory>();
+        services.AddSingleton<IRelationalStructuredLogDialect, FakeDialect>();
 
         services.AddRelationalStructuredLogPersistence();
+        var diagnosticsCount = Count<IStructuredLogStorageDiagnostics>(services);
+        var storeCount = Count<IStructuredLogStore>(services);
+        var writeBufferCount = Count<IStructuredLogWriteBuffer>(services);
+
         services.AddRelationalStructuredLogPersistence();
 
-        var descriptors = services.Where(x => x.ServiceType == typeof(IStructuredLogStorageDiagnostics)).ToList();
+        Assert.Equal(diagnosticsCount, Count<IStructuredLogStorageDiagnostics>(services));
+        Assert.Equal(storeCount, Count<IStructuredLogStore>(services));
+        Assert.Equal(writeBufferCount, Count<IStructuredLogWriteBuffer>(services));
 
-        Assert.Single(descriptors);
+        await using var serviceProvider = services.BuildServiceProvider();
+        Assert.NotNull(serviceProvider.GetRequiredService<IStructuredLogStorageDiagnostics>());
+    }
+
+    private static int Count<T>(IEnumerable<ServiceDescriptor> services) => services.Count(x => x.ServiceType == typeof(T));
+
+    private class FakeConnectionFactory : IRelationalStructuredLogConnectionFactory
+    {
+        public ValueTask<DbConnection> OpenConnectionAsync(CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+    }
+
+    private class FakeDialect : IRelationalStructuredLogDialect
+    {
+        public string ProviderName => "Fake";
+        public string ParameterPrefix => "@";
+        public string QuoteIdentifier(string identifier) => identifier;
+        public string ApplyLimit(string sql, int limit) => sql;
+        public string ApplyOffset(string sql, int offset) => sql;
     }
 }


### PR DESCRIPTION
## Summary

- Avoids duplicate `IStructuredLogStorageDiagnostics` enumeration when relational persistence registration is called more than once.
- Adds a delegating storage diagnostics adapter so the endpoint still reads from the existing hosted `IStructuredLogWriteBuffer` instance.
- Adds a regression test for duplicate relational registration.

## Context

Follow-up to elsa-workflows/elsa-core#7446. Greptile flagged that the diagnostics endpoint consumes `IEnumerable<IStructuredLogStorageDiagnostics>`, so duplicate registrations could double-count the same write buffer.

## Validation

- `dotnet test test/unit/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests/Elsa.Diagnostics.StructuredLogs.Persistence.Relational.UnitTests.csproj`
