### PR TITLE
[codex] Protect sensitive workflow input descriptors and state

### DIFF
--- a/src/clients/Elsa.Api.Client/Resources/ActivityDescriptors/Models/InputDescriptor.cs
+++ b/src/clients/Elsa.Api.Client/Resources/ActivityDescriptors/Models/InputDescriptor.cs
@@ -44,6 +44,11 @@ public class InputDescriptor : PropertyDescriptor
     public bool? IsReadOnly { get; set; }
     
     /// <summary>
+    /// True if the input can contain secrets and should be treated as sensitive.
+    /// </summary>
+    public bool IsSensitive { get; set; }
+
+    /// <summary>
     /// The storage driver type to use for persistence.
     /// If no driver is specified, the referenced memory block will remain in memory for as long as the expression execution context exists.
     /// </summary>

--- a/src/modules/Elsa.Workflows.Core/Extensions/ActivityExecutionContextExtensions.InputEvaluation.cs
+++ b/src/modules/Elsa.Workflows.Core/Extensions/ActivityExecutionContextExtensions.InputEvaluation.cs
@@ -143,6 +143,12 @@ public static partial class ActivityExecutionContextExtensions
 
     private static Task StoreInputValueAsync(ActivityExecutionContext context, InputDescriptor inputDescriptor, object value)
     {
+        if (inputDescriptor.IsSensitive)
+        {
+            context.ActivityState.Remove(inputDescriptor.Name);
+            return Task.CompletedTask;
+        }
+
         // Store the serialized input value in the activity state.
         // Serializing the value ensures we store a copy of the value and not a reference to the input, which may change over time.
         if (inputDescriptor.IsSerializable != false)

--- a/src/modules/Elsa.Workflows.Core/Services/ActivityDescriber.cs
+++ b/src/modules/Elsa.Workflows.Core/Services/ActivityDescriber.cs
@@ -164,7 +164,10 @@ public class ActivityDescriber(IPropertyDefaultValueResolver defaultValueResolve
             null,
             propertyInfo,
             uiSpecification
-        );
+        )
+        {
+            IsSensitive = inputAttribute?.CanContainSecrets ?? false
+        };
     }
 
     /// <inheritdoc />

--- a/src/modules/Elsa.Workflows.Management/Services/HostMethodActivityDescriber.cs
+++ b/src/modules/Elsa.Workflows.Management/Services/HostMethodActivityDescriber.cs
@@ -146,7 +146,8 @@ public class HostMethodActivityDescriber(IActivityDescriber activityDescriber) :
             Order = inputAttribute?.Order ?? 0,
             IsBrowsable = inputAttribute?.IsBrowsable ?? true,
             AutoEvaluate = inputAttribute?.AutoEvaluate ?? true,
-            IsSerializable = inputAttribute?.IsSerializable ?? true
+            IsSerializable = inputAttribute?.IsSerializable ?? true,
+            IsSensitive = inputAttribute?.CanContainSecrets ?? false
         };
     }
 
@@ -176,7 +177,8 @@ public class HostMethodActivityDescriber(IActivityDescriber activityDescriber) :
             Order = inputAttribute?.Order ?? 0,
             IsBrowsable = inputAttribute?.IsBrowsable ?? true,
             AutoEvaluate = inputAttribute?.AutoEvaluate ?? true,
-            IsSerializable = inputAttribute?.IsSerializable ?? true
+            IsSerializable = inputAttribute?.IsSerializable ?? true,
+            IsSensitive = inputAttribute?.CanContainSecrets ?? false
         };
     }
 

--- a/test/unit/Elsa.Workflows.Core.UnitTests/Extensions/ActivityExecutionContextExtensions/InputEvaluationTests.cs
+++ b/test/unit/Elsa.Workflows.Core.UnitTests/Extensions/ActivityExecutionContextExtensions/InputEvaluationTests.cs
@@ -1,0 +1,57 @@
+using Elsa.Testing.Shared;
+using Elsa.Workflows.Attributes;
+using Elsa.Workflows.Models;
+using Xunit;
+
+namespace Elsa.Workflows.Core.UnitTests.Extensions.ActivityExecutionContextExtensions;
+
+public class InputEvaluationTests
+{
+    private readonly ActivityWithSensitiveInputs _activity = new();
+    private readonly ActivityTestFixture _fixture;
+
+    public InputEvaluationTests()
+    {
+        _fixture = new(_activity);
+    }
+
+    [Fact]
+    public async Task EvaluateInputPropertiesAsync_WhenInputIsSensitive_RemovesItFromActivityState()
+    {
+        _fixture.ConfigureContext(context => context.ActivityState[nameof(ActivityWithSensitiveInputs.SensitiveText)] = "stale-secret");
+
+        var context = await ActivateAsync();
+
+        Assert.False(context.ActivityState.ContainsKey(nameof(ActivityWithSensitiveInputs.SensitiveText)));
+        Assert.Equal("secret", _activity.CapturedSensitiveText);
+    }
+
+    [Fact]
+    public async Task EvaluateInputPropertiesAsync_WhenInputIsNotSensitive_StoresItInActivityState()
+    {
+        var context = await ActivateAsync();
+
+        Assert.Equal("public", context.ActivityState[nameof(ActivityWithSensitiveInputs.PublicText)]);
+        Assert.Equal("public", _activity.CapturedPublicText);
+    }
+
+    private Task<ActivityExecutionContext> ActivateAsync() => _fixture.ExecuteAsync();
+
+    private sealed class ActivityWithSensitiveInputs : CodeActivity
+    {
+        [Input(CanContainSecrets = true)]
+        public Input<string?> SensitiveText { get; set; } = new("secret");
+
+        [Input]
+        public Input<string?> PublicText { get; set; } = new("public");
+
+        public string? CapturedSensitiveText { get; private set; }
+        public string? CapturedPublicText { get; private set; }
+
+        protected override void Execute(ActivityExecutionContext context)
+        {
+            CapturedSensitiveText = context.Get(SensitiveText);
+            CapturedPublicText = context.Get(PublicText);
+        }
+    }
+}

--- a/test/unit/Elsa.Workflows.Core.UnitTests/Services/ActivityDescriberTests.cs
+++ b/test/unit/Elsa.Workflows.Core.UnitTests/Services/ActivityDescriberTests.cs
@@ -1,0 +1,46 @@
+using System.Reflection;
+using Elsa.Workflows.Attributes;
+using Elsa.Workflows.Models;
+using NSubstitute;
+using Xunit;
+
+namespace Elsa.Workflows.Core.UnitTests.Services;
+
+public class ActivityDescriberTests
+{
+    private readonly IActivityDescriber _describer;
+
+    public ActivityDescriberTests()
+    {
+        var defaultValueResolver = Substitute.For<IPropertyDefaultValueResolver>();
+        var propertyUIHandlerResolver = Substitute.For<IPropertyUIHandlerResolver>();
+
+        defaultValueResolver.GetDefaultValue(Arg.Any<PropertyInfo>()).Returns((object?)null);
+        propertyUIHandlerResolver
+            .GetUIPropertiesAsync(Arg.Any<PropertyInfo>(), Arg.Any<object?>(), Arg.Any<CancellationToken>())
+            .Returns(_ => new ValueTask<IDictionary<string, object>>(new Dictionary<string, object>()));
+
+        _describer = new ActivityDescriber(defaultValueResolver, propertyUIHandlerResolver);
+    }
+
+    [Fact]
+    public async Task DescribeActivityAsync_MapsCanContainSecretsToInputDescriptorSensitivity()
+    {
+        var descriptor = await _describer.DescribeActivityAsync(typeof(ActivityWithSensitiveInputs));
+
+        var sensitiveInput = descriptor.Inputs.Single(x => x.Name == nameof(ActivityWithSensitiveInputs.SensitiveText));
+        var publicInput = descriptor.Inputs.Single(x => x.Name == nameof(ActivityWithSensitiveInputs.PublicText));
+
+        Assert.True(sensitiveInput.IsSensitive);
+        Assert.False(publicInput.IsSensitive);
+    }
+
+    private sealed class ActivityWithSensitiveInputs : CodeActivity
+    {
+        [Input(CanContainSecrets = true)]
+        public Input<string?> SensitiveText { get; set; } = new("secret");
+
+        [Input]
+        public Input<string?> PublicText { get; set; } = new("public");
+    }
+}


### PR DESCRIPTION
## Summary
- Maps `InputAttribute.CanContainSecrets` to `InputDescriptor.IsSensitive` for core activity descriptors and hosted method descriptors.
- Adds `IsSensitive` to the API client activity descriptor input model for Studio/client consumption.
- Skips sensitive evaluated input values in `ActivityState` by removing any existing state entry while preserving non-sensitive input state behavior.

## Validation
- `dotnet test test/unit/Elsa.Workflows.Core.UnitTests/Elsa.Workflows.Core.UnitTests.csproj` - passed, 198 tests.
- `dotnet build src/clients/Elsa.Api.Client/Elsa.Api.Client.csproj` - passed for net8.0, net9.0, net10.0.

Refs #7551.
Closes #7552.
Closes #7557.
Closes #7558.
Closes #7559.
