### PR TITLE
Update safe dependency patch versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -139,7 +139,7 @@
         <PackageVersion Include="Newtonsoft.Json" Version="13.0.4"/>
 		<PackageVersion Include="Npgsql" Version="10.0.3"/>
         <PackageVersion Include="NSubstitute" Version="5.3.0"/>
-        <PackageVersion Include="NuGet.Packaging" Version="7.0.1"/>
+        <PackageVersion Include="NuGet.Packaging" Version="7.6.0"/>
         <PackageVersion Include="NuGet.Protocol" Version="7.0.1"/>
         <PackageVersion Include="Nuplane" Version="0.0.8"/>
         <PackageVersion Include="Nuplane.Abstractions" Version="0.0.8"/>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,40 +8,40 @@
         <PackageVersion Include="FastEndpoints" Version="7.1.1" />
         <PackageVersion Include="FastEndpoints.Security" Version="7.1.1" />
         <PackageVersion Include="FastEndpoints.Swagger" Version="7.1.1" />
-        <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="9.0.13"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components" Version="9.0.13"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.13"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.13"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="9.0.13"/>
-        <PackageVersion Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="9.0.13"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.13"/>
-        <PackageVersion Include="Microsoft.Data.Sqlite" Version="9.0.13"/>
-        <PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="9.0.13"/>
-        <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.13"/>
-        <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.13"/>
-        <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.13"/>
-        <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.13"/>
-        <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.13"/>
-        <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.13"/>
-        <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="9.0.13"/>
-        <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.13"/>
-        <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.13"/>
-        <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="9.0.13"/>
-        <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.13"/>
-        <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.13"/>
-        <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="9.0.13"/>
-        <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.13"/>
-        <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.13"/>
-        <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="9.0.13"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="9.0.16"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Components" Version="9.0.16"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.16"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.16"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="9.0.16"/>
+        <PackageVersion Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="9.0.16"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.16"/>
+        <PackageVersion Include="Microsoft.Data.Sqlite" Version="9.0.16"/>
+        <PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="9.0.16"/>
+        <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.16"/>
+        <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.16"/>
+        <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.16"/>
+        <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.16"/>
+        <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.16"/>
+        <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.16"/>
+        <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="9.0.16"/>
+        <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.16"/>
+        <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.16"/>
+        <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="9.0.16"/>
+        <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16"/>
+        <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.16"/>
+        <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="9.0.16"/>
+        <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.16"/>
+        <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.16"/>
+        <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="9.0.16"/>
         <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.10.0"/>
-        <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.13"/>
-        <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.13"/>
+        <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.16"/>
+        <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.16"/>
         <PackageVersion Include="Microsoft.Extensions.Resilience" Version="9.10.0"/>
-        <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.13"/>
-        <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.13"/>
-        <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.13"/>
+        <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.16"/>
+        <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.16"/>
+        <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.16"/>
 		<PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4"/>
-        <PackageVersion Include="Oracle.EntityFrameworkCore" Version="9.23.26100"/>
+        <PackageVersion Include="Oracle.EntityFrameworkCore" Version="9.23.26200"/>
         <PackageVersion Include="Scrutor" Version="6.1.0"/>
     </ItemGroup>
     <!-- .NET 10 specific package versions -->
@@ -49,40 +49,40 @@
         <PackageVersion Include="FastEndpoints" Version="7.2.0" />
         <PackageVersion Include="FastEndpoints.Security" Version="7.2.0" />
         <PackageVersion Include="FastEndpoints.Swagger" Version="7.2.0" />
-        <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="10.0.3"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components" Version="10.0.3"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.3"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.3"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.3"/>
-        <PackageVersion Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="10.0.3"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3"/>
-        <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.3"/>
-        <PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="10.0.3"/>
-        <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.3"/>
-        <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.3"/>
-        <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.3"/>
-        <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.3"/>
-        <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.3"/>
-        <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.3"/>
-        <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.3"/>
-        <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.3"/>
-        <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.3"/>
-        <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.3"/>
-        <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3"/>
-        <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3"/>
-        <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="10.0.3"/>
-        <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.3"/>
-        <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.3"/>
-        <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="10.0.3"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="10.0.8"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Components" Version="10.0.8"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.8"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.8"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.8"/>
+        <PackageVersion Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="10.0.8"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8"/>
+        <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.8"/>
+        <PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="10.0.8"/>
+        <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.8"/>
+        <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8"/>
+        <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8"/>
+        <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.8"/>
+        <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8"/>
+        <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.8"/>
+        <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.8"/>
+        <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.8"/>
+        <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.8"/>
+        <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8"/>
+        <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8"/>
+        <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8"/>
+        <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="10.0.8"/>
+        <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.8"/>
+        <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.8"/>
+        <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="10.0.8"/>
         <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.1.0"/>
-        <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.3"/>
-        <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.3"/>
+        <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.8"/>
+        <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.8"/>
         <PackageVersion Include="Microsoft.Extensions.Resilience" Version="10.1.0"/>
-        <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.3"/>
-        <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3"/>
-        <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.3"/>
-        <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0"/>
-        <PackageVersion Include="Oracle.EntityFrameworkCore" Version="10.23.26000"/>
+        <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.8"/>
+        <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8"/>
+        <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.8"/>
+        <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1"/>
+        <PackageVersion Include="Oracle.EntityFrameworkCore" Version="10.23.26200"/>
         <PackageVersion Include="Scrutor" Version="7.0.0"/>
     </ItemGroup>
     <ItemGroup>
@@ -109,21 +109,21 @@
         <PackageVersion Include="Elsa.PackageManifest.Generator" Version="0.0.1-preview.28"/>
         <PackageVersion Include="Datadog.Trace.Bundle" Version="3.32.0"/>
         <PackageVersion Include="DistributedLock" Version="2.7.1"/>
-        <PackageVersion Include="DistributedLock.Core" Version="1.0.8"/>
+        <PackageVersion Include="DistributedLock.Core" Version="1.0.9"/>
         <PackageVersion Include="DistributedLock.FileSystem" Version="1.0.3"/>
         <PackageVersion Include="Elastic.Clients.Elasticsearch" Version="9.2.2"/>
-        <PackageVersion Include="FluentStorage" Version="6.0.0"/>
-        <PackageVersion Include="FluentStorage.Azure.Blobs" Version="6.0.0"/>
+        <PackageVersion Include="FluentStorage" Version="6.0.4"/>
+        <PackageVersion Include="FluentStorage.Azure.Blobs" Version="6.0.4"/>
         <PackageVersion Include="FluentMigrator.Runner" Version="8.0.1"/>
         <PackageVersion Include="FluentMigrator.Runner.SQLite" Version="8.0.1"/>
         <PackageVersion Include="Fluid.Core" Version="2.31.0"/>
         <PackageVersion Include="Fody" Version="6.9.3" PrivateAssets="All"/>
-        <PackageVersion Include="GitHubActionsTestLogger" Version="3.0.1" PrivateAssets="All"/>
-        <PackageVersion Include="Humanizer.Core" Version="3.0.1"/>
+        <PackageVersion Include="GitHubActionsTestLogger" Version="3.0.4" PrivateAssets="All"/>
+        <PackageVersion Include="Humanizer.Core" Version="3.0.10"/>
         <PackageVersion Include="IronCompress" Version="1.7.0"/>
         <PackageVersion Include="JetBrains.Annotations" Version="2025.2.4"/>
         <PackageVersion Include="Jint" Version="4.4.2"/>
-        <PackageVersion Include="LinqKit.Core" Version="1.2.9"/>
+        <PackageVersion Include="LinqKit.Core" Version="1.2.11"/>
         <PackageVersion Include="MailKit" Version="4.14.1"/>
         <PackageVersion Include="MassTransit" Version="8.5.7"/>
         <PackageVersion Include="MassTransit.Azure.ServiceBus.Core" Version="8.5.7"/>
@@ -158,9 +158,9 @@
         <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.14.0"/>
         <PackageVersion Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.14.0-beta.1"/>
         <PackageVersion Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.14.0-beta.1"/>
-        <PackageVersion Include="Parlot" Version="1.5.6"/>
-        <PackageVersion Include="Polly" Version="8.6.5"/>
-        <PackageVersion Include="Polly.Extensions" Version="8.6.5"/>
+        <PackageVersion Include="Parlot" Version="1.5.7"/>
+        <PackageVersion Include="Polly" Version="8.6.6"/>
+        <PackageVersion Include="Polly.Extensions" Version="8.6.6"/>
         <PackageVersion Include="Polly.Extensions.Http" Version="3.0.0"/>
         <PackageVersion Include="PolySharp" Version="1.15.0" PrivateAssets="All"/>
         <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="9.0.0"/>
@@ -176,18 +176,18 @@
         <PackageVersion Include="StackExchange.Redis" Version="2.10.1"/>
         <PackageVersion Include="System.CommandLine" Version="2.0.0"/>
         <PackageVersion Include="System.Data.SqlClient" Version="4.9.0"/>
-		<PackageVersion Include="System.Formats.Asn1" Version="10.0.3"/>
-        <PackageVersion Include="System.Linq.Async" Version="7.0.0"/>
-        <PackageVersion Include="System.Linq.Dynamic.Core" Version="1.7.1"/>
+		<PackageVersion Include="System.Formats.Asn1" Version="10.0.8"/>
+        <PackageVersion Include="System.Linq.Async" Version="7.0.1"/>
+        <PackageVersion Include="System.Linq.Dynamic.Core" Version="1.7.2"/>
         <PackageVersion Include="System.Net.Http" Version="4.3.4"/>
-		<PackageVersion Include="System.Text.Json" Version="10.0.3"/>
+		<PackageVersion Include="System.Text.Json" Version="10.0.8"/>
         <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1"/>
         <PackageVersion Include="Testcontainers" Version="4.9.0"/>
         <PackageVersion Include="Testcontainers.MsSql" Version="4.9.0"/>
         <PackageVersion Include="Testcontainers.PostgreSql" Version="4.9.0"/>
         <PackageVersion Include="Testcontainers.RabbitMq" Version="4.9.0"/>
         <PackageVersion Include="Testcontainers.Redis" Version="4.9.0"/>
-        <PackageVersion Include="ThrottleDebounce" Version="2.0.1"/>
+        <PackageVersion Include="ThrottleDebounce" Version="2.0.2"/>
         <PackageVersion Include="WebhooksCore" Version="0.0.6"/>
         <PackageVersion Include="xunit" Version="2.9.3"/>
         <PackageVersion Include="xunit.abstractions" Version="2.0.3"/>

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -20,6 +20,8 @@
 
   <ItemGroup>
     <PackageReference Include="Nuke.Components" Version="10.1.0" />
+    <PackageReference Include="NuGet.Packaging" Version="7.6.0" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.8" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- update Microsoft servicing package pins for net8/net9 and net10 target groups
- apply patch-only library updates identified by the dependency sweep
- pin vulnerable NUKE build transitive packages explicitly

## Validation
- dotnet restore build/_build.csproj
- dotnet restore Elsa.sln
- dotnet list build/_build.csproj package --vulnerable --include-transitive
- dotnet list Elsa.sln package --vulnerable --include-transitive
- dotnet build build/_build.csproj --no-restore
- dotnet build Elsa.sln --no-restore