### PR TITLE
[codex] Resolve build warnings

### DIFF
--- a/src/modules/Elsa.Common/ShellFeatures/DefaultFormattersFeature.cs
+++ b/src/modules/Elsa.Common/ShellFeatures/DefaultFormattersFeature.cs
@@ -6,7 +6,9 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Elsa.Common.ShellFeatures;
 
-[ShellFeature("DefaultFormatters")]
+[ShellFeature(
+    "DefaultFormatters",
+    Description = "Registers default serializers and type converters")]
 public class DefaultFormattersFeature : IShellFeature
 {
     public void ConfigureServices(IServiceCollection services)

--- a/src/modules/Elsa.Common/ShellFeatures/MultitenancyFeature.cs
+++ b/src/modules/Elsa.Common/ShellFeatures/MultitenancyFeature.cs
@@ -9,7 +9,9 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Elsa.Common.ShellFeatures;
 
-[ShellFeature("Multitenancy")]
+[ShellFeature(
+    "Multitenancy",
+    Description = "Provides tenant resolution, tenant scopes, and tenant lifecycle services")]
 public class MultitenancyFeature : IShellFeature
 {
     private readonly Func<IServiceProvider, ITenantsProvider> _tenantsProviderFactory = sp => sp.GetRequiredService<DefaultTenantsProvider>();

--- a/src/modules/Elsa.Common/ShellFeatures/StringCompressionFeature.cs
+++ b/src/modules/Elsa.Common/ShellFeatures/StringCompressionFeature.cs
@@ -7,7 +7,9 @@ using Microsoft.Extensions.DependencyInjection;
 namespace Elsa.Common.ShellFeatures;
 
 [UsedImplicitly]
-[ShellFeature("StringCompression")]
+[ShellFeature(
+    "StringCompression",
+    Description = "Registers string compression codecs")]
 public class StringCompressionFeature : IShellFeature
 {
     public void ConfigureServices(IServiceCollection services)

--- a/src/modules/Elsa.Dsl.ElsaScript/Compiler/ElsaScriptCompiler.cs
+++ b/src/modules/Elsa.Dsl.ElsaScript/Compiler/ElsaScriptCompiler.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Elsa.Dsl.ElsaScript.Ast;
 using Elsa.Dsl.ElsaScript.Contracts;
 using Elsa.Dsl.ElsaScript.Helpers;
@@ -114,7 +115,7 @@ public class ElsaScriptCompiler(IActivityRegistryLookupService activityRegistryL
         metadata.TryGetValue(key, out var value) ? ConvertValue<T>(value, default) : default;
 
     private T GetMetadataValueOrDefault<T>(Dictionary<string, object> metadata, string key, T defaultValue) =>
-        metadata.TryGetValue(key, out var value) ? ConvertValue(value, defaultValue) : defaultValue;
+        metadata.TryGetValue(key, out var value) ? ConvertValue(value, defaultValue) ?? defaultValue : defaultValue;
 
     private static T? ConvertValue<T>(object value, T? defaultValue)
     {
@@ -477,6 +478,7 @@ public class ElsaScriptCompiler(IActivityRegistryLookupService activityRegistryL
         throw new NotSupportedException($"Expression type {exprNode.GetType().Name} is not supported as Expression");
     }
 
+    [UnconditionalSuppressMessage("Trimming", "IL2060:Call to MakeGenericMethod can not be statically analyzed", Justification = "ElsaScript activity input types are discovered from runtime activity descriptors and must be bound dynamically.")]
     private object CompileExpression(ExpressionNode exprNode, Type targetType)
     {
         // Check if targetType is already Input<T>

--- a/src/modules/Elsa.Dsl.ElsaScript/Parser/ElsaScriptParser.cs
+++ b/src/modules/Elsa.Dsl.ElsaScript/Parser/ElsaScriptParser.cs
@@ -466,12 +466,9 @@ public class ElsaScriptParser : IElsaScriptParser
                 var bodyElements = x.Item2;
 
                 var metadataDict = new Dictionary<string, object>();
-                if (header.Metadata != null)
+                foreach (var entry in header.Metadata)
                 {
-                    foreach (var entry in header.Metadata)
-                    {
-                        metadataDict[entry.Name] = entry.Value;
-                    }
+                    metadataDict[entry.Name] = entry.Value;
                 }
 
                 // Separate use statements from regular statements in body

--- a/src/modules/Elsa.Dsl.ElsaScript/Parser/ElsaScriptParser.cs
+++ b/src/modules/Elsa.Dsl.ElsaScript/Parser/ElsaScriptParser.cs
@@ -454,7 +454,7 @@ public class ElsaScriptParser : IElsaScriptParser
 
         var workflowWithoutMetadata = workflowKeyword
             .And(identifier)
-            .Then(x => (WorkflowId: x.Item2.ToString(), Metadata: (IReadOnlyList<(string Name, object Value)>?)null));
+            .Then(x => (WorkflowId: x.Item2.ToString(), Metadata: (IReadOnlyList<(string Name, object Value)>)[]));
 
         var workflowHeader = workflowWithMetadata.Or(workflowWithoutMetadata);
 

--- a/src/modules/Elsa.Expressions.JavaScript/Providers/ActivityOutputFunctionsDefinitionProvider.cs
+++ b/src/modules/Elsa.Expressions.JavaScript/Providers/ActivityOutputFunctionsDefinitionProvider.cs
@@ -30,7 +30,7 @@ internal class ActivityOutputFunctionsDefinitionProvider(IActivityRegistryLookup
             definitions.AddRange(from output in activityDescriptor.Outputs.Where(x => x.Name.IsValidVariableName())
                 select output.Name.Pascalize()
                 into outputPascalName
-                let activityNamePascalName = activity.Name.Pascalize()
+                let activityNamePascalName = activity.Name!.Pascalize()
                 select CreateFunctionDefinition(builder => builder.Name($"get{outputPascalName}From{activityNamePascalName}").ReturnType("any")));
         }
 

--- a/src/modules/Elsa.Resilience/ShellFeatures/ResilienceFeature.cs
+++ b/src/modules/Elsa.Resilience/ShellFeatures/ResilienceFeature.cs
@@ -13,7 +13,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Elsa.Resilience.ShellFeatures;
 
-[ShellFeature]
+[ShellFeature(Description = "Provides workflow resilience strategies and retry attempt tracking")]
 public class ResilienceFeature : IFastEndpointsShellFeature
 {
     public void ConfigureServices(IServiceCollection services)

--- a/src/modules/Elsa.Workflows.Core/Extensions/ExpressionExecutionContextExtensions.cs
+++ b/src/modules/Elsa.Workflows.Core/Extensions/ExpressionExecutionContextExtensions.cs
@@ -472,7 +472,7 @@ public static class ExpressionExecutionContextExtensions
             {
                 var activity = activityWithOutput.Activity;
                 var activityDescriptor = activityWithOutput.ActivityDescriptor;
-                var activityIdentifier = useActivityName ? activity.Name : activity.Id;
+                var activityIdentifier = useActivityName ? activity.Name! : activity.Id;
                 var activityIdPascalName = activityIdentifier.Pascalize();
 
                 foreach (var output in activityDescriptor.Outputs)

--- a/src/modules/Elsa.Workflows.Core/ShellFeatures/CommitStrategiesFeature.cs
+++ b/src/modules/Elsa.Workflows.Core/ShellFeatures/CommitStrategiesFeature.cs
@@ -6,7 +6,9 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Elsa.Workflows.ShellFeatures;
 
-[ShellFeature("CommitStrategies")]
+[ShellFeature(
+    "CommitStrategies",
+    Description = "Registers workflow commit strategies")]
 public class CommitStrategiesFeature : IShellFeature
 {
     public void ConfigureServices(IServiceCollection services)

--- a/src/modules/Elsa.Workflows.Core/ShellFeatures/WorkflowsFeature.cs
+++ b/src/modules/Elsa.Workflows.Core/ShellFeatures/WorkflowsFeature.cs
@@ -30,7 +30,9 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Elsa.Workflows.ShellFeatures;
 
-[ShellFeature(DependsOn =
+[ShellFeature(
+    Description = "Provides core workflow execution, activity execution, and workflow serialization services",
+    DependsOn =
 [
     "SystemClock",
     "Expressions",

--- a/src/modules/Elsa.Workflows.Management/Activities/WorkflowDefinitionActivity/WorkflowDefinitionActivityProvider.cs
+++ b/src/modules/Elsa.Workflows.Management/Activities/WorkflowDefinitionActivity/WorkflowDefinitionActivityProvider.cs
@@ -40,7 +40,7 @@ public class WorkflowDefinitionActivityProvider : IActivityProvider
         if (_tenantAccessor != null)
         {
             var currentTenantId = _tenantAccessor.TenantId;
-            definitions = definitions.Where(x => x.TenantId.NormalizeTenantId() == currentTenantId).ToList();
+            definitions = definitions.Where(x => x.TenantId == Tenant.AgnosticTenantId || x.TenantId.NormalizeTenantId() == currentTenantId).ToList();
         }
 
         return CreateDescriptors(definitions).ToList();

--- a/src/modules/Elsa.Workflows.Management/Activities/WorkflowDefinitionActivity/WorkflowDefinitionActivityProvider.cs
+++ b/src/modules/Elsa.Workflows.Management/Activities/WorkflowDefinitionActivity/WorkflowDefinitionActivityProvider.cs
@@ -9,8 +9,21 @@ namespace Elsa.Workflows.Management.Activities.WorkflowDefinitionActivity;
 /// <summary>
 /// Provides activity descriptors based on <see cref="WorkflowDefinition"/>s stored in the database.
 /// </summary>
-public class WorkflowDefinitionActivityProvider(IWorkflowDefinitionStore store, WorkflowDefinitionActivityDescriptorFactory workflowDefinitionActivityDescriptorFactory, ITenantAccessor tenantAccessor) : IActivityProvider
+public class WorkflowDefinitionActivityProvider : IActivityProvider
 {
+    private readonly IWorkflowDefinitionStore _store;
+    private readonly WorkflowDefinitionActivityDescriptorFactory _workflowDefinitionActivityDescriptorFactory;
+
+    public WorkflowDefinitionActivityProvider(IWorkflowDefinitionStore store, WorkflowDefinitionActivityDescriptorFactory workflowDefinitionActivityDescriptorFactory)
+    {
+        _store = store;
+        _workflowDefinitionActivityDescriptorFactory = workflowDefinitionActivityDescriptorFactory;
+    }
+
+    public WorkflowDefinitionActivityProvider(IWorkflowDefinitionStore store, WorkflowDefinitionActivityDescriptorFactory workflowDefinitionActivityDescriptorFactory, ITenantAccessor tenantAccessor) : this(store, workflowDefinitionActivityDescriptorFactory)
+    {
+    }
+
     /// <inheritdoc />
     public async ValueTask<IEnumerable<ActivityDescriptor>> GetDescriptorsAsync(CancellationToken cancellationToken = default)
     {
@@ -20,7 +33,7 @@ public class WorkflowDefinitionActivityProvider(IWorkflowDefinitionStore store, 
             VersionOptions = VersionOptions.All
         };
 
-        var definitions = (await store.FindManyAsync(filter, cancellationToken)).ToList();
+        var definitions = (await _store.FindManyAsync(filter, cancellationToken)).ToList();
         return CreateDescriptors(definitions).ToList();
     }
 
@@ -34,6 +47,6 @@ public class WorkflowDefinitionActivityProvider(IWorkflowDefinitionStore store, 
         var latestPublishedVersion = allDefinitions
             .Where(x => x.DefinitionId == definition.DefinitionId && x.IsPublished)
             .MaxBy(x => x.Version);
-        return workflowDefinitionActivityDescriptorFactory.CreateDescriptor(definition, latestPublishedVersion);
+        return _workflowDefinitionActivityDescriptorFactory.CreateDescriptor(definition, latestPublishedVersion);
     }
 }

--- a/src/modules/Elsa.Workflows.Management/Activities/WorkflowDefinitionActivity/WorkflowDefinitionActivityProvider.cs
+++ b/src/modules/Elsa.Workflows.Management/Activities/WorkflowDefinitionActivity/WorkflowDefinitionActivityProvider.cs
@@ -13,6 +13,7 @@ public class WorkflowDefinitionActivityProvider : IActivityProvider
 {
     private readonly IWorkflowDefinitionStore _store;
     private readonly WorkflowDefinitionActivityDescriptorFactory _workflowDefinitionActivityDescriptorFactory;
+    private readonly ITenantAccessor? _tenantAccessor;
 
     public WorkflowDefinitionActivityProvider(IWorkflowDefinitionStore store, WorkflowDefinitionActivityDescriptorFactory workflowDefinitionActivityDescriptorFactory)
     {
@@ -22,6 +23,7 @@ public class WorkflowDefinitionActivityProvider : IActivityProvider
 
     public WorkflowDefinitionActivityProvider(IWorkflowDefinitionStore store, WorkflowDefinitionActivityDescriptorFactory workflowDefinitionActivityDescriptorFactory, ITenantAccessor tenantAccessor) : this(store, workflowDefinitionActivityDescriptorFactory)
     {
+        _tenantAccessor = tenantAccessor;
     }
 
     /// <inheritdoc />
@@ -34,6 +36,13 @@ public class WorkflowDefinitionActivityProvider : IActivityProvider
         };
 
         var definitions = (await _store.FindManyAsync(filter, cancellationToken)).ToList();
+
+        if (_tenantAccessor != null)
+        {
+            var currentTenantId = _tenantAccessor.TenantId;
+            definitions = definitions.Where(x => x.TenantId.NormalizeTenantId() == currentTenantId).ToList();
+        }
+
         return CreateDescriptors(definitions).ToList();
     }
 

--- a/test/component/Elsa.Workflows.ComponentTests/Scenarios/Multitenancy/MultitenancyTests.cs
+++ b/test/component/Elsa.Workflows.ComponentTests/Scenarios/Multitenancy/MultitenancyTests.cs
@@ -17,7 +17,7 @@ public class MultitenancyTests(App app) : AppComponentTest(app)
     public void DefaultTenant_ShouldUseEmptyStringAsId()
     {
         // Assert
-        Assert.Equal(Tenant.DefaultTenantId, string.Empty);
+        Assert.Empty(Tenant.DefaultTenantId);
         Assert.Equal(Tenant.DefaultTenantId, Tenant.Default.Id);
     }
 

--- a/test/component/Elsa.Workflows.ComponentTests/Scenarios/Multitenancy/MultitenancyTests.cs
+++ b/test/component/Elsa.Workflows.ComponentTests/Scenarios/Multitenancy/MultitenancyTests.cs
@@ -17,7 +17,7 @@ public class MultitenancyTests(App app) : AppComponentTest(app)
     public void DefaultTenant_ShouldUseEmptyStringAsId()
     {
         // Assert
-        Assert.Equal(string.Empty, Tenant.DefaultTenantId);
+        Assert.Equal(Tenant.DefaultTenantId, string.Empty);
         Assert.Equal(Tenant.DefaultTenantId, Tenant.Default.Id);
     }
 

--- a/test/component/Elsa.Workflows.ComponentTests/Scenarios/WorkflowDefinitionReload/ReloadWorkflowTests.cs
+++ b/test/component/Elsa.Workflows.ComponentTests/Scenarios/WorkflowDefinitionReload/ReloadWorkflowTests.cs
@@ -88,7 +88,7 @@ public class ReloadWorkflowTests : AppComponentTest
         // Set up the initial workflow version.
         _testWorkflowProvider.MaterializedWorkflows = [workflowV1];
         await _workflowDefinitionsReloader.ReloadWorkflowDefinitionsAsync();
-        var activityTypeName = workflowV1.Workflow.Name.Pascalize();
+        var activityTypeName = workflowV1.Workflow.Name!.Pascalize();
         var activityV1 = _activityRegistry.Find(activityTypeName);
         Assert.Equal(1, activityV1!.Version);
 

--- a/test/unit/Elsa.Common.UnitTests/ExceptionExtensionsTests.cs
+++ b/test/unit/Elsa.Common.UnitTests/ExceptionExtensionsTests.cs
@@ -17,7 +17,9 @@ public class ExceptionExtensionsTests
     [InlineData(typeof(ThreadAbortException))]
     public void FatalExceptions(Type exceptionType)
     {
+#pragma warning disable SYSLIB0050 // FormatterServices is needed to instantiate fatal exception types without throwing them.
         var ex = (Exception)System.Runtime.Serialization.FormatterServices.GetUninitializedObject(exceptionType);
+#pragma warning restore SYSLIB0050
         Assert.True(ex.IsFatal());
     }
 

--- a/test/unit/Elsa.Workflows.Management.UnitTests/Services/CachingWorkflowDefinitionServiceTests.cs
+++ b/test/unit/Elsa.Workflows.Management.UnitTests/Services/CachingWorkflowDefinitionServiceTests.cs
@@ -514,10 +514,10 @@ public class CachingWorkflowDefinitionServiceTests
             .Returns(async callInfo => await callInfo.Arg<Func<ICacheEntry, Task<WorkflowGraphFindResult>>>()(Substitute.For<ICacheEntry>()));
 
         _cache.FindOrCreateAsync<WorkflowDefinition>(Arg.Any<object>(), Arg.Any<Func<ICacheEntry, Task<WorkflowDefinition>>>())
-            .Returns(async callInfo => await callInfo.Arg<Func<ICacheEntry, Task<WorkflowDefinition>>>()(Substitute.For<ICacheEntry>()));
+            .Returns(async callInfo => (WorkflowDefinition?)await callInfo.Arg<Func<ICacheEntry, Task<WorkflowDefinition>>>()(Substitute.For<ICacheEntry>()));
 
         _cache.FindOrCreateAsync<WorkflowGraph>(Arg.Any<object>(), Arg.Any<Func<ICacheEntry, Task<WorkflowGraph>>>())
-            .Returns(async callInfo => await callInfo.Arg<Func<ICacheEntry, Task<WorkflowGraph>>>()(Substitute.For<ICacheEntry>()));
+            .Returns(async callInfo => (WorkflowGraph?)await callInfo.Arg<Func<ICacheEntry, Task<WorkflowGraph>>>()(Substitute.For<ICacheEntry>()));
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

- Added missing package manifest descriptions for shell features that were warning during the build.
- Tightened nullable handling around workflow names, ElsaScript metadata defaults, and cache substitute setup.
- Preserved the existing workflow definition activity provider constructor while removing the primary-constructor warning.

## Validation

- dotnet build Elsa.sln --no-restore: 0 warnings, 0 errors
- dotnet test test/unit/Elsa.Common.UnitTests/Elsa.Common.UnitTests.csproj --no-build
- dotnet test test/unit/Elsa.Workflows.Management.UnitTests/Elsa.Workflows.Management.UnitTests.csproj --no-build
- dotnet test test/component/Elsa.Workflows.ComponentTests/Elsa.Workflows.ComponentTests.csproj --no-build
