### PR TITLE
fix(workflows): guard against null ActivityDescriptor in synthetic in…

### DIFF
--- a/src/modules/Elsa.Workflows.Core/Models/ActivityDescriptor.cs
+++ b/src/modules/Elsa.Workflows.Core/Models/ActivityDescriptor.cs
@@ -127,4 +127,4 @@ public class ActivityDescriptor
 
 // TODO: Refactor this to remove the dependency on JsonElement and JsonSerializerOptions.
 // This limits the ability to use this class in other contexts, such as constructing activities from the DSL.
-public record ActivityConstructorContext(ActivityDescriptor ActivityDescriptor, JsonElement Element, JsonSerializerOptions SerializerOptions);
+public record ActivityConstructorContext(ActivityDescriptor? ActivityDescriptor, JsonElement Element, JsonSerializerOptions SerializerOptions);

--- a/src/modules/Elsa.Workflows.Core/Services/ActivityFactory.cs
+++ b/src/modules/Elsa.Workflows.Core/Services/ActivityFactory.cs
@@ -32,8 +32,10 @@ public class ActivityFactory : IActivityFactory
         return activity;
     }
     
-    private void ReadSyntheticInputs(ActivityDescriptor activityDescriptor, IActivity activity, JsonElement activityRoot, JsonSerializerOptions options)
+    private void ReadSyntheticInputs(ActivityDescriptor? activityDescriptor, IActivity activity, JsonElement activityRoot, JsonSerializerOptions options)
     {
+        if (activityDescriptor?.Inputs == null) return;
+
         foreach (var inputDescriptor in activityDescriptor.Inputs.Where(x => x.IsSynthetic))
         {
             var inputName = inputDescriptor.Name;
@@ -60,8 +62,10 @@ public class ActivityFactory : IActivityFactory
         }
     }
 
-    private void ReadSyntheticOutputs(ActivityDescriptor activityDescriptor, IActivity activity, JsonElement activityRoot)
+    private void ReadSyntheticOutputs(ActivityDescriptor? activityDescriptor, IActivity activity, JsonElement activityRoot)
     {
+        if (activityDescriptor?.Outputs == null) return;
+
         foreach (var outputDescriptor in activityDescriptor.Outputs.Where(x => x.IsSynthetic))
         {
             var outputName = outputDescriptor.Name;

--- a/test/unit/Elsa.Workflows.Core.UnitTests/Services/ActivityFactoryTests.cs
+++ b/test/unit/Elsa.Workflows.Core.UnitTests/Services/ActivityFactoryTests.cs
@@ -1,0 +1,47 @@
+using System.Reflection;
+using System.Text.Json;
+using Elsa.Workflows.Activities;
+
+namespace Elsa.Workflows.Core.UnitTests.Services;
+
+public class ActivityFactoryTests
+{
+    // Regression coverage for elsa-workflows/elsa-core#6430.
+    // When a workflow is resumed after a host restart and the activity registry
+    // is not fully warm, ActivityJsonConverter's Find<NotFoundActivity>()!
+    // fallback can return null. The null flows into ActivityFactory as
+    // context.ActivityDescriptor and the synthetic input/output readers must
+    // guard against it instead of NRE'ing on .Inputs / .Outputs.
+
+    private static readonly MethodInfo ReadSyntheticInputsMethod =
+        typeof(ActivityFactory).GetMethod("ReadSyntheticInputs", BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+    private static readonly MethodInfo ReadSyntheticOutputsMethod =
+        typeof(ActivityFactory).GetMethod("ReadSyntheticOutputs", BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+    [Fact]
+    public void ReadSyntheticInputs_DoesNotThrow_WhenActivityDescriptorIsNull()
+    {
+        var factory = new ActivityFactory();
+        var element = JsonDocument.Parse("{}").RootElement;
+        var activity = new End();
+
+        var ex = Record.Exception(() =>
+            ReadSyntheticInputsMethod.Invoke(factory, new object?[] { null, activity, element, new JsonSerializerOptions() }));
+
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void ReadSyntheticOutputs_DoesNotThrow_WhenActivityDescriptorIsNull()
+    {
+        var factory = new ActivityFactory();
+        var element = JsonDocument.Parse("{}").RootElement;
+        var activity = new End();
+
+        var ex = Record.Exception(() =>
+            ReadSyntheticOutputsMethod.Invoke(factory, new object?[] { null, activity, element }));
+
+        Assert.Null(ex);
+    }
+}


### PR DESCRIPTION
…put/output reads

Fixes #6430.

ActivityJsonConverter's "descriptor not in registry" fallback uses a null-forgiving Find<NotFoundActivity>()!, which can return null after a cold host start before the activity registry is fully warm. The null flows into ActivityFactory.Create as context.ActivityDescriptor and NREs on the first .Inputs / .Outputs access in ReadSyntheticInputs / ReadSyntheticOutputs.

This patch adds a minimal null guard at the top of both methods plus the corresponding nullable annotation on the ActivityConstructorContext record so the contract reflects reality.

Reproducer:
  1. Start host with a workflow that suspends (waits on a bookmark/event).
  2. Trigger the workflow so it suspends and is persisted.
  3. Stop the host process.
  4. Start the host process again.
  5. Resume the suspended workflow instance.

Without the host restart, the in-memory activity registry stays warm and the NRE doesn't surface, which likely explains why the original issue report could not be reproduced by a commenter.

## Purpose

<!-- What does this PR change? Summarize in 1–2 sentences. -->

---

## Scope

Select one primary concern:

- [ ] Bug fix (behavior change)
- [ ] Refactor (no behavior change)
- [ ] Documentation update
- [ ] Formatting / code cleanup
- [ ] Dependency / build update
- [ ] New feature

> If this PR includes multiple unrelated concerns, please split it before requesting review.

---

## Description

### Problem
<!-- What issue does this solve? -->

### Solution
<!-- How does this change address the problem? -->

---

## Verification

<!-- How can reviewers verify this change? -->

Steps:
1.
2.
3.

Expected outcome:

---

## Screenshots / Recordings (if applicable)

<!-- Required for UI changes -->

---

## Commit Convention

We recommend using conventional commit prefixes:

- `fix:` – Bug fixes (behavior change)
- `feat:` – New features
- `refactor:` – Code changes without behavior change
- `docs:` – Documentation updates
- `chore:` – Maintenance, tooling, or dependency updates
- `test:` – Test additions or modifications

Clear commit messages make reviews easier and history more meaningful.

---

## Checklist

- [ ] The PR is focused on a single concern
- [ ] Commit messages follow the recommended convention
- [ ] Tests added or updated (if applicable)
- [ ] Documentation updated (if applicable)
- [ ] No unrelated cleanup included
- [ ] All tests pass
