### PR TITLE
[codex] Enforce role assignment authorization

### DIFF
--- a/src/common/Elsa.Api.Common/PermissionNames.cs
+++ b/src/common/Elsa.Api.Common/PermissionNames.cs
@@ -3,6 +3,7 @@ namespace Elsa;
 public static class PermissionNames
 {
     public const string All = "*";
+    public const string ClaimType = "permissions";
 
     /// <summary>
     /// Permission required to pause, resume, force-drain, or query the workflow runtime's graceful-shutdown status.

--- a/src/modules/Elsa.Identity/Contracts/IRoleAuthorizationService.cs
+++ b/src/modules/Elsa.Identity/Contracts/IRoleAuthorizationService.cs
@@ -1,0 +1,25 @@
+using System.Security.Claims;
+using Elsa.Identity.Entities;
+
+namespace Elsa.Identity.Contracts;
+
+/// <summary>
+/// Authorizes role assignment and role permission changes.
+/// </summary>
+public interface IRoleAuthorizationService
+{
+    /// <summary>
+    /// Returns true when the user can assign all requested roles.
+    /// </summary>
+    Task<bool> CanAssignRolesAsync(ClaimsPrincipal user, IEnumerable<string>? roleIds, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns true when the user can create a role with the requested permissions.
+    /// </summary>
+    bool CanCreateRoleWithPermissions(ClaimsPrincipal user, IEnumerable<string>? permissions);
+
+    /// <summary>
+    /// Returns true when the user can mutate the specified role.
+    /// </summary>
+    bool CanMutateRole(ClaimsPrincipal user, Role role, IEnumerable<string>? replacementPermissions = null);
+}

--- a/src/modules/Elsa.Identity/Contracts/IRoleAuthorizationService.cs
+++ b/src/modules/Elsa.Identity/Contracts/IRoleAuthorizationService.cs
@@ -21,5 +21,8 @@ public interface IRoleAuthorizationService
     /// <summary>
     /// Returns true when the user can mutate the specified role.
     /// </summary>
+    /// <remarks>
+    /// When replacement permissions are supplied, authorization is evaluated against both the current permissions and the replacement permissions so callers cannot modify permissions they do not already hold.
+    /// </remarks>
     bool CanMutateRole(ClaimsPrincipal user, Role role, IEnumerable<string>? replacementPermissions = null);
 }

--- a/src/modules/Elsa.Identity/Endpoints/Roles/Create/Endpoint.cs
+++ b/src/modules/Elsa.Identity/Endpoints/Roles/Create/Endpoint.cs
@@ -1,6 +1,8 @@
 using Elsa.Abstractions;
 using Elsa.Identity.Contracts;
+using Elsa.Identity.Models;
 using JetBrains.Annotations;
+using Microsoft.AspNetCore.Http;
 
 namespace Elsa.Identity.Endpoints.Roles.Create;
 
@@ -8,7 +10,7 @@ namespace Elsa.Identity.Endpoints.Roles.Create;
 /// An endpoint that creates a new role.
 /// </summary>
 [PublicAPI]
-internal class Create(IRoleManager roleManager) : ElsaEndpoint<Request, Response>
+internal class Create(IRoleManager roleManager, IRoleAuthorizationService roleAuthorizationService) : ElsaEndpoint<Request, Response>
 {
     /// <inheritdoc />
     public override void Configure()
@@ -21,11 +23,26 @@ internal class Create(IRoleManager roleManager) : ElsaEndpoint<Request, Response
     /// <inheritdoc />
     public override async Task HandleAsync(Request request, CancellationToken cancellationToken)
     {
-        var result = await roleManager.CreateRoleAsync(
-            request.Name,
-            request.Permissions,
-            request.Id,
-            cancellationToken);
+        if (!roleAuthorizationService.CanCreateRoleWithPermissions(User, request.Permissions))
+        {
+            await Send.ForbiddenAsync(cancellationToken);
+            return;
+        }
+
+        CreateRoleResult result;
+        try
+        {
+            result = await roleManager.CreateRoleAsync(
+                request.Name,
+                request.Permissions,
+                request.Id,
+                cancellationToken);
+        }
+        catch (InvalidOperationException)
+        {
+            await Send.ErrorsAsync(StatusCodes.Status409Conflict, cancellationToken);
+            return;
+        }
 
         var response = new Response(
             result.Role.Id,

--- a/src/modules/Elsa.Identity/Endpoints/Roles/Create/Endpoint.cs
+++ b/src/modules/Elsa.Identity/Endpoints/Roles/Create/Endpoint.cs
@@ -38,7 +38,7 @@ internal class Create(IRoleManager roleManager, IRoleAuthorizationService roleAu
                 request.Id,
                 cancellationToken);
         }
-        catch (InvalidOperationException)
+        catch (InvalidOperationException ex) when (ex.Message.Contains("already exists", StringComparison.OrdinalIgnoreCase))
         {
             await Send.ErrorsAsync(StatusCodes.Status409Conflict, cancellationToken);
             return;

--- a/src/modules/Elsa.Identity/Endpoints/Roles/Update/Endpoint.cs
+++ b/src/modules/Elsa.Identity/Endpoints/Roles/Update/Endpoint.cs
@@ -8,7 +8,7 @@ namespace Elsa.Identity.Endpoints.Roles.Update;
 /// An endpoint that updates an existing role.
 /// </summary>
 [PublicAPI]
-internal class Update(IRoleStore roleStore) : ElsaEndpoint<Request, Response>
+internal class Update(IRoleStore roleStore, IRoleAuthorizationService roleAuthorizationService) : ElsaEndpoint<Request, Response>
 {
     /// <inheritdoc />
     public override void Configure()
@@ -30,6 +30,12 @@ internal class Update(IRoleStore roleStore) : ElsaEndpoint<Request, Response>
         if (role == null)
         {
             await Send.NotFoundAsync(cancellationToken);
+            return;
+        }
+
+        if (!roleAuthorizationService.CanMutateRole(User, role, request.Permissions))
+        {
+            await Send.ForbiddenAsync(cancellationToken);
             return;
         }
 

--- a/src/modules/Elsa.Identity/Endpoints/Users/Create/Endpoint.cs
+++ b/src/modules/Elsa.Identity/Endpoints/Users/Create/Endpoint.cs
@@ -8,7 +8,7 @@ namespace Elsa.Identity.Endpoints.Users.Create;
 /// An endpoint that creates a new user.
 /// </summary>
 [PublicAPI]
-internal class Create(IUserManager userManager) : ElsaEndpoint<Request, Response>
+internal class Create(IUserManager userManager, IRoleAuthorizationService roleAuthorizationService) : ElsaEndpoint<Request, Response>
 {
     /// <inheritdoc />
     public override void Configure()
@@ -20,6 +20,12 @@ internal class Create(IUserManager userManager) : ElsaEndpoint<Request, Response
     /// <inheritdoc />
     public override async Task HandleAsync(Request request, CancellationToken cancellationToken)
     {
+        if (!await roleAuthorizationService.CanAssignRolesAsync(User, request.Roles, cancellationToken))
+        {
+            await Send.ForbiddenAsync(cancellationToken);
+            return;
+        }
+
         var result = await userManager.CreateUserAsync(
             request.Name,
             request.Password,

--- a/src/modules/Elsa.Identity/Endpoints/Users/Update/Endpoint.cs
+++ b/src/modules/Elsa.Identity/Endpoints/Users/Update/Endpoint.cs
@@ -8,7 +8,7 @@ namespace Elsa.Identity.Endpoints.Users.Update;
 /// An endpoint that updates an existing user's password and roles.
 /// </summary>
 [PublicAPI]
-internal class Update(IUserStore userStore, ISecretHasher secretHasher) : ElsaEndpoint<Request, Response>
+internal class Update(IUserStore userStore, ISecretHasher secretHasher, IRoleAuthorizationService roleAuthorizationService) : ElsaEndpoint<Request, Response>
 {
     /// <inheritdoc />
     public override void Configure()
@@ -32,7 +32,15 @@ internal class Update(IUserStore userStore, ISecretHasher secretHasher) : ElsaEn
         }
 
         if (request.Roles != null)
+        {
+            if (!await roleAuthorizationService.CanAssignRolesAsync(User, request.Roles, cancellationToken))
+            {
+                await Send.ForbiddenAsync(cancellationToken);
+                return;
+            }
+
             user.Roles = request.Roles;
+        }
 
         if (!string.IsNullOrWhiteSpace(request.Password))
         {

--- a/src/modules/Elsa.Identity/Features/IdentityFeature.cs
+++ b/src/modules/Elsa.Identity/Features/IdentityFeature.cs
@@ -191,6 +191,7 @@ public class IdentityFeature : FeatureBase
             .AddScoped(RoleProvider)
             .AddScoped<IUserManager, UserManager>()
             .AddScoped<IRoleManager, RoleManager>()
+            .AddScoped<IRoleAuthorizationService, RoleAuthorizationService>()
             .AddScoped<ISecretHasher, DefaultSecretHasher>()
             .AddScoped<IAccessTokenIssuer, DefaultAccessTokenIssuer>()
             .AddScoped<IUserCredentialsValidator, DefaultUserCredentialsValidator>()

--- a/src/modules/Elsa.Identity/Services/RoleAuthorizationService.cs
+++ b/src/modules/Elsa.Identity/Services/RoleAuthorizationService.cs
@@ -8,8 +8,6 @@ namespace Elsa.Identity.Services;
 /// <inheritdoc />
 public class RoleAuthorizationService(IRoleProvider roleProvider) : IRoleAuthorizationService
 {
-    private const string PermissionClaimType = "permissions";
-
     /// <inheritdoc />
     public async Task<bool> CanAssignRolesAsync(ClaimsPrincipal user, IEnumerable<string>? roleIds, CancellationToken cancellationToken = default)
     {
@@ -45,7 +43,7 @@ public class RoleAuthorizationService(IRoleProvider roleProvider) : IRoleAuthori
     private static bool HasAllPermissions(ClaimsPrincipal user, IEnumerable<string>? permissions)
     {
         var grantedPermissions = user
-            .FindAll(PermissionClaimType)
+            .FindAll(PermissionNames.ClaimType)
             .Select(x => x.Value)
             .Where(x => !string.IsNullOrWhiteSpace(x))
             .ToHashSet(StringComparer.Ordinal);

--- a/src/modules/Elsa.Identity/Services/RoleAuthorizationService.cs
+++ b/src/modules/Elsa.Identity/Services/RoleAuthorizationService.cs
@@ -1,0 +1,55 @@
+using System.Security.Claims;
+using Elsa.Extensions;
+using Elsa.Identity.Contracts;
+using Elsa.Identity.Entities;
+
+namespace Elsa.Identity.Services;
+
+/// <inheritdoc />
+public class RoleAuthorizationService(IRoleProvider roleProvider) : IRoleAuthorizationService
+{
+    private const string PermissionClaimType = "permissions";
+
+    /// <inheritdoc />
+    public async Task<bool> CanAssignRolesAsync(ClaimsPrincipal user, IEnumerable<string>? roleIds, CancellationToken cancellationToken = default)
+    {
+        var requestedRoleIds = roleIds?.Where(x => !string.IsNullOrWhiteSpace(x)).Distinct().ToList();
+        if (requestedRoleIds == null || requestedRoleIds.Count == 0)
+            return true;
+
+        var requestedRoleIdSet = requestedRoleIds.ToHashSet(StringComparer.Ordinal);
+        var roles = (await roleProvider.FindByIdsAsync(requestedRoleIds, cancellationToken)).Where(x => requestedRoleIdSet.Contains(x.Id));
+        var permissions = roles.SelectMany(x => x.Permissions);
+        return HasAllPermissions(user, permissions);
+    }
+
+    /// <inheritdoc />
+    public bool CanCreateRoleWithPermissions(ClaimsPrincipal user, IEnumerable<string>? permissions) => HasAllPermissions(user, permissions);
+
+    /// <inheritdoc />
+    public bool CanMutateRole(ClaimsPrincipal user, Role role, IEnumerable<string>? replacementPermissions = null)
+    {
+        var permissions = replacementPermissions == null
+            ? role.Permissions
+            : role.Permissions.Concat(replacementPermissions);
+
+        return HasAllPermissions(user, permissions);
+    }
+
+    private static bool HasAllPermissions(ClaimsPrincipal user, IEnumerable<string>? permissions)
+    {
+        var grantedPermissions = user
+            .FindAll(PermissionClaimType)
+            .Select(x => x.Value)
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .ToHashSet(StringComparer.Ordinal);
+
+        if (grantedPermissions.Contains(PermissionNames.All))
+            return true;
+
+        return permissions?
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .Distinct()
+            .All(grantedPermissions.Contains) ?? true;
+    }
+}

--- a/src/modules/Elsa.Identity/Services/RoleAuthorizationService.cs
+++ b/src/modules/Elsa.Identity/Services/RoleAuthorizationService.cs
@@ -18,7 +18,13 @@ public class RoleAuthorizationService(IRoleProvider roleProvider) : IRoleAuthori
             return true;
 
         var requestedRoleIdSet = requestedRoleIds.ToHashSet(StringComparer.Ordinal);
-        var roles = (await roleProvider.FindByIdsAsync(requestedRoleIds, cancellationToken)).Where(x => requestedRoleIdSet.Contains(x.Id));
+        var roles = (await roleProvider.FindByIdsAsync(requestedRoleIds, cancellationToken))
+            .Where(x => requestedRoleIdSet.Contains(x.Id))
+            .ToList();
+        var resolvedRoleIdSet = roles.Select(x => x.Id).ToHashSet(StringComparer.Ordinal);
+        if (!resolvedRoleIdSet.SetEquals(requestedRoleIdSet))
+            return false;
+
         var permissions = roles.SelectMany(x => x.Permissions);
         return HasAllPermissions(user, permissions);
     }

--- a/src/modules/Elsa.Identity/Services/RoleManager.cs
+++ b/src/modules/Elsa.Identity/Services/RoleManager.cs
@@ -11,10 +11,12 @@ namespace Elsa.Identity.Services;
 public class RoleManager : IRoleManager
 {
     private readonly IRoleStore _roleStore;
+    private readonly IRoleProvider _roleProvider;
 
-    public RoleManager(IRoleStore roleStore)
+    public RoleManager(IRoleStore roleStore, IRoleProvider roleProvider)
     {
         _roleStore = roleStore;
+        _roleProvider = roleProvider;
     }
 
     /// <inheritdoc />
@@ -26,6 +28,9 @@ public class RoleManager : IRoleManager
     {
         var roleId = id ?? name.Kebaberize();
 
+        if (await RoleExistsAsync(roleId, cancellationToken))
+            throw new InvalidOperationException($"A role with ID '{roleId}' already exists.");
+
         var role = new Role
         {
             Id = roleId,
@@ -36,5 +41,15 @@ public class RoleManager : IRoleManager
         await _roleStore.SaveAsync(role, cancellationToken);
 
         return new CreateRoleResult(role);
+    }
+
+    private async Task<bool> RoleExistsAsync(string roleId, CancellationToken cancellationToken)
+    {
+        var storedRole = await _roleStore.FindAsync(new() { Id = roleId }, cancellationToken);
+        if (storedRole != null)
+            return true;
+
+        var providedRoles = await _roleProvider.FindManyAsync(new() { Id = roleId }, cancellationToken);
+        return providedRoles.Any(x => x.Id == roleId);
     }
 }

--- a/src/modules/Elsa.Identity/ShellFeatures/IdentityFeature.cs
+++ b/src/modules/Elsa.Identity/ShellFeatures/IdentityFeature.cs
@@ -70,6 +70,7 @@ public class IdentityFeature : IFastEndpointsShellFeature
         services
             .AddScoped<IUserManager, UserManager>()
             .AddScoped<IRoleManager, RoleManager>()
+            .AddScoped<IRoleAuthorizationService, RoleAuthorizationService>()
             .AddScoped<ISecretHasher, DefaultSecretHasher>()
             .AddScoped<IAccessTokenIssuer, DefaultAccessTokenIssuer>()
             .AddScoped<IUserCredentialsValidator, DefaultUserCredentialsValidator>()

--- a/test/unit/Elsa.Identity.UnitTests/Services/RoleAuthorizationServiceTests.cs
+++ b/test/unit/Elsa.Identity.UnitTests/Services/RoleAuthorizationServiceTests.cs
@@ -38,6 +38,14 @@ public class RoleAuthorizationServiceTests
     }
 
     [Fact]
+    public async Task CannotAssignUnknownRoleId()
+    {
+        var canAssignRoles = await _service.CanAssignRolesAsync(CreateUser(PermissionNames.All), ["future-admin"]);
+
+        Assert.False(canAssignRoles);
+    }
+
+    [Fact]
     public void CannotMutatePrivilegedRoleWithOnlyRoleUpdatePermission()
     {
         var role = new Role

--- a/test/unit/Elsa.Identity.UnitTests/Services/RoleAuthorizationServiceTests.cs
+++ b/test/unit/Elsa.Identity.UnitTests/Services/RoleAuthorizationServiceTests.cs
@@ -73,7 +73,7 @@ public class RoleAuthorizationServiceTests
     private static ClaimsPrincipal CreateUser(params string[] permissions)
     {
         var identity = new ClaimsIdentity("test");
-        identity.AddClaims(permissions.Select(x => new Claim("permissions", x)));
+        identity.AddClaims(permissions.Select(x => new Claim(PermissionNames.ClaimType, x)));
         return new(identity);
     }
 }

--- a/test/unit/Elsa.Identity.UnitTests/Services/RoleAuthorizationServiceTests.cs
+++ b/test/unit/Elsa.Identity.UnitTests/Services/RoleAuthorizationServiceTests.cs
@@ -1,0 +1,71 @@
+using System.Security.Claims;
+using Elsa.Common.Services;
+using Elsa.Identity.Entities;
+using Elsa.Identity.Providers;
+using Elsa.Identity.Services;
+
+namespace Elsa.Identity.UnitTests.Services;
+
+public class RoleAuthorizationServiceTests
+{
+    private readonly MemoryRoleStore _roleStore;
+    private readonly RoleAuthorizationService _service;
+
+    public RoleAuthorizationServiceTests()
+    {
+        _roleStore = new MemoryRoleStore(new MemoryStore<Role>());
+        _service = new RoleAuthorizationService(new StoreBasedRoleProvider(_roleStore));
+    }
+
+    [Fact]
+    public async Task CannotAssignAdminRoleWithOnlyUserWritePermission()
+    {
+        await AddRoleAsync("admin", PermissionNames.All);
+
+        var canAssignRoles = await _service.CanAssignRolesAsync(CreateUser("create:user"), ["admin"]);
+
+        Assert.False(canAssignRoles);
+    }
+
+    [Fact]
+    public async Task CanAssignAdminRoleWithAllPermission()
+    {
+        await AddRoleAsync("admin", PermissionNames.All);
+
+        var canAssignRoles = await _service.CanAssignRolesAsync(CreateUser(PermissionNames.All), ["admin"]);
+
+        Assert.True(canAssignRoles);
+    }
+
+    [Fact]
+    public void CannotMutatePrivilegedRoleWithOnlyRoleUpdatePermission()
+    {
+        var role = new Role
+        {
+            Id = "admin",
+            Name = "Admin",
+            Permissions = [PermissionNames.All]
+        };
+
+        var canMutateRole = _service.CanMutateRole(CreateUser("update:role"), role, ["read:workflow-definitions"]);
+
+        Assert.False(canMutateRole);
+    }
+
+    private Task AddRoleAsync(string id, params string[] permissions)
+    {
+        return _roleStore.SaveAsync(new Role
+        {
+            Id = id,
+            Name = id,
+            Permissions = permissions
+        });
+    }
+
+    private static ClaimsPrincipal CreateUser(params string[] permissions)
+    {
+        var identity = new ClaimsIdentity("test");
+        identity.AddClaims(permissions.Select(x => new Claim("permissions", x)));
+        return new(identity);
+    }
+}

--- a/test/unit/Elsa.Identity.UnitTests/Services/RoleManagerTests.cs
+++ b/test/unit/Elsa.Identity.UnitTests/Services/RoleManagerTests.cs
@@ -1,0 +1,44 @@
+using Elsa.Common.Services;
+using Elsa.Identity.Entities;
+using Elsa.Identity.Providers;
+using Elsa.Identity.Services;
+
+namespace Elsa.Identity.UnitTests.Services;
+
+public class RoleManagerTests
+{
+    private readonly MemoryRoleStore _roleStore;
+    private readonly RoleManager _manager;
+
+    public RoleManagerTests()
+    {
+        _roleStore = new MemoryRoleStore(new MemoryStore<Role>());
+        _manager = new RoleManager(_roleStore, new StoreBasedRoleProvider(_roleStore));
+    }
+
+    [Fact]
+    public async Task CreateRoleRejectsExistingRoleId()
+    {
+        await _roleStore.SaveAsync(new Role
+        {
+            Id = "admin",
+            Name = "Admin",
+            Permissions = [PermissionNames.All]
+        });
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => _manager.CreateRoleAsync("Replacement", [], "admin"));
+
+        var role = await _roleStore.FindAsync(new() { Id = "admin" });
+        Assert.NotNull(role);
+        Assert.Equal("Admin", role.Name);
+        Assert.Equal([PermissionNames.All], role.Permissions);
+    }
+
+    [Fact]
+    public async Task CreateRoleRejectsProvidedAdminRoleIdCollision()
+    {
+        var manager = new RoleManager(_roleStore, new AdminRoleProvider());
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => manager.CreateRoleAsync("Replacement", [], "admin"));
+    }
+}


### PR DESCRIPTION
Fixes #7477

## Summary
- add role assignment authorization checks before user and role mutations can assign protected roles
- register a reusable role authorization service in the identity feature pipeline
- cover manager/service behavior with focused unit tests

## Validation
- dotnet test test/unit/Elsa.Identity.UnitTests/Elsa.Identity.UnitTests.csproj
- dotnet build src/modules/Elsa.Identity/Elsa.Identity.csproj --no-restore