### PR TITLE
Do not await bookmark scheduling on application start to prevent startup from hanging

### DIFF
--- a/src/modules/Elsa.Scheduling/Handlers/UpdateTenantSchedules.cs
+++ b/src/modules/Elsa.Scheduling/Handlers/UpdateTenantSchedules.cs
@@ -28,7 +28,9 @@ public class UpdateTenantSchedules : ITenantActivatedEvent, ITenantDeletedEvent
         var bookmarks = (await GetBookmarksAsync(serviceProvider, cancellationToken)).ToList();
 
         await triggerScheduler.ScheduleAsync(triggers, args.CancellationToken);
-        await bookmarkScheduler.ScheduleAsync(bookmarks, args.CancellationToken);
+
+        // Explicitly no await to prevent the scheduling from blocking application start
+        _ = bookmarkScheduler.ScheduleAsync(bookmarks, args.CancellationToken);
     }
 
     public async Task TenantDeletedAsync(TenantDeletedEventArgs args)


### PR DESCRIPTION
I will have to say this is my suggestion on fixing the problem directly, there might be a better way of solving this problem. For example by moving the entire scheduling into a background worker instead of running directly in the tenant activated event.

## Purpose

This makes the Application not wait for all the bookmarks to be queued before continueing the start of the application.

---

## Scope

Select one primary concern:

- [x] Bug fix (behavior change)
- [ ] Refactor (no behavior change)
- [ ] Documentation update
- [ ] Formatting / code cleanup
- [ ] Dependency / build update
- [ ] New feature

---

## Description

### Problem
this solves the problem described in #7470

### Solution
By not awaiting the scheduling of the bookmarks, the program flow will continue and not hang the IHostedService responsible of activating the tenants

---

## Verification

This can be verified by queuing a large amount of bookmarks and restarting the application. After this change the startup will continue while the log wil show the bookmarks are still being enqueued

---

## Checklist

- [x] The PR is focused on a single concern
- [x] Commit messages follow the recommended convention
- [ ] Tests added or updated (if applicable)
- [ ] Documentation updated (if applicable)
- [x] No unrelated cleanup included
- [ ] All tests pass
