### PR TITLE
Stabilize bulk dispatch fire-and-forget component test

### DIFF
--- a/test/component/Elsa.Workflows.ComponentTests/Scenarios/Activities/Composition/BulkDispatchWorkflows/BulkDispatchWorkflowsTests.cs
+++ b/test/component/Elsa.Workflows.ComponentTests/Scenarios/Activities/Composition/BulkDispatchWorkflows/BulkDispatchWorkflowsTests.cs
@@ -7,6 +7,8 @@ using Elsa.Workflows.ComponentTests.Abstractions;
 using Elsa.Workflows.ComponentTests.Fixtures;
 using Elsa.Workflows.ComponentTests.Scenarios.Activities.Composition.BulkDispatchWorkflows.Workflows;
 using Elsa.Workflows.Management;
+using Elsa.Workflows.Management.Entities;
+using Elsa.Workflows.Management.Filters;
 using Elsa.Workflows.Models;
 using Elsa.Workflows.State;
 using Microsoft.Extensions.DependencyInjection;
@@ -17,10 +19,12 @@ public class BulkDispatchWorkflowsTests : AppComponentTest
 {
     private const int ChildWorkflowTimeoutSeconds = 30;
     private readonly AsyncWorkflowRunner _workflowRunner;
+    private readonly IWorkflowInstanceStore _workflowInstanceStore;
 
     public BulkDispatchWorkflowsTests(App app) : base(app)
     {
         _workflowRunner = Scope.ServiceProvider.GetRequiredService<AsyncWorkflowRunner>();
+        _workflowInstanceStore = Scope.ServiceProvider.GetRequiredService<IWorkflowInstanceStore>();
     }
 
     [Fact(DisplayName = "BulkDispatchWorkflows should wait for all child workflows to complete")]
@@ -37,21 +41,19 @@ public class BulkDispatchWorkflowsTests : AppComponentTest
     {
         var expectedChildCount = 3;
 
-        // Run the main workflow and wait for child workflows to complete
-        var (result, completedChildWorkflows) = await RunWorkflowAndWaitForChildWorkflowsAsync(
-            BulkDispatchFireAndForgetWorkflow.DefinitionId,
+        var result = await RunWorkflowAsync(BulkDispatchFireAndForgetWorkflow.DefinitionId);
+
+        AssertWorkflowFinished(result);
+        var childWorkflowInstances = await WaitForChildWorkflowInstancesAsync(
+            result.WorkflowExecutionContext.Id,
             SlowBulkChildWorkflow.DefinitionId,
             expectedChildCount);
 
-        AssertWorkflowFinished(result);
-        var mainWorkflowCompletedAt = result.WorkflowExecutionContext.UpdatedAt;
-
-        // Assert that all child workflows completed after the main workflow
-        Assert.Equal(expectedChildCount, completedChildWorkflows.Count);
-        foreach (var childContext in completedChildWorkflows)
+        Assert.Equal(expectedChildCount, childWorkflowInstances.Count);
+        foreach (var childWorkflowInstance in childWorkflowInstances)
         {
-            Assert.True(childContext.UpdatedAt > mainWorkflowCompletedAt,
-                $"Child workflow should complete after main workflow. Main: {mainWorkflowCompletedAt}, Child: {childContext.UpdatedAt}");
+            Assert.Equal(result.WorkflowExecutionContext.Id, childWorkflowInstance.ParentWorkflowInstanceId);
+            Assert.False(childWorkflowInstance.WorkflowState.Properties.ContainsKey("WaitForCompletion"));
         }
     }
 
@@ -175,5 +177,29 @@ public class BulkDispatchWorkflowsTests : AppComponentTest
         {
             workflowEvents.WorkflowStateCommitted -= OnWorkflowStateCommitted;
         }
+    }
+
+    private async Task<IReadOnlyCollection<WorkflowInstance>> WaitForChildWorkflowInstancesAsync(
+        string parentWorkflowInstanceId,
+        string childWorkflowDefinitionId,
+        int expectedChildCount)
+    {
+        var timeoutAt = DateTimeOffset.UtcNow.AddSeconds(ChildWorkflowTimeoutSeconds);
+        var filter = new WorkflowInstanceFilter
+        {
+            DefinitionId = childWorkflowDefinitionId,
+            ParentWorkflowInstanceIds = [parentWorkflowInstanceId]
+        };
+
+        while (DateTimeOffset.UtcNow < timeoutAt)
+        {
+            var instances = (await _workflowInstanceStore.FindManyAsync(filter)).ToList();
+            if (instances.Count >= expectedChildCount)
+                return instances;
+
+            await Task.Delay(TimeSpan.FromMilliseconds(100));
+        }
+
+        throw new TimeoutException($"Expected {expectedChildCount} child workflow instances of definition '{childWorkflowDefinitionId}' for parent '{parentWorkflowInstanceId}'.");
     }
 }

--- a/test/component/Elsa.Workflows.ComponentTests/Scenarios/Activities/Composition/BulkDispatchWorkflows/BulkDispatchWorkflowsTests.cs
+++ b/test/component/Elsa.Workflows.ComponentTests/Scenarios/Activities/Composition/BulkDispatchWorkflows/BulkDispatchWorkflowsTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Elsa.Common.Models;
 using Elsa.Testing.Shared;
 using Elsa.Testing.Shared.Models;
@@ -18,6 +19,8 @@ namespace Elsa.Workflows.ComponentTests.Scenarios.Activities.Composition.BulkDis
 public class BulkDispatchWorkflowsTests : AppComponentTest
 {
     private const int ChildWorkflowTimeoutSeconds = 30;
+    private const int ChildWorkflowPollingIntervalMilliseconds = 100;
+    private const string WaitForCompletionPropertyName = nameof(Elsa.Workflows.Runtime.Activities.BulkDispatchWorkflows.WaitForCompletion);
     private readonly AsyncWorkflowRunner _workflowRunner;
     private readonly IWorkflowInstanceStore _workflowInstanceStore;
 
@@ -53,7 +56,7 @@ public class BulkDispatchWorkflowsTests : AppComponentTest
         foreach (var childWorkflowInstance in childWorkflowInstances)
         {
             Assert.Equal(result.WorkflowExecutionContext.Id, childWorkflowInstance.ParentWorkflowInstanceId);
-            Assert.False(childWorkflowInstance.WorkflowState.Properties.ContainsKey("WaitForCompletion"));
+            Assert.False(childWorkflowInstance.WorkflowState.Properties.ContainsKey(WaitForCompletionPropertyName));
         }
     }
 
@@ -182,9 +185,11 @@ public class BulkDispatchWorkflowsTests : AppComponentTest
     private async Task<IReadOnlyCollection<WorkflowInstance>> WaitForChildWorkflowInstancesAsync(
         string parentWorkflowInstanceId,
         string childWorkflowDefinitionId,
-        int expectedChildCount)
+        int expectedChildCount,
+        CancellationToken cancellationToken = default)
     {
-        var timeoutAt = DateTimeOffset.UtcNow.AddSeconds(ChildWorkflowTimeoutSeconds);
+        var timeout = TimeSpan.FromSeconds(ChildWorkflowTimeoutSeconds);
+        var stopwatch = Stopwatch.StartNew();
         var filter = new WorkflowInstanceFilter
         {
             DefinitionId = childWorkflowDefinitionId,
@@ -192,15 +197,15 @@ public class BulkDispatchWorkflowsTests : AppComponentTest
         };
         var actualChildCount = 0;
 
-        while (DateTimeOffset.UtcNow < timeoutAt)
+        while (stopwatch.Elapsed < timeout)
         {
-            var instances = (await _workflowInstanceStore.FindManyAsync(filter)).ToList();
+            var instances = (await _workflowInstanceStore.FindManyAsync(filter, cancellationToken)).ToList();
             actualChildCount = instances.Count;
 
             if (instances.Count >= expectedChildCount)
                 return instances;
 
-            await Task.Delay(TimeSpan.FromMilliseconds(100));
+            await Task.Delay(TimeSpan.FromMilliseconds(ChildWorkflowPollingIntervalMilliseconds), cancellationToken);
         }
 
         throw new TimeoutException($"Expected {expectedChildCount} child workflow instances of definition '{childWorkflowDefinitionId}' for parent '{parentWorkflowInstanceId}', but found {actualChildCount}.");

--- a/test/component/Elsa.Workflows.ComponentTests/Scenarios/Activities/Composition/BulkDispatchWorkflows/BulkDispatchWorkflowsTests.cs
+++ b/test/component/Elsa.Workflows.ComponentTests/Scenarios/Activities/Composition/BulkDispatchWorkflows/BulkDispatchWorkflowsTests.cs
@@ -190,16 +190,19 @@ public class BulkDispatchWorkflowsTests : AppComponentTest
             DefinitionId = childWorkflowDefinitionId,
             ParentWorkflowInstanceIds = [parentWorkflowInstanceId]
         };
+        var actualChildCount = 0;
 
         while (DateTimeOffset.UtcNow < timeoutAt)
         {
             var instances = (await _workflowInstanceStore.FindManyAsync(filter)).ToList();
+            actualChildCount = instances.Count;
+
             if (instances.Count >= expectedChildCount)
                 return instances;
 
             await Task.Delay(TimeSpan.FromMilliseconds(100));
         }
 
-        throw new TimeoutException($"Expected {expectedChildCount} child workflow instances of definition '{childWorkflowDefinitionId}' for parent '{parentWorkflowInstanceId}'.");
+        throw new TimeoutException($"Expected {expectedChildCount} child workflow instances of definition '{childWorkflowDefinitionId}' for parent '{parentWorkflowInstanceId}', but found {actualChildCount}.");
     }
 }

--- a/test/component/Elsa.Workflows.ComponentTests/Scenarios/Activities/Composition/BulkDispatchWorkflows/BulkDispatchWorkflowsTests.cs
+++ b/test/component/Elsa.Workflows.ComponentTests/Scenarios/Activities/Composition/BulkDispatchWorkflows/BulkDispatchWorkflowsTests.cs
@@ -19,7 +19,9 @@ namespace Elsa.Workflows.ComponentTests.Scenarios.Activities.Composition.BulkDis
 public class BulkDispatchWorkflowsTests : AppComponentTest
 {
     private const int ChildWorkflowTimeoutSeconds = 30;
-    private const int ChildWorkflowPollingIntervalMilliseconds = 100;
+    private const int InitialChildWorkflowPollingIntervalMilliseconds = 250;
+    private const int MaxChildWorkflowPollingIntervalMilliseconds = 1000;
+    // The runtime persists this marker under the activity property name; resume handlers read the same key from WorkflowState.Properties.
     private const string WaitForCompletionPropertyName = nameof(Elsa.Workflows.Runtime.Activities.BulkDispatchWorkflows.WaitForCompletion);
     private readonly AsyncWorkflowRunner _workflowRunner;
     private readonly IWorkflowInstanceStore _workflowInstanceStore;
@@ -189,6 +191,8 @@ public class BulkDispatchWorkflowsTests : AppComponentTest
         CancellationToken cancellationToken = default)
     {
         var timeout = TimeSpan.FromSeconds(ChildWorkflowTimeoutSeconds);
+        var pollingInterval = TimeSpan.FromMilliseconds(InitialChildWorkflowPollingIntervalMilliseconds);
+        var maxPollingInterval = TimeSpan.FromMilliseconds(MaxChildWorkflowPollingIntervalMilliseconds);
         var stopwatch = Stopwatch.StartNew();
         var filter = new WorkflowInstanceFilter
         {
@@ -205,7 +209,8 @@ public class BulkDispatchWorkflowsTests : AppComponentTest
             if (instances.Count >= expectedChildCount)
                 return instances;
 
-            await Task.Delay(TimeSpan.FromMilliseconds(ChildWorkflowPollingIntervalMilliseconds), cancellationToken);
+            await Task.Delay(pollingInterval, cancellationToken);
+            pollingInterval = TimeSpan.FromMilliseconds(Math.Min(pollingInterval.TotalMilliseconds * 2, maxPollingInterval.TotalMilliseconds));
         }
 
         throw new TimeoutException($"Expected {expectedChildCount} child workflow instances of definition '{childWorkflowDefinitionId}' for parent '{parentWorkflowInstanceId}', but found {actualChildCount}.");


### PR DESCRIPTION
## Summary
- Stabilizes the shared component test `BulkDispatchWorkflows should dispatch and not wait when WaitForCompletion is false`.
- Changes the fire-and-forget assertion to wait for persisted child workflow instances for the specific parent instead of waiting for delayed child workflows to complete.
- Verifies dispatched child instances are linked to the parent and do not carry the `WaitForCompletion` marker.

## Root Cause
The runtime path is correct for `WaitForCompletion = false`: bulk dispatch omits the wait marker and completes the parent immediately after dispatching children. The flaky test was depending on delayed background child workflows completing and then comparing commit timestamps, which is outside the fire-and-forget contract and can time out under shared CI load.

## Validation
- Reproduced the original timeout locally before the change.
- `dotnet test test/component/Elsa.Workflows.ComponentTests/Elsa.Workflows.ComponentTests.csproj --filter "FullyQualifiedName~BulkDispatchWorkflowsTests.BulkDispatchFireAndForget_ShouldNotWaitForChildWorkflows"`
- 5x `dotnet test test/component/Elsa.Workflows.ComponentTests/Elsa.Workflows.ComponentTests.csproj --no-build -p:CollectCoverage=false --filter "FullyQualifiedName~BulkDispatchWorkflowsTests.BulkDispatchFireAndForget_ShouldNotWaitForChildWorkflows" --logger "console;verbosity=minimal"`
- `dotnet test test/component/Elsa.Workflows.ComponentTests/Elsa.Workflows.ComponentTests.csproj --no-build -p:CollectCoverage=false --filter "FullyQualifiedName~BulkDispatchWorkflowsTests" --logger "console;verbosity=minimal"`
- `git diff --check`