### PR TITLE
[codex] Validate workflow secret references adoption

### DIFF
--- a/Elsa.sln
+++ b/Elsa.sln
@@ -355,6 +355,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Diagnostics.OpenTeleme
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "secrets", "secrets", "{D3E5E9EF-DE26-41BF-A239-3241B5B5FD89}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Secrets.JavaScript", "src\modules\Elsa.Secrets.JavaScript\Elsa.Secrets.JavaScript.csproj", "{80F7ED38-15BA-4C82-88C8-12135B33F7EF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1431,6 +1433,18 @@ Global
 		{B6A62D42-D9AA-47BE-BCBC-FCB866D346F0}.Release|x64.Build.0 = Release|Any CPU
 		{B6A62D42-D9AA-47BE-BCBC-FCB866D346F0}.Release|x86.ActiveCfg = Release|Any CPU
 		{B6A62D42-D9AA-47BE-BCBC-FCB866D346F0}.Release|x86.Build.0 = Release|Any CPU
+		{80F7ED38-15BA-4C82-88C8-12135B33F7EF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{80F7ED38-15BA-4C82-88C8-12135B33F7EF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{80F7ED38-15BA-4C82-88C8-12135B33F7EF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{80F7ED38-15BA-4C82-88C8-12135B33F7EF}.Debug|x64.Build.0 = Debug|Any CPU
+		{80F7ED38-15BA-4C82-88C8-12135B33F7EF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{80F7ED38-15BA-4C82-88C8-12135B33F7EF}.Debug|x86.Build.0 = Debug|Any CPU
+		{80F7ED38-15BA-4C82-88C8-12135B33F7EF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{80F7ED38-15BA-4C82-88C8-12135B33F7EF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{80F7ED38-15BA-4C82-88C8-12135B33F7EF}.Release|x64.ActiveCfg = Release|Any CPU
+		{80F7ED38-15BA-4C82-88C8-12135B33F7EF}.Release|x64.Build.0 = Release|Any CPU
+		{80F7ED38-15BA-4C82-88C8-12135B33F7EF}.Release|x86.ActiveCfg = Release|Any CPU
+		{80F7ED38-15BA-4C82-88C8-12135B33F7EF}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1558,6 +1572,7 @@ Global
 		{B6A62D42-D9AA-47BE-BCBC-FCB866D346F0} = {1B8D5897-902E-4632-8698-E89CAF3DDF54}
 		{D3E5E9EF-DE26-41BF-A239-3241B5B5FD89} = {5BA4A8FA-F7F4-45B3-AEC8-8886D35AAC79}
 		{09B4B78B-FE02-44E2-8667-E182AF921C54} = {D3E5E9EF-DE26-41BF-A239-3241B5B5FD89}
+		{80F7ED38-15BA-4C82-88C8-12135B33F7EF} = {D3E5E9EF-DE26-41BF-A239-3241B5B5FD89}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D4B5CEAA-7D70-4FCB-A68E-B03FBE5E0E5E}

--- a/doc/wiki/identity-tenancy-security.md
+++ b/doc/wiki/identity-tenancy-security.md
@@ -114,7 +114,6 @@ Start in [src/modules/Elsa.Secrets](../../src/modules/Elsa.Secrets).
 
 - [ISecretManager](../../src/modules/Elsa.Secrets/Contracts/ISecretManager.cs): create, get, rotate, revoke, delete, and test secrets.
 - [ISecretResolver](../../src/modules/Elsa.Secrets/Contracts/ISecretResolver.cs): resolve the latest active secret value by immutable technical name.
-- [ISecretProvider](../../src/modules/Elsa.Secrets/Contracts/ISecretProvider.cs): legacy-compatible provider adapter backed by `ISecretResolver`.
 - [ISecretStore](../../src/modules/Elsa.Secrets/Contracts/ISecretStore.cs) / [ISecretStoreRegistry](../../src/modules/Elsa.Secrets/Contracts/ISecretStoreRegistry.cs): pluggable backend stores.
 - [ISecretTypeRegistry](../../src/modules/Elsa.Secrets/Contracts/ISecretTypeRegistry.cs): extensible secret types (text, RSA key, X.509 certificate reference).
 - [ISecretRepository](../../src/modules/Elsa.Secrets/Contracts/ISecretRepository.cs): durable secret and version storage.
@@ -150,11 +149,26 @@ Permission constants are in [SecretsPermissions](../../src/modules/Elsa.Secrets/
 
 ### Using Secrets In Workflows
 
-Activities with sensitive inputs can use a `SecretReference` in place of a literal value. The runtime calls `ISecretResolver` at the point of use so workflow definitions store only the reference, not the resolved value.
+Activities with sensitive inputs can use the `Secret` expression in place of a literal value. Studio presents this as a no-code picker for inputs marked as sensitive, such as the HTTP Request `Authorization` input. The picker stores a `SecretReference` with the secret name, optional type, and optional scope; it does not store the current secret value in the workflow definition.
+
+At runtime, the `Secret` expression calls `ISecretResolver` at the point of use and returns the latest active version. Rotating a secret through `ISecretManager.RotateAsync` updates future workflow runs without editing workflow JSON. If a reference includes a type or scope, resolution must match those constraints; for example, a text token reference should not resolve an RSA key, and a `production` reference should not resolve a `development` secret. Expired, revoked, missing, or incompatible secrets fail with a non-secret error message.
+
+Sensitive activity inputs are not written to activity state after evaluation. Prefer a `Secret` expression for credentials such as bearer tokens, API keys, passwords, and connection strings instead of literals, variables, logs, workflow outputs, incident messages, or custom headers that are not marked sensitive. Treat any custom activity input that can carry credentials as sensitive by setting `CanContainSecrets = true`.
+
+JavaScript expressions can resolve secrets when the host enables `Elsa.Secrets.JavaScript`:
+
+```javascript
+const token = await getSecret("crm:token");
+return `Bearer ${token}`;
+```
+
+`getSecret(name)` returns a `Promise<string>`, so JavaScript must either `await` it inside an async function/IIFE or compose it with `.then(...)`. Do not write resolved values to logs, variables, outputs, exceptions, or activity state. Use the `Secret` expression for simple no-code binding, and use `getSecret` only when a script needs to combine a secret with runtime data.
 
 ### Tests
 
 - [test/unit/Elsa.Secrets.UnitTests](../../test/unit/Elsa.Secrets.UnitTests)
+- [test/integration/Elsa.JavaScript.IntegrationTests](../../test/integration/Elsa.JavaScript.IntegrationTests)
+- [test/integration/Elsa.Activities.IntegrationTests](../../test/integration/Elsa.Activities.IntegrationTests)
 
 Spec: [specs/007-secrets-module/spec.md](../../specs/007-secrets-module/spec.md).
 

--- a/src/clients/Elsa.Api.Client/Resources/ActivityDescriptors/Models/InputDescriptor.cs
+++ b/src/clients/Elsa.Api.Client/Resources/ActivityDescriptors/Models/InputDescriptor.cs
@@ -44,6 +44,11 @@ public class InputDescriptor : PropertyDescriptor
     public bool? IsReadOnly { get; set; }
     
     /// <summary>
+    /// True if the input can contain secrets and should be treated as sensitive.
+    /// </summary>
+    public bool IsSensitive { get; set; }
+
+    /// <summary>
     /// The storage driver type to use for persistence.
     /// If no driver is specified, the referenced memory block will remain in memory for as long as the expression execution context exists.
     /// </summary>

--- a/src/modules/Elsa.Secrets.JavaScript/Elsa.Secrets.JavaScript.csproj
+++ b/src/modules/Elsa.Secrets.JavaScript/Elsa.Secrets.JavaScript.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <Description>
+            Provides JavaScript expression functions for resolving Elsa secrets.
+        </Description>
+        <PackageTags>elsa module secrets javascript workflow security</PackageTags>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Elsa.Expressions.JavaScript\Elsa.Expressions.JavaScript.csproj" />
+        <ProjectReference Include="..\Elsa.Secrets\Elsa.Secrets.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/modules/Elsa.Secrets.JavaScript/Extensions/ModuleExtensions.cs
+++ b/src/modules/Elsa.Secrets.JavaScript/Extensions/ModuleExtensions.cs
@@ -1,0 +1,13 @@
+using Elsa.Features.Services;
+using Elsa.Secrets.JavaScript.Features;
+
+// ReSharper disable once CheckNamespace
+namespace Elsa.Extensions;
+
+public static class ModuleExtensions
+{
+    public static IModule UseSecretsJavaScript(this IModule module, Action<SecretsJavaScriptFeature>? configure = null)
+    {
+        return module.Use(configure);
+    }
+}

--- a/src/modules/Elsa.Secrets.JavaScript/Features/SecretsJavaScriptFeature.cs
+++ b/src/modules/Elsa.Secrets.JavaScript/Features/SecretsJavaScriptFeature.cs
@@ -1,0 +1,22 @@
+using Elsa.Expressions.JavaScript.Extensions;
+using Elsa.Expressions.JavaScript.Features;
+using Elsa.Features.Abstractions;
+using Elsa.Features.Attributes;
+using Elsa.Features.Services;
+using Elsa.Secrets.Features;
+using Elsa.Secrets.JavaScript.Scripting.JavaScript;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Elsa.Secrets.JavaScript.Features;
+
+[DependsOn(typeof(JavaScriptFeature))]
+[DependsOn(typeof(SecretsFeature))]
+public class SecretsJavaScriptFeature(IModule module) : FeatureBase(module)
+{
+    public override void Apply()
+    {
+        Services
+            .AddNotificationHandler<SecretsJavaScriptHandler>()
+            .AddFunctionDefinitionProvider<SecretsJavaScriptHandler>();
+    }
+}

--- a/src/modules/Elsa.Secrets.JavaScript/FodyWeavers.xml
+++ b/src/modules/Elsa.Secrets.JavaScript/FodyWeavers.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
+  <ConfigureAwait ContinueOnCapturedContext="false" />
+</Weavers>

--- a/src/modules/Elsa.Secrets.JavaScript/Scripting/JavaScript/SecretsJavaScriptHandler.cs
+++ b/src/modules/Elsa.Secrets.JavaScript/Scripting/JavaScript/SecretsJavaScriptHandler.cs
@@ -1,0 +1,27 @@
+using Elsa.Expressions.JavaScript.Notifications;
+using Elsa.Expressions.JavaScript.TypeDefinitions.Abstractions;
+using Elsa.Expressions.JavaScript.TypeDefinitions.Models;
+using Elsa.Mediator.Contracts;
+using Elsa.Secrets.Contracts;
+using JetBrains.Annotations;
+
+namespace Elsa.Secrets.JavaScript.Scripting.JavaScript;
+
+[UsedImplicitly]
+public class SecretsJavaScriptHandler(ISecretResolver secretResolver) : FunctionDefinitionProvider, INotificationHandler<EvaluatingJavaScript>
+{
+    public Task HandleAsync(EvaluatingJavaScript notification, CancellationToken cancellationToken)
+    {
+        var context = notification.Context;
+        notification.Engine.SetValue("getSecret", (Func<string, Task<string>>)(name => secretResolver.ResolveAsync(name, context.CancellationToken)));
+        return Task.CompletedTask;
+    }
+
+    protected override IEnumerable<FunctionDefinition> GetFunctionDefinitions(TypeDefinitionContext context)
+    {
+        yield return CreateFunctionDefinition(function => function
+            .Name("getSecret")
+            .ReturnType("Promise<string>")
+            .Parameter("name", "string"));
+    }
+}

--- a/src/modules/Elsa.Secrets.JavaScript/ShellFeatures/SecretsJavaScriptFeature.cs
+++ b/src/modules/Elsa.Secrets.JavaScript/ShellFeatures/SecretsJavaScriptFeature.cs
@@ -1,0 +1,24 @@
+using CShells.Features;
+using Elsa.Expressions.JavaScript.Extensions;
+using Elsa.Expressions.JavaScript.ShellFeatures;
+using Elsa.Secrets.JavaScript.Scripting.JavaScript;
+using Elsa.Secrets.ShellFeatures;
+using JetBrains.Annotations;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Elsa.Secrets.JavaScript.ShellFeatures;
+
+[ShellFeature(
+    DisplayName = "Secrets JavaScript",
+    Description = "Provides JavaScript expression functions for resolving Elsa secrets.",
+    DependsOn = [typeof(JavaScriptFeature), typeof(SecretsFeature)])]
+[UsedImplicitly]
+public class SecretsJavaScriptFeature : IShellFeature
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services
+            .AddNotificationHandler<SecretsJavaScriptHandler>()
+            .AddFunctionDefinitionProvider<SecretsJavaScriptHandler>();
+    }
+}

--- a/src/modules/Elsa.Secrets/Elsa.Secrets.csproj
+++ b/src/modules/Elsa.Secrets/Elsa.Secrets.csproj
@@ -14,6 +14,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\common\Elsa.Api.Common\Elsa.Api.Common.csproj" />
+        <ProjectReference Include="..\Elsa.Expressions\Elsa.Expressions.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/modules/Elsa.Secrets/Expressions/SecretExpression.cs
+++ b/src/modules/Elsa.Secrets/Expressions/SecretExpression.cs
@@ -1,0 +1,19 @@
+using Elsa.Expressions.Models;
+
+namespace Elsa.Secrets.Expressions;
+
+/// <summary>
+/// Creates Secret expressions that store references to named secrets.
+/// </summary>
+public static class SecretExpression
+{
+    /// <summary>
+    /// The Secret expression type name.
+    /// </summary>
+    public const string TypeName = "Secret";
+
+    /// <summary>
+    /// Creates a Secret expression for the specified reference.
+    /// </summary>
+    public static Expression Create(SecretReference reference) => new(TypeName, reference);
+}

--- a/src/modules/Elsa.Secrets/Expressions/SecretExpressionHandler.cs
+++ b/src/modules/Elsa.Secrets/Expressions/SecretExpressionHandler.cs
@@ -1,0 +1,24 @@
+using Elsa.Expressions.Contracts;
+using Elsa.Expressions.Helpers;
+using Elsa.Expressions.Models;
+
+namespace Elsa.Secrets.Expressions;
+
+/// <summary>
+/// Resolves Secret expressions through the configured secret resolver.
+/// </summary>
+public class SecretExpressionHandler(ISecretResolver secretResolver, IWellKnownTypeRegistry wellKnownTypeRegistry) : IExpressionHandler
+{
+    /// <inheritdoc />
+    public async ValueTask<object?> EvaluateAsync(Expression expression, Type returnType, ExpressionExecutionContext context, ExpressionEvaluatorOptions options)
+    {
+        if (expression.Value is not SecretReference reference)
+            throw new InvalidOperationException("Secret expression value must be a SecretReference.");
+
+        if (string.IsNullOrWhiteSpace(reference.Name))
+            throw new InvalidOperationException("Secret expression reference must specify a secret name.");
+
+        var value = await secretResolver.ResolveAsync(reference, context.CancellationToken);
+        return value.ConvertTo(returnType, new ObjectConverterOptions(WellKnownTypeRegistry: wellKnownTypeRegistry));
+    }
+}

--- a/src/modules/Elsa.Secrets/Extensions/ServiceCollectionExtensions.cs
+++ b/src/modules/Elsa.Secrets/Extensions/ServiceCollectionExtensions.cs
@@ -1,3 +1,5 @@
+using Elsa.Expressions.Contracts;
+using Elsa.Secrets.Providers;
 using Elsa.Secrets.Repositories;
 using Elsa.Secrets.Services;
 using Elsa.Secrets.Stores;
@@ -22,6 +24,7 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<ISecretResolver, DefaultSecretResolver>();
         services.TryAddSingleton<ISecretStoreRegistry, SecretStoreRegistry>();
         services.TryAddSingleton<ISecretTypeRegistry, SecretTypeRegistry>();
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IExpressionDescriptorProvider, SecretExpressionDescriptorProvider>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<ISecretStore, EncryptedSecretStore>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<ISecretStore, ConfigurationSecretStore>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<ISecretTypeProvider, TextSecretTypeProvider>());

--- a/src/modules/Elsa.Secrets/Providers/SecretExpressionDescriptorProvider.cs
+++ b/src/modules/Elsa.Secrets/Providers/SecretExpressionDescriptorProvider.cs
@@ -1,0 +1,44 @@
+using System.Text.Json;
+using Elsa.Expressions.Contracts;
+using Elsa.Expressions.Models;
+using Elsa.Secrets.Expressions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Elsa.Secrets.Providers;
+
+/// <summary>
+/// Provides the Secret expression descriptor.
+/// </summary>
+public class SecretExpressionDescriptorProvider : IExpressionDescriptorProvider
+{
+    private const string SecretPickerUIHint = "secret-picker";
+    private const string SecretPickerEndpoint = "/secrets/picker";
+
+    /// <inheritdoc />
+    public IEnumerable<ExpressionDescriptor> GetDescriptors()
+    {
+        yield return new()
+        {
+            Type = SecretExpression.TypeName,
+            DisplayName = "Secret",
+            HandlerFactory = ActivatorUtilities.GetServiceOrCreateInstance<SecretExpressionHandler>,
+            Properties = new Dictionary<string, object>
+            {
+                ["UIHint"] = SecretPickerUIHint,
+                ["PickerEndpoint"] = SecretPickerEndpoint
+            },
+            Deserialize = Deserialize
+        };
+    }
+
+    private static Expression Deserialize(ExpressionSerializationContext context)
+    {
+        var valueElement = context.JsonElement.TryGetProperty("value", out var v) ? v : default;
+
+        if (valueElement.ValueKind is JsonValueKind.Undefined or JsonValueKind.Null)
+            return new Expression(SecretExpression.TypeName, null);
+
+        var reference = valueElement.Deserialize<SecretReference>(context.Options);
+        return new Expression(SecretExpression.TypeName, reference);
+    }
+}

--- a/src/modules/Elsa.Workflows.Core/Extensions/ActivityExecutionContextExtensions.InputEvaluation.cs
+++ b/src/modules/Elsa.Workflows.Core/Extensions/ActivityExecutionContextExtensions.InputEvaluation.cs
@@ -143,6 +143,12 @@ public static partial class ActivityExecutionContextExtensions
 
     private static Task StoreInputValueAsync(ActivityExecutionContext context, InputDescriptor inputDescriptor, object value)
     {
+        if (inputDescriptor.IsSensitive)
+        {
+            context.ActivityState.Remove(inputDescriptor.Name);
+            return Task.CompletedTask;
+        }
+
         // Store the serialized input value in the activity state.
         // Serializing the value ensures we store a copy of the value and not a reference to the input, which may change over time.
         if (inputDescriptor.IsSerializable != false)

--- a/src/modules/Elsa.Workflows.Core/Services/ActivityDescriber.cs
+++ b/src/modules/Elsa.Workflows.Core/Services/ActivityDescriber.cs
@@ -164,7 +164,10 @@ public class ActivityDescriber(IPropertyDefaultValueResolver defaultValueResolve
             null,
             propertyInfo,
             uiSpecification
-        );
+        )
+        {
+            IsSensitive = inputAttribute?.CanContainSecrets ?? false
+        };
     }
 
     /// <inheritdoc />

--- a/src/modules/Elsa.Workflows.Management/Services/HostMethodActivityDescriber.cs
+++ b/src/modules/Elsa.Workflows.Management/Services/HostMethodActivityDescriber.cs
@@ -146,7 +146,8 @@ public class HostMethodActivityDescriber(IActivityDescriber activityDescriber) :
             Order = inputAttribute?.Order ?? 0,
             IsBrowsable = inputAttribute?.IsBrowsable ?? true,
             AutoEvaluate = inputAttribute?.AutoEvaluate ?? true,
-            IsSerializable = inputAttribute?.IsSerializable ?? true
+            IsSerializable = inputAttribute?.IsSerializable ?? true,
+            IsSensitive = inputAttribute?.CanContainSecrets ?? false
         };
     }
 
@@ -176,7 +177,8 @@ public class HostMethodActivityDescriber(IActivityDescriber activityDescriber) :
             Order = inputAttribute?.Order ?? 0,
             IsBrowsable = inputAttribute?.IsBrowsable ?? true,
             AutoEvaluate = inputAttribute?.AutoEvaluate ?? true,
-            IsSerializable = inputAttribute?.IsSerializable ?? true
+            IsSerializable = inputAttribute?.IsSerializable ?? true,
+            IsSensitive = inputAttribute?.CanContainSecrets ?? false
         };
     }
 

--- a/test/integration/Elsa.Activities.IntegrationTests/Elsa.Activities.IntegrationTests.csproj
+++ b/test/integration/Elsa.Activities.IntegrationTests/Elsa.Activities.IntegrationTests.csproj
@@ -9,6 +9,7 @@
       <ProjectReference Include="..\..\..\src\common\Elsa.Testing.Shared.Integration\Elsa.Testing.Shared.Integration.csproj" />
       <ProjectReference Include="..\..\..\src\common\Elsa.Testing.Shared\Elsa.Testing.Shared.csproj" />
       <ProjectReference Include="..\..\..\src\modules\Elsa.Http\Elsa.Http.csproj" />
+      <ProjectReference Include="..\..\..\src\modules\Elsa.Secrets\Elsa.Secrets.csproj" />
       <ProjectReference Include="..\..\..\src\modules\Elsa.Workflows.Core\Elsa.Workflows.Core.csproj" />
       <ProjectReference Include="..\..\unit\Elsa.Activities.UnitTests\Elsa.Activities.UnitTests.csproj" />
     </ItemGroup>

--- a/test/integration/Elsa.Activities.IntegrationTests/Http/SendHttpRequestSecretExpressionTests.cs
+++ b/test/integration/Elsa.Activities.IntegrationTests/Http/SendHttpRequestSecretExpressionTests.cs
@@ -1,0 +1,91 @@
+using System.Net;
+using Elsa.Activities.UnitTests.Http.Helpers;
+using Elsa.Expressions.Contracts;
+using Elsa.Extensions;
+using Elsa.Http;
+using Elsa.Secrets.Contracts;
+using Elsa.Secrets.Expressions;
+using Elsa.Secrets.Models;
+using Elsa.Secrets.Providers;
+using Elsa.Testing.Shared;
+using Elsa.Workflows;
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Management;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit.Abstractions;
+
+namespace Elsa.Activities.IntegrationTests.Http;
+
+public class SendHttpRequestSecretExpressionTests(ITestOutputHelper testOutputHelper)
+{
+    private const string SecretName = "api:authorization";
+    private const string SecretValue = "Bearer resolved-token";
+
+    [Fact(DisplayName = "SendHttpRequest resolves Authorization from Secret expression without persisting the secret")]
+    public async Task ResolvesAuthorizationSecretExpressionWithoutPersistingSecret()
+    {
+        var capturedRequests = new List<HttpRequestMessage>();
+        var fixture = CreateFixture(CreateCapturingHandler(capturedRequests));
+        var activity = new SendHttpRequest
+        {
+            Url = new(new Uri("https://api.example.com/secure")),
+            Method = new("GET"),
+            Authorization = new(SecretExpression.Create(new SecretReference(SecretName, SecretTypeNames.Text, "production"))),
+            ExpectedStatusCodes = new List<HttpStatusCodeCase>()
+        };
+
+        await fixture.BuildAsync();
+
+        var workflowJson = fixture.Services.GetRequiredService<IWorkflowSerializer>().Serialize(Workflow.FromActivity(activity));
+        Assert.Contains(SecretName, workflowJson);
+        Assert.DoesNotContain(SecretValue, workflowJson);
+
+        var result = await fixture.RunActivityAsync(activity);
+
+        var capturedRequest = Assert.Single(capturedRequests);
+        Assert.NotNull(capturedRequest.Headers.Authorization);
+        Assert.Equal(SecretValue, capturedRequest.Headers.Authorization.ToString());
+
+        var activityContext = Assert.Single(result.Journal.ActivityExecutionContexts, x => x.Activity == activity);
+        Assert.False(activityContext.ActivityState.ContainsKey(nameof(SendHttpRequestBase.Authorization)));
+
+        var workflowStateJson = fixture.Services.GetRequiredService<IWorkflowStateSerializer>().Serialize(result.WorkflowState);
+        Assert.DoesNotContain(SecretValue, workflowStateJson);
+    }
+
+    private WorkflowTestFixture CreateFixture(HttpMessageHandler handler)
+    {
+        return new WorkflowTestFixture(testOutputHelper)
+            .ConfigureServices(services =>
+            {
+                services.AddSingleton<ISecretResolver>(new TestSecretResolver());
+                services.AddSingleton<IExpressionDescriptorProvider, SecretExpressionDescriptorProvider>();
+            })
+            .ConfigureElsa(elsa => elsa.UseHttp(http =>
+            {
+                http.HttpClientBuilder = builder => builder.ConfigurePrimaryHttpMessageHandler(() => handler);
+            }));
+    }
+
+    private static HttpMessageHandler CreateCapturingHandler(ICollection<HttpRequestMessage> capturedRequests) =>
+        new TestHttpMessageHandler((request, _) =>
+        {
+            capturedRequests.Add(request);
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+        });
+
+    private class TestSecretResolver : ISecretResolver
+    {
+        public Task<string> ResolveAsync(string name, CancellationToken cancellationToken = default)
+        {
+            Assert.Equal(SecretName, name);
+            return Task.FromResult(SecretValue);
+        }
+
+        public Task<string> ResolveAsync(SecretReference reference, CancellationToken cancellationToken = default)
+        {
+            Assert.Equal(new SecretReference(SecretName, SecretTypeNames.Text, "production"), reference);
+            return Task.FromResult(SecretValue);
+        }
+    }
+}

--- a/test/integration/Elsa.JavaScript.IntegrationTests/Elsa.JavaScript.IntegrationTests.csproj
+++ b/test/integration/Elsa.JavaScript.IntegrationTests/Elsa.JavaScript.IntegrationTests.csproj
@@ -8,6 +8,7 @@
       <ProjectReference Include="..\..\..\src\common\Elsa.Testing.Shared.Integration\Elsa.Testing.Shared.Integration.csproj" />
       <ProjectReference Include="..\..\..\src\common\Elsa.Testing.Shared\Elsa.Testing.Shared.csproj" />
       <ProjectReference Include="..\..\..\src\modules\Elsa.Expressions.JavaScript\Elsa.Expressions.JavaScript.csproj" />
+      <ProjectReference Include="..\..\..\src\modules\Elsa.Secrets.JavaScript\Elsa.Secrets.JavaScript.csproj" />
     </ItemGroup>
 
 </Project>

--- a/test/integration/Elsa.JavaScript.IntegrationTests/SecretsJavaScriptTests.cs
+++ b/test/integration/Elsa.JavaScript.IntegrationTests/SecretsJavaScriptTests.cs
@@ -1,0 +1,108 @@
+using Elsa.Expressions.JavaScript.Contracts;
+using Elsa.Expressions.JavaScript.TypeDefinitions.Contracts;
+using Elsa.Expressions.JavaScript.TypeDefinitions.Models;
+using Elsa.Extensions;
+using Elsa.Features.Services;
+using Elsa.Secrets.Contracts;
+using Elsa.Secrets.Models;
+using Elsa.Testing.Shared;
+using Elsa.Workflows;
+using Elsa.Workflows.Activities;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit.Abstractions;
+
+namespace Elsa.JavaScript.IntegrationTests;
+
+public class SecretsJavaScriptTests
+{
+    private readonly TestSecretResolver _secretResolver = new();
+    private readonly WorkflowTestFixture _fixture;
+
+    public SecretsJavaScriptTests(ITestOutputHelper testOutputHelper)
+    {
+        _fixture = new(testOutputHelper);
+        _fixture
+            .ConfigureServices(services => services.AddSingleton<ISecretResolver>(_secretResolver))
+            .ConfigureElsa(ConfigureElsa);
+    }
+
+    [Fact]
+    public async Task GetSecret_ReturnsPromiseCompatibleSecretValue()
+    {
+        var result = await EvaluateScriptAsync<string>("return getSecret('api:key');");
+
+        Assert.Equal("secret-value", result);
+        Assert.Equal(["api:key"], _secretResolver.ResolvedNames);
+    }
+
+    [Fact]
+    public async Task GetSecret_ComposesWithThen()
+    {
+        var result = await EvaluateScriptAsync<string>("return getSecret('api:key').then(value => value + '-suffix');");
+
+        Assert.Equal("secret-value-suffix", result);
+    }
+
+    [Fact]
+    public async Task GetSecret_ComposesWithAsyncIife()
+    {
+        var result = await EvaluateScriptAsync<string>("return (async () => await getSecret('api:key'))();");
+
+        Assert.Equal("secret-value", result);
+    }
+
+    [Fact]
+    public async Task TypeDefinitions_DocumentGetSecretAsPromiseOfString()
+    {
+        var typeDefinitions = await GenerateTypeDefinitionsAsync();
+
+        Assert.Contains("declare function getSecret(name: string): Promise<string>;", typeDefinitions);
+    }
+
+    private static void ConfigureElsa(IModule module)
+    {
+        module.UseSecretsJavaScript();
+    }
+
+    private async Task<T> EvaluateScriptAsync<T>(string script)
+    {
+        var context = await _fixture.CreateExpressionExecutionContextAsync();
+        var evaluator = _fixture.Services.GetRequiredService<IJavaScriptEvaluator>();
+        var result = await evaluator.EvaluateAsync(script, typeof(T), context);
+
+        return result is T typedResult ? typedResult : (T)Convert.ChangeType(result, typeof(T))!;
+    }
+
+    private async Task<string> GenerateTypeDefinitionsAsync()
+    {
+        await _fixture.BuildAsync();
+        var workflow = new Workflow();
+        var workflowGraphBuilder = _fixture.Services.GetRequiredService<IWorkflowGraphBuilder>();
+        var workflowGraph = await workflowGraphBuilder.BuildAsync(workflow);
+        var typeDefinitionContext = new TypeDefinitionContext(workflowGraph, null, null, CancellationToken.None);
+        var typeDefinitionService = _fixture.Services.GetRequiredService<ITypeDefinitionService>();
+
+        return await typeDefinitionService.GenerateTypeDefinitionsAsync(typeDefinitionContext);
+    }
+
+    private class TestSecretResolver : ISecretResolver
+    {
+        private readonly Dictionary<string, string> _secrets = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["api:key"] = "secret-value"
+        };
+
+        public List<string> ResolvedNames { get; } = [];
+
+        public Task<string> ResolveAsync(string name, CancellationToken cancellationToken = default)
+        {
+            ResolvedNames.Add(name);
+            return Task.FromResult(_secrets[name]);
+        }
+
+        public Task<string> ResolveAsync(SecretReference reference, CancellationToken cancellationToken = default)
+        {
+            return ResolveAsync(reference.Name, cancellationToken);
+        }
+    }
+}

--- a/test/unit/Elsa.Secrets.UnitTests/Elsa.Secrets.UnitTests.csproj
+++ b/test/unit/Elsa.Secrets.UnitTests/Elsa.Secrets.UnitTests.csproj
@@ -7,6 +7,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\..\src\modules\Elsa.Secrets\Elsa.Secrets.csproj" />
+        <ProjectReference Include="..\..\..\src\modules\Elsa.Workflows.Core\Elsa.Workflows.Core.csproj" />
     </ItemGroup>
 
 </Project>

--- a/test/unit/Elsa.Secrets.UnitTests/SecretExpressionTests.cs
+++ b/test/unit/Elsa.Secrets.UnitTests/SecretExpressionTests.cs
@@ -1,0 +1,193 @@
+using System.Text.Json;
+using Elsa.Expressions.Contracts;
+using Elsa.Expressions.Models;
+using Elsa.Expressions.Options;
+using Elsa.Expressions.Services;
+using Elsa.Secrets.Contracts;
+using Elsa.Secrets.Expressions;
+using Elsa.Secrets.Extensions;
+using Elsa.Secrets.Models;
+using Elsa.Secrets.Providers;
+using Elsa.Workflows.Models;
+using Elsa.Workflows.Serialization.Converters;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Elsa.Secrets.UnitTests;
+
+public class SecretExpressionTests
+{
+    private readonly SecretTestFixture _fixture = new();
+    private readonly IWellKnownTypeRegistry _wellKnownTypeRegistry = new WellKnownTypeRegistry(Microsoft.Extensions.Options.Options.Create(new ExpressionOptions()));
+    private readonly SecretExpressionHandler _handler;
+
+    public SecretExpressionTests()
+    {
+        _handler = new(_fixture.Resolver, _wellKnownTypeRegistry);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_ResolvesSecretReference()
+    {
+        await _fixture.Manager.CreateAsync(new CreateSecretRequest { Name = "api:key", Value = "top-secret" });
+
+        var result = await EvaluateAsync<string>(new("api:key"));
+
+        Assert.Equal("top-secret", result);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_Throws_WhenSecretIsMissing()
+    {
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => EvaluateAsync<string>(new("api:key")));
+
+        Assert.Equal("Secret 'api:key' was not found.", exception.Message);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_Throws_WhenSecretTypeDoesNotMatchReference()
+    {
+        await _fixture.Manager.CreateAsync(new CreateSecretRequest { Name = "api:key", TypeName = SecretTypeNames.Text, Value = "top-secret" });
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => EvaluateAsync<string>(new("api:key", SecretTypeNames.RsaKey)));
+
+        Assert.Equal("Secret 'api:key' is not compatible with required type 'rsa-key'.", exception.Message);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_Throws_WhenSecretScopeDoesNotMatchReference()
+    {
+        await _fixture.Manager.CreateAsync(new CreateSecretRequest { Name = "api:key", Scope = "production", Value = "top-secret" });
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => EvaluateAsync<string>(new("api:key", Scope: "development")));
+
+        Assert.Equal("Secret 'api:key' is not compatible with required scope 'development'.", exception.Message);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_PassesCancellationTokenToResolver()
+    {
+        using var cancellationTokenSource = new CancellationTokenSource();
+        var resolver = new CapturingSecretResolver("top-secret");
+        var handler = new SecretExpressionHandler(resolver, _wellKnownTypeRegistry);
+        var context = CreateContext(cancellationTokenSource.Token);
+
+        await handler.EvaluateAsync(SecretExpression.Create(new("api:key")), typeof(string), context, ExpressionEvaluatorOptions.Empty);
+
+        Assert.Equal(cancellationTokenSource.Token, resolver.CancellationToken);
+    }
+
+    [Fact]
+    public void SecretExpression_RoundTripsAsSecretReference()
+    {
+        var options = CreateSerializerOptions();
+        var expression = SecretExpression.Create(new("api:key", SecretTypeNames.Text, "production"));
+
+        var json = JsonSerializer.Serialize(expression, options);
+        var deserializedExpression = JsonSerializer.Deserialize<Expression>(json, options)!;
+        var deserializedReference = Assert.IsType<SecretReference>(deserializedExpression.Value);
+
+        Assert.Contains("\"type\":\"Secret\"", json);
+        Assert.Contains("\"name\":\"api:key\"", json);
+        Assert.Contains("\"typeName\":\"text\"", json);
+        Assert.Contains("\"scope\":\"production\"", json);
+        Assert.DoesNotContain("top-secret", json);
+        Assert.Equal(SecretExpression.TypeName, deserializedExpression.Type);
+        Assert.Equal(new SecretReference("api:key", SecretTypeNames.Text, "production"), deserializedReference);
+    }
+
+    [Fact]
+    public void WorkflowInputJson_StoresSecretReferenceNotSecretValue()
+    {
+        var options = CreateSerializerOptions();
+        var input = new Input<string>(SecretExpression.Create(new("api:key", SecretTypeNames.Text, "production")));
+
+        var json = JsonSerializer.Serialize(input, options);
+        var deserializedInput = JsonSerializer.Deserialize<Input<string>>(json, options)!;
+        var deserializedReference = Assert.IsType<SecretReference>(deserializedInput.Expression!.Value);
+
+        Assert.Contains("\"expression\":{\"type\":\"Secret\"", json);
+        Assert.Contains("\"value\":{\"name\":\"api:key\"", json);
+        Assert.DoesNotContain("top-secret", json);
+        Assert.Equal(new SecretReference("api:key", SecretTypeNames.Text, "production"), deserializedReference);
+    }
+
+    [Fact]
+    public void AddSecretsServices_RegistersSecretExpressionDescriptorProvider()
+    {
+        var services = new ServiceCollection();
+
+        services.AddSecretsServices();
+
+        var serviceProvider = services.BuildServiceProvider();
+        var provider = serviceProvider.GetServices<IExpressionDescriptorProvider>().Single(x => x is SecretExpressionDescriptorProvider);
+        var descriptor = provider.GetDescriptors().Single();
+
+        Assert.Equal(SecretExpression.TypeName, descriptor.Type);
+        Assert.Equal("secret-picker", descriptor.Properties["UIHint"]);
+        Assert.Equal("/secrets/picker", descriptor.Properties["PickerEndpoint"]);
+    }
+
+    private async Task<T?> EvaluateAsync<T>(SecretReference reference)
+    {
+        var expression = SecretExpression.Create(reference);
+        var context = CreateContext();
+        return (T?)await _handler.EvaluateAsync(expression, typeof(T), context, ExpressionEvaluatorOptions.Empty);
+    }
+
+    private static ExpressionExecutionContext CreateContext(CancellationToken cancellationToken = default)
+    {
+        return new(new ServiceCollection().BuildServiceProvider(), new MemoryRegister(), cancellationToken: cancellationToken);
+    }
+
+    private static JsonSerializerOptions CreateSerializerOptions()
+    {
+        var registry = new TestExpressionDescriptorRegistry(new SecretExpressionDescriptorProvider().GetDescriptors());
+        var serviceProvider = new ServiceCollection()
+            .AddSingleton<IExpressionDescriptorRegistry>(registry)
+            .BuildServiceProvider();
+
+        return new()
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            Converters =
+            {
+                new TypeJsonConverter(),
+                new ExpressionJsonConverterFactory(registry),
+                new InputJsonConverterFactory(serviceProvider)
+            }
+        };
+    }
+
+    private class CapturingSecretResolver(string value) : ISecretResolver
+    {
+        public CancellationToken CancellationToken { get; private set; }
+
+        public Task<string> ResolveAsync(string name, CancellationToken cancellationToken = default) => ResolveAsync(new SecretReference(name), cancellationToken);
+
+        public Task<string> ResolveAsync(SecretReference reference, CancellationToken cancellationToken = default)
+        {
+            CancellationToken = cancellationToken;
+            return Task.FromResult(value);
+        }
+    }
+
+    private class TestExpressionDescriptorRegistry(IEnumerable<ExpressionDescriptor> descriptors) : IExpressionDescriptorRegistry
+    {
+        private readonly Dictionary<string, ExpressionDescriptor> _descriptors = descriptors.ToDictionary(x => x.Type);
+
+        public void Add(ExpressionDescriptor descriptor) => _descriptors[descriptor.Type] = descriptor;
+
+        public void AddRange(IEnumerable<ExpressionDescriptor> descriptors)
+        {
+            foreach (var descriptor in descriptors)
+                Add(descriptor);
+        }
+
+        public IEnumerable<ExpressionDescriptor> ListAll() => _descriptors.Values;
+
+        public ExpressionDescriptor? Find(Func<ExpressionDescriptor, bool> predicate) => _descriptors.Values.FirstOrDefault(predicate);
+
+        public ExpressionDescriptor? Find(string type) => _descriptors.GetValueOrDefault(type);
+    }
+}

--- a/test/unit/Elsa.Workflows.Core.UnitTests/Extensions/ActivityExecutionContextExtensions/InputEvaluationTests.cs
+++ b/test/unit/Elsa.Workflows.Core.UnitTests/Extensions/ActivityExecutionContextExtensions/InputEvaluationTests.cs
@@ -1,0 +1,57 @@
+using Elsa.Testing.Shared;
+using Elsa.Workflows.Attributes;
+using Elsa.Workflows.Models;
+using Xunit;
+
+namespace Elsa.Workflows.Core.UnitTests.Extensions.ActivityExecutionContextExtensions;
+
+public class InputEvaluationTests
+{
+    private readonly ActivityWithSensitiveInputs _activity = new();
+    private readonly ActivityTestFixture _fixture;
+
+    public InputEvaluationTests()
+    {
+        _fixture = new(_activity);
+    }
+
+    [Fact]
+    public async Task EvaluateInputPropertiesAsync_WhenInputIsSensitive_RemovesItFromActivityState()
+    {
+        _fixture.ConfigureContext(context => context.ActivityState[nameof(ActivityWithSensitiveInputs.SensitiveText)] = "stale-secret");
+
+        var context = await ActivateAsync();
+
+        Assert.False(context.ActivityState.ContainsKey(nameof(ActivityWithSensitiveInputs.SensitiveText)));
+        Assert.Equal("secret", _activity.CapturedSensitiveText);
+    }
+
+    [Fact]
+    public async Task EvaluateInputPropertiesAsync_WhenInputIsNotSensitive_StoresItInActivityState()
+    {
+        var context = await ActivateAsync();
+
+        Assert.Equal("public", context.ActivityState[nameof(ActivityWithSensitiveInputs.PublicText)]);
+        Assert.Equal("public", _activity.CapturedPublicText);
+    }
+
+    private Task<ActivityExecutionContext> ActivateAsync() => _fixture.ExecuteAsync();
+
+    private sealed class ActivityWithSensitiveInputs : CodeActivity
+    {
+        [Input(CanContainSecrets = true)]
+        public Input<string?> SensitiveText { get; set; } = new("secret");
+
+        [Input]
+        public Input<string?> PublicText { get; set; } = new("public");
+
+        public string? CapturedSensitiveText { get; private set; }
+        public string? CapturedPublicText { get; private set; }
+
+        protected override void Execute(ActivityExecutionContext context)
+        {
+            CapturedSensitiveText = context.Get(SensitiveText);
+            CapturedPublicText = context.Get(PublicText);
+        }
+    }
+}

--- a/test/unit/Elsa.Workflows.Core.UnitTests/Services/ActivityDescriberTests.cs
+++ b/test/unit/Elsa.Workflows.Core.UnitTests/Services/ActivityDescriberTests.cs
@@ -1,0 +1,46 @@
+using System.Reflection;
+using Elsa.Workflows.Attributes;
+using Elsa.Workflows.Models;
+using NSubstitute;
+using Xunit;
+
+namespace Elsa.Workflows.Core.UnitTests.Services;
+
+public class ActivityDescriberTests
+{
+    private readonly IActivityDescriber _describer;
+
+    public ActivityDescriberTests()
+    {
+        var defaultValueResolver = Substitute.For<IPropertyDefaultValueResolver>();
+        var propertyUIHandlerResolver = Substitute.For<IPropertyUIHandlerResolver>();
+
+        defaultValueResolver.GetDefaultValue(Arg.Any<PropertyInfo>()).Returns((object?)null);
+        propertyUIHandlerResolver
+            .GetUIPropertiesAsync(Arg.Any<PropertyInfo>(), Arg.Any<object?>(), Arg.Any<CancellationToken>())
+            .Returns(_ => new ValueTask<IDictionary<string, object>>(new Dictionary<string, object>()));
+
+        _describer = new ActivityDescriber(defaultValueResolver, propertyUIHandlerResolver);
+    }
+
+    [Fact]
+    public async Task DescribeActivityAsync_MapsCanContainSecretsToInputDescriptorSensitivity()
+    {
+        var descriptor = await _describer.DescribeActivityAsync(typeof(ActivityWithSensitiveInputs));
+
+        var sensitiveInput = descriptor.Inputs.Single(x => x.Name == nameof(ActivityWithSensitiveInputs.SensitiveText));
+        var publicInput = descriptor.Inputs.Single(x => x.Name == nameof(ActivityWithSensitiveInputs.PublicText));
+
+        Assert.True(sensitiveInput.IsSensitive);
+        Assert.False(publicInput.IsSensitive);
+    }
+
+    private sealed class ActivityWithSensitiveInputs : CodeActivity
+    {
+        [Input(CanContainSecrets = true)]
+        public Input<string?> SensitiveText { get; set; } = new("secret");
+
+        [Input]
+        public Input<string?> PublicText { get; set; } = new("public");
+    }
+}


### PR DESCRIPTION
## Summary

This S5 branch locally integrates the completed S1/S2/S4 branches and adds the adoption validation layer:

- validates the HTTP Request `Authorization` secret-reference path end to end
- documents no-code Secret picker usage and JavaScript `getSecret` usage, including async behavior, rotation, scopes/types, and leakage guidance
- records cross-module validation through targeted tests and full solution build

Merged locally for validation:

- #7573 / `origin/codex/workflow-secret-references-s1`
- #7574 / `origin/codex/workflow-secret-references-s2`
- #7575 / `origin/codex/workflow-secret-references-s4`

## Validation

- `dotnet test test/unit/Elsa.Workflows.Core.UnitTests/Elsa.Workflows.Core.UnitTests.csproj` - passed, 198 tests
- `dotnet test test/unit/Elsa.Secrets.UnitTests/Elsa.Secrets.UnitTests.csproj` - passed, 53 tests
- `dotnet test test/integration/Elsa.JavaScript.IntegrationTests/Elsa.JavaScript.IntegrationTests.csproj` - passed, 73 tests
- `dotnet test test/integration/Elsa.Activities.IntegrationTests/Elsa.Activities.IntegrationTests.csproj --filter FullyQualifiedName~SendHttpRequestSecretExpressionTests` - passed, 1 test
- `dotnet build Elsa.sln` - passed, 0 warnings, 0 errors

## Notes

The HTTP validation confirms that `SendHttpRequestBase.Authorization` can resolve a `Secret` expression to the outgoing header while workflow JSON and workflow state do not contain the resolved secret value. No Studio code is changed here; docs reference the no-code picker behavior expected from the Studio slice.

Refs #7551.
Closes #7556.
Closes #7569.
Closes #7570.
Closes #7571.
