### PR TITLE
[codex] Authorize workflow instance SignalR observation

### DIFF
--- a/Elsa.sln
+++ b/Elsa.sln
@@ -343,6 +343,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Secrets", "src\modules
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Secrets.UnitTests", "test\unit\Elsa.Secrets.UnitTests\Elsa.Secrets.UnitTests.csproj", "{7D905CEC-B30B-4C99-B5F7-3052D33EC8E9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Workflows.Api.UnitTests", "test\unit\Elsa.Workflows.Api.UnitTests\Elsa.Workflows.Api.UnitTests.csproj", "{81CFD2E0-2E5E-4810-ADB8-A08301199166}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1359,6 +1361,18 @@ Global
 		{7D905CEC-B30B-4C99-B5F7-3052D33EC8E9}.Release|x64.Build.0 = Release|Any CPU
 		{7D905CEC-B30B-4C99-B5F7-3052D33EC8E9}.Release|x86.ActiveCfg = Release|Any CPU
 		{7D905CEC-B30B-4C99-B5F7-3052D33EC8E9}.Release|x86.Build.0 = Release|Any CPU
+		{81CFD2E0-2E5E-4810-ADB8-A08301199166}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{81CFD2E0-2E5E-4810-ADB8-A08301199166}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{81CFD2E0-2E5E-4810-ADB8-A08301199166}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{81CFD2E0-2E5E-4810-ADB8-A08301199166}.Debug|x64.Build.0 = Debug|Any CPU
+		{81CFD2E0-2E5E-4810-ADB8-A08301199166}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{81CFD2E0-2E5E-4810-ADB8-A08301199166}.Debug|x86.Build.0 = Debug|Any CPU
+		{81CFD2E0-2E5E-4810-ADB8-A08301199166}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{81CFD2E0-2E5E-4810-ADB8-A08301199166}.Release|Any CPU.Build.0 = Release|Any CPU
+		{81CFD2E0-2E5E-4810-ADB8-A08301199166}.Release|x64.ActiveCfg = Release|Any CPU
+		{81CFD2E0-2E5E-4810-ADB8-A08301199166}.Release|x64.Build.0 = Release|Any CPU
+		{81CFD2E0-2E5E-4810-ADB8-A08301199166}.Release|x86.ActiveCfg = Release|Any CPU
+		{81CFD2E0-2E5E-4810-ADB8-A08301199166}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1480,6 +1494,7 @@ Global
 		{93E9213A-694D-4AB4-870E-05E44F793133} = {1B8D5897-902E-4632-8698-E89CAF3DDF54}
 		{09B4B78B-FE02-44E2-8667-E182AF921C54} = {5BA4A8FA-F7F4-45B3-AEC8-8886D35AAC79}
 		{7D905CEC-B30B-4C99-B5F7-3052D33EC8E9} = {18453B51-25EB-4317-A4B3-B10518252E92}
+		{81CFD2E0-2E5E-4810-ADB8-A08301199166} = {18453B51-25EB-4317-A4B3-B10518252E92}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D4B5CEAA-7D70-4FCB-A68E-B03FBE5E0E5E}

--- a/src/modules/Elsa.Workflows.Api/RealTime/Hubs/WorkflowInstanceHub.cs
+++ b/src/modules/Elsa.Workflows.Api/RealTime/Hubs/WorkflowInstanceHub.cs
@@ -5,6 +5,7 @@ using Elsa.Workflows.Api.RealTime.Contracts;
 using Elsa.Workflows.Management;
 using Elsa.Workflows.Management.Entities;
 using Elsa.Workflows.Management.Filters;
+using FastEndpoints.Security;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
@@ -21,7 +22,7 @@ public class WorkflowInstanceHub : Hub<IWorkflowInstanceClient>
 {
     private const string ReadWorkflowInstancesPermission = "read:workflow-instances";
     private const string ReadAllPermission = "read:*";
-    private const string PermissionsClaimType = "permissions";
+    private static readonly string[] ReadPermissions = [PermissionNames.All, ReadAllPermission, ReadWorkflowInstancesPermission];
     private readonly IWorkflowInstanceStore? _workflowInstanceStore;
     private readonly ITenantAccessor? _tenantAccessor;
 
@@ -66,7 +67,7 @@ public class WorkflowInstanceHub : Hub<IWorkflowInstanceClient>
         if (user?.Identity?.IsAuthenticated != true)
             return false;
 
-        return user.FindAll(PermissionsClaimType).Any(x => x.Value is PermissionNames.All or ReadAllPermission or ReadWorkflowInstancesPermission);
+        return ReadPermissions.Any(user.HasPermission);
     }
 
     private bool TryGetRequiredServices([NotNullWhen(true)] out IWorkflowInstanceStore? workflowInstanceStore, out ITenantAccessor? tenantAccessor)

--- a/src/modules/Elsa.Workflows.Api/RealTime/Hubs/WorkflowInstanceHub.cs
+++ b/src/modules/Elsa.Workflows.Api/RealTime/Hubs/WorkflowInstanceHub.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using Elsa.Common.Multitenancy;
 using Elsa.Extensions;
 using Elsa.Workflows.Api.RealTime.Contracts;
@@ -9,7 +8,6 @@ using FastEndpoints.Security;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Elsa.Workflows.Api.RealTime.Hubs;
 
@@ -23,20 +21,14 @@ public class WorkflowInstanceHub : Hub<IWorkflowInstanceClient>
     private const string ReadWorkflowInstancesPermission = "read:workflow-instances";
     private const string ReadAllPermission = "read:*";
     private static readonly string[] ReadPermissions = [PermissionNames.All, ReadAllPermission, ReadWorkflowInstancesPermission];
-    private readonly IWorkflowInstanceStore? _workflowInstanceStore;
+    private readonly IWorkflowInstanceStore _workflowInstanceStore;
     private readonly ITenantAccessor? _tenantAccessor;
 
     /// <inheritdoc />
-    [ActivatorUtilitiesConstructor]
     public WorkflowInstanceHub(IWorkflowInstanceStore workflowInstanceStore, ITenantAccessor? tenantAccessor = null)
     {
         _workflowInstanceStore = workflowInstanceStore;
         _tenantAccessor = tenantAccessor;
-    }
-
-    /// <inheritdoc />
-    public WorkflowInstanceHub()
-    {
     }
     
     /// <summary>
@@ -48,16 +40,13 @@ public class WorkflowInstanceHub : Hub<IWorkflowInstanceClient>
         if (!CanReadWorkflowInstances())
             throw new HubException("Access denied.");
 
-        if (!TryGetRequiredServices(out var workflowInstanceStore, out var tenantAccessor))
-            throw new HubException("Access denied.");
+        var workflowInstance = await _workflowInstanceStore.FindAsync(new WorkflowInstanceFilter { Id = instanceId }, Context.ConnectionAborted);
 
-        var workflowInstance = await workflowInstanceStore.FindAsync(new WorkflowInstanceFilter { Id = instanceId }, Context.ConnectionAborted);
-
-        if (!CanAccessTenant(workflowInstance, tenantAccessor))
+        if (!CanAccessTenant(workflowInstance, _tenantAccessor))
             throw new HubException("Access denied.");
 
         // Join the user to the workflow instance group.
-        await Groups.AddToGroupAsync(Context.ConnectionId, instanceId);
+        await Groups.AddToGroupAsync(Context.ConnectionId, instanceId, Context.ConnectionAborted);
     }
 
     private bool CanReadWorkflowInstances()
@@ -70,15 +59,6 @@ public class WorkflowInstanceHub : Hub<IWorkflowInstanceClient>
         return ReadPermissions.Any(user.HasPermission);
     }
 
-    private bool TryGetRequiredServices([NotNullWhen(true)] out IWorkflowInstanceStore? workflowInstanceStore, out ITenantAccessor? tenantAccessor)
-    {
-        var services = Context.GetHttpContext()?.RequestServices;
-        workflowInstanceStore = _workflowInstanceStore ?? services?.GetService<IWorkflowInstanceStore>();
-        tenantAccessor = _tenantAccessor ?? services?.GetService<ITenantAccessor>();
-
-        return workflowInstanceStore != null;
-    }
-
     private static bool CanAccessTenant(WorkflowInstance? workflowInstance, ITenantAccessor? tenantAccessor)
     {
         if (workflowInstance == null)
@@ -88,7 +68,8 @@ public class WorkflowInstanceHub : Hub<IWorkflowInstanceClient>
             return true;
 
         var workflowInstanceTenantId = workflowInstance.TenantId.NormalizeTenantId();
+        var currentTenantId = tenantAccessor.TenantId.NormalizeTenantId();
 
-        return workflowInstanceTenantId == Tenant.AgnosticTenantId || workflowInstanceTenantId == tenantAccessor.TenantId;
+        return workflowInstanceTenantId == Tenant.AgnosticTenantId || workflowInstanceTenantId == currentTenantId;
     }
 }

--- a/src/modules/Elsa.Workflows.Api/RealTime/Hubs/WorkflowInstanceHub.cs
+++ b/src/modules/Elsa.Workflows.Api/RealTime/Hubs/WorkflowInstanceHub.cs
@@ -5,7 +5,6 @@ using Elsa.Workflows.Api.RealTime.Contracts;
 using Elsa.Workflows.Management;
 using Elsa.Workflows.Management.Entities;
 using Elsa.Workflows.Management.Filters;
-using Elsa.Workflows.Runtime;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
@@ -28,14 +27,14 @@ public class WorkflowInstanceHub : Hub<IWorkflowInstanceClient>
 
     /// <inheritdoc />
     [ActivatorUtilitiesConstructor]
-    public WorkflowInstanceHub(IWorkflowInstanceStore workflowInstanceStore, ITenantAccessor tenantAccessor)
+    public WorkflowInstanceHub(IWorkflowInstanceStore workflowInstanceStore, ITenantAccessor? tenantAccessor = null)
     {
         _workflowInstanceStore = workflowInstanceStore;
         _tenantAccessor = tenantAccessor;
     }
 
     /// <inheritdoc />
-    public WorkflowInstanceHub(IWorkflowRuntime workflowRuntime)
+    public WorkflowInstanceHub()
     {
     }
     
@@ -70,19 +69,22 @@ public class WorkflowInstanceHub : Hub<IWorkflowInstanceClient>
         return user.FindAll(PermissionsClaimType).Any(x => x.Value is PermissionNames.All or ReadAllPermission or ReadWorkflowInstancesPermission);
     }
 
-    private bool TryGetRequiredServices([NotNullWhen(true)] out IWorkflowInstanceStore? workflowInstanceStore, [NotNullWhen(true)] out ITenantAccessor? tenantAccessor)
+    private bool TryGetRequiredServices([NotNullWhen(true)] out IWorkflowInstanceStore? workflowInstanceStore, out ITenantAccessor? tenantAccessor)
     {
         var services = Context.GetHttpContext()?.RequestServices;
         workflowInstanceStore = _workflowInstanceStore ?? services?.GetService<IWorkflowInstanceStore>();
         tenantAccessor = _tenantAccessor ?? services?.GetService<ITenantAccessor>();
 
-        return workflowInstanceStore != null && tenantAccessor != null;
+        return workflowInstanceStore != null;
     }
 
-    private static bool CanAccessTenant(WorkflowInstance? workflowInstance, ITenantAccessor tenantAccessor)
+    private static bool CanAccessTenant(WorkflowInstance? workflowInstance, ITenantAccessor? tenantAccessor)
     {
         if (workflowInstance == null)
             return false;
+
+        if (tenantAccessor == null)
+            return true;
 
         var workflowInstanceTenantId = workflowInstance.TenantId.NormalizeTenantId();
 

--- a/src/modules/Elsa.Workflows.Api/RealTime/Hubs/WorkflowInstanceHub.cs
+++ b/src/modules/Elsa.Workflows.Api/RealTime/Hubs/WorkflowInstanceHub.cs
@@ -1,8 +1,15 @@
+using System.Diagnostics.CodeAnalysis;
+using Elsa.Common.Multitenancy;
+using Elsa.Extensions;
 using Elsa.Workflows.Api.RealTime.Contracts;
+using Elsa.Workflows.Management;
+using Elsa.Workflows.Management.Entities;
+using Elsa.Workflows.Management.Filters;
 using Elsa.Workflows.Runtime;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Elsa.Workflows.Api.RealTime.Hubs;
 
@@ -13,12 +20,23 @@ namespace Elsa.Workflows.Api.RealTime.Hubs;
 [Authorize]
 public class WorkflowInstanceHub : Hub<IWorkflowInstanceClient>
 {
-    private readonly IWorkflowRuntime _workflowRuntime;
+    private const string ReadWorkflowInstancesPermission = "read:workflow-instances";
+    private const string ReadAllPermission = "read:*";
+    private const string PermissionsClaimType = "permissions";
+    private readonly IWorkflowInstanceStore? _workflowInstanceStore;
+    private readonly ITenantAccessor? _tenantAccessor;
+
+    /// <inheritdoc />
+    [ActivatorUtilitiesConstructor]
+    public WorkflowInstanceHub(IWorkflowInstanceStore workflowInstanceStore, ITenantAccessor tenantAccessor)
+    {
+        _workflowInstanceStore = workflowInstanceStore;
+        _tenantAccessor = tenantAccessor;
+    }
 
     /// <inheritdoc />
     public WorkflowInstanceHub(IWorkflowRuntime workflowRuntime)
     {
-        _workflowRuntime = workflowRuntime;
     }
     
     /// <summary>
@@ -27,7 +45,47 @@ public class WorkflowInstanceHub : Hub<IWorkflowInstanceClient>
     /// <param name="instanceId">The ID of the workflow instance to observe.</param>
     public async Task ObserveInstanceAsync(string instanceId)
     {
+        if (!CanReadWorkflowInstances())
+            throw new HubException("Access denied.");
+
+        if (!TryGetRequiredServices(out var workflowInstanceStore, out var tenantAccessor))
+            throw new HubException("Access denied.");
+
+        var workflowInstance = await workflowInstanceStore.FindAsync(new WorkflowInstanceFilter { Id = instanceId }, Context.ConnectionAborted);
+
+        if (!CanAccessTenant(workflowInstance, tenantAccessor))
+            throw new HubException("Access denied.");
+
         // Join the user to the workflow instance group.
         await Groups.AddToGroupAsync(Context.ConnectionId, instanceId);
+    }
+
+    private bool CanReadWorkflowInstances()
+    {
+        var user = Context.User;
+
+        if (user?.Identity?.IsAuthenticated != true)
+            return false;
+
+        return user.FindAll(PermissionsClaimType).Any(x => x.Value is PermissionNames.All or ReadAllPermission or ReadWorkflowInstancesPermission);
+    }
+
+    private bool TryGetRequiredServices([NotNullWhen(true)] out IWorkflowInstanceStore? workflowInstanceStore, [NotNullWhen(true)] out ITenantAccessor? tenantAccessor)
+    {
+        var services = Context.GetHttpContext()?.RequestServices;
+        workflowInstanceStore = _workflowInstanceStore ?? services?.GetService<IWorkflowInstanceStore>();
+        tenantAccessor = _tenantAccessor ?? services?.GetService<ITenantAccessor>();
+
+        return workflowInstanceStore != null && tenantAccessor != null;
+    }
+
+    private static bool CanAccessTenant(WorkflowInstance? workflowInstance, ITenantAccessor tenantAccessor)
+    {
+        if (workflowInstance == null)
+            return false;
+
+        var workflowInstanceTenantId = workflowInstance.TenantId.NormalizeTenantId();
+
+        return workflowInstanceTenantId == Tenant.AgnosticTenantId || workflowInstanceTenantId == tenantAccessor.TenantId;
     }
 }

--- a/test/unit/Elsa.Workflows.Api.UnitTests/Elsa.Workflows.Api.UnitTests.csproj
+++ b/test/unit/Elsa.Workflows.Api.UnitTests/Elsa.Workflows.Api.UnitTests.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <Include>[Elsa.Workflows.Api]*</Include>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\src\common\Elsa.Testing.Shared\Elsa.Testing.Shared.csproj" />
+        <ProjectReference Include="..\..\..\src\modules\Elsa.Workflows.Api\Elsa.Workflows.Api.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/test/unit/Elsa.Workflows.Api.UnitTests/RealTime/Hubs/WorkflowInstanceHubTests.cs
+++ b/test/unit/Elsa.Workflows.Api.UnitTests/RealTime/Hubs/WorkflowInstanceHubTests.cs
@@ -24,10 +24,13 @@ public class WorkflowInstanceHubTests : IDisposable
     private readonly IGroupManager _groups;
     private readonly HubCallerContext _context;
     private readonly WorkflowInstanceHub _hub;
+    private readonly string _originalPermissionsClaimType;
+    private readonly CancellationTokenSource _connectionAbortedTokenSource = new();
     private WorkflowInstance? _workflowInstance;
 
     public WorkflowInstanceHubTests()
     {
+        _originalPermissionsClaimType = GetPermissionsClaimType();
         UsePermissionsClaimType("permissions");
         _workflowInstanceStore = Substitute.For<IWorkflowInstanceStore>();
         _tenantAccessor = Substitute.For<ITenantAccessor>();
@@ -42,14 +45,15 @@ public class WorkflowInstanceHubTests : IDisposable
 
         _tenantAccessor.TenantId.Returns(TenantId);
         _context.ConnectionId.Returns(ConnectionId);
-        _context.ConnectionAborted.Returns(CancellationToken.None);
+        _context.ConnectionAborted.Returns(_connectionAbortedTokenSource.Token);
         UseUser(ReadWorkflowInstancesPermission);
         StubWorkflowInstance();
     }
 
     public void Dispose()
     {
-        UsePermissionsClaimType("permissions");
+        UsePermissionsClaimType(_originalPermissionsClaimType);
+        _connectionAbortedTokenSource.Dispose();
     }
 
     [Fact]
@@ -57,7 +61,7 @@ public class WorkflowInstanceHubTests : IDisposable
     {
         await _hub.ObserveInstanceAsync(WorkflowInstanceId);
 
-        await _groups.Received(1).AddToGroupAsync(ConnectionId, WorkflowInstanceId, Arg.Any<CancellationToken>());
+        await _groups.Received(1).AddToGroupAsync(ConnectionId, WorkflowInstanceId, _connectionAbortedTokenSource.Token);
     }
 
     [Theory]
@@ -69,7 +73,7 @@ public class WorkflowInstanceHubTests : IDisposable
 
         await _hub.ObserveInstanceAsync(WorkflowInstanceId);
 
-        await _groups.Received(1).AddToGroupAsync(ConnectionId, WorkflowInstanceId, Arg.Any<CancellationToken>());
+        await _groups.Received(1).AddToGroupAsync(ConnectionId, WorkflowInstanceId, _connectionAbortedTokenSource.Token);
     }
 
     [Fact]
@@ -80,7 +84,7 @@ public class WorkflowInstanceHubTests : IDisposable
 
         await _hub.ObserveInstanceAsync(WorkflowInstanceId);
 
-        await _groups.Received(1).AddToGroupAsync(ConnectionId, WorkflowInstanceId, Arg.Any<CancellationToken>());
+        await _groups.Received(1).AddToGroupAsync(ConnectionId, WorkflowInstanceId, _connectionAbortedTokenSource.Token);
     }
 
     [Fact]
@@ -120,7 +124,7 @@ public class WorkflowInstanceHubTests : IDisposable
 
         await _hub.ObserveInstanceAsync(WorkflowInstanceId);
 
-        await _groups.Received(1).AddToGroupAsync(ConnectionId, WorkflowInstanceId, Arg.Any<CancellationToken>());
+        await _groups.Received(1).AddToGroupAsync(ConnectionId, WorkflowInstanceId, _connectionAbortedTokenSource.Token);
     }
 
     [Fact]
@@ -134,7 +138,18 @@ public class WorkflowInstanceHubTests : IDisposable
 
         await hub.ObserveInstanceAsync(WorkflowInstanceId);
 
-        await _groups.Received(1).AddToGroupAsync(ConnectionId, WorkflowInstanceId, Arg.Any<CancellationToken>());
+        await _groups.Received(1).AddToGroupAsync(ConnectionId, WorkflowInstanceId, _connectionAbortedTokenSource.Token);
+    }
+
+    [Fact]
+    public async Task ObserveInstanceAsync_WithNonCanonicalCurrentTenant_NormalizesBeforeComparing()
+    {
+        _tenantAccessor.TenantId.Returns(string.Empty);
+        UseWorkflowInstanceTenant(null);
+
+        await _hub.ObserveInstanceAsync(WorkflowInstanceId);
+
+        await _groups.Received(1).AddToGroupAsync(ConnectionId, WorkflowInstanceId, _connectionAbortedTokenSource.Token);
     }
 
     private void UseUser(params string[] permissions)
@@ -184,6 +199,12 @@ public class WorkflowInstanceHubTests : IDisposable
     {
         var property = typeof(SecurityOptions).GetProperty(nameof(SecurityOptions.PermissionsClaimType))!;
         property.SetValue(new Config().Security, claimType);
+    }
+
+    private static string GetPermissionsClaimType()
+    {
+        var property = typeof(SecurityOptions).GetProperty(nameof(SecurityOptions.PermissionsClaimType))!;
+        return (string)property.GetValue(new Config().Security)!;
     }
 }
 

--- a/test/unit/Elsa.Workflows.Api.UnitTests/RealTime/Hubs/WorkflowInstanceHubTests.cs
+++ b/test/unit/Elsa.Workflows.Api.UnitTests/RealTime/Hubs/WorkflowInstanceHubTests.cs
@@ -1,0 +1,141 @@
+using System.Security.Claims;
+using Elsa.Common.Multitenancy;
+using Elsa.Workflows.Api.RealTime.Hubs;
+using Elsa.Workflows.Management;
+using Elsa.Workflows.Management.Entities;
+using Elsa.Workflows.Management.Filters;
+using Microsoft.AspNetCore.SignalR;
+using NSubstitute;
+
+namespace Elsa.Workflows.Api.UnitTests.RealTime.Hubs;
+
+public class WorkflowInstanceHubTests
+{
+    private const string ConnectionId = "connection-1";
+    private const string WorkflowInstanceId = "workflow-instance-1";
+    private const string TenantId = "tenant-a";
+    private const string OtherTenantId = "tenant-b";
+    private const string ReadWorkflowInstancesPermission = "read:workflow-instances";
+    private readonly IWorkflowInstanceStore _workflowInstanceStore;
+    private readonly ITenantAccessor _tenantAccessor;
+    private readonly IGroupManager _groups;
+    private readonly HubCallerContext _context;
+    private readonly WorkflowInstanceHub _hub;
+    private WorkflowInstance? _workflowInstance;
+
+    public WorkflowInstanceHubTests()
+    {
+        _workflowInstanceStore = Substitute.For<IWorkflowInstanceStore>();
+        _tenantAccessor = Substitute.For<ITenantAccessor>();
+        _groups = Substitute.For<IGroupManager>();
+        _context = Substitute.For<HubCallerContext>();
+        _workflowInstance = CreateWorkflowInstance(TenantId);
+        _hub = new WorkflowInstanceHub(_workflowInstanceStore, _tenantAccessor)
+        {
+            Context = _context,
+            Groups = _groups
+        };
+
+        _tenantAccessor.TenantId.Returns(TenantId);
+        _context.ConnectionId.Returns(ConnectionId);
+        _context.ConnectionAborted.Returns(CancellationToken.None);
+        UseUser(ReadWorkflowInstancesPermission);
+        StubWorkflowInstance();
+    }
+
+    [Fact]
+    public async Task ObserveInstanceAsync_WithReadPermissionAndMatchingTenant_JoinsInstanceGroup()
+    {
+        await _hub.ObserveInstanceAsync(WorkflowInstanceId);
+
+        await _groups.Received(1).AddToGroupAsync(ConnectionId, WorkflowInstanceId, Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData("*")]
+    [InlineData("read:*")]
+    public async Task ObserveInstanceAsync_WithWildcardReadPermission_JoinsInstanceGroup(string permission)
+    {
+        UseUser(permission);
+
+        await _hub.ObserveInstanceAsync(WorkflowInstanceId);
+
+        await _groups.Received(1).AddToGroupAsync(ConnectionId, WorkflowInstanceId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ObserveInstanceAsync_WithoutReadPermission_DoesNotJoinInstanceGroup()
+    {
+        UseUser("write:workflow-instances");
+
+        await Assert.ThrowsAsync<HubException>(() => _hub.ObserveInstanceAsync(WorkflowInstanceId));
+
+        await _groups.DidNotReceive().AddToGroupAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ObserveInstanceAsync_WithDifferentTenant_DoesNotJoinInstanceGroup()
+    {
+        UseWorkflowInstanceTenant(OtherTenantId);
+
+        await Assert.ThrowsAsync<HubException>(() => _hub.ObserveInstanceAsync(WorkflowInstanceId));
+
+        await _groups.DidNotReceive().AddToGroupAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ObserveInstanceAsync_WhenInstanceIsNotVisible_DoesNotJoinInstanceGroup()
+    {
+        UseWorkflowInstance(null);
+
+        await Assert.ThrowsAsync<HubException>(() => _hub.ObserveInstanceAsync(WorkflowInstanceId));
+
+        await _groups.DidNotReceive().AddToGroupAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ObserveInstanceAsync_WithTenantAgnosticInstance_JoinsInstanceGroup()
+    {
+        UseWorkflowInstanceTenant(Tenant.AgnosticTenantId);
+
+        await _hub.ObserveInstanceAsync(WorkflowInstanceId);
+
+        await _groups.Received(1).AddToGroupAsync(ConnectionId, WorkflowInstanceId, Arg.Any<CancellationToken>());
+    }
+
+    private void UseUser(params string[] permissions)
+    {
+        var claims = permissions.Select(x => new Claim("permissions", x));
+        var identity = new ClaimsIdentity(claims, "Test");
+        _context.User.Returns(new ClaimsPrincipal(identity));
+    }
+
+    private void UseWorkflowInstanceTenant(string? tenantId)
+    {
+        UseWorkflowInstance(CreateWorkflowInstance(tenantId));
+    }
+
+    private void UseWorkflowInstance(WorkflowInstance? workflowInstance)
+    {
+        _workflowInstance = workflowInstance;
+        StubWorkflowInstance();
+    }
+
+    private void StubWorkflowInstance()
+    {
+        _workflowInstanceStore
+            .FindAsync(Arg.Is<WorkflowInstanceFilter>(x => x.Id == WorkflowInstanceId), Arg.Any<CancellationToken>())
+            .Returns(_ => new ValueTask<WorkflowInstance?>(_workflowInstance));
+    }
+
+    private static WorkflowInstance CreateWorkflowInstance(string? tenantId)
+    {
+        return new()
+        {
+            Id = WorkflowInstanceId,
+            TenantId = tenantId,
+            DefinitionId = "definition-1",
+            DefinitionVersionId = "definition-version-1"
+        };
+    }
+}

--- a/test/unit/Elsa.Workflows.Api.UnitTests/RealTime/Hubs/WorkflowInstanceHubTests.cs
+++ b/test/unit/Elsa.Workflows.Api.UnitTests/RealTime/Hubs/WorkflowInstanceHubTests.cs
@@ -103,6 +103,20 @@ public class WorkflowInstanceHubTests
         await _groups.Received(1).AddToGroupAsync(ConnectionId, WorkflowInstanceId, Arg.Any<CancellationToken>());
     }
 
+    [Fact]
+    public async Task ObserveInstanceAsync_WithoutTenantAccessor_JoinsVisibleInstanceGroup()
+    {
+        var hub = new WorkflowInstanceHub(_workflowInstanceStore)
+        {
+            Context = _context,
+            Groups = _groups
+        };
+
+        await hub.ObserveInstanceAsync(WorkflowInstanceId);
+
+        await _groups.Received(1).AddToGroupAsync(ConnectionId, WorkflowInstanceId, Arg.Any<CancellationToken>());
+    }
+
     private void UseUser(params string[] permissions)
     {
         var claims = permissions.Select(x => new Claim("permissions", x));

--- a/test/unit/Elsa.Workflows.Api.UnitTests/RealTime/Hubs/WorkflowInstanceHubTests.cs
+++ b/test/unit/Elsa.Workflows.Api.UnitTests/RealTime/Hubs/WorkflowInstanceHubTests.cs
@@ -4,18 +4,21 @@ using Elsa.Workflows.Api.RealTime.Hubs;
 using Elsa.Workflows.Management;
 using Elsa.Workflows.Management.Entities;
 using Elsa.Workflows.Management.Filters;
+using FastEndpoints;
 using Microsoft.AspNetCore.SignalR;
 using NSubstitute;
 
 namespace Elsa.Workflows.Api.UnitTests.RealTime.Hubs;
 
-public class WorkflowInstanceHubTests
+[Collection(nameof(WorkflowInstanceHubTestsCollection))]
+public class WorkflowInstanceHubTests : IDisposable
 {
     private const string ConnectionId = "connection-1";
     private const string WorkflowInstanceId = "workflow-instance-1";
     private const string TenantId = "tenant-a";
     private const string OtherTenantId = "tenant-b";
     private const string ReadWorkflowInstancesPermission = "read:workflow-instances";
+    private const string CustomPermissionsClaimType = "elsa-permissions";
     private readonly IWorkflowInstanceStore _workflowInstanceStore;
     private readonly ITenantAccessor _tenantAccessor;
     private readonly IGroupManager _groups;
@@ -25,6 +28,7 @@ public class WorkflowInstanceHubTests
 
     public WorkflowInstanceHubTests()
     {
+        UsePermissionsClaimType("permissions");
         _workflowInstanceStore = Substitute.For<IWorkflowInstanceStore>();
         _tenantAccessor = Substitute.For<ITenantAccessor>();
         _groups = Substitute.For<IGroupManager>();
@@ -43,6 +47,11 @@ public class WorkflowInstanceHubTests
         StubWorkflowInstance();
     }
 
+    public void Dispose()
+    {
+        UsePermissionsClaimType("permissions");
+    }
+
     [Fact]
     public async Task ObserveInstanceAsync_WithReadPermissionAndMatchingTenant_JoinsInstanceGroup()
     {
@@ -57,6 +66,17 @@ public class WorkflowInstanceHubTests
     public async Task ObserveInstanceAsync_WithWildcardReadPermission_JoinsInstanceGroup(string permission)
     {
         UseUser(permission);
+
+        await _hub.ObserveInstanceAsync(WorkflowInstanceId);
+
+        await _groups.Received(1).AddToGroupAsync(ConnectionId, WorkflowInstanceId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ObserveInstanceAsync_UsesConfiguredFastEndpointsPermissionClaimType()
+    {
+        UsePermissionsClaimType(CustomPermissionsClaimType);
+        UseUserClaim(CustomPermissionsClaimType, ReadWorkflowInstancesPermission);
 
         await _hub.ObserveInstanceAsync(WorkflowInstanceId);
 
@@ -124,6 +144,13 @@ public class WorkflowInstanceHubTests
         _context.User.Returns(new ClaimsPrincipal(identity));
     }
 
+    private void UseUserClaim(string claimType, params string[] permissions)
+    {
+        var claims = permissions.Select(x => new Claim(claimType, x));
+        var identity = new ClaimsIdentity(claims, "Test");
+        _context.User.Returns(new ClaimsPrincipal(identity));
+    }
+
     private void UseWorkflowInstanceTenant(string? tenantId)
     {
         UseWorkflowInstance(CreateWorkflowInstance(tenantId));
@@ -152,4 +179,13 @@ public class WorkflowInstanceHubTests
             DefinitionVersionId = "definition-version-1"
         };
     }
+
+    private static void UsePermissionsClaimType(string claimType)
+    {
+        var property = typeof(SecurityOptions).GetProperty(nameof(SecurityOptions.PermissionsClaimType))!;
+        property.SetValue(new Config().Security, claimType);
+    }
 }
+
+[CollectionDefinition(nameof(WorkflowInstanceHubTestsCollection), DisableParallelization = true)]
+public class WorkflowInstanceHubTestsCollection;


### PR DESCRIPTION
Fixes #7483

## Summary
- authorize SignalR workflow instance observation before joining instance groups
- enforce workflow instance visibility checks through existing workflow API patterns
- add unit coverage for authorized, unauthorized, and missing instance paths

## Validation
- dotnet test test/unit/Elsa.Workflows.Api.UnitTests/Elsa.Workflows.Api.UnitTests.csproj
- dotnet build src/modules/Elsa.Workflows.Api/Elsa.Workflows.Api.csproj
- git diff --check