### PR TITLE
Fix structured log write buffer shutdown flush

### DIFF
--- a/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Services/StructuredLogWriteBuffer.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Services/StructuredLogWriteBuffer.cs
@@ -158,8 +158,13 @@ public class StructuredLogWriteBuffer(
             {
                 var signalTask = _signal.WaitAsync(cancellationToken);
                 var timerTask = timer.WaitForNextTickAsync(cancellationToken).AsTask();
-                await Task.WhenAny(signalTask, timerTask);
-                await FlushAsync(cancellationToken);
+                var completedTask = await Task.WhenAny(signalTask, timerTask);
+                await completedTask;
+
+                if (cancellationToken.IsCancellationRequested)
+                    return;
+
+                await FlushAsync();
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {

--- a/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Services/StructuredLogWriteBuffer.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/Services/StructuredLogWriteBuffer.cs
@@ -149,17 +149,13 @@ public class StructuredLogWriteBuffer(
 
     private async Task ProcessQueueAsync()
     {
-        using var timer = new PeriodicTimer(options.Value.WriteQueue.FlushInterval);
         var cancellationToken = _stopTokenSource.Token;
 
         while (!cancellationToken.IsCancellationRequested)
         {
             try
             {
-                var signalTask = _signal.WaitAsync(cancellationToken);
-                var timerTask = timer.WaitForNextTickAsync(cancellationToken).AsTask();
-                var completedTask = await Task.WhenAny(signalTask, timerTask);
-                await completedTask;
+                await _signal.WaitAsync(options.Value.WriteQueue.FlushInterval, cancellationToken);
 
                 if (cancellationToken.IsCancellationRequested)
                     return;
@@ -174,9 +170,12 @@ public class StructuredLogWriteBuffer(
             {
                 return;
             }
-            catch (Exception e) when (!cancellationToken.IsCancellationRequested)
+            catch (Exception e)
             {
                 Trace.TraceError("Failed to flush structured log writes: {0}", e);
+
+                if (cancellationToken.IsCancellationRequested)
+                    return;
             }
         }
     }


### PR DESCRIPTION
## Summary
- avoid cancelling an in-progress structured log buffer flush during background shutdown
- ensure the background loop observes the completed wait task before flushing
- preserve shutdown flush behavior so queued SQLite log writes are persisted

## Verification
- dotnet test test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests.csproj -c Release --filter StopAsync_FlushesQueuedWrites
- dotnet test test/integration/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.IntegrationTests.csproj -c Release
- dotnet test test/integration/Elsa.Diagnostics.StructuredLogs.IntegrationTests/Elsa.Diagnostics.StructuredLogs.IntegrationTests.csproj -c Release
- git diff --check