### PR TITLE
Chore: Update Jint, Rebus and their dependencies to latest versions + Swashbuckle .net10 bugfix

### DIFF
--- a/src/activities/Elsa.Activities.Http.OpenApi/Elsa.Activities.Http.OpenApi.csproj
+++ b/src/activities/Elsa.Activities.Http.OpenApi/Elsa.Activities.Http.OpenApi.csproj
@@ -19,17 +19,22 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.3.0" />
-    </ItemGroup>
-
-    <ItemGroup>
       <ProjectReference Include="..\Elsa.Activities.Http\Elsa.Activities.Http.csproj" />
     </ItemGroup>
 
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0'">
+        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.3.0" />
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0'">
+        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.3.0" />
+    </ItemGroup>
+
     <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0'">
-        <PackageReference Include="System.Linq.Async" Version="6.0.1">
-            <ExcludeAssets>compile</ExcludeAssets>
-        </PackageReference>
+      <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.1.7" />
+      <PackageReference Include="System.Linq.Async" Version="6.0.1">
+          <ExcludeAssets>compile</ExcludeAssets>
+      </PackageReference>
     </ItemGroup>
 
 

--- a/src/activities/Elsa.Activities.Http.OpenApi/Elsa.Activities.Http.OpenApi.csproj
+++ b/src/activities/Elsa.Activities.Http.OpenApi/Elsa.Activities.Http.OpenApi.csproj
@@ -31,7 +31,7 @@
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0'">
-      <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.1.7" />
+      <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.2.3" />
       <PackageReference Include="System.Linq.Async" Version="6.0.1">
           <ExcludeAssets>compile</ExcludeAssets>
       </PackageReference>

--- a/src/activities/Elsa.Activities.Http.OpenApi/HttpEndpointDocumentFilter.cs
+++ b/src/activities/Elsa.Activities.Http.OpenApi/HttpEndpointDocumentFilter.cs
@@ -1,4 +1,4 @@
-﻿using System.Runtime.CompilerServices;
+using System.Runtime.CompilerServices;
 using Elsa.Activities.Http.Bookmarks;
 using Elsa.Activities.Http.Options;
 using Elsa.Models;
@@ -7,7 +7,11 @@ using Elsa.Services.Models;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+#if NET10_0_OR_GREATER
+using Microsoft.OpenApi;
+#else
 using Microsoft.OpenApi.Models;
+#endif
 using Open.Linq.AsyncExtensions;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
@@ -31,12 +35,16 @@ public class HttpEndpointDocumentFilter : IDocumentFilter
 
     public void Apply(OpenApiDocument swaggerDoc, DocumentFilterContext context)
     {
+#if NET10_0_OR_GREATER
+        swaggerDoc.Tags ??= new HashSet<OpenApiTag>();
+#else
         swaggerDoc.Tags ??= new List<OpenApiTag>();
+#endif
 
         var tag = new OpenApiTag
         {
             Name = "Workflow Endpoints",
-            Description = "A collection of HTTP endpoints exposed by workflows",
+            Description = "A collection of HTTP endpoints exposed by workflows"
         };
 
         var schemaRepository = context.SchemaRepository;
@@ -55,17 +63,21 @@ public class HttpEndpointDocumentFilter : IDocumentFilter
                 Description = first.Description,
                 Operations = grouping.ToDictionary(GetOperationType, httpEndpoint =>
                 {
-                    var operation = new OpenApiOperation
-                    {
-                        Tags = { tag },
-                    };
+                    var operation = new OpenApiOperation();
 
-                    if (httpEndpoint.TargetType != null || httpEndpoint.JsonSchema != null)
+#if NET10_0_OR_GREATER
+                    operation.Tags ??= new HashSet<OpenApiTagReference>();
+                    operation.Tags.Add(new OpenApiTagReference(tag.Name, swaggerDoc));
+#else
+                    operation.Tags.Add(tag);
+#endif
+
+                    if (httpEndpoint.TargetType != null || !string.IsNullOrWhiteSpace(httpEndpoint.JsonSchema))
                     {
                         operation.RequestBody = new OpenApiRequestBody
                         {
                             Required = true,
-                            Content =
+                            Content = new Dictionary<string, OpenApiMediaType>
                             {
                                 ["Unspecified"] = new OpenApiMediaType
                                 {
@@ -126,6 +138,21 @@ public class HttpEndpointDocumentFilter : IDocumentFilter
         return new HttpEndpointDescriptor(activityId, path, method, displayName, description, targetType, schema);
     }
 
+#if NET10_0_OR_GREATER
+    private HttpMethod GetOperationType(HttpEndpointDescriptor httpEndpoint) =>
+        httpEndpoint.Method switch
+        {
+            { } s when s.Equals(HttpMethods.Get, StringComparison.OrdinalIgnoreCase) => HttpMethod.Get,
+            { } s when s.Equals(HttpMethods.Post, StringComparison.OrdinalIgnoreCase) => HttpMethod.Post,
+            { } s when s.Equals(HttpMethods.Patch, StringComparison.OrdinalIgnoreCase) => HttpMethod.Patch,
+            { } s when s.Equals(HttpMethods.Delete, StringComparison.OrdinalIgnoreCase) => HttpMethod.Delete,
+            { } s when s.Equals(HttpMethods.Put, StringComparison.OrdinalIgnoreCase) => HttpMethod.Put,
+            { } s when s.Equals(HttpMethods.Options, StringComparison.OrdinalIgnoreCase) => HttpMethod.Options,
+            { } s when s.Equals(HttpMethods.Head, StringComparison.OrdinalIgnoreCase) => HttpMethod.Head,
+            { } s when s.Equals(HttpMethods.Trace, StringComparison.OrdinalIgnoreCase) => HttpMethod.Trace,
+            _ => HttpMethod.Get
+        };
+#else
     private OperationType GetOperationType(HttpEndpointDescriptor httpEndpoint) =>
         httpEndpoint.Method switch
         {
@@ -133,12 +160,13 @@ public class HttpEndpointDocumentFilter : IDocumentFilter
             { } s when s.Equals(HttpMethods.Post, StringComparison.OrdinalIgnoreCase) => OperationType.Post,
             { } s when s.Equals(HttpMethods.Patch, StringComparison.OrdinalIgnoreCase) => OperationType.Patch,
             { } s when s.Equals(HttpMethods.Delete, StringComparison.OrdinalIgnoreCase) => OperationType.Delete,
-            { } s when s.Equals(HttpMethods.Put, StringComparison.OrdinalIgnoreCase) => OperationType.Patch,
+            { } s when s.Equals(HttpMethods.Put, StringComparison.OrdinalIgnoreCase) => OperationType.Put,
             { } s when s.Equals(HttpMethods.Options, StringComparison.OrdinalIgnoreCase) => OperationType.Options,
             { } s when s.Equals(HttpMethods.Head, StringComparison.OrdinalIgnoreCase) => OperationType.Head,
             { } s when s.Equals(HttpMethods.Trace, StringComparison.OrdinalIgnoreCase) => OperationType.Trace,
             _ => OperationType.Get
         };
+#endif
 }
 
 internal record HttpEndpointDescriptor(string Id, string Path, string Method, string? DisplayName, string? Description, Type? TargetType, string? JsonSchema);

--- a/src/activities/Elsa.Activities.Telnyx/Elsa.Activities.Telnyx.csproj
+++ b/src/activities/Elsa.Activities.Telnyx/Elsa.Activities.Telnyx.csproj
@@ -28,7 +28,7 @@
         <PackageReference Include="Refit" Version="8.0.0" />
         <PackageReference Include="Refit.HttpClientFactory" Version="6.0.94" />
         <PackageReference Include="Refit.Newtonsoft.Json" Version="6.0.94" />
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0'">

--- a/src/activities/Elsa.Activities.Temporal.Quartz/Elsa.Activities.Temporal.Quartz.csproj
+++ b/src/activities/Elsa.Activities.Temporal.Quartz/Elsa.Activities.Temporal.Quartz.csproj
@@ -12,7 +12,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.16" />
         <PackageReference Include="Quartz" Version="3.5.0" />
         <PackageReference Include="Quartz.Extensions.DependencyInjection" Version="3.5.0" />
         <PackageReference Include="Quartz.Extensions.Hosting" Version="3.5.0" />

--- a/src/activities/webhooks/Elsa.Activities.Webhooks/Elsa.Activities.Webhooks.csproj
+++ b/src/activities/webhooks/Elsa.Activities.Webhooks/Elsa.Activities.Webhooks.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <Import Project="..\..\..\..\common.props" />
     <Import Project="..\..\..\..\configureawait.props" />
@@ -13,8 +13,8 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/clients/Elsa.Client/Elsa.Client.csproj
+++ b/src/clients/Elsa.Client/Elsa.Client.csproj
@@ -13,7 +13,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="NodaTime" Version="3.0.9" />
         <PackageReference Include="NodaTime.Serialization.JsonNet" Version="3.0.0" />
         <PackageReference Include="Refit" Version="8.0.0" />

--- a/src/core/Elsa.Abstractions/Elsa.Abstractions.csproj
+++ b/src/core/Elsa.Abstractions/Elsa.Abstractions.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <Import Project="..\..\..\common.props" />
     <Import Project="..\..\..\configureawait.props" />
@@ -18,17 +18,18 @@
         <PackageReference Include="LinqKit.Core" Version="1.2.5" />
         <PackageReference Include="MediatR" Version="12.4.1" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.1" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.16" />
         <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="8.0.1" />
         <PackageReference Include="Microsoft.Extensions.Primitives" Version="6.0.0" />
         <PackageReference Include="NodaTime" Version="3.0.9" />
         <PackageReference Include="NodaTime.Serialization.JsonNet" Version="3.0.0" />
         <PackageReference Include="Open.Linq.AsyncExtensions" Version="1.2.0" />
-        <PackageReference Include="Rebus" Version="8.7.1" />
+        <PackageReference Include="Rebus" Version="8.9.2" />
         <PackageReference Include="System.Linq.Async" Version="5.1.0" />
-        <PackageReference Include="System.Text.Json" Version="9.0.1" />
-        <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
+        <PackageReference Include="System.Text.Json" Version="10.0.8" />
+        <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
     </ItemGroup>
 
 </Project>

--- a/src/core/Elsa.Core/Elsa.Core.csproj
+++ b/src/core/Elsa.Core/Elsa.Core.csproj
@@ -23,12 +23,11 @@
         <PackageReference Include="MediatR" Version="12.4.1" />
         <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="9.0.1" />
         <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.1" />
         <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
         <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.0" />
         <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16" />
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.1" />
         <PackageReference Include="Microsoft.Extensions.Localization" Version="9.0.1" />
         <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
@@ -36,8 +35,8 @@
         <PackageReference Include="netbox" Version="2.5.3" />
         <PackageReference Include="NodaTime.Serialization.JsonNet" Version="3.0.0" />
         <PackageReference Include="Open.Linq.AsyncExtensions" Version="1.2.0" />
-        <PackageReference Include="Rebus.Microsoft.Extensions.Logging" Version="5.1.0" />
-        <PackageReference Include="Rebus.ServiceProvider" Version="10.3.0" />
+        <PackageReference Include="Rebus.Microsoft.Extensions.Logging" Version="5.2.0" />
+        <PackageReference Include="Rebus.ServiceProvider" Version="10.7.2" />
         <PackageReference Include="Scrutor" Version="3.3.0" />
         <PackageReference Include="System.Linq.Async" Version="5.1.0" />
         <PackageReference Include="System.Threading.Channels" Version="9.0.0" />

--- a/src/core/Elsa/Elsa.csproj
+++ b/src/core/Elsa/Elsa.csproj
@@ -20,7 +20,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
+      <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.16" />
     </ItemGroup>
 
 </Project>

--- a/src/designer/elsa-workflows-studio/src/globals/tailwind.css
+++ b/src/designer/elsa-workflows-studio/src/globals/tailwind.css
@@ -2510,6 +2510,10 @@ select {
   left: 0.5rem;
 }
 
+.elsa-top-10 {
+  top: 2.5rem;
+}
+
 .elsa-bottom-10 {
   bottom: 2.5rem;
 }
@@ -2653,12 +2657,16 @@ select {
   margin-top: 4rem;
 }
 
-.elsa--mt-2 {
-  margin-top: -0.5rem;
-}
-
 .elsa-mb-2 {
   margin-bottom: 0.5rem;
+}
+
+.-elsa-mr-1 {
+  margin-right: -0.25rem;
+}
+
+.elsa--mt-2 {
+  margin-top: -0.5rem;
 }
 
 .-elsa-ml-0\.5 {
@@ -2675,10 +2683,6 @@ select {
 
 .elsa-ml-0 {
   margin-left: 0px;
-}
-
-.-elsa-mr-1 {
-  margin-right: -0.25rem;
 }
 
 .elsa-ml-3\.5 {
@@ -12427,10 +12431,6 @@ svg.jtk-connector.jtk-hover path {
 
   .sm\:elsa-w-full {
     width: 100%;
-  }
-
-  .sm\:elsa-max-w-4xl {
-    max-width: 56rem;
   }
 
   .sm\:elsa-max-w-md {

--- a/src/indexing/Elsa.Indexing.Elasticsearch/Elsa.Indexing.Elasticsearch.csproj
+++ b/src/indexing/Elsa.Indexing.Elasticsearch/Elsa.Indexing.Elasticsearch.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
     <Import Project="..\..\..\common.props" />
     <Import Project="..\..\..\configureawait.props" />
     
@@ -18,7 +18,7 @@
 
     <ItemGroup>
       <PackageReference Include="NEST" Version="7.14.1" />
-      <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+      <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
 </Project>

--- a/src/modules/secrets/Elsa.Secrets.Api/Endpoints/OAuth2/Callback.cs
+++ b/src/modules/secrets/Elsa.Secrets.Api/Endpoints/OAuth2/Callback.cs
@@ -1,11 +1,12 @@
-using System.Threading;
-using System.Threading.Tasks;
 using Elsa.Secrets.Extensions;
 using Elsa.Secrets.Http.Services;
 using Elsa.Secrets.Manager;
 using Elsa.Secrets.Persistence;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Elsa.Secrets.Api.Endpoints.OAuth2
 {
@@ -13,6 +14,7 @@ namespace Elsa.Secrets.Api.Endpoints.OAuth2
     [ApiVersion("1")]
     [Route("v{apiVersion:apiVersion}/oauth2/callback")]
     [Produces("application/json")]
+    [Tags("Secrets")]
     public class SetAuthCodeCallback : Controller
     {
         private readonly ISecretsManager _secretsManager;

--- a/src/modules/secrets/Elsa.Secrets.Api/Endpoints/OAuth2/GetUrl.cs
+++ b/src/modules/secrets/Elsa.Secrets.Api/Endpoints/OAuth2/GetUrl.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Net.Mime;
 using System.Threading;
@@ -16,6 +16,7 @@ namespace Elsa.Secrets.Api.Endpoints.OAuth2;
 [ApiVersion("1")]
 [Route("v{apiVersion:apiVersion}/oauth2/url/{secretId}")]
 [Produces(MediaTypeNames.Application.Json)]
+[Tags("Secrets")]
 public class GetUrl : Controller
 {
 	private readonly ISecretsManager _secretsManager;

--- a/src/modules/secrets/Elsa.Secrets.Api/Endpoints/Secrets/Delete.cs
+++ b/src/modules/secrets/Elsa.Secrets.Api/Endpoints/Secrets/Delete.cs
@@ -11,6 +11,7 @@ namespace Elsa.Secrets.Api.Endpoints.Secrets
     [ApiVersion("1")]
     [Route("v{apiVersion:apiVersion}/secrets/{id}")]
     [Produces("application/json")]
+    [Tags("Secrets")]
     public class Delete : Controller
     {
         private readonly ISecretsStore _secretsStore;

--- a/src/modules/secrets/Elsa.Secrets.Api/Endpoints/Secrets/List.cs
+++ b/src/modules/secrets/Elsa.Secrets.Api/Endpoints/Secrets/List.cs
@@ -15,6 +15,7 @@ namespace Elsa.Secrets.Api.Endpoints.Secrets
     [ApiVersion("1")]
     [Route("v{apiVersion:apiVersion}/secrets")]
     [Produces(MediaTypeNames.Application.Json)]
+    [Tags("Secrets")]
     public class List : Controller
     {
         private readonly ISecretsManager _secretsManager;

--- a/src/modules/secrets/Elsa.Secrets.Api/Endpoints/Secrets/Save.cs
+++ b/src/modules/secrets/Elsa.Secrets.Api/Endpoints/Secrets/Save.cs
@@ -1,10 +1,11 @@
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Elsa.Secrets.Api.Models;
 using Elsa.Secrets.Manager;
 using Elsa.Secrets.Models;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Elsa.Secrets.Api.Endpoints.Secrets
 {
@@ -12,6 +13,7 @@ namespace Elsa.Secrets.Api.Endpoints.Secrets
     [ApiVersion("1")]
     [Route("v{apiVersion:apiVersion}/secrets")]
     [Produces("application/json")]
+    [Tags("Secrets")]
     public class Save : Controller
     {
         private readonly ISecretsManager _secretsManager;

--- a/src/modules/secrets/Elsa.Secrets.Http/Elsa.Secrets.Http.csproj
+++ b/src/modules/secrets/Elsa.Secrets.Http/Elsa.Secrets.Http.csproj
@@ -12,7 +12,7 @@
     </PropertyGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0'">
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.1" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.16" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0'">

--- a/src/modules/secrets/Elsa.Secrets.Sql/Elsa.Secrets.Sql.csproj
+++ b/src/modules/secrets/Elsa.Secrets.Sql/Elsa.Secrets.Sql.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient" Version="3.1.7" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.16" />
     <PackageReference Include="Npgsql" Version="6.0.11" />
   </ItemGroup>
 

--- a/src/modules/secrets/Elsa.Secrets/Elsa.Secrets.csproj
+++ b/src/modules/secrets/Elsa.Secrets/Elsa.Secrets.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.16" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/modules/workflowsettings/Elsa.WorkflowSettings/Elsa.WorkflowSettings.csproj
+++ b/src/modules/workflowsettings/Elsa.WorkflowSettings/Elsa.WorkflowSettings.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <Import Project="..\..\..\..\common.props" />
     <Import Project="..\..\..\..\configureawait.props" />
@@ -13,7 +13,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/aspnet/Elsa.Samples.ContextualWorkflowHttp/Elsa.Samples.ContextualWorkflowHttp.csproj
+++ b/src/samples/aspnet/Elsa.Samples.ContextualWorkflowHttp/Elsa.Samples.ContextualWorkflowHttp.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/aspnet/Elsa.Samples.CorrelationHttp/Elsa.Samples.CorrelationHttp.csproj
+++ b/src/samples/aspnet/Elsa.Samples.CorrelationHttp/Elsa.Samples.CorrelationHttp.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/aspnet/Elsa.Samples.CustomActivities/Elsa.Samples.CustomActivities.csproj
+++ b/src/samples/aspnet/Elsa.Samples.CustomActivities/Elsa.Samples.CustomActivities.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/aspnet/Elsa.Samples.DocumentApproval/Elsa.Samples.DocumentApproval.csproj
+++ b/src/samples/aspnet/Elsa.Samples.DocumentApproval/Elsa.Samples.DocumentApproval.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/aspnet/Elsa.Samples.ExtendHttpEndpoint/Elsa.Samples.ExtendHttpEndpoint.csproj
+++ b/src/samples/aspnet/Elsa.Samples.ExtendHttpEndpoint/Elsa.Samples.ExtendHttpEndpoint.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/aspnet/Elsa.Samples.FaultyWorkflows/Elsa.Samples.FaultyWorkflows.csproj
+++ b/src/samples/aspnet/Elsa.Samples.FaultyWorkflows/Elsa.Samples.FaultyWorkflows.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/aspnet/Elsa.Samples.ForkJoinTimerAndSignalHttp/Elsa.Samples.ForkJoinTimerAndSignalHttp.csproj
+++ b/src/samples/aspnet/Elsa.Samples.ForkJoinTimerAndSignalHttp/Elsa.Samples.ForkJoinTimerAndSignalHttp.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -6,7 +6,7 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/aspnet/Elsa.Samples.HelloWorldHttp/Elsa.Samples.HelloWorldHttp.csproj
+++ b/src/samples/aspnet/Elsa.Samples.HelloWorldHttp/Elsa.Samples.HelloWorldHttp.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/aspnet/Elsa.Samples.HttpEndpointSecurity/Elsa.Samples.HttpEndpointSecurity.csproj
+++ b/src/samples/aspnet/Elsa.Samples.HttpEndpointSecurity/Elsa.Samples.HttpEndpointSecurity.csproj
@@ -1,12 +1,12 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
     </PropertyGroup>
     
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.16" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/aspnet/Elsa.Samples.InfiniteLoopDetection/Elsa.Samples.InfiniteLoopDetection.csproj
+++ b/src/samples/aspnet/Elsa.Samples.InfiniteLoopDetection/Elsa.Samples.InfiniteLoopDetection.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/aspnet/Elsa.Samples.Interrupts/Elsa.Samples.Interrupts.csproj
+++ b/src/samples/aspnet/Elsa.Samples.Interrupts/Elsa.Samples.Interrupts.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/aspnet/Elsa.Samples.InvokeWorkflowFromController/Elsa.Samples.InvokeWorkflowFromController.csproj
+++ b/src/samples/aspnet/Elsa.Samples.InvokeWorkflowFromController/Elsa.Samples.InvokeWorkflowFromController.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/aspnet/Elsa.Samples.MassTransitRabbitMq/Elsa.Samples.MassTransitRabbitMq.csproj
+++ b/src/samples/aspnet/Elsa.Samples.MassTransitRabbitMq/Elsa.Samples.MassTransitRabbitMq.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -14,7 +14,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+      <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
 </Project>

--- a/src/samples/aspnet/Elsa.Samples.NestedForks/Elsa.Samples.NestedForks.csproj
+++ b/src/samples/aspnet/Elsa.Samples.NestedForks/Elsa.Samples.NestedForks.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/aspnet/Elsa.Samples.ReadModelHttp/Elsa.Samples.ReadModelHttp.csproj
+++ b/src/samples/aspnet/Elsa.Samples.ReadModelHttp/Elsa.Samples.ReadModelHttp.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/aspnet/Elsa.Samples.SendHttp/Elsa.Samples.SendHttp.csproj
+++ b/src/samples/aspnet/Elsa.Samples.SendHttp/Elsa.Samples.SendHttp.csproj
@@ -1,11 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/samples/aspnet/Elsa.Samples.SignalApi/Elsa.Samples.SignalApi.csproj
+++ b/src/samples/aspnet/Elsa.Samples.SignalApi/Elsa.Samples.SignalApi.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/aspnet/Elsa.Samples.UniqueCorrelatedWorkflows/Elsa.Samples.UniqueCorrelatedWorkflows.csproj
+++ b/src/samples/aspnet/Elsa.Samples.UniqueCorrelatedWorkflows/Elsa.Samples.UniqueCorrelatedWorkflows.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/console/Elsa.Samples.BuildAndDispatchConsole/Elsa.Samples.BuildAndDispatchConsole.csproj
+++ b/src/samples/console/Elsa.Samples.BuildAndDispatchConsole/Elsa.Samples.BuildAndDispatchConsole.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/console/Elsa.Samples.CompensationConsole/Elsa.Samples.CompensationConsole.csproj
+++ b/src/samples/console/Elsa.Samples.CompensationConsole/Elsa.Samples.CompensationConsole.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/console/Elsa.Samples.CustomActivityOutcomes/Elsa.Samples.CustomActivityOutcomes.csproj
+++ b/src/samples/console/Elsa.Samples.CustomActivityOutcomes/Elsa.Samples.CustomActivityOutcomes.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/console/Elsa.Samples.CustomOutcomeActivityConsole/Elsa.Samples.CustomOutcomeActivityConsole.csproj
+++ b/src/samples/console/Elsa.Samples.CustomOutcomeActivityConsole/Elsa.Samples.CustomOutcomeActivityConsole.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/console/Elsa.Samples.DeclarativeCompositeActivitiesConsole/Elsa.Samples.DeclarativeCompositeActivitiesConsole.csproj
+++ b/src/samples/console/Elsa.Samples.DeclarativeCompositeActivitiesConsole/Elsa.Samples.DeclarativeCompositeActivitiesConsole.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/console/Elsa.Samples.Elasticsearch/Elsa.Samples.Elasticsearch.csproj
+++ b/src/samples/console/Elsa.Samples.Elasticsearch/Elsa.Samples.Elasticsearch.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/console/Elsa.Samples.EntityChanged/Elsa.Samples.EntityChanged.csproj
+++ b/src/samples/console/Elsa.Samples.EntityChanged/Elsa.Samples.EntityChanged.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -8,8 +8,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/console/Elsa.Samples.FileBasedWorkflow/Elsa.Samples.FileBasedWorkflow.csproj
+++ b/src/samples/console/Elsa.Samples.FileBasedWorkflow/Elsa.Samples.FileBasedWorkflow.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/console/Elsa.Samples.ForEachLoopConsole/Elsa.Samples.ForEachLoopConsole.csproj
+++ b/src/samples/console/Elsa.Samples.ForEachLoopConsole/Elsa.Samples.ForEachLoopConsole.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/console/Elsa.Samples.ForLoopConsole/Elsa.Samples.ForLoopConsole.csproj
+++ b/src/samples/console/Elsa.Samples.ForLoopConsole/Elsa.Samples.ForLoopConsole.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/console/Elsa.Samples.Forks/Elsa.Samples.Forks.csproj
+++ b/src/samples/console/Elsa.Samples.Forks/Elsa.Samples.Forks.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/console/Elsa.Samples.HappinessConsole/Elsa.Samples.HappinessConsole.csproj
+++ b/src/samples/console/Elsa.Samples.HappinessConsole/Elsa.Samples.HappinessConsole.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -8,8 +8,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/console/Elsa.Samples.HelloWorldConsole/Elsa.Samples.HelloWorldConsole.csproj
+++ b/src/samples/console/Elsa.Samples.HelloWorldConsole/Elsa.Samples.HelloWorldConsole.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/console/Elsa.Samples.IfThenElse/Elsa.Samples.IfThenElse.csproj
+++ b/src/samples/console/Elsa.Samples.IfThenElse/Elsa.Samples.IfThenElse.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/console/Elsa.Samples.ProgrammaticCompositeActivitiesConsole/Elsa.Samples.ProgrammaticCompositeActivitiesConsole.csproj
+++ b/src/samples/console/Elsa.Samples.ProgrammaticCompositeActivitiesConsole/Elsa.Samples.ProgrammaticCompositeActivitiesConsole.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -7,9 +7,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.16" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/console/Elsa.Samples.ReadLineEchoConsole/Elsa.Samples.ReadLineEchoConsole.csproj
+++ b/src/samples/console/Elsa.Samples.ReadLineEchoConsole/Elsa.Samples.ReadLineEchoConsole.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/console/Elsa.Samples.ReadLineToFile/Elsa.Samples.ReadLineToFile.csproj
+++ b/src/samples/console/Elsa.Samples.ReadLineToFile/Elsa.Samples.ReadLineToFile.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/console/Elsa.Samples.RpaWebConsole/Elsa.Samples.RpaWebConsole.csproj
+++ b/src/samples/console/Elsa.Samples.RpaWebConsole/Elsa.Samples.RpaWebConsole.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/console/Elsa.Samples.Serialization/Elsa.Samples.Serialization.csproj
+++ b/src/samples/console/Elsa.Samples.Serialization/Elsa.Samples.Serialization.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.16" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/console/Elsa.Samples.SignalingConsole/Elsa.Samples.SignalingConsole.csproj
+++ b/src/samples/console/Elsa.Samples.SignalingConsole/Elsa.Samples.SignalingConsole.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/console/Elsa.Samples.SwitchConsole/Elsa.Samples.SwitchConsole.csproj
+++ b/src/samples/console/Elsa.Samples.SwitchConsole/Elsa.Samples.SwitchConsole.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -8,8 +8,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/console/Elsa.Samples.UserTaskConsole/Elsa.Samples.UserTaskConsole.csproj
+++ b/src/samples/console/Elsa.Samples.UserTaskConsole/Elsa.Samples.UserTaskConsole.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -8,8 +8,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/console/Elsa.Samples.WhileLoopConsole/Elsa.Samples.WhileLoopConsole.csproj
+++ b/src/samples/console/Elsa.Samples.WhileLoopConsole/Elsa.Samples.WhileLoopConsole.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/dashboard/aspnetcore/ElsaDashboard.Samples.AspNetCore.Monolith/ElsaDashboard.Samples.AspNetCore.Monolith.csproj
+++ b/src/samples/dashboard/aspnetcore/ElsaDashboard.Samples.AspNetCore.Monolith/ElsaDashboard.Samples.AspNetCore.Monolith.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -7,7 +7,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Identity.Client" Version="4.67.2" />
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/dashboard/aspnetcore/ElsaDashboard.Samples.AspNetCore.SubPath/ElsaDashboard.Samples.AspNetCore.SubPath.csproj
+++ b/src/samples/dashboard/aspnetcore/ElsaDashboard.Samples.AspNetCore.SubPath/ElsaDashboard.Samples.AspNetCore.SubPath.csproj
@@ -1,11 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/persistence/Elsa.Samples.Persistence.EntityFramework/Elsa.Samples.Persistence.EntityFramework.csproj
+++ b/src/samples/persistence/Elsa.Samples.Persistence.EntityFramework/Elsa.Samples.Persistence.EntityFramework.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -16,11 +16,11 @@
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0'">
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.16" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0'">
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0'">

--- a/src/samples/persistence/Elsa.Samples.Persistence.YesSql/Elsa.Samples.Persistence.YesSql.csproj
+++ b/src/samples/persistence/Elsa.Samples.Persistence.YesSql/Elsa.Samples.Persistence.YesSql.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/worker/Elsa.Samples.AzureServiceBusWorker/Elsa.Samples.AzureServiceBusWorker.csproj
+++ b/src/samples/worker/Elsa.Samples.AzureServiceBusWorker/Elsa.Samples.AzureServiceBusWorker.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Worker">
+﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -6,8 +6,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.16" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/worker/Elsa.Samples.BreakLoop/Elsa.Samples.BreakLoop.csproj
+++ b/src/samples/worker/Elsa.Samples.BreakLoop/Elsa.Samples.BreakLoop.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Worker">
+﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -6,8 +6,8 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.16" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/worker/Elsa.Samples.CustomAttributesChildWorker/Elsa.Samples.CustomAttributesChildWorker.csproj
+++ b/src/samples/worker/Elsa.Samples.CustomAttributesChildWorker/Elsa.Samples.CustomAttributesChildWorker.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Worker">
+﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.16" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/worker/Elsa.Samples.DistributedLock/Elsa.Samples.DistributedLock.csproj
+++ b/src/samples/worker/Elsa.Samples.DistributedLock/Elsa.Samples.DistributedLock.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -7,9 +7,9 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.16" />
         <PackageReference Include="DistributedLock.Redis" Version="1.0.1" />
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/worker/Elsa.Samples.Faulting/Elsa.Samples.Faulting.csproj
+++ b/src/samples/worker/Elsa.Samples.Faulting/Elsa.Samples.Faulting.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Worker">
+﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -7,8 +7,8 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Data.SqlClient" Version="3.1.7" />
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.16" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/worker/Elsa.Samples.MqttWorker/Elsa.Samples.MqttWorker.csproj
+++ b/src/samples/worker/Elsa.Samples.MqttWorker/Elsa.Samples.MqttWorker.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
+      <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.16" />
       <PackageReference Include="MQTTnet" Version="4.2.0.706" />
     </ItemGroup>
 

--- a/src/samples/worker/Elsa.Samples.MultiTenantChildWorker/Elsa.Samples.MultiTenantChildWorker.csproj
+++ b/src/samples/worker/Elsa.Samples.MultiTenantChildWorker/Elsa.Samples.MultiTenantChildWorker.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Worker">
+﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -6,8 +6,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.16" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/worker/Elsa.Samples.RabbitMqWorker/Elsa.Samples.RabbitMqWorker.csproj
+++ b/src/samples/worker/Elsa.Samples.RabbitMqWorker/Elsa.Samples.RabbitMqWorker.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -8,8 +8,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.16" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/worker/Elsa.Samples.RebusErrorWorker/Elsa.Samples.RebusErrorWorker.csproj
+++ b/src/samples/worker/Elsa.Samples.RebusErrorWorker/Elsa.Samples.RebusErrorWorker.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Worker">
+﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -6,9 +6,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.16" />
         <PackageReference Include="Rebus.AzureServiceBus" Version="10.2.0" />
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/worker/Elsa.Samples.RebusWorker/Elsa.Samples.RebusWorker.csproj
+++ b/src/samples/worker/Elsa.Samples.RebusWorker/Elsa.Samples.RebusWorker.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Worker">
+﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -6,9 +6,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.16" />
         <PackageReference Include="Rebus.AzureServiceBus" Version="10.2.0" />
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/worker/Elsa.Samples.RunChildWorkflowWorker/Elsa.Samples.RunChildWorkflowWorker.csproj
+++ b/src/samples/worker/Elsa.Samples.RunChildWorkflowWorker/Elsa.Samples.RunChildWorkflowWorker.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Worker">
+﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -6,8 +6,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.16" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/worker/Elsa.Samples.Timers.Hangfire/Elsa.Samples.Timers.Hangfire.csproj
+++ b/src/samples/worker/Elsa.Samples.Timers.Hangfire/Elsa.Samples.Timers.Hangfire.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -9,8 +9,8 @@
 
     <ItemGroup>
         <PackageReference Include="Hangfire.SqlServer" Version="1.8.5" />
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.16" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/worker/Elsa.Samples.Timers.Quartz/Elsa.Samples.Timers.Quartz.csproj
+++ b/src/samples/worker/Elsa.Samples.Timers.Quartz/Elsa.Samples.Timers.Quartz.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Worker">
+﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -8,8 +8,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.16" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/worker/Elsa.Samples.WatchDirectoryWorker/Elsa.Samples.WatchDirectoryWorker.csproj
+++ b/src/samples/worker/Elsa.Samples.WatchDirectoryWorker/Elsa.Samples.WatchDirectoryWorker.csproj
@@ -17,8 +17,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.16" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/worker/Elsa.Samples.WhileLoopWorker/Elsa.Samples.WhileLoopWorker.csproj
+++ b/src/samples/worker/Elsa.Samples.WhileLoopWorker/Elsa.Samples.WhileLoopWorker.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Worker">
+﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -7,8 +7,8 @@
     
     <ItemGroup>
         <PackageReference Include="Microsoft.Data.SqlClient" Version="3.1.7" />
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.16" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/scripting/Elsa.Scripting.JavaScript/Converters/Jint/ByteArrayConverter.cs
+++ b/src/scripting/Elsa.Scripting.JavaScript/Converters/Jint/ByteArrayConverter.cs
@@ -11,14 +11,15 @@ namespace Elsa.Scripting.JavaScript.Converters.Jint
     {
         public bool TryConvert(Engine engine, object value, out JsValue result)
         {
-            result = JsValue.Null;
-            
-            if (value is not byte[] buffer)
-                return false;
+            if (value is byte[] bytes)
+            {
+                var buffer = engine.Intrinsics.ArrayBuffer.Construct(bytes);
+                result = buffer;
+                return true;
+            }
 
-            result = new ObjectWrapper(engine, buffer);
-            
-            return true;
+            result = JsValue.Null;
+            return false;
         }
     }
 }

--- a/src/scripting/Elsa.Scripting.JavaScript/Elsa.Scripting.JavaScript.csproj
+++ b/src/scripting/Elsa.Scripting.JavaScript/Elsa.Scripting.JavaScript.csproj
@@ -14,11 +14,15 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Jint" Version="3.0.0-beta-2037" />
+        <PackageReference Include="Jint" Version="4.9.2" />
     </ItemGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\..\core\Elsa.Core\Elsa.Core.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <InternalsVisibleTo Include="Elsa.UnitTests" />
     </ItemGroup>
     
 </Project>

--- a/src/server/Elsa.Server.Api/Elsa.Server.Api.csproj
+++ b/src/server/Elsa.Server.Api/Elsa.Server.Api.csproj
@@ -34,10 +34,10 @@
         <PackageReference Include="System.Linq.Async" Version="6.0.1">
             <ExcludeAssets>compile</ExcludeAssets>
         </PackageReference>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
-        <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.1.7" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
+        <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.2.3" />
         <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="10.0.1" />
-        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.1.7" />
+        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.2.3" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/server/Elsa.Server.Api/Elsa.Server.Api.csproj
+++ b/src/server/Elsa.Server.Api/Elsa.Server.Api.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <Import Project="..\..\..\common.props" />
     <Import Project="..\..\..\configureawait.props" />
@@ -15,10 +15,18 @@
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0'">
         <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.1" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.3.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="7.0.2" />
+        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.3.0" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0'">
         <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="9.0.1" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.3.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="7.0.2" />
+        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.3.0" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0'">
@@ -35,13 +43,9 @@
     <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
         <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="NodaTime.Serialization.SystemTextJson" Version="1.0.0" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.0" />
-        <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.3.0" />
-        <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="7.0.2" />
-        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.3.0" />
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/server/Elsa.Server.Api/Extensions/DocumentFilters/RemoveEmptyControllerTagsFilter .cs
+++ b/src/server/Elsa.Server.Api/Extensions/DocumentFilters/RemoveEmptyControllerTagsFilter .cs
@@ -1,0 +1,73 @@
+#if NET10_0_OR_GREATER
+using Microsoft.OpenApi;
+#else
+using Microsoft.OpenApi.Models;
+#endif
+using Swashbuckle.AspNetCore.SwaggerGen;
+using System.Linq;
+
+namespace Elsa.Server.Api.Extensions.DocumentFilters
+{
+    /// <summary>
+    /// Removes any top-level tag definitions from the OpenAPI document that aren't actually assigned to any endpoint operations.
+    /// This helps to keep the generated documentation clean and focused on relevant tags.
+    /// </summary>
+    /// /// <remarks>
+    /// <para>
+    /// <b>Root Cause:</b> Swashbuckle's annotation engine bypasses its custom tag selection rules 
+    /// when using <c>[SwaggerOperation(Tags = ...)]</c>. This leaves behind "ghost" controller-named tags 
+    /// at the root level of the generated OpenAPI document that contain zero active endpoints.
+    /// See Swashbuckle Issue #2618 (https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/2618).
+    /// </para>
+    /// <para>
+    /// <b>.NET 10 Conflict:</b> In .NET 10, the native <c>Microsoft.AspNetCore.OpenApi</c> pipeline 
+    /// implicitly pushes default metadata tags down the <c>ApiExplorer</c> framework prior to Swashbuckle 
+    /// evaluation. This renders internal interception strategies like <c>TagActionsBy</c> ineffective.
+    /// </para>
+    /// <para>
+    /// <b>Resolution:</b> This filter executes exactly once per document build. It scans all actively mapped 
+    /// operations, compiles a list of utilized tags, and purges any unmapped root-level tag headers to preserve 
+    /// clean layout grouping in the Swagger UI.
+    /// </para>
+    /// </remarks>
+    public class RemoveEmptyControllerTagsFilter : IDocumentFilter
+    {
+        public void Apply(OpenApiDocument swaggerDoc, DocumentFilterContext context)
+        {
+            // 1. Find all tags that are actually assigned to at least one endpoint operation
+#if NET10_0_OR_GREATER
+            // In .NET 10, operation.Tags is ISet<OpenApiTagReference>
+            var activeTags = swaggerDoc.Paths.Values
+                .SelectMany(path => path.Operations?.Values ?? Enumerable.Empty<OpenApiOperation>())
+                .SelectMany(op => op.Tags?.Select(t => t.Reference?.Id) ?? Enumerable.Empty<string?>())
+                .Where(id => !string.IsNullOrEmpty(id))
+                .ToHashSet();
+#else
+            // In .NET 8/9, operation.Tags is IList<OpenApiTag>
+            var activeTags = swaggerDoc.Paths.Values
+                .SelectMany(path => path.Operations?.Values ?? Enumerable.Empty<OpenApiOperation>())
+                .SelectMany(op => op.Tags?.Select(t => t.Name) ?? Enumerable.Empty<string?>())
+                .Where(name => !string.IsNullOrEmpty(name))
+                .ToHashSet();
+#endif
+
+            // 2. Remove any top-level tag definitions that aren't actively used by an operation
+            if (swaggerDoc.Tags != null)
+            {
+#if NET10_0_OR_GREATER
+                // In .NET 10, swaggerDoc.Tags is ISet<OpenApiTag>
+                var tagsToRemove = swaggerDoc.Tags.Where(tag => !activeTags.Contains(tag.Name)).ToList();
+                foreach (var tag in tagsToRemove)
+                {
+                    swaggerDoc.Tags.Remove(tag);
+                }
+#else
+                // In .NET 8/9, swaggerDoc.Tags is IList<OpenApiTag>
+                swaggerDoc.Tags = swaggerDoc.Tags
+                    .Where(tag => activeTags.Contains(tag.Name))
+                    .ToList();
+#endif
+            }
+        }
+    }
+}

--- a/src/server/Elsa.Server.Api/Extensions/DocumentFilters/RemoveEmptyControllerTagsFilter.cs
+++ b/src/server/Elsa.Server.Api/Extensions/DocumentFilters/RemoveEmptyControllerTagsFilter.cs
@@ -12,7 +12,7 @@ namespace Elsa.Server.Api.Extensions.DocumentFilters
     /// Removes any top-level tag definitions from the OpenAPI document that aren't actually assigned to any endpoint operations.
     /// This helps to keep the generated documentation clean and focused on relevant tags.
     /// </summary>
-    /// /// <remarks>
+    /// <remarks>
     /// <para>
     /// <b>Root Cause:</b> Swashbuckle's annotation engine bypasses its custom tag selection rules 
     /// when using <c>[SwaggerOperation(Tags = ...)]</c>. This leaves behind "ghost" controller-named tags 

--- a/src/server/Elsa.Server.Api/Extensions/ServiceCollectionExtensions.cs
+++ b/src/server/Elsa.Server.Api/Extensions/ServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using Elsa;
 using Elsa.Models;
 using Elsa.Server.Api;
 using Elsa.Server.Api.Extensions;
+using Elsa.Server.Api.Extensions.DocumentFilters;
 using Elsa.Server.Api.Extensions.SchemaFilters;
 using Elsa.Server.Api.Mapping;
 using Elsa.Server.Api.Services;
@@ -103,6 +104,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
                     //Allow enums to be displayed
                     c.SchemaFilter<XEnumNamesSchemaFilter>();
+                    c.DocumentFilter<RemoveEmptyControllerTagsFilter>();
                     configure?.Invoke(c);
                 });
     }

--- a/test/component/Elsa.ComponentTests/Elsa.ComponentTests.csproj
+++ b/test/component/Elsa.ComponentTests/Elsa.ComponentTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -8,7 +8,7 @@
     
     <ItemGroup>
         <PackageReference Include="AutoFixture" Version="4.18.1" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.1" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.16" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
         <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
         <PackageReference Include="xunit" Version="2.9.3" />

--- a/test/integration/Elsa.Core.IntegrationTests/Elsa.Core.IntegrationTests.csproj
+++ b/test/integration/Elsa.Core.IntegrationTests/Elsa.Core.IntegrationTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -13,7 +13,7 @@
         <PackageReference Include="Moq" Version="4.16.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
         <PackageReference Include="NodaTime.Testing" Version="3.0.9" />
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="XunitXml.TestLogger" Version="5.0.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
@@ -27,7 +27,7 @@
         <PackageReference Include="YesSql.Core" Version="3.0.7" />
         <PackageReference Include="YesSql.Provider.Sqlite" Version="3.0.7" />
         <PackageReference Include="YesSql.Provider.PostgreSql" Version="3.0.7" />
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.16" />
         <PackageReference Include="Hangfire.AspNetCore" Version="1.8.5" />
         <PackageReference Include="Hangfire.InMemory" Version="0.5.1" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.1" />

--- a/test/shared/Elsa.Testing.Shared/Elsa.Testing.Shared.csproj
+++ b/test/shared/Elsa.Testing.Shared/Elsa.Testing.Shared.csproj
@@ -12,13 +12,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1"/>
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.16"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.1"/>
         <PackageReference Include="AutoFixture" Version="4.18.1"/>
         <PackageReference Include="Autofixture.AutoMoq" Version="4.18.1"/>
         <PackageReference Include="AutoFixture.Xunit2" Version="4.18.1"/>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1"/>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.1"/>        
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.16"/>        
         <PackageReference Include="NodaTime" Version="3.2.0"/>
         <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0"/>
         <PackageReference Include="xunit.extensibility.core" Version="2.9.1"/>

--- a/test/unit/Elsa.UnitTests/Elsa.UnitTests.csproj
+++ b/test/unit/Elsa.UnitTests/Elsa.UnitTests.csproj
@@ -22,7 +22,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/unit/Elsa.UnitTests/Scripting/JavaScript/Services/JintJavaScriptEvaluatorTests.cs
+++ b/test/unit/Elsa.UnitTests/Scripting/JavaScript/Services/JintJavaScriptEvaluatorTests.cs
@@ -1,10 +1,16 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using AutoFixture.Xunit2;
+using Elsa.Scripting.JavaScript.Converters.Jint;
 using Elsa.Scripting.JavaScript.Messages;
 using Elsa.Services.Models;
 using Elsa.Testing.Shared;
 using Elsa.Testing.Shared.AutoFixture.Attributes;
+using Jint;
+using Jint.Native;
 using MediatR;
 using Moq;
 using Xunit;
@@ -128,6 +134,100 @@ namespace Elsa.Scripting.JavaScript.Services
             var result = await sut.EvaluateAsync("duration1.Plus(duration2)", typeof(NodaTime.Duration), context1);
 
             Assert.Equal(NodaTime.Duration.FromHours(36), result);
+        }
+
+        [Theory(DisplayName = "ByteArrayConverter: The EvaluateAsync method should expose a byte array as an ArrayBuffer and preserve its values"), AutoMoqData]
+        public async Task EvaluateAsync_ShouldExposeByteArrayAsArrayBufferWithCorrectValues(
+            [Frozen] IMediator mediator,
+            [JintEvaluatorWithConverter] JintJavaScriptEvaluator sut,
+            [StubActivityExecutionContext] ActivityExecutionContext context1)
+        {
+            var bytes = new byte[] { 1, 2, 3, 4 };
+            object returnedValue = null;
+
+            Mock.Get(mediator)
+                .Setup(x => x.Publish(It.Is<EvaluatingJavaScriptExpression>(e => e.ActivityExecutionContext == context1), It.IsAny<CancellationToken>()))
+                .Callback((EvaluatingJavaScriptExpression expression, CancellationToken t) => { expression.Engine.SetValue("MyVariable", returnedValue); });
+
+            returnedValue = bytes;
+
+            // Check length
+            var lengthResult = await sut.EvaluateAsync("MyVariable.byteLength", typeof(object), context1);
+            Assert.Equal((double)bytes.Length, lengthResult);
+
+            // Check values
+            var jsArray = await sut.EvaluateAsync("Array.from(new Uint8Array(MyVariable))", typeof(object), context1);
+            var resultArray = ((IEnumerable<object>)jsArray).Select(Convert.ToByte).ToArray();
+            Assert.Equal(bytes, resultArray);
+        }
+
+        [Fact(DisplayName = "ByteArrayConverter: Should return false and JsValue.Null for null input")]
+        public void TryConvert_ShouldReturnFalse_ForNull()
+        {
+            var converter = new ByteArrayConverter();
+            var engine = new Engine();
+            var result = JsValue.Undefined;
+
+            var success = converter.TryConvert(engine, null, out result);
+
+            Assert.False(success);
+            Assert.Equal(JsValue.Null, result);
+        }
+
+        [Fact(DisplayName = "ByteArrayConverter: Should return false for non-byte array input")]
+        public void TryConvert_ShouldReturnFalse_ForNonByteArray()
+        {
+            var converter = new ByteArrayConverter();
+            var engine = new Engine();
+            var result = JsValue.Undefined;
+
+            var success = converter.TryConvert(engine, new int[] { 1, 2, 3 }, out result);
+
+            Assert.False(success);
+            Assert.Equal(JsValue.Null, result);
+        }
+
+        [Theory(DisplayName = "ByteArrayConverter: Should roundtrip a byte array from .NET to JS and back"), AutoMoqData]
+        public async Task EvaluateAsync_ShouldRoundtripByteArray(
+            [Frozen] IMediator mediator,
+            [JintEvaluatorWithConverter] JintJavaScriptEvaluator sut,
+            [StubActivityExecutionContext] ActivityExecutionContext context1)
+        {
+            var bytes = new byte[] { 10, 20, 30, 40 };
+            object returnedValue = null;
+
+            Mock.Get(mediator)
+                .Setup(x => x.Publish(It.Is<EvaluatingJavaScriptExpression>(e => e.ActivityExecutionContext == context1), It.IsAny<CancellationToken>()))
+                .Callback((EvaluatingJavaScriptExpression expression, CancellationToken t) => { expression.Engine.SetValue("MyVariable", returnedValue); });
+
+            returnedValue = bytes;
+            var jsArray = await sut.EvaluateAsync("Array.from(new Uint8Array(MyVariable))", typeof(object), context1);
+
+            var resultArray = ((IEnumerable<object>)jsArray).Select(x => Convert.ToByte(x)).ToArray();
+            Assert.Equal(bytes, resultArray);
+        }
+
+        [Theory(DisplayName = "ByteArrayConverter: Should reflect mutation of ArrayBuffer in JS when read back in .NET"), AutoMoqData]
+        public async Task EvaluateAsync_ShouldReflectJsMutation(
+            [Frozen] IMediator mediator,
+            [JintEvaluatorWithConverter] JintJavaScriptEvaluator sut,
+            [StubActivityExecutionContext] ActivityExecutionContext context1)
+        {
+            var bytes = new byte[] { 1, 2, 3, 4 };
+            object returnedValue = null;
+
+            Mock.Get(mediator)
+                .Setup(x => x.Publish(It.Is<EvaluatingJavaScriptExpression>(e => e.ActivityExecutionContext == context1), It.IsAny<CancellationToken>()))
+                .Callback((EvaluatingJavaScriptExpression expression, CancellationToken t) => { expression.Engine.SetValue("MyVariable", returnedValue); });
+            
+            returnedValue = bytes;
+
+            await sut.EvaluateAsync("new Uint8Array(MyVariable)[0] = 99", typeof(object), context1);
+            var jsArray = await sut.EvaluateAsync("Array.from(new Uint8Array(MyVariable))", typeof(object), context1);
+
+            var resultArray = ((IEnumerable<object>)jsArray).Select(x => Convert.ToByte(x)).ToArray();
+            var expected = new byte[] { 99, 2, 3, 4 };
+            Assert.Equal(expected, resultArray);
         }
     }
 }


### PR DESCRIPTION
## Purpose

Updates `Jint`, `Rebus` and their dependencies to latest versions.
Some .net10 fixes for Swashbuckle/OpenAPI issues.

---

## Scope

Select one primary concern:

- [ ] Bug fix (behaviour change)
- [ ] Refactor (no behaviour change)
- [ ] Documentation update
- [ ] Formatting / code cleanup
- [x] Dependency / build update
- [ ] New feature

---

## Description

### Problem

#### Jint
Currently `Jint` is on a beta version `3.0.0-beta-2037` which even if moved to the non beta `3.0.0` it does not compile as the api changed before beta closed.
The latest version is `4.9.2` which changes the Parser from `Esprima` to `Acornima`.

#### Rebus
`Rebus` is also outdated being on version `8.7.1`.
The latest is version `8.9.2` which brings .net10 support with it which Elsa support already so should have been updated already.

#### Swashbuckle .NET 10 Compatibility Fixes
- Refer to this issue for full details: #7429

### Solution
Upgraded `System.Text.Encodings.Web` to `10.0.8` and other key dependencies (`Newtonsoft.Json`, `Microsoft.Extensions.Hosting`, etc.) across multiple projects for compatibility, security, and performance improvements.

Upgraded `Jint`:

- Updated `Jint` to `4.9.2` from beta version
- Enhanced `ByteArrayConverter` to handle byte arrays as `ArrayBuffer` in JavaScript
- Added new tests for validation

Upgrade `Rebus` dependencies across core projects:

- Upgraded `Rebus` to version `8.9.2` in Elsa.Abstractions.csproj.
- Upgraded `Rebus.ServiceProvider` to version `10.7.2` in Elsa.Core.csproj.
- Upgraded `Rebus.Microsoft.Extensions.Logging` to version `5.2.0` in Elsa.Core.csproj.

Upgraded `System.Text.Encodings.Web` to `10.0.8` and other key dependencies (`Newtonsoft.Json`, `Microsoft.Extensions.Hosting`, etc.) across multiple projects for compatibility, security, and performance improvements.

These upgrades ensure compatibility with the latest features, bug fixes, and improved integration with .NET 8/9/10 targets.

Duplicate Swashbuckle packages references:

- Removed duplicate Swashbuckle (Swagger) package references from Elsa.Server.Api.csproj for consistent multi-targeting.
- Ensured only one version per framework is referenced.

### Swashbuckle .NET 10 Compatibility Fixes

#### Package Updates
- **Conditionally upgrade Swashbuckle.AspNetCore.SwaggerGen** in Elsa.Activities.Http.OpenApi project
  - Keep v6.3.0 for .NET 8/9 (maintains backward compatibility)
  - Upgrade to v10.2.1 for .NET 10 (supports new OpenAPI model)

#### HttpEndpointDocumentFilter.cs
- **Add conditional compilation for OpenAPI model breaking changes in .NET 10:**
  - `swaggerDoc.Tags`: `IList<OpenApiTag>` (.NET 8/9) → `ISet<OpenApiTag>` (.NET 10)
  - `operation.Tags`: `IList<OpenApiTag>` (.NET 8/9) → `ISet<OpenApiTagReference>` (.NET 10)
- **Fix null reference exception** in `RequestBody.Content` by explicit dictionary initialization
- **Improve schema validation** to check for null or whitespace in `JsonSchema` property
- Resolves `ReflectionTypeLoadException`: "Method 'Apply' does not have an implementation"

#### RemoveEmptyControllerTagsFilter.cs
- **Add conditional compilation for .NET 10 tag handling:**
  - Use `OpenApiTagReference.Reference.Id` for tag identification (.NET 10)
  - Use `OpenApiTag.Name` for tag identification (.NET 8/9)
  - Use `Remove()` method for `ISet<OpenApiTag>` (.NET 10)
  - Use reassignment with `ToList()` for `IList<OpenApiTag>` (.NET 8/9)

---

## Verification

Steps:
1. Run the new tests in "test/unit/Elsa.UnitTests/Scripting/JavaScript/Services/JintJavaScriptEvaluatorTests.cs"
2. Run sample JavaScript based workflows

Expected outcome:

Tests pass and samples run without exceptions.
Eliminates runtime type loading errors on .NET 10
Swagger page does not show Tags with no Operations

---

## Screenshots / Recordings (if applicable)

N/A

---

## Checklist

- [x] The PR is focused on a single concern
- [ ] Commit messages follow the recommended convention
- [x] Tests added or updated (if applicable)
- [ ] Documentation updated (if applicable)
- [x] No unrelated cleanup included
- [x] All tests pass
