### PR TITLE
Preserve activity descriptors on empty refresh

### DIFF
--- a/src/modules/Elsa.Workflows.Core/Services/ActivityRegistry.cs
+++ b/src/modules/Elsa.Workflows.Core/Services/ActivityRegistry.cs
@@ -192,13 +192,11 @@ public class ActivityRegistry(IActivityDescriber activityDescriber, IEnumerable<
         // Group descriptors by normalized tenant ID
         // Normalize null to "*" so both map to the same agnostic group, avoiding redundant processing
         var descriptorsByTenant = descriptors.GroupBy(d => NormalizeTenantIdForGrouping(d.TenantId));
-        var refreshedRegistries = new HashSet<TenantRegistryData>();
 
         foreach (var group in descriptorsByTenant)
         {
             var tenantId = group.Key;
             var registry = GetOrCreateRegistry(tenantId);
-            refreshedRegistries.Add(registry);
 
             // Remove old descriptors for this provider from this tenant's registry
             if (registry.ProvidedActivityDescriptors.TryGetValue(providerType, out var oldDescriptors))
@@ -218,20 +216,6 @@ public class ActivityRegistry(IActivityDescriber activityDescriber, IEnumerable<
 
             // Update the provider's descriptor list in this registry
             registry.ProvidedActivityDescriptors[providerType] = providerDescriptors;
-        }
-
-        foreach (var registry in GetRegistriesWithProvider(providerType))
-        {
-            if (refreshedRegistries.Contains(registry))
-                continue;
-
-            if (!registry.ProvidedActivityDescriptors.TryRemove(providerType, out var oldDescriptors))
-                continue;
-
-            foreach (var oldDescriptor in oldDescriptors.ToList())
-            {
-                RemoveDescriptor(registry, oldDescriptor);
-            }
         }
     }
 
@@ -320,18 +304,6 @@ public class ActivityRegistry(IActivityDescriber activityDescriber, IEnumerable<
     private ICollection<ActivityDescriptor> GetOrCreateProviderDescriptors(TenantRegistryData registry, Type providerType)
     {
         return registry.ProvidedActivityDescriptors.GetOrAdd(providerType, _ => new List<ActivityDescriptor>());
-    }
-
-    private IEnumerable<TenantRegistryData> GetRegistriesWithProvider(Type providerType)
-    {
-        if (_agnosticRegistry.ProvidedActivityDescriptors.ContainsKey(providerType))
-            yield return _agnosticRegistry;
-
-        foreach (var registry in _tenantRegistries.Values)
-        {
-            if (registry.ProvidedActivityDescriptors.ContainsKey(providerType))
-                yield return registry;
-        }
     }
 
     private static void UpdateLatestDescriptor(TenantRegistryData registry, ActivityDescriptor descriptor)

--- a/test/unit/Elsa.Workflows.Core.UnitTests/Services/ActivityRegistryTests.cs
+++ b/test/unit/Elsa.Workflows.Core.UnitTests/Services/ActivityRegistryTests.cs
@@ -405,7 +405,7 @@ public class ActivityRegistryTests
     }
 
     [Fact]
-    public async Task RefreshDescriptorsAsync_RemovesLatestDescriptor_WhenProviderDropsTenantGroup()
+    public async Task RefreshDescriptorsAsync_PreservesExistingDescriptors_WhenProviderReturnsNoTenantGroups()
     {
         // Arrange
         var provider = new MutableProvider(
@@ -422,7 +422,7 @@ public class ActivityRegistryTests
         var result = _registry.Find(TestActivityType);
 
         // Assert
-        Assert.Null(result);
+        AssertDescriptor(result, CurrentTenant, 2);
     }
 
 


### PR DESCRIPTION
## Summary
- preserve existing activity descriptors when a provider refresh returns no tenant groups
- update the ActivityRegistry unit test to cover this transient empty-refresh behavior

## Validation
- dotnet test test/unit/Elsa.Workflows.Core.UnitTests/Elsa.Workflows.Core.UnitTests.csproj --filter ActivityRegistryTests -p:CollectCoverage=false
- dotnet test test/component/Elsa.Workflows.ComponentTests/Elsa.Workflows.ComponentTests.csproj --configuration Release --filter "FullyQualifiedName~Scenarios.InputOutput.InputOutputTests|FullyQualifiedName~Scenarios.LogPersistenceModes.InputOutputLoggingTests|FullyQualifiedName~Scenarios.WorkflowActivities.AutoUpdateTests|FullyQualifiedName~Scenarios.WorkflowDefinitionExport.WorkflowDefinitionExportTests" -p:CollectCoverage=false