### PR TITLE
Add dashboard API foundation

### DIFF
--- a/Elsa.sln
+++ b/Elsa.sln
@@ -369,6 +369,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Secrets.Persistence.EF
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Secrets.Persistence.EFCore.Oracle", "src\modules\Elsa.Secrets.Persistence.EFCore.Oracle\Elsa.Secrets.Persistence.EFCore.Oracle.csproj", "{729FD075-2863-48AB-A3C0-A4F7A9277263}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Dashboard.Api", "src\modules\Elsa.Dashboard.Api\Elsa.Dashboard.Api.csproj", "{4FD4C59B-2804-4F6B-AD38-2562CC01C510}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Dashboard.Api.UnitTests", "test\unit\Elsa.Dashboard.Api.UnitTests\Elsa.Dashboard.Api.UnitTests.csproj", "{157EDBA7-B04F-4EA0-8377-434D1065ACF6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1529,6 +1533,30 @@ Global
 		{729FD075-2863-48AB-A3C0-A4F7A9277263}.Release|x64.Build.0 = Release|Any CPU
 		{729FD075-2863-48AB-A3C0-A4F7A9277263}.Release|x86.ActiveCfg = Release|Any CPU
 		{729FD075-2863-48AB-A3C0-A4F7A9277263}.Release|x86.Build.0 = Release|Any CPU
+		{4FD4C59B-2804-4F6B-AD38-2562CC01C510}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4FD4C59B-2804-4F6B-AD38-2562CC01C510}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4FD4C59B-2804-4F6B-AD38-2562CC01C510}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4FD4C59B-2804-4F6B-AD38-2562CC01C510}.Debug|x64.Build.0 = Debug|Any CPU
+		{4FD4C59B-2804-4F6B-AD38-2562CC01C510}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4FD4C59B-2804-4F6B-AD38-2562CC01C510}.Debug|x86.Build.0 = Debug|Any CPU
+		{4FD4C59B-2804-4F6B-AD38-2562CC01C510}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4FD4C59B-2804-4F6B-AD38-2562CC01C510}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4FD4C59B-2804-4F6B-AD38-2562CC01C510}.Release|x64.ActiveCfg = Release|Any CPU
+		{4FD4C59B-2804-4F6B-AD38-2562CC01C510}.Release|x64.Build.0 = Release|Any CPU
+		{4FD4C59B-2804-4F6B-AD38-2562CC01C510}.Release|x86.ActiveCfg = Release|Any CPU
+		{4FD4C59B-2804-4F6B-AD38-2562CC01C510}.Release|x86.Build.0 = Release|Any CPU
+		{157EDBA7-B04F-4EA0-8377-434D1065ACF6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{157EDBA7-B04F-4EA0-8377-434D1065ACF6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{157EDBA7-B04F-4EA0-8377-434D1065ACF6}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{157EDBA7-B04F-4EA0-8377-434D1065ACF6}.Debug|x64.Build.0 = Debug|Any CPU
+		{157EDBA7-B04F-4EA0-8377-434D1065ACF6}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{157EDBA7-B04F-4EA0-8377-434D1065ACF6}.Debug|x86.Build.0 = Debug|Any CPU
+		{157EDBA7-B04F-4EA0-8377-434D1065ACF6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{157EDBA7-B04F-4EA0-8377-434D1065ACF6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{157EDBA7-B04F-4EA0-8377-434D1065ACF6}.Release|x64.ActiveCfg = Release|Any CPU
+		{157EDBA7-B04F-4EA0-8377-434D1065ACF6}.Release|x64.Build.0 = Release|Any CPU
+		{157EDBA7-B04F-4EA0-8377-434D1065ACF6}.Release|x86.ActiveCfg = Release|Any CPU
+		{157EDBA7-B04F-4EA0-8377-434D1065ACF6}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1663,6 +1691,8 @@ Global
 		{4DEE0574-C5B3-4765-9C48-89D384A17780} = {D3E5E9EF-DE26-41BF-A239-3241B5B5FD89}
 		{151C46EF-FE3D-400B-8CBE-F86886B3EB96} = {D3E5E9EF-DE26-41BF-A239-3241B5B5FD89}
 		{8F4AD54E-8586-4D8C-82E6-69218DD4280F} = {78FD90A4-90A5-445F-97F2-74BA835AFA5D}
+		{4FD4C59B-2804-4F6B-AD38-2562CC01C510} = {5BA4A8FA-F7F4-45B3-AEC8-8886D35AAC79}
+		{157EDBA7-B04F-4EA0-8377-434D1065ACF6} = {18453B51-25EB-4317-A4B3-B10518252E92}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D4B5CEAA-7D70-4FCB-A68E-B03FBE5E0E5E}

--- a/src/apps/Elsa.ModularServer.Web/Elsa.ModularServer.Web.csproj
+++ b/src/apps/Elsa.ModularServer.Web/Elsa.ModularServer.Web.csproj
@@ -11,6 +11,7 @@
         <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
     </ItemGroup>
     <ItemGroup>
+      <ProjectReference Include="..\..\modules\Elsa.Dashboard.Api\Elsa.Dashboard.Api.csproj" />
       <ProjectReference Include="..\..\modules\Elsa.Diagnostics.ConsoleLogs\Elsa.Diagnostics.ConsoleLogs.csproj" />
       <ProjectReference Include="..\..\modules\Elsa.Diagnostics.OpenTelemetry\Elsa.Diagnostics.OpenTelemetry.csproj" />
       <ProjectReference Include="..\..\modules\Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite\Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.csproj" />

--- a/src/apps/Elsa.ModularServer.Web/Program.cs
+++ b/src/apps/Elsa.ModularServer.Web/Program.cs
@@ -2,6 +2,7 @@ using ConsoleLogStreaming.Core.Capture;
 using CShells.AspNetCore.Configuration;
 using CShells.AspNetCore.Extensions;
 using CShells.DependencyInjection;
+using Elsa.Dashboard.Api.ShellFeatures;
 using Elsa.ModularServer.Web;
 using Elsa.ModularServer.Web.Catalog;
 using Elsa.ShellFeatures;
@@ -73,6 +74,7 @@ builder.AddShells(shells => shells
             typeof(WorkflowRuntimeFeature),
             typeof(WorkflowsFeature),
             typeof(DistributedRuntimeFeature),
+            typeof(DashboardApiFeature),
             typeof(WorkflowsApiFeature));
     }));
 

--- a/src/apps/Elsa.Server.Web/Elsa.Server.Web.csproj
+++ b/src/apps/Elsa.Server.Web/Elsa.Server.Web.csproj
@@ -3,6 +3,7 @@
     <ItemGroup>
 		<ProjectReference Include="..\..\modules\Elsa.Caching\Elsa.Caching.csproj" />
 		<ProjectReference Include="..\..\modules\Elsa.Common\Elsa.Common.csproj" />
+		<ProjectReference Include="..\..\modules\Elsa.Dashboard.Api\Elsa.Dashboard.Api.csproj" />
 		<ProjectReference Include="..\..\modules\Elsa.Diagnostics.StructuredLogs\Elsa.Diagnostics.StructuredLogs.csproj" />
 		<ProjectReference Include="..\..\modules\Elsa.Dsl.ElsaScript\Elsa.Dsl.ElsaScript.csproj" />
 		<ProjectReference Include="..\..\modules\Elsa.Expressions\Elsa.Expressions.csproj" />

--- a/src/apps/Elsa.Server.Web/Program.cs
+++ b/src/apps/Elsa.Server.Web/Program.cs
@@ -95,6 +95,7 @@ services
                 runtime.DistributedLockingOptions = options => options.AllowLocalLockProviderInDistributedRuntime = allowLocalDistributedRuntimeLockProvider;
             })
             .UseWorkflowsApi()
+            .UseDashboardApi()
             .UseFluentStorageProvider()
             .UseElsaScriptBlobStorage()
             .UseScheduling()

--- a/src/modules/Elsa.Dashboard.Api/AssemblyInfo.cs
+++ b/src/modules/Elsa.Dashboard.Api/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Elsa.Dashboard.Api.UnitTests")]

--- a/src/modules/Elsa.Dashboard.Api/Contracts/IDashboardProvider.cs
+++ b/src/modules/Elsa.Dashboard.Api/Contracts/IDashboardProvider.cs
@@ -1,0 +1,16 @@
+using Elsa.Dashboard.Api.Models;
+
+namespace Elsa.Dashboard.Api.Contracts;
+
+public interface IDashboardProvider
+{
+    Task<DashboardOverview> GetOverviewAsync(DashboardQuery query, CancellationToken cancellationToken = default);
+
+    Task<DashboardTrendResponse> GetWorkflowTrendsAsync(DashboardTrendRequest request, CancellationToken cancellationToken = default);
+
+    Task<DashboardNeedsAttentionResponse> GetNeedsAttentionAsync(DashboardQuery query, int take, CancellationToken cancellationToken = default);
+
+    Task<DashboardRecentActivityResponse> GetRecentActivityAsync(DashboardQuery query, int take, CancellationToken cancellationToken = default);
+
+    Task<DashboardWorkflowHotspotsResponse> GetWorkflowHotspotsAsync(DashboardWorkflowHotspotsRequest request, CancellationToken cancellationToken = default);
+}

--- a/src/modules/Elsa.Dashboard.Api/Elsa.Dashboard.Api.csproj
+++ b/src/modules/Elsa.Dashboard.Api/Elsa.Dashboard.Api.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <Description>Provides operational dashboard API endpoints for Elsa hosts.</Description>
+        <PackageTags>elsa module dashboard operations workflows diagnostics</PackageTags>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="ConsoleLogStreaming.Core" />
+        <PackageReference Include="CShells" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\common\Elsa.Api.Common\Elsa.Api.Common.csproj" />
+        <ProjectReference Include="..\Elsa.Diagnostics.ConsoleLogs\Elsa.Diagnostics.ConsoleLogs.csproj" />
+        <ProjectReference Include="..\Elsa.Diagnostics.StructuredLogs\Elsa.Diagnostics.StructuredLogs.csproj" />
+        <ProjectReference Include="..\Elsa.Workflows.Management\Elsa.Workflows.Management.csproj" />
+        <ProjectReference Include="..\Elsa.Workflows.Runtime\Elsa.Workflows.Runtime.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/modules/Elsa.Dashboard.Api/Endpoints/Dashboard/NeedsAttention/Endpoint.cs
+++ b/src/modules/Elsa.Dashboard.Api/Endpoints/Dashboard/NeedsAttention/Endpoint.cs
@@ -1,0 +1,25 @@
+using Elsa.Abstractions;
+using Elsa.Dashboard.Api.Contracts;
+using Elsa.Dashboard.Api.Models;
+using Elsa.Dashboard.Api.Permissions;
+using JetBrains.Annotations;
+
+namespace Elsa.Dashboard.Api.Endpoints.Dashboard.NeedsAttention;
+
+[PublicAPI]
+internal class Endpoint(IDashboardProvider dashboardProvider) : ElsaEndpointWithoutRequest<DashboardNeedsAttentionResponse>
+{
+    public override void Configure()
+    {
+        Get("/dashboard/needs-attention");
+        ConfigurePermissions(DashboardPermissions.Read);
+    }
+
+    public override async Task<DashboardNeedsAttentionResponse> ExecuteAsync(CancellationToken cancellationToken)
+    {
+        var range = Query<string?>("range", false);
+        var take = Query<int?>("take", false) ?? 8;
+        var includeSystem = Query<bool>("includeSystem", false);
+        return await dashboardProvider.GetNeedsAttentionAsync(new(range, includeSystem), take, cancellationToken);
+    }
+}

--- a/src/modules/Elsa.Dashboard.Api/Endpoints/Dashboard/Overview/Endpoint.cs
+++ b/src/modules/Elsa.Dashboard.Api/Endpoints/Dashboard/Overview/Endpoint.cs
@@ -1,0 +1,24 @@
+using Elsa.Abstractions;
+using Elsa.Dashboard.Api.Contracts;
+using Elsa.Dashboard.Api.Models;
+using Elsa.Dashboard.Api.Permissions;
+using JetBrains.Annotations;
+
+namespace Elsa.Dashboard.Api.Endpoints.Dashboard.Overview;
+
+[PublicAPI]
+internal class Endpoint(IDashboardProvider dashboardProvider) : ElsaEndpointWithoutRequest<DashboardOverview>
+{
+    public override void Configure()
+    {
+        Get("/dashboard/overview");
+        ConfigurePermissions(DashboardPermissions.Read);
+    }
+
+    public override async Task<DashboardOverview> ExecuteAsync(CancellationToken cancellationToken)
+    {
+        var range = Query<string?>("range", false);
+        var includeSystem = Query<bool>("includeSystem", false);
+        return await dashboardProvider.GetOverviewAsync(new(range, includeSystem), cancellationToken);
+    }
+}

--- a/src/modules/Elsa.Dashboard.Api/Endpoints/Dashboard/RecentActivity/Endpoint.cs
+++ b/src/modules/Elsa.Dashboard.Api/Endpoints/Dashboard/RecentActivity/Endpoint.cs
@@ -1,0 +1,25 @@
+using Elsa.Abstractions;
+using Elsa.Dashboard.Api.Contracts;
+using Elsa.Dashboard.Api.Models;
+using Elsa.Dashboard.Api.Permissions;
+using JetBrains.Annotations;
+
+namespace Elsa.Dashboard.Api.Endpoints.Dashboard.RecentActivity;
+
+[PublicAPI]
+internal class Endpoint(IDashboardProvider dashboardProvider) : ElsaEndpointWithoutRequest<DashboardRecentActivityResponse>
+{
+    public override void Configure()
+    {
+        Get("/dashboard/recent-activity");
+        ConfigurePermissions(DashboardPermissions.Read);
+    }
+
+    public override async Task<DashboardRecentActivityResponse> ExecuteAsync(CancellationToken cancellationToken)
+    {
+        var range = Query<string?>("range", false);
+        var take = Query<int?>("take", false) ?? 20;
+        var includeSystem = Query<bool>("includeSystem", false);
+        return await dashboardProvider.GetRecentActivityAsync(new(range, includeSystem), take, cancellationToken);
+    }
+}

--- a/src/modules/Elsa.Dashboard.Api/Endpoints/Dashboard/WorkflowHotspots/Endpoint.cs
+++ b/src/modules/Elsa.Dashboard.Api/Endpoints/Dashboard/WorkflowHotspots/Endpoint.cs
@@ -1,0 +1,22 @@
+using Elsa.Abstractions;
+using Elsa.Dashboard.Api.Contracts;
+using Elsa.Dashboard.Api.Models;
+using Elsa.Dashboard.Api.Permissions;
+using JetBrains.Annotations;
+
+namespace Elsa.Dashboard.Api.Endpoints.Dashboard.WorkflowHotspots;
+
+[PublicAPI]
+internal class Endpoint(IDashboardProvider dashboardProvider) : ElsaEndpoint<DashboardWorkflowHotspotsRequest, DashboardWorkflowHotspotsResponse>
+{
+    public override void Configure()
+    {
+        Post("/dashboard/workflow-hotspots");
+        ConfigurePermissions(DashboardPermissions.Read);
+    }
+
+    public override async Task<DashboardWorkflowHotspotsResponse> ExecuteAsync(DashboardWorkflowHotspotsRequest request, CancellationToken cancellationToken)
+    {
+        return await dashboardProvider.GetWorkflowHotspotsAsync(request, cancellationToken);
+    }
+}

--- a/src/modules/Elsa.Dashboard.Api/Endpoints/Dashboard/WorkflowTrends/Endpoint.cs
+++ b/src/modules/Elsa.Dashboard.Api/Endpoints/Dashboard/WorkflowTrends/Endpoint.cs
@@ -1,0 +1,22 @@
+using Elsa.Abstractions;
+using Elsa.Dashboard.Api.Contracts;
+using Elsa.Dashboard.Api.Models;
+using Elsa.Dashboard.Api.Permissions;
+using JetBrains.Annotations;
+
+namespace Elsa.Dashboard.Api.Endpoints.Dashboard.WorkflowTrends;
+
+[PublicAPI]
+internal class Endpoint(IDashboardProvider dashboardProvider) : ElsaEndpoint<DashboardTrendRequest, DashboardTrendResponse>
+{
+    public override void Configure()
+    {
+        Post("/dashboard/workflow-trends");
+        ConfigurePermissions(DashboardPermissions.Read);
+    }
+
+    public override async Task<DashboardTrendResponse> ExecuteAsync(DashboardTrendRequest request, CancellationToken cancellationToken)
+    {
+        return await dashboardProvider.GetWorkflowTrendsAsync(request, cancellationToken);
+    }
+}

--- a/src/modules/Elsa.Dashboard.Api/Extensions/ModuleExtensions.cs
+++ b/src/modules/Elsa.Dashboard.Api/Extensions/ModuleExtensions.cs
@@ -1,0 +1,13 @@
+using Elsa.Dashboard.Api.Features;
+using Elsa.Features.Services;
+
+namespace Elsa.Extensions;
+
+public static class DashboardModuleExtensions
+{
+    public static IModule UseDashboardApi(this IModule module, Action<DashboardApiFeature>? configure = null)
+    {
+        module.Configure(configure);
+        return module;
+    }
+}

--- a/src/modules/Elsa.Dashboard.Api/Extensions/ServiceCollectionExtensions.cs
+++ b/src/modules/Elsa.Dashboard.Api/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,15 @@
+using Elsa.Dashboard.Api.Contracts;
+using Elsa.Dashboard.Api.Services;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Elsa.Dashboard.Api.Extensions;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddDashboardApiServices(this IServiceCollection services)
+    {
+        return services
+            .AddScoped<DashboardRangeResolver>()
+            .AddScoped<IDashboardProvider, DefaultDashboardProvider>();
+    }
+}

--- a/src/modules/Elsa.Dashboard.Api/Features/DashboardApiFeature.cs
+++ b/src/modules/Elsa.Dashboard.Api/Features/DashboardApiFeature.cs
@@ -1,0 +1,25 @@
+using Elsa.Dashboard.Api.Extensions;
+using Elsa.Extensions;
+using Elsa.Features.Abstractions;
+using Elsa.Features.Attributes;
+using Elsa.Features.Services;
+using Elsa.Workflows.Management.Features;
+using Elsa.Workflows.Runtime.Features;
+
+namespace Elsa.Dashboard.Api.Features;
+
+[DependsOn(typeof(WorkflowInstancesFeature))]
+[DependsOn(typeof(WorkflowRuntimeFeature))]
+public class DashboardApiFeature(IModule module) : FeatureBase(module)
+{
+    public override void Configure()
+    {
+        Module.AddFastEndpointsAssembly<DashboardApiFeature>();
+    }
+
+    public override void Apply()
+    {
+        Services.AddDashboardApiServices();
+        Module.AddFastEndpointsFromModule();
+    }
+}

--- a/src/modules/Elsa.Dashboard.Api/FodyWeavers.xml
+++ b/src/modules/Elsa.Dashboard.Api/FodyWeavers.xml
@@ -1,0 +1,3 @@
+﻿<Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
+  <ConfigureAwait />
+</Weavers>

--- a/src/modules/Elsa.Dashboard.Api/Models/DashboardModels.cs
+++ b/src/modules/Elsa.Dashboard.Api/Models/DashboardModels.cs
@@ -1,0 +1,211 @@
+namespace Elsa.Dashboard.Api.Models;
+
+public record DashboardQuery(string? Range = null, bool IncludeSystem = false);
+
+public record DashboardOverview
+{
+    public DashboardCapabilityStatus Capability { get; init; } = DashboardCapabilityStatus.Available;
+    public string? BackendName { get; init; }
+    public string? EnvironmentName { get; init; }
+    public DashboardRuntimeStatus Runtime { get; init; } = new();
+    public DashboardWorkflowInstanceMetrics WorkflowInstances { get; init; } = new();
+    public DashboardDiagnosticsSummary Diagnostics { get; init; } = new();
+    public string AppliedRange { get; init; } = DashboardRangeKeys.TwentyFourHours;
+    public DateTimeOffset From { get; init; }
+    public DateTimeOffset To { get; init; }
+}
+
+public record DashboardCapabilityStatus
+{
+    public static DashboardCapabilityStatus Available { get; } = new("Available");
+    public static DashboardCapabilityStatus NotInstalled { get; } = new("NotInstalled");
+    public static DashboardCapabilityStatus Unauthorized { get; } = new("Unauthorized");
+    public static DashboardCapabilityStatus Unavailable { get; } = new("Unavailable");
+
+    public DashboardCapabilityStatus(string status, string? reason = null)
+    {
+        Status = status;
+        Reason = reason;
+    }
+
+    public string Status { get; init; }
+    public string? Reason { get; init; }
+}
+
+public record DashboardRuntimeStatus
+{
+    public string Status { get; init; } = DashboardRuntimeStatusKeys.Unavailable;
+    public bool IsAcceptingWork { get; init; }
+    public int ActiveExecutionCycleCount { get; init; }
+    public int IngressSourceCount { get; init; }
+    public int FailedIngressSourceCount { get; init; }
+    public DateTimeOffset? PausedAt { get; init; }
+    public DateTimeOffset? DrainStartedAt { get; init; }
+    public string? Reason { get; init; }
+}
+
+public record DashboardWorkflowInstanceMetrics
+{
+    public long Running { get; init; }
+    public long Completed { get; init; }
+    public long Faulted { get; init; }
+    public long Suspended { get; init; }
+    public long Interrupted { get; init; }
+    public long IncidentBearing { get; init; }
+    public TimeSpan? AverageDuration { get; init; }
+}
+
+public record DashboardDiagnosticsSummary
+{
+    public DashboardStructuredLogSummary StructuredLogs { get; init; } = new();
+    public DashboardConsoleLogSummary ConsoleLogs { get; init; } = new();
+}
+
+public record DashboardStructuredLogSummary
+{
+    public DashboardCapabilityStatus Capability { get; init; } = DashboardCapabilityStatus.NotInstalled;
+    public int SourceCount { get; init; }
+    public int StaleSourceCount { get; init; }
+    public int RecentErrorOrCriticalCount { get; init; }
+    public long DroppedWriteCount { get; init; }
+    public long DroppedEventCount { get; init; }
+}
+
+public record DashboardConsoleLogSummary
+{
+    public DashboardCapabilityStatus Capability { get; init; } = DashboardCapabilityStatus.NotInstalled;
+    public int SourceCount { get; init; }
+    public int StaleSourceCount { get; init; }
+    public int RecentStderrCount { get; init; }
+    public long DroppedLineCount { get; init; }
+}
+
+public record DashboardFinding
+{
+    public string Id { get; init; } = null!;
+    public string Severity { get; init; } = DashboardFindingSeverity.Info;
+    public string Message { get; init; } = null!;
+    public string? TargetKind { get; init; }
+    public string? Target { get; init; }
+    public int Priority { get; init; }
+}
+
+public record DashboardNeedsAttentionResponse
+{
+    public IReadOnlyCollection<DashboardFinding> Findings { get; init; } = [];
+    public DashboardCapabilityStatus Capability { get; init; } = DashboardCapabilityStatus.Available;
+    public string AppliedRange { get; init; } = DashboardRangeKeys.TwentyFourHours;
+}
+
+public record DashboardTrendRequest
+{
+    public string? Range { get; init; }
+    public string? Granularity { get; init; }
+    public bool IncludeSystem { get; init; }
+}
+
+public record DashboardTrendResponse
+{
+    public IReadOnlyCollection<DashboardTrendBucket> Buckets { get; init; } = [];
+    public string AppliedRange { get; init; } = DashboardRangeKeys.TwentyFourHours;
+    public string Granularity { get; init; } = DashboardTrendGranularity.Hour;
+    public DateTimeOffset From { get; init; }
+    public DateTimeOffset To { get; init; }
+}
+
+public record DashboardTrendBucket
+{
+    public DateTimeOffset From { get; init; }
+    public DateTimeOffset To { get; init; }
+    public long CreatedOrStarted { get; init; }
+    public long Finished { get; init; }
+    public long Faulted { get; init; }
+    public long Suspended { get; init; }
+    public long IncidentBearing { get; init; }
+}
+
+public record DashboardRecentActivityItem
+{
+    public string InstanceId { get; init; } = null!;
+    public string DefinitionId { get; init; } = null!;
+    public string? WorkflowName { get; init; }
+    public string Status { get; init; } = null!;
+    public string SubStatus { get; init; } = null!;
+    public int IncidentCount { get; init; }
+    public TimeSpan? Duration { get; init; }
+    public DateTimeOffset CreatedAt { get; init; }
+    public DateTimeOffset? UpdatedAt { get; init; }
+    public DateTimeOffset? FinishedAt { get; init; }
+}
+
+public record DashboardRecentActivityResponse
+{
+    public IReadOnlyCollection<DashboardRecentActivityItem> Items { get; init; } = [];
+    public string AppliedRange { get; init; } = DashboardRangeKeys.TwentyFourHours;
+    public DateTimeOffset From { get; init; }
+    public DateTimeOffset To { get; init; }
+}
+
+public record DashboardWorkflowHotspotsRequest
+{
+    public string? Range { get; init; }
+    public string Metric { get; init; } = DashboardHotspotMetric.Faults;
+    public int Take { get; init; } = 10;
+    public bool IncludeSystem { get; init; }
+}
+
+public record DashboardWorkflowHotspotsResponse
+{
+    public IReadOnlyCollection<DashboardHotspot> Items { get; init; } = [];
+    public string AppliedRange { get; init; } = DashboardRangeKeys.TwentyFourHours;
+    public string Metric { get; init; } = DashboardHotspotMetric.Faults;
+    public DateTimeOffset From { get; init; }
+    public DateTimeOffset To { get; init; }
+}
+
+public record DashboardHotspot
+{
+    public string DefinitionId { get; init; } = null!;
+    public string? WorkflowName { get; init; }
+    public long Value { get; init; }
+    public TimeSpan? AverageDuration { get; init; }
+}
+
+public static class DashboardRangeKeys
+{
+    public const string OneHour = "1h";
+    public const string TwentyFourHours = "24h";
+    public const string SevenDays = "7d";
+}
+
+public static class DashboardRuntimeStatusKeys
+{
+    public const string AcceptingWork = "AcceptingWork";
+    public const string Paused = "Paused";
+    public const string Draining = "Draining";
+    public const string Unavailable = "Unavailable";
+}
+
+public static class DashboardTrendGranularity
+{
+    public const string Minute = "minute";
+    public const string Hour = "hour";
+    public const string Day = "day";
+}
+
+public static class DashboardFindingSeverity
+{
+    public const string Info = "Info";
+    public const string Warning = "Warning";
+    public const string Error = "Error";
+    public const string Critical = "Critical";
+    public const string Success = "Success";
+}
+
+public static class DashboardHotspotMetric
+{
+    public const string Faults = "Faults";
+    public const string Executions = "Executions";
+    public const string Incidents = "Incidents";
+    public const string Duration = "Duration";
+}

--- a/src/modules/Elsa.Dashboard.Api/Permissions/DashboardPermissions.cs
+++ b/src/modules/Elsa.Dashboard.Api/Permissions/DashboardPermissions.cs
@@ -1,0 +1,6 @@
+namespace Elsa.Dashboard.Api.Permissions;
+
+public static class DashboardPermissions
+{
+    public const string Read = "read:dashboard";
+}

--- a/src/modules/Elsa.Dashboard.Api/Services/DashboardRangeResolver.cs
+++ b/src/modules/Elsa.Dashboard.Api/Services/DashboardRangeResolver.cs
@@ -1,0 +1,47 @@
+using Elsa.Common;
+using Elsa.Dashboard.Api.Models;
+
+namespace Elsa.Dashboard.Api.Services;
+
+public class DashboardRangeResolver(ISystemClock clock)
+{
+    public DashboardRange Resolve(string? range)
+    {
+        var key = Normalize(range);
+        var duration = key switch
+        {
+            DashboardRangeKeys.OneHour => TimeSpan.FromHours(1),
+            DashboardRangeKeys.SevenDays => TimeSpan.FromDays(7),
+            _ => TimeSpan.FromHours(24)
+        };
+        var to = clock.UtcNow;
+        return new(key, to.Subtract(duration), to);
+    }
+
+    public string ResolveGranularity(string? granularity, string range) =>
+        string.IsNullOrWhiteSpace(granularity)
+            ? range switch
+            {
+                DashboardRangeKeys.OneHour => DashboardTrendGranularity.Minute,
+                DashboardRangeKeys.SevenDays => DashboardTrendGranularity.Day,
+                _ => DashboardTrendGranularity.Hour
+            }
+            : granularity;
+
+    public TimeSpan GetBucketSize(string granularity) =>
+        granularity.Equals(DashboardTrendGranularity.Minute, StringComparison.OrdinalIgnoreCase)
+            ? TimeSpan.FromMinutes(5)
+            : granularity.Equals(DashboardTrendGranularity.Day, StringComparison.OrdinalIgnoreCase)
+                ? TimeSpan.FromDays(1)
+                : TimeSpan.FromHours(1);
+
+    private static string Normalize(string? range) =>
+        range?.Trim().ToLowerInvariant() switch
+        {
+            DashboardRangeKeys.OneHour => DashboardRangeKeys.OneHour,
+            DashboardRangeKeys.SevenDays => DashboardRangeKeys.SevenDays,
+            _ => DashboardRangeKeys.TwentyFourHours
+        };
+}
+
+public record DashboardRange(string Key, DateTimeOffset From, DateTimeOffset To);

--- a/src/modules/Elsa.Dashboard.Api/Services/DefaultDashboardProvider.cs
+++ b/src/modules/Elsa.Dashboard.Api/Services/DefaultDashboardProvider.cs
@@ -1,0 +1,374 @@
+using ConsoleLogStreaming.Core;
+using ConsoleLogStreaming.Core.Models;
+using Elsa.Common.Entities;
+using Elsa.Common.Models;
+using Elsa.Dashboard.Api.Contracts;
+using Elsa.Dashboard.Api.Models;
+using Elsa.Diagnostics.StructuredLogs.Contracts;
+using Elsa.Diagnostics.StructuredLogs.Models;
+using Elsa.Workflows;
+using Elsa.Workflows.Management;
+using Elsa.Workflows.Management.Entities;
+using Elsa.Workflows.Management.Enums;
+using Elsa.Workflows.Management.Filters;
+using Elsa.Workflows.Management.Models;
+using Elsa.Workflows.Runtime;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Elsa.Dashboard.Api.Services;
+
+public class DefaultDashboardProvider(
+    IWorkflowInstanceStore workflowInstanceStore,
+    IWorkflowRuntimeAdminService runtimeAdminService,
+    DashboardRangeResolver rangeResolver,
+    IServiceProvider serviceProvider,
+    IHostEnvironment environment) : IDashboardProvider
+{
+    public async Task<DashboardOverview> GetOverviewAsync(DashboardQuery query, CancellationToken cancellationToken = default)
+    {
+        var range = rangeResolver.Resolve(query.Range);
+        var runtime = GetRuntimeStatus();
+        var workflowMetrics = await GetWorkflowMetricsAsync(range, query.IncludeSystem, cancellationToken);
+        var diagnostics = await GetDiagnosticsSummaryAsync(range, cancellationToken);
+
+        return new()
+        {
+            BackendName = environment.ApplicationName,
+            EnvironmentName = environment.EnvironmentName,
+            Runtime = runtime,
+            WorkflowInstances = workflowMetrics,
+            Diagnostics = diagnostics,
+            AppliedRange = range.Key,
+            From = range.From,
+            To = range.To
+        };
+    }
+
+    public async Task<DashboardTrendResponse> GetWorkflowTrendsAsync(DashboardTrendRequest request, CancellationToken cancellationToken = default)
+    {
+        var range = rangeResolver.Resolve(request.Range);
+        var granularity = rangeResolver.ResolveGranularity(request.Granularity, range.Key);
+        var bucketSize = rangeResolver.GetBucketSize(granularity);
+        var buckets = new List<DashboardTrendBucket>();
+
+        for (var bucketFrom = range.From; bucketFrom < range.To; bucketFrom = bucketFrom.Add(bucketSize))
+        {
+            var bucketTo = Min(bucketFrom.Add(bucketSize), range.To);
+            buckets.Add(new()
+            {
+                From = bucketFrom,
+                To = bucketTo,
+                CreatedOrStarted = await CountAsync(request.IncludeSystem, nameof(WorkflowInstance.CreatedAt), bucketFrom, bucketTo, cancellationToken),
+                Finished = await CountAsync(request.IncludeSystem, nameof(WorkflowInstance.FinishedAt), bucketFrom, bucketTo, cancellationToken, subStatus: WorkflowSubStatus.Finished),
+                Faulted = await CountAsync(request.IncludeSystem, nameof(WorkflowInstance.UpdatedAt), bucketFrom, bucketTo, cancellationToken, subStatus: WorkflowSubStatus.Faulted),
+                Suspended = await CountAsync(request.IncludeSystem, nameof(WorkflowInstance.UpdatedAt), bucketFrom, bucketTo, cancellationToken, subStatus: WorkflowSubStatus.Suspended),
+                IncidentBearing = await CountAsync(request.IncludeSystem, nameof(WorkflowInstance.UpdatedAt), bucketFrom, bucketTo, cancellationToken, hasIncidents: true)
+            });
+        }
+
+        return new()
+        {
+            Buckets = buckets,
+            AppliedRange = range.Key,
+            Granularity = granularity,
+            From = range.From,
+            To = range.To
+        };
+    }
+
+    public async Task<DashboardNeedsAttentionResponse> GetNeedsAttentionAsync(DashboardQuery query, int take, CancellationToken cancellationToken = default)
+    {
+        var range = rangeResolver.Resolve(query.Range);
+        var overview = await GetOverviewAsync(query, cancellationToken);
+        var findings = new List<DashboardFinding>();
+
+        if (overview.Runtime.Status == DashboardRuntimeStatusKeys.Paused)
+            findings.Add(Finding("runtime-paused", DashboardFindingSeverity.Warning, "Runtime is paused", "Runtime", "runtime", 10));
+        else if (overview.Runtime.Status == DashboardRuntimeStatusKeys.Draining)
+            findings.Add(Finding("runtime-draining", DashboardFindingSeverity.Warning, "Runtime is draining", "Runtime", "runtime", 20));
+
+        if (overview.Runtime.FailedIngressSourceCount > 0)
+            findings.Add(Finding("ingress-source-failures", DashboardFindingSeverity.Warning, $"{overview.Runtime.FailedIngressSourceCount} ingress sources need attention", "Runtime", "runtime", 30));
+
+        if (overview.WorkflowInstances.Faulted > 0)
+            findings.Add(Finding("workflow-faults", DashboardFindingSeverity.Error, $"{overview.WorkflowInstances.Faulted} workflows faulted in the selected range", "WorkflowInstances", "faulted", 40));
+
+        if (overview.WorkflowInstances.Interrupted > 0)
+            findings.Add(Finding("workflow-interrupted", DashboardFindingSeverity.Warning, $"{overview.WorkflowInstances.Interrupted} workflows were interrupted in the selected range", "WorkflowInstances", "interrupted", 50));
+
+        if (overview.WorkflowInstances.IncidentBearing > 0)
+            findings.Add(Finding("workflow-incidents", DashboardFindingSeverity.Error, $"{overview.WorkflowInstances.IncidentBearing} workflows have incidents", "WorkflowInstances", "incidents", 60));
+
+        var structuredLogs = overview.Diagnostics.StructuredLogs;
+        if (structuredLogs.StaleSourceCount > 0)
+            findings.Add(Finding("structured-log-stale-sources", DashboardFindingSeverity.Warning, $"{structuredLogs.StaleSourceCount} structured log sources are stale", "StructuredLogs", "sources", 70));
+        if (structuredLogs.DroppedWriteCount > 0)
+            findings.Add(Finding("structured-log-dropped-writes", DashboardFindingSeverity.Error, "Structured log storage dropped writes", "StructuredLogs", "storage", 80));
+        if (structuredLogs.RecentErrorOrCriticalCount > 0)
+            findings.Add(Finding("structured-log-errors", DashboardFindingSeverity.Error, $"{structuredLogs.RecentErrorOrCriticalCount} error or critical structured logs were recorded", "StructuredLogs", "errors", 90));
+
+        var consoleLogs = overview.Diagnostics.ConsoleLogs;
+        if (consoleLogs.StaleSourceCount > 0)
+            findings.Add(Finding("console-log-stale-sources", DashboardFindingSeverity.Warning, $"{consoleLogs.StaleSourceCount} console log sources are stale", "ConsoleLogs", "sources", 100));
+        if (consoleLogs.DroppedLineCount > 0)
+            findings.Add(Finding("console-log-dropped-lines", DashboardFindingSeverity.Warning, "Console log capture dropped lines", "ConsoleLogs", "dropped", 110));
+
+        return new()
+        {
+            Findings = findings.OrderBy(x => x.Priority).Take(Math.Clamp(take, 1, 50)).ToList(),
+            AppliedRange = range.Key
+        };
+    }
+
+    public async Task<DashboardRecentActivityResponse> GetRecentActivityAsync(DashboardQuery query, int take, CancellationToken cancellationToken = default)
+    {
+        var range = rangeResolver.Resolve(query.Range);
+        var filter = CreateRangeFilter(query.IncludeSystem, nameof(WorkflowInstance.UpdatedAt), range.From, range.To);
+        var order = new WorkflowInstanceOrder<DateTimeOffset?>
+        {
+            KeySelector = x => x.UpdatedAt,
+            Direction = OrderDirection.Descending
+        };
+        var page = await workflowInstanceStore.SummarizeManyAsync(filter, PageArgs.FromPage(0, Math.Clamp(take, 1, 100)), order, cancellationToken);
+
+        return new()
+        {
+            Items = page.Items.Select(MapRecentActivity).ToList(),
+            AppliedRange = range.Key,
+            From = range.From,
+            To = range.To
+        };
+    }
+
+    public async Task<DashboardWorkflowHotspotsResponse> GetWorkflowHotspotsAsync(DashboardWorkflowHotspotsRequest request, CancellationToken cancellationToken = default)
+    {
+        var range = rangeResolver.Resolve(request.Range);
+        var summaries = await workflowInstanceStore.SummarizeManyAsync(CreateRangeFilter(request.IncludeSystem, nameof(WorkflowInstance.UpdatedAt), range.From, range.To), cancellationToken);
+        var metric = NormalizeHotspotMetric(request.Metric);
+        var hotspots = summaries
+            .GroupBy(x => x.DefinitionId)
+            .Select(x => CreateHotspot(x, metric))
+            .OrderByDescending(x => x.Value)
+            .ThenBy(x => x.WorkflowName)
+            .Take(Math.Clamp(request.Take, 1, 50))
+            .ToList();
+
+        return new()
+        {
+            Items = hotspots,
+            AppliedRange = range.Key,
+            Metric = metric,
+            From = range.From,
+            To = range.To
+        };
+    }
+
+    private async Task<DashboardWorkflowInstanceMetrics> GetWorkflowMetricsAsync(DashboardRange range, bool includeSystem, CancellationToken cancellationToken)
+    {
+        var completedSummaries = (await workflowInstanceStore.SummarizeManyAsync(
+            CreateRangeFilter(includeSystem, nameof(WorkflowInstance.FinishedAt), range.From, range.To, subStatus: WorkflowSubStatus.Finished),
+            cancellationToken)).ToList();
+        var durations = completedSummaries
+            .Where(x => x.FinishedAt != null)
+            .Select(x => x.FinishedAt!.Value - x.CreatedAt)
+            .Where(x => x >= TimeSpan.Zero)
+            .ToList();
+
+        return new()
+        {
+            Running = await CountAsync(includeSystem, status: WorkflowStatus.Running, cancellationToken: cancellationToken),
+            Completed = completedSummaries.Count,
+            Faulted = await CountAsync(includeSystem, nameof(WorkflowInstance.UpdatedAt), range.From, range.To, cancellationToken, subStatus: WorkflowSubStatus.Faulted),
+            Suspended = await CountAsync(includeSystem, subStatus: WorkflowSubStatus.Suspended, cancellationToken: cancellationToken),
+            Interrupted = await CountAsync(includeSystem, nameof(WorkflowInstance.UpdatedAt), range.From, range.To, cancellationToken, subStatus: WorkflowSubStatus.Interrupted),
+            IncidentBearing = await CountAsync(includeSystem, hasIncidents: true, cancellationToken: cancellationToken),
+            AverageDuration = durations.Count == 0 ? null : TimeSpan.FromTicks(Convert.ToInt64(durations.Average(x => x.Ticks)))
+        };
+    }
+
+    private DashboardRuntimeStatus GetRuntimeStatus()
+    {
+        var status = runtimeAdminService.GetStatus();
+        var state = status.State;
+        var runtimeStatus = state.IsAcceptingNewWork
+            ? DashboardRuntimeStatusKeys.AcceptingWork
+            : state.DrainStartedAt != null
+                ? DashboardRuntimeStatusKeys.Draining
+                : DashboardRuntimeStatusKeys.Paused;
+        var failedSourceCount = status.Sources.Count(x => x.LastError != null);
+
+        return new()
+        {
+            Status = runtimeStatus,
+            IsAcceptingWork = state.IsAcceptingNewWork,
+            ActiveExecutionCycleCount = status.ActiveExecutionCycleCount,
+            IngressSourceCount = status.Sources.Count,
+            FailedIngressSourceCount = failedSourceCount,
+            PausedAt = state.PausedAt,
+            DrainStartedAt = state.DrainStartedAt,
+            Reason = state.Reason.ToString()
+        };
+    }
+
+    private async Task<DashboardDiagnosticsSummary> GetDiagnosticsSummaryAsync(DashboardRange range, CancellationToken cancellationToken)
+    {
+        var structuredLogs = await GetStructuredLogSummaryAsync(range, cancellationToken);
+        var consoleLogs = await GetConsoleLogSummaryAsync(range, cancellationToken);
+        return new()
+        {
+            StructuredLogs = structuredLogs,
+            ConsoleLogs = consoleLogs
+        };
+    }
+
+    private async Task<DashboardStructuredLogSummary> GetStructuredLogSummaryAsync(DashboardRange range, CancellationToken cancellationToken)
+    {
+        var provider = serviceProvider.GetService<IStructuredLogProvider>();
+        if (provider == null)
+            return new();
+
+        var sources = await provider.ListSourcesAsync(cancellationToken);
+        var storageDiagnostics = serviceProvider.GetServices<IStructuredLogStorageDiagnostics>().ToList();
+        var recentErrors = await provider.GetRecentAsync(new()
+        {
+            Levels = [StructuredLogLevel.Error, StructuredLogLevel.Critical],
+            From = range.From,
+            To = range.To,
+            Take = 1000
+        }, cancellationToken);
+
+        return new()
+        {
+            Capability = DashboardCapabilityStatus.Available,
+            SourceCount = sources.Count,
+            StaleSourceCount = sources.Count(x => x.Status == StructuredLogSourceStatus.Stale || x.Status == StructuredLogSourceStatus.Disconnected),
+            RecentErrorOrCriticalCount = recentErrors.Items.Count,
+            DroppedWriteCount = storageDiagnostics.Aggregate(0L, (total, x) => checked(total + x.DroppedWriteCount)),
+            DroppedEventCount = recentErrors.DroppedEvents
+        };
+    }
+
+    private async Task<DashboardConsoleLogSummary> GetConsoleLogSummaryAsync(DashboardRange range, CancellationToken cancellationToken)
+    {
+        var provider = serviceProvider.GetService<IConsoleLogProvider>();
+        if (provider == null)
+            return new();
+
+        var sources = await provider.ListSourcesAsync(cancellationToken);
+        var recentStderr = await provider.GetRecentAsync(new()
+        {
+            Stream = ConsoleStream.Stderr,
+            From = range.From,
+            To = range.To,
+            Limit = 1000
+        }, cancellationToken);
+
+        return new()
+        {
+            Capability = DashboardCapabilityStatus.Available,
+            SourceCount = sources.Count,
+            StaleSourceCount = sources.Count(x => x.Health is ConsoleLogSourceHealth.Stale or ConsoleLogSourceHealth.Disconnected),
+            RecentStderrCount = recentStderr.Items.Count,
+            DroppedLineCount = recentStderr.Dropped.Aggregate(0L, (total, x) => checked(total + x.Count))
+        };
+    }
+
+    private async Task<long> CountAsync(
+        bool includeSystem,
+        string? timestampColumn = null,
+        DateTimeOffset? from = null,
+        DateTimeOffset? to = null,
+        CancellationToken cancellationToken = default,
+        WorkflowStatus? status = null,
+        WorkflowSubStatus? subStatus = null,
+        bool? hasIncidents = null)
+    {
+        return await workflowInstanceStore.CountAsync(CreateRangeFilter(includeSystem, timestampColumn, from, to, status, subStatus, hasIncidents), cancellationToken);
+    }
+
+    private static WorkflowInstanceFilter CreateRangeFilter(
+        bool includeSystem,
+        string? timestampColumn,
+        DateTimeOffset? from,
+        DateTimeOffset? to,
+        WorkflowStatus? status = null,
+        WorkflowSubStatus? subStatus = null,
+        bool? hasIncidents = null)
+    {
+        var timestampFilters = new List<TimestampFilter>();
+        if (timestampColumn != null && from != null)
+            timestampFilters.Add(new() { Column = timestampColumn, Operator = TimestampFilterOperator.GreaterThanOrEqual, Timestamp = from.Value });
+        if (timestampColumn != null && to != null)
+            timestampFilters.Add(new() { Column = timestampColumn, Operator = TimestampFilterOperator.LessThan, Timestamp = to.Value });
+
+        return new()
+        {
+            IsSystem = includeSystem ? null : false,
+            WorkflowStatus = status,
+            WorkflowSubStatus = subStatus,
+            HasIncidents = hasIncidents,
+            TimestampFilters = timestampFilters.Count == 0 ? null : timestampFilters
+        };
+    }
+
+    private static DashboardRecentActivityItem MapRecentActivity(WorkflowInstanceSummary summary) => new()
+    {
+        InstanceId = summary.Id,
+        DefinitionId = summary.DefinitionId,
+        WorkflowName = summary.Name,
+        Status = summary.Status.ToString(),
+        SubStatus = summary.SubStatus.ToString(),
+        IncidentCount = summary.IncidentCount,
+        Duration = summary.FinishedAt == null ? null : summary.FinishedAt.Value - summary.CreatedAt,
+        CreatedAt = summary.CreatedAt,
+        UpdatedAt = summary.UpdatedAt,
+        FinishedAt = summary.FinishedAt
+    };
+
+    private static DashboardHotspot CreateHotspot(IGrouping<string, WorkflowInstanceSummary> group, string metric)
+    {
+        var items = group.ToList();
+        var durations = items
+            .Where(x => x.FinishedAt != null)
+            .Select(x => x.FinishedAt!.Value - x.CreatedAt)
+            .Where(x => x >= TimeSpan.Zero)
+            .ToList();
+        var value = metric switch
+        {
+            DashboardHotspotMetric.Executions => items.Count,
+            DashboardHotspotMetric.Incidents => items.Sum(x => x.IncidentCount),
+            DashboardHotspotMetric.Duration => durations.Count == 0 ? 0 : Convert.ToInt64(durations.Average(x => x.TotalMilliseconds)),
+            _ => items.LongCount(x => x.SubStatus == WorkflowSubStatus.Faulted)
+        };
+
+        return new()
+        {
+            DefinitionId = group.Key,
+            WorkflowName = items.Select(x => x.Name).FirstOrDefault(x => !string.IsNullOrWhiteSpace(x)),
+            Value = value,
+            AverageDuration = durations.Count == 0 ? null : TimeSpan.FromTicks(Convert.ToInt64(durations.Average(x => x.Ticks)))
+        };
+    }
+
+    private static string NormalizeHotspotMetric(string? metric) =>
+        metric?.Trim().ToLowerInvariant() switch
+        {
+            "executions" => DashboardHotspotMetric.Executions,
+            "incidents" => DashboardHotspotMetric.Incidents,
+            "duration" => DashboardHotspotMetric.Duration,
+            _ => DashboardHotspotMetric.Faults
+        };
+
+    private static DashboardFinding Finding(string id, string severity, string message, string? targetKind, string? target, int priority) => new()
+    {
+        Id = id,
+        Severity = severity,
+        Message = message,
+        TargetKind = targetKind,
+        Target = target,
+        Priority = priority
+    };
+
+    private static DateTimeOffset Min(DateTimeOffset left, DateTimeOffset right) => left <= right ? left : right;
+}

--- a/src/modules/Elsa.Dashboard.Api/ShellFeatures/DashboardApiFeature.cs
+++ b/src/modules/Elsa.Dashboard.Api/ShellFeatures/DashboardApiFeature.cs
@@ -1,0 +1,20 @@
+using CShells.FastEndpoints.Features;
+using CShells.Features;
+using Elsa.Dashboard.Api.Extensions;
+using JetBrains.Annotations;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Elsa.Dashboard.Api.ShellFeatures;
+
+[ShellFeature(
+    DisplayName = "Dashboard API",
+    Description = "Provides operational dashboard API endpoints for Elsa Studio",
+    DependsOn = ["ElsaFastEndpoints", "WorkflowInstances", "WorkflowRuntime"])]
+[UsedImplicitly]
+public class DashboardApiFeature : IFastEndpointsShellFeature
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.AddDashboardApiServices();
+    }
+}

--- a/test/unit/Elsa.Dashboard.Api.UnitTests/DashboardRangeResolverTests.cs
+++ b/test/unit/Elsa.Dashboard.Api.UnitTests/DashboardRangeResolverTests.cs
@@ -1,0 +1,55 @@
+using Elsa.Common;
+using Elsa.Dashboard.Api.Models;
+using Elsa.Dashboard.Api.Services;
+
+namespace Elsa.Dashboard.Api.UnitTests;
+
+public class DashboardRangeResolverTests
+{
+    private readonly DateTimeOffset _now = new(2026, 06, 01, 12, 00, 00, TimeSpan.Zero);
+    private readonly DashboardRangeResolver _resolver;
+
+    public DashboardRangeResolverTests()
+    {
+        _resolver = new(new TestClock(_now));
+    }
+
+    [Theory]
+    [InlineData("1h", DashboardRangeKeys.OneHour, 1)]
+    [InlineData("24h", DashboardRangeKeys.TwentyFourHours, 24)]
+    [InlineData("7d", DashboardRangeKeys.SevenDays, 168)]
+    [InlineData(null, DashboardRangeKeys.TwentyFourHours, 24)]
+    [InlineData("unknown", DashboardRangeKeys.TwentyFourHours, 24)]
+    public void Resolve_ReturnsExpectedRange(string? input, string expectedKey, int expectedHours)
+    {
+        var range = _resolver.Resolve(input);
+
+        Assert.Equal(expectedKey, range.Key);
+        Assert.Equal(_now, range.To);
+        Assert.Equal(_now.AddHours(-expectedHours), range.From);
+    }
+
+    [Theory]
+    [InlineData(DashboardRangeKeys.OneHour, DashboardTrendGranularity.Minute)]
+    [InlineData(DashboardRangeKeys.TwentyFourHours, DashboardTrendGranularity.Hour)]
+    [InlineData(DashboardRangeKeys.SevenDays, DashboardTrendGranularity.Day)]
+    public void ResolveGranularity_ChoosesDefaultForRange(string range, string expectedGranularity)
+    {
+        var granularity = _resolver.ResolveGranularity(null, range);
+
+        Assert.Equal(expectedGranularity, granularity);
+    }
+
+    [Fact]
+    public void ResolveGranularity_PreservesExplicitGranularity()
+    {
+        var granularity = _resolver.ResolveGranularity("custom", DashboardRangeKeys.OneHour);
+
+        Assert.Equal("custom", granularity);
+    }
+
+    private class TestClock(DateTimeOffset utcNow) : ISystemClock
+    {
+        public DateTimeOffset UtcNow { get; } = utcNow;
+    }
+}

--- a/test/unit/Elsa.Dashboard.Api.UnitTests/Elsa.Dashboard.Api.UnitTests.csproj
+++ b/test/unit/Elsa.Dashboard.Api.UnitTests/Elsa.Dashboard.Api.UnitTests.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <Include>[Elsa.Dashboard.Api]*</Include>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\src\modules\Elsa.Dashboard.Api\Elsa.Dashboard.Api.csproj" />
+    </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

Adds the Core `Elsa.Dashboard.Api` foundation for the operational Studio dashboard:

- new dashboard API module and shell/feature registration
- Refit-aligned DTO/request/response contract endpoints
- initial workflow aggregate, trend, needs-attention, recent activity, hotspot, runtime, and diagnostics summary provider
- optional diagnostics capability handling when structured/console log providers are absent
- sample host registration in `Elsa.Server.Web` and `Elsa.ModularServer.Web`
- range resolver unit tests

Closes #7646
Closes #7647
Refs #7648
Refs #7649
Refs #7650
Refs #7651
Refs #7652
Refs #7653
Refs #7654
Refs #7655

## Validation

- `dotnet build src/modules/Elsa.Dashboard.Api/Elsa.Dashboard.Api.csproj --no-restore`
- `dotnet test test/unit/Elsa.Dashboard.Api.UnitTests/Elsa.Dashboard.Api.UnitTests.csproj --no-build --no-restore`
- `dotnet build src/apps/Elsa.ModularServer.Web/Elsa.ModularServer.Web.csproj`
- `dotnet build src/apps/Elsa.Server.Web/Elsa.Server.Web.csproj --no-restore` after rerunning sequentially because a concurrent build locked a PDB
