### PR TITLE
[codex] Enforce HTTP workflow request body limits while reading

### DIFF
--- a/src/modules/Elsa.Http/Activities/HttpEndpoint.cs
+++ b/src/modules/Elsa.Http/Activities/HttpEndpoint.cs
@@ -221,79 +221,84 @@ public class HttpEndpoint : Trigger<HttpRequest>
         context.Set(QueryStringData, queryStringDictionary);
         context.Set(Headers, headersDictionary);
 
-        // Validate request size.
-        if (!ValidateRequestSize(context, httpContext))
+        // Validate declared request size before reading, then enforce the same limit while reading.
+        if (!ValidateDeclaredRequestSize(context, httpContext))
         {
             await HandleRequestTooLargeAsync(context, httpContext);
             return;
         }
 
-        // Handle Form Fields
-        if (request.HasFormContentType)
+        ApplyRequestSizeLimit(context, request);
+
+        try
         {
-            var formFields = request.Form.ToObjectDictionary();
-
-            ParsedContent.Set(context, formFields);
-
-            // Read files, if any.
-            var files = ReadFilesAsync(context, request);
-
-            if (files.Any())
+            // Handle Form Fields
+            if (request.HasFormContentType)
             {
-                if (!ValidateFileSizes(context, httpContext, files))
+                var form = await request.ReadFormAsync(context.CancellationToken);
+                var formFields = form.ToObjectDictionary();
+
+                ParsedContent.Set(context, formFields);
+
+                // Read files, if any.
+                var files = form.Files;
+
+                if (files.Any())
                 {
-                    await HandleFileSizeTooLargeAsync(context, httpContext);
+                    if (!ValidateFileSizes(context, httpContext, files))
+                    {
+                        await HandleFileSizeTooLargeAsync(context, httpContext);
+                        return;
+                    }
+
+                    if (!ValidateFileExtensionWhitelist(context, httpContext, files))
+                    {
+                        await HandleInvalidFileExtensionWhitelistAsync(context, httpContext);
+                        return;
+                    }
+
+                    if (!ValidateFileExtensionBlacklist(context, httpContext, files))
+                    {
+                        await HandleInvalidFileExtensionBlacklistAsync(context, httpContext);
+                        return;
+                    }
+
+                    if (!ValidateFileMimeTypes(context, httpContext, files))
+                    {
+                        await HandleInvalidFileMimeTypesAsync(context, httpContext);
+                        return;
+                    }
+
+                    Files.Set(context, files.ToArray());
+                    File.Set(context, files.FirstOrDefault());
+                }
+            }
+            else
+            {
+                // Parse Non-Form content.
+                try
+                {
+                    var content = await ParseContentAsync(context, request);
+                    ParsedContent.Set(context, content);
+                }
+                catch (JsonException e)
+                {
+                    await HandleInvalidJsonPayloadAsync(context, httpContext, e);
                     return;
                 }
-
-                if (!ValidateFileExtensionWhitelist(context, httpContext, files))
-                {
-                    await HandleInvalidFileExtensionWhitelistAsync(context, httpContext);
-                    return;
-                }
-
-                if (!ValidateFileExtensionBlacklist(context, httpContext, files))
-                {
-                    await HandleInvalidFileExtensionBlacklistAsync(context, httpContext);
-                    return;
-                }
-
-                if (!ValidateFileMimeTypes(context, httpContext, files))
-                {
-                    await HandleInvalidFileMimeTypesAsync(context, httpContext);
-                    return;
-                }
-
-                Files.Set(context, files.ToArray());
-                File.Set(context, files.FirstOrDefault());
             }
         }
-        else
+        catch (RequestBodyTooLargeException)
         {
-            // Parse Non-Form content.
-            try
-            {
-                var content = await ParseContentAsync(context, request);
-                ParsedContent.Set(context, content);
-            }
-            catch (JsonException e)
-            {
-                await HandleInvalidJsonPayloadAsync(context, httpContext, e);
-                return;
-            }
-
+            await HandleRequestTooLargeAsync(context, httpContext);
+            return;
         }
 
         // Complete.
         await context.CompleteActivityAsync();
     }
 
-    private IFormFileCollection ReadFilesAsync(ActivityExecutionContext context, HttpRequest request)
-    {
-        return request.HasFormContentType ? request.Form.Files : new FormFileCollection();
-    }
-
-    private bool ValidateRequestSize(ActivityExecutionContext context, HttpContext httpContext)
+    private bool ValidateDeclaredRequestSize(ActivityExecutionContext context, HttpContext httpContext)
     {
         var requestSizeLimit = RequestSizeLimit.GetOrDefault(context);
 
@@ -302,6 +307,16 @@ public class HttpEndpoint : Trigger<HttpRequest>
 
         var requestSize = httpContext.Request.ContentLength ?? 0;
         return requestSize <= requestSizeLimit;
+    }
+
+    private void ApplyRequestSizeLimit(ActivityExecutionContext context, HttpRequest request)
+    {
+        var requestSizeLimit = RequestSizeLimit.GetOrDefault(context);
+
+        if (!requestSizeLimit.HasValue || request.Body is RequestSizeLimitStream)
+            return;
+
+        request.Body = new RequestSizeLimitStream(request.Body, requestSizeLimit.Value);
     }
 
     private async Task HandleRequestTooLargeAsync(ActivityExecutionContext context, HttpContext httpContext)
@@ -477,7 +492,13 @@ public class HttpEndpoint : Trigger<HttpRequest>
         return await context.ParseContentAsync(contentStream, contentType, targetType, headers!, cancellationToken);
     }
 
-    private static bool HasContent(HttpRequest httpRequest) => httpRequest.Headers.ContentLength > 0;
+    private static bool HasContent(HttpRequest httpRequest)
+    {
+        if (httpRequest.ContentLength > 0)
+            return true;
+
+        return httpRequest.ContentLength == null && !string.IsNullOrWhiteSpace(httpRequest.ContentType);
+    }
 
     private IEnumerable<object> GetBookmarkPayloads(ExpressionExecutionContext context)
     {
@@ -517,4 +538,76 @@ public class HttpEndpoint : Trigger<HttpRequest>
 
         return routeData;
     }
+
+    private sealed class RequestSizeLimitStream(Stream inner, long requestSizeLimit) : Stream
+    {
+        private long _bytesRead;
+
+        public override bool CanRead => inner.CanRead;
+        public override bool CanSeek => inner.CanSeek;
+        public override bool CanWrite => false;
+        public override long Length => inner.Length;
+
+        public override long Position
+        {
+            get => inner.Position;
+            set => inner.Position = value;
+        }
+
+        public override void Flush() => inner.Flush();
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            var bytesRead = inner.Read(buffer, offset, GetPermittedReadCount(count));
+            CountBytesRead(bytesRead);
+            return bytesRead;
+        }
+
+        public override int Read(Span<byte> buffer)
+        {
+            var bytesRead = inner.Read(buffer[..GetPermittedReadCount(buffer.Length)]);
+            CountBytesRead(bytesRead);
+            return bytesRead;
+        }
+
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            var bytesRead = await inner.ReadAsync(buffer[..GetPermittedReadCount(buffer.Length)], cancellationToken);
+            CountBytesRead(bytesRead);
+            return bytesRead;
+        }
+
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            var bytesRead = await inner.ReadAsync(buffer, offset, GetPermittedReadCount(count), cancellationToken);
+            CountBytesRead(bytesRead);
+            return bytesRead;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => inner.Seek(offset, origin);
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        private int GetPermittedReadCount(int requestedCount)
+        {
+            if (requestedCount == 0)
+                return 0;
+
+            var remainingBytes = requestSizeLimit - _bytesRead;
+            var readLimit = Math.Max(0, remainingBytes) + 1;
+            return (int)Math.Min(requestedCount, readLimit);
+        }
+
+        private void CountBytesRead(int bytesRead)
+        {
+            _bytesRead += bytesRead;
+
+            if (_bytesRead > requestSizeLimit)
+                throw new RequestBodyTooLargeException();
+        }
+    }
+
+    private sealed class RequestBodyTooLargeException : Exception;
 }

--- a/src/modules/Elsa.Http/Activities/HttpEndpoint.cs
+++ b/src/modules/Elsa.Http/Activities/HttpEndpoint.cs
@@ -544,14 +544,14 @@ public class HttpEndpoint : Trigger<HttpRequest>
         private long _bytesRead;
 
         public override bool CanRead => inner.CanRead;
-        public override bool CanSeek => inner.CanSeek;
+        public override bool CanSeek => false;
         public override bool CanWrite => false;
         public override long Length => inner.Length;
 
         public override long Position
         {
             get => inner.Position;
-            set => inner.Position = value;
+            set => throw new NotSupportedException();
         }
 
         public override void Flush() => inner.Flush();
@@ -584,7 +584,7 @@ public class HttpEndpoint : Trigger<HttpRequest>
             return bytesRead;
         }
 
-        public override long Seek(long offset, SeekOrigin origin) => inner.Seek(offset, origin);
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
 
         public override void SetLength(long value) => throw new NotSupportedException();
 
@@ -596,8 +596,10 @@ public class HttpEndpoint : Trigger<HttpRequest>
                 return 0;
 
             var remainingBytes = requestSizeLimit - _bytesRead;
-            var readLimit = Math.Max(0, remainingBytes) + 1;
-            return (int)Math.Min(requestedCount, readLimit);
+            if (remainingBytes >= requestedCount)
+                return requestedCount;
+
+            return (int)Math.Max(0, remainingBytes) + 1;
         }
 
         private void CountBytesRead(int bytesRead)

--- a/src/modules/Elsa.Http/Activities/HttpEndpoint.cs
+++ b/src/modules/Elsa.Http/Activities/HttpEndpoint.cs
@@ -599,7 +599,10 @@ public class HttpEndpoint : Trigger<HttpRequest>
             if (remainingBytes >= requestedCount)
                 return requestedCount;
 
-            return (int)Math.Max(0, remainingBytes) + 1;
+            if (remainingBytes < 0)
+                return 1;
+
+            return (int)remainingBytes + 1;
         }
 
         private void CountBytesRead(int bytesRead)

--- a/test/component/Elsa.Workflows.ComponentTests/Scenarios/Activities/Http/HttpEndpointContentTests.cs
+++ b/test/component/Elsa.Workflows.ComponentTests/Scenarios/Activities/Http/HttpEndpointContentTests.cs
@@ -8,6 +8,8 @@ namespace Elsa.Workflows.ComponentTests.Scenarios.Activities.Http;
 
 public class HttpEndpointContentTests(App app) : AppComponentTest(app)
 {
+    private const string RequestSizeLimitPath = "test/request-size-limit";
+
     [Fact]
     public async Task JsonContent_ValidJson_ReturnsEchoedJson()
     {
@@ -103,6 +105,37 @@ public class HttpEndpointContentTests(App app) : AppComponentTest(app)
         AssertOkResponseContains(response, responseContent, "No form data received");
     }
 
+    [Fact]
+    public async Task RequestSizeLimit_NoContentLengthOversizedBody_ReturnsPayloadTooLarge()
+    {
+        // Arrange
+        var client = WorkflowServer.CreateHttpWorkflowClient();
+        using var content = new NoLengthStringContent("0123456789", "text/plain");
+        Assert.Null(content.Headers.ContentLength);
+
+        // Act
+        var response = await client.PostAsync(RequestSizeLimitPath, content);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.RequestEntityTooLarge, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task RequestSizeLimit_NoContentLengthSmallBody_ReturnsEchoedContent()
+    {
+        // Arrange
+        var client = WorkflowServer.CreateHttpWorkflowClient();
+        using var content = new NoLengthStringContent("small", "text/plain");
+        Assert.Null(content.Headers.ContentLength);
+
+        // Act
+        var response = await client.PostAsync(RequestSizeLimitPath, content);
+        var responseContent = await response.Content.ReadAsStringAsync();
+
+        // Assert
+        AssertOkResponseContains(response, responseContent, "small");
+    }
+
     private async Task<HttpResponseMessage> PostJsonContentAsync(string jsonContent)
     {
         var client = WorkflowServer.CreateHttpWorkflowClient();
@@ -130,6 +163,29 @@ public class HttpEndpointContentTests(App app) : AppComponentTest(app)
         foreach (var fragment in expectedFragments)
         {
             Assert.Contains(fragment, responseContent);
+        }
+    }
+
+    private sealed class NoLengthStringContent : HttpContent
+    {
+        private readonly string _content;
+
+        public NoLengthStringContent(string content, string mediaType)
+        {
+            _content = content;
+            Headers.ContentType = new(mediaType);
+        }
+
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context)
+        {
+            var bytes = Encoding.UTF8.GetBytes(_content);
+            return stream.WriteAsync(bytes, 0, bytes.Length);
+        }
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = 0;
+            return false;
         }
     }
 }

--- a/test/component/Elsa.Workflows.ComponentTests/Scenarios/Activities/Http/Workflows/RequestSizeLimitWorkflow.cs
+++ b/test/component/Elsa.Workflows.ComponentTests/Scenarios/Activities/Http/Workflows/RequestSizeLimitWorkflow.cs
@@ -1,0 +1,39 @@
+using System.Net;
+using Elsa.Http;
+using Elsa.Workflows.Activities;
+using Microsoft.AspNetCore.Http;
+
+namespace Elsa.Workflows.ComponentTests.Scenarios.Activities.Http.Workflows;
+
+public class RequestSizeLimitWorkflow : WorkflowBase
+{
+    public static readonly string DefinitionId = Guid.NewGuid().ToString();
+
+    protected override void Build(IWorkflowBuilder builder)
+    {
+        builder.WithDefinitionId(DefinitionId);
+
+        var parsedContentVariable = builder.WithVariable<object>();
+
+        builder.Root = new Sequence
+        {
+            Activities =
+            [
+                new HttpEndpoint
+                {
+                    Path = new("test/request-size-limit"),
+                    SupportedMethods = new([HttpMethods.Post]),
+                    RequestSizeLimit = new(8),
+                    CanStartWorkflow = true,
+                    ParsedContent = new(parsedContentVariable)
+                },
+                new WriteHttpResponse
+                {
+                    Content = new(context => parsedContentVariable.Get(context)?.ToString() ?? "No content received"),
+                    ContentType = new("text/plain"),
+                    StatusCode = new(HttpStatusCode.OK)
+                }
+            ]
+        };
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #7479.

- enforces HTTP workflow request body limits during stream reads, including no-ContentLength bodies
- preserves ContentLength preflight rejection for known oversized requests
- adds component regression coverage for oversized and valid small no-ContentLength bodies

## Validation

- `dotnet test test/component/Elsa.Workflows.ComponentTests/Elsa.Workflows.ComponentTests.csproj --filter "FullyQualifiedName~HttpEndpointContentTests" /p:CollectCoverage=false`
- `dotnet test test/unit/Elsa.Activities.UnitTests/Elsa.Activities.UnitTests.csproj --filter "FullyQualifiedName~HttpEndpointTests" /p:CollectCoverage=false`
