### PR TITLE
Prototype workflow instance metadata persistence

### DIFF
--- a/Elsa.sln
+++ b/Elsa.sln
@@ -385,6 +385,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.ModularPersistence.Mon
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.ModularPersistence.MongoDb.IntegrationTests", "test\integration\Elsa.ModularPersistence.MongoDb.IntegrationTests\Elsa.ModularPersistence.MongoDb.IntegrationTests.csproj", "{2616EDC3-CF46-497F-AFF0-DA7005B1F952}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Workflows.Management.Persistence.ModularPersistence", "src\modules\Elsa.Workflows.Management.Persistence.ModularPersistence\Elsa.Workflows.Management.Persistence.ModularPersistence.csproj", "{99DCA80E-ADE4-4CBE-8885-110ABA468A08}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Workflows.Management.Persistence.ModularPersistence.UnitTests", "test\unit\Elsa.Workflows.Management.Persistence.ModularPersistence.UnitTests\Elsa.Workflows.Management.Persistence.ModularPersistence.UnitTests.csproj", "{5F9FDC6D-1171-432D-B993-100C64D5E5D2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1641,6 +1645,30 @@ Global
 		{2616EDC3-CF46-497F-AFF0-DA7005B1F952}.Release|x64.Build.0 = Release|Any CPU
 		{2616EDC3-CF46-497F-AFF0-DA7005B1F952}.Release|x86.ActiveCfg = Release|Any CPU
 		{2616EDC3-CF46-497F-AFF0-DA7005B1F952}.Release|x86.Build.0 = Release|Any CPU
+		{99DCA80E-ADE4-4CBE-8885-110ABA468A08}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{99DCA80E-ADE4-4CBE-8885-110ABA468A08}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{99DCA80E-ADE4-4CBE-8885-110ABA468A08}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{99DCA80E-ADE4-4CBE-8885-110ABA468A08}.Debug|x64.Build.0 = Debug|Any CPU
+		{99DCA80E-ADE4-4CBE-8885-110ABA468A08}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{99DCA80E-ADE4-4CBE-8885-110ABA468A08}.Debug|x86.Build.0 = Debug|Any CPU
+		{99DCA80E-ADE4-4CBE-8885-110ABA468A08}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{99DCA80E-ADE4-4CBE-8885-110ABA468A08}.Release|Any CPU.Build.0 = Release|Any CPU
+		{99DCA80E-ADE4-4CBE-8885-110ABA468A08}.Release|x64.ActiveCfg = Release|Any CPU
+		{99DCA80E-ADE4-4CBE-8885-110ABA468A08}.Release|x64.Build.0 = Release|Any CPU
+		{99DCA80E-ADE4-4CBE-8885-110ABA468A08}.Release|x86.ActiveCfg = Release|Any CPU
+		{99DCA80E-ADE4-4CBE-8885-110ABA468A08}.Release|x86.Build.0 = Release|Any CPU
+		{5F9FDC6D-1171-432D-B993-100C64D5E5D2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5F9FDC6D-1171-432D-B993-100C64D5E5D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5F9FDC6D-1171-432D-B993-100C64D5E5D2}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5F9FDC6D-1171-432D-B993-100C64D5E5D2}.Debug|x64.Build.0 = Debug|Any CPU
+		{5F9FDC6D-1171-432D-B993-100C64D5E5D2}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5F9FDC6D-1171-432D-B993-100C64D5E5D2}.Debug|x86.Build.0 = Debug|Any CPU
+		{5F9FDC6D-1171-432D-B993-100C64D5E5D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5F9FDC6D-1171-432D-B993-100C64D5E5D2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5F9FDC6D-1171-432D-B993-100C64D5E5D2}.Release|x64.ActiveCfg = Release|Any CPU
+		{5F9FDC6D-1171-432D-B993-100C64D5E5D2}.Release|x64.Build.0 = Release|Any CPU
+		{5F9FDC6D-1171-432D-B993-100C64D5E5D2}.Release|x86.ActiveCfg = Release|Any CPU
+		{5F9FDC6D-1171-432D-B993-100C64D5E5D2}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1783,6 +1811,8 @@ Global
 		{C3514903-2A7C-4962-BE1E-71D36BBFA6EC} = {5BA4A8FA-F7F4-45B3-AEC8-8886D35AAC79}
 		{842A010A-5AE2-417E-8170-8CAC0BFF2C7D} = {18453B51-25EB-4317-A4B3-B10518252E92}
 		{2616EDC3-CF46-497F-AFF0-DA7005B1F952} = {1B8D5897-902E-4632-8698-E89CAF3DDF54}
+		{99DCA80E-ADE4-4CBE-8885-110ABA468A08} = {5BA4A8FA-F7F4-45B3-AEC8-8886D35AAC79}
+		{5F9FDC6D-1171-432D-B993-100C64D5E5D2} = {18453B51-25EB-4317-A4B3-B10518252E92}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D4B5CEAA-7D70-4FCB-A68E-B03FBE5E0E5E}

--- a/design/persistence-vnext-workflow-instance-metadata.md
+++ b/design/persistence-vnext-workflow-instance-metadata.md
@@ -1,0 +1,48 @@
+# Persistence vNext Workflow Instance Metadata Projection
+
+This proof-of-concept keeps workflow execution persistence intact and adds a side-by-side metadata projection for management/catalog queries.
+
+## Intent
+
+Workflow instances have two very different persistence concerns:
+
+- management metadata: ID, definition IDs, status, sub-status, correlation, timestamps, incident count, tenant, and name
+- runtime state: the serialized workflow state graph used by execution hot paths
+
+The POC models only the first concern through `Elsa.ModularPersistence`. It registers a provider-neutral storage manifest and writes metadata documents through `IDocumentStore`. Modules or hosts can query summaries, IDs, and counts without owning SQL Server, SQLite, PostgreSQL, or MongoDB migrations.
+
+## Package
+
+`Elsa.Workflows.Management.Persistence.ModularPersistence` contributes:
+
+- `WorkflowInstanceMetadataStorageManifest`, the declared provider-neutral schema
+- `WorkflowInstanceMetadataRecord`, a document that intentionally excludes `WorkflowState`
+- `IWorkflowInstanceMetadataStore`, a side-by-side query store for summaries, IDs, and counts
+- `ModularPersistenceWorkflowInstanceMetadataStore`, an implementation over `IDocumentStore`
+- `WorkflowInstanceMetadataBenchmarkEstimator`, a deterministic sizing model for small and large state payload decisions
+
+The package does not replace `IWorkflowInstanceStore` and does not alter the current EF Core persistence path.
+
+## Query Boundary
+
+Only declared-index-backed filters are supported. Exact ID, definition ID, definition version ID, version, parent ID, correlation ID, exact names, statuses, executing/system flags, incident presence, and timestamp ranges are mapped to `DocumentQueryFilter`.
+
+`SearchTerm` and the contains-style `Name` filter are rejected because they require provider-specific text search or scans. A future production version should add explicit text-search capability descriptors instead of hiding a scan behind the portable API.
+
+## Benchmark Interpretation
+
+The estimator is not a substitute for provider benchmarks. It exists to force the workflow-state decision to stay visible:
+
+| Scenario | Instances | Metadata bytes each | State bytes each | Metadata-only total | Full document total |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Small state | 1,000 | 1 KB | 8 KB | 1 MB | 9 MB |
+| Large state | 1,000 | 1 KB | 512 KB | 1 MB | 513 MB |
+
+Metadata reads should not hydrate the workflow state blob. Any proposal to write workflow state through Persistence vNext needs provider-specific benchmark evidence and a separate decision record.
+
+## Next Steps
+
+1. Add live provider contract tests for SQLite and MongoDB once local container support is available.
+2. Add production text-search capability descriptors if management search must move to this projection.
+3. Decide whether the projection is maintained synchronously with workflow instance writes, through outbox events, or by a repairable projector.
+4. Benchmark write amplification against real workflow state payloads before considering a full state document path.

--- a/src/modules/Elsa.Workflows.Management.Persistence.ModularPersistence/Benchmarks/WorkflowInstanceMetadataBenchmarkEstimate.cs
+++ b/src/modules/Elsa.Workflows.Management.Persistence.ModularPersistence/Benchmarks/WorkflowInstanceMetadataBenchmarkEstimate.cs
@@ -1,0 +1,12 @@
+namespace Elsa.Workflows.Management.Persistence.ModularPersistence.Benchmarks;
+
+public sealed record WorkflowInstanceMetadataBenchmarkEstimate(
+    string Name,
+    int InstanceCount,
+    int AverageMetadataBytes,
+    int AverageWorkflowStateBytes,
+    long MetadataOnlyBytes,
+    long FullDocumentBytes,
+    decimal MetadataToFullDocumentRatio,
+    string ReadPath,
+    string WritePath);

--- a/src/modules/Elsa.Workflows.Management.Persistence.ModularPersistence/Benchmarks/WorkflowInstanceMetadataBenchmarkEstimator.cs
+++ b/src/modules/Elsa.Workflows.Management.Persistence.ModularPersistence/Benchmarks/WorkflowInstanceMetadataBenchmarkEstimator.cs
@@ -1,0 +1,36 @@
+namespace Elsa.Workflows.Management.Persistence.ModularPersistence.Benchmarks;
+
+public static class WorkflowInstanceMetadataBenchmarkEstimator
+{
+    public const int DefaultMetadataBytes = 1024;
+
+    public static IReadOnlyCollection<WorkflowInstanceMetadataBenchmarkEstimate> Estimate(IEnumerable<WorkflowInstanceMetadataBenchmarkScenario> scenarios) =>
+        scenarios.Select(Estimate).ToArray();
+
+    public static WorkflowInstanceMetadataBenchmarkEstimate Estimate(WorkflowInstanceMetadataBenchmarkScenario scenario)
+    {
+        if (scenario.InstanceCount < 0)
+            throw new ArgumentOutOfRangeException(nameof(scenario.InstanceCount), "Instance count cannot be negative.");
+
+        if (scenario.AverageMetadataBytes <= 0)
+            throw new ArgumentOutOfRangeException(nameof(scenario.AverageMetadataBytes), "Average metadata bytes must be greater than zero.");
+
+        if (scenario.AverageWorkflowStateBytes < 0)
+            throw new ArgumentOutOfRangeException(nameof(scenario.AverageWorkflowStateBytes), "Average workflow state bytes cannot be negative.");
+
+        var metadataOnlyBytes = scenario.TotalMetadataBytes;
+        var fullDocumentBytes = scenario.TotalFullDocumentBytes;
+        var ratio = fullDocumentBytes == 0 ? 0 : decimal.Round(metadataOnlyBytes / (decimal)fullDocumentBytes, 4);
+
+        return new WorkflowInstanceMetadataBenchmarkEstimate(
+            scenario.Name,
+            scenario.InstanceCount,
+            scenario.AverageMetadataBytes,
+            scenario.AverageWorkflowStateBytes,
+            metadataOnlyBytes,
+            fullDocumentBytes,
+            ratio,
+            "Declared metadata indexes only; no workflow state materialization.",
+            "Metadata projection write only; workflow state blob remains on the existing persistence path.");
+    }
+}

--- a/src/modules/Elsa.Workflows.Management.Persistence.ModularPersistence/Benchmarks/WorkflowInstanceMetadataBenchmarkScenario.cs
+++ b/src/modules/Elsa.Workflows.Management.Persistence.ModularPersistence/Benchmarks/WorkflowInstanceMetadataBenchmarkScenario.cs
@@ -1,0 +1,14 @@
+namespace Elsa.Workflows.Management.Persistence.ModularPersistence.Benchmarks;
+
+public sealed record WorkflowInstanceMetadataBenchmarkScenario(
+    string Name,
+    int InstanceCount,
+    int AverageWorkflowStateBytes,
+    int AverageMetadataBytes = WorkflowInstanceMetadataBenchmarkEstimator.DefaultMetadataBytes)
+{
+    public long TotalMetadataBytes => (long)InstanceCount * AverageMetadataBytes;
+
+    public long TotalWorkflowStateBytes => (long)InstanceCount * AverageWorkflowStateBytes;
+
+    public long TotalFullDocumentBytes => TotalMetadataBytes + TotalWorkflowStateBytes;
+}

--- a/src/modules/Elsa.Workflows.Management.Persistence.ModularPersistence/Elsa.Workflows.Management.Persistence.ModularPersistence.csproj
+++ b/src/modules/Elsa.Workflows.Management.Persistence.ModularPersistence/Elsa.Workflows.Management.Persistence.ModularPersistence.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <Description>
+            Provides an experimental Persistence vNext metadata projection for Elsa workflow instances.
+        </Description>
+        <PackageTags>elsa module workflows management modular-persistence persistence</PackageTags>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Elsa.ModularPersistence\Elsa.ModularPersistence.csproj" />
+        <ProjectReference Include="..\Elsa.Workflows.Management\Elsa.Workflows.Management.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/modules/Elsa.Workflows.Management.Persistence.ModularPersistence/Extensions/WorkflowInstancesFeatureModularPersistenceExtensions.cs
+++ b/src/modules/Elsa.Workflows.Management.Persistence.ModularPersistence/Extensions/WorkflowInstancesFeatureModularPersistenceExtensions.cs
@@ -1,0 +1,19 @@
+using Elsa.Extensions;
+using Elsa.ModularPersistence.Documents;
+using Elsa.Workflows.Management.Features;
+using Elsa.Workflows.Management.Persistence.ModularPersistence.Storage;
+using Elsa.Workflows.Management.Persistence.ModularPersistence.Stores;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Elsa.Workflows.Management.Persistence.ModularPersistence.Extensions;
+
+public static class WorkflowInstancesFeatureModularPersistenceExtensions
+{
+    public static WorkflowInstancesFeature UseModularPersistenceMetadata(this WorkflowInstancesFeature feature, Func<IServiceProvider, IDocumentStore> documentStoreFactory)
+    {
+        feature.Module.UseModularPersistence(modularPersistence => modularPersistence.RegisterManifest(WorkflowInstanceMetadataStorageManifest.Create()));
+        feature.Module.Services.AddSingleton(documentStoreFactory);
+        feature.Module.Services.AddScoped<IWorkflowInstanceMetadataStore, ModularPersistenceWorkflowInstanceMetadataStore>();
+        return feature;
+    }
+}

--- a/src/modules/Elsa.Workflows.Management.Persistence.ModularPersistence/FodyWeavers.xml
+++ b/src/modules/Elsa.Workflows.Management.Persistence.ModularPersistence/FodyWeavers.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
+  <ConfigureAwait />
+</Weavers>

--- a/src/modules/Elsa.Workflows.Management.Persistence.ModularPersistence/Storage/WorkflowInstanceMetadataRecord.cs
+++ b/src/modules/Elsa.Workflows.Management.Persistence.ModularPersistence/Storage/WorkflowInstanceMetadataRecord.cs
@@ -1,0 +1,63 @@
+using Elsa.Workflows.Management.Entities;
+using Elsa.Workflows.Management.Models;
+
+namespace Elsa.Workflows.Management.Persistence.ModularPersistence.Storage;
+
+public sealed class WorkflowInstanceMetadataRecord
+{
+    public string Id { get; set; } = default!;
+    public string? TenantId { get; set; }
+    public string DefinitionId { get; set; } = default!;
+    public string DefinitionVersionId { get; set; } = default!;
+    public int Version { get; set; }
+    public string? ParentWorkflowInstanceId { get; set; }
+    public WorkflowStatus Status { get; set; }
+    public WorkflowSubStatus SubStatus { get; set; }
+    public bool IsExecuting { get; set; }
+    public string? CorrelationId { get; set; }
+    public string? Name { get; set; }
+    public int IncidentCount { get; set; }
+    public bool IsSystem { get; set; }
+    public DateTimeOffset CreatedAt { get; set; }
+    public DateTimeOffset UpdatedAt { get; set; }
+    public DateTimeOffset? FinishedAt { get; set; }
+
+    public static WorkflowInstanceMetadataRecord FromInstance(WorkflowInstance instance) =>
+        new()
+        {
+            Id = instance.Id,
+            TenantId = instance.TenantId,
+            DefinitionId = instance.DefinitionId,
+            DefinitionVersionId = instance.DefinitionVersionId,
+            Version = instance.Version,
+            ParentWorkflowInstanceId = instance.ParentWorkflowInstanceId,
+            Status = instance.Status,
+            SubStatus = instance.SubStatus,
+            IsExecuting = instance.IsExecuting,
+            CorrelationId = instance.CorrelationId,
+            Name = instance.Name,
+            IncidentCount = instance.IncidentCount,
+            IsSystem = instance.IsSystem,
+            CreatedAt = instance.CreatedAt,
+            UpdatedAt = instance.UpdatedAt,
+            FinishedAt = instance.FinishedAt
+        };
+
+    public WorkflowInstanceSummary ToSummary() =>
+        new()
+        {
+            Id = Id,
+            TenantId = TenantId,
+            DefinitionId = DefinitionId,
+            DefinitionVersionId = DefinitionVersionId,
+            Version = Version,
+            Status = Status,
+            SubStatus = SubStatus,
+            CorrelationId = CorrelationId,
+            Name = Name,
+            IncidentCount = IncidentCount,
+            CreatedAt = CreatedAt,
+            UpdatedAt = UpdatedAt,
+            FinishedAt = FinishedAt
+        };
+}

--- a/src/modules/Elsa.Workflows.Management.Persistence.ModularPersistence/Storage/WorkflowInstanceMetadataStorageManifest.cs
+++ b/src/modules/Elsa.Workflows.Management.Persistence.ModularPersistence/Storage/WorkflowInstanceMetadataStorageManifest.cs
@@ -1,0 +1,82 @@
+using Elsa.ModularPersistence.Descriptors;
+
+namespace Elsa.Workflows.Management.Persistence.ModularPersistence.Storage;
+
+public static class WorkflowInstanceMetadataStorageManifest
+{
+    public const string SchemaName = "elsa.workflow-instances";
+    public const string StorageUnitName = "WorkflowInstanceMetadata";
+
+    public const string IdIndexName = "IX_WorkflowInstanceMetadata_Id";
+    public const string DefinitionIdIndexName = "IX_WorkflowInstanceMetadata_DefinitionId";
+    public const string DefinitionVersionIdIndexName = "IX_WorkflowInstanceMetadata_DefinitionVersionId";
+    public const string DefinitionIdVersionIndexName = "IX_WorkflowInstanceMetadata_DefinitionId_Version";
+    public const string VersionIndexName = "IX_WorkflowInstanceMetadata_Version";
+    public const string ParentWorkflowInstanceIdIndexName = "IX_WorkflowInstanceMetadata_ParentWorkflowInstanceId";
+    public const string CorrelationIdIndexName = "IX_WorkflowInstanceMetadata_CorrelationId";
+    public const string NameIndexName = "IX_WorkflowInstanceMetadata_Name";
+    public const string StatusIndexName = "IX_WorkflowInstanceMetadata_Status";
+    public const string SubStatusIndexName = "IX_WorkflowInstanceMetadata_SubStatus";
+    public const string StatusSubStatusIndexName = "IX_WorkflowInstanceMetadata_Status_SubStatus";
+    public const string StatusDefinitionIdIndexName = "IX_WorkflowInstanceMetadata_Status_DefinitionId";
+    public const string SubStatusDefinitionIdIndexName = "IX_WorkflowInstanceMetadata_SubStatus_DefinitionId";
+    public const string StatusSubStatusDefinitionVersionIndexName = "IX_WorkflowInstanceMetadata_Status_SubStatus_DefinitionId_Version";
+    public const string IsExecutingIndexName = "IX_WorkflowInstanceMetadata_IsExecuting";
+    public const string HasIncidentsIndexName = "IX_WorkflowInstanceMetadata_IncidentCount";
+    public const string IsSystemIndexName = "IX_WorkflowInstanceMetadata_IsSystem";
+    public const string CreatedAtIndexName = "IX_WorkflowInstanceMetadata_CreatedAt";
+    public const string UpdatedAtIndexName = "IX_WorkflowInstanceMetadata_UpdatedAt";
+    public const string FinishedAtIndexName = "IX_WorkflowInstanceMetadata_FinishedAt";
+
+    public static StorageManifestDescriptor Create() =>
+        new(
+            SchemaName,
+            new StorageManifestVersion(1),
+            [
+                new StorageUnitDescriptor(
+                    StorageUnitName,
+                    [
+                        new StorageFieldDescriptor("Id", StorageFieldType.String, true),
+                        new StorageFieldDescriptor("TenantId", StorageFieldType.String),
+                        new StorageFieldDescriptor("DefinitionId", StorageFieldType.String, true),
+                        new StorageFieldDescriptor("DefinitionVersionId", StorageFieldType.String, true),
+                        new StorageFieldDescriptor("Version", StorageFieldType.Int32, true),
+                        new StorageFieldDescriptor("ParentWorkflowInstanceId", StorageFieldType.String),
+                        new StorageFieldDescriptor("Status", StorageFieldType.String, true),
+                        new StorageFieldDescriptor("SubStatus", StorageFieldType.String, true),
+                        new StorageFieldDescriptor("IsExecuting", StorageFieldType.Boolean, true),
+                        new StorageFieldDescriptor("CorrelationId", StorageFieldType.String),
+                        new StorageFieldDescriptor("Name", StorageFieldType.String),
+                        new StorageFieldDescriptor("IncidentCount", StorageFieldType.Int32, true),
+                        new StorageFieldDescriptor("IsSystem", StorageFieldType.Boolean, true),
+                        new StorageFieldDescriptor("CreatedAt", StorageFieldType.DateTimeOffset, true),
+                        new StorageFieldDescriptor("UpdatedAt", StorageFieldType.DateTimeOffset, true),
+                        new StorageFieldDescriptor("FinishedAt", StorageFieldType.DateTimeOffset)
+                    ],
+                    [
+                        new StorageKeyDescriptor("PK_WorkflowInstanceMetadata", ["Id"])
+                    ],
+                    [
+                        new StorageIndexDescriptor(IdIndexName, [new StorageIndexFieldDescriptor("Id")], true),
+                        new StorageIndexDescriptor(DefinitionIdIndexName, [new StorageIndexFieldDescriptor("DefinitionId")]),
+                        new StorageIndexDescriptor(DefinitionVersionIdIndexName, [new StorageIndexFieldDescriptor("DefinitionVersionId")]),
+                        new StorageIndexDescriptor(DefinitionIdVersionIndexName, [new StorageIndexFieldDescriptor("DefinitionId"), new StorageIndexFieldDescriptor("Version")]),
+                        new StorageIndexDescriptor(VersionIndexName, [new StorageIndexFieldDescriptor("Version")]),
+                        new StorageIndexDescriptor(ParentWorkflowInstanceIdIndexName, [new StorageIndexFieldDescriptor("ParentWorkflowInstanceId")]),
+                        new StorageIndexDescriptor(CorrelationIdIndexName, [new StorageIndexFieldDescriptor("CorrelationId")]),
+                        new StorageIndexDescriptor(NameIndexName, [new StorageIndexFieldDescriptor("Name")]),
+                        new StorageIndexDescriptor(StatusIndexName, [new StorageIndexFieldDescriptor("Status")]),
+                        new StorageIndexDescriptor(SubStatusIndexName, [new StorageIndexFieldDescriptor("SubStatus")]),
+                        new StorageIndexDescriptor(StatusSubStatusIndexName, [new StorageIndexFieldDescriptor("Status"), new StorageIndexFieldDescriptor("SubStatus")]),
+                        new StorageIndexDescriptor(StatusDefinitionIdIndexName, [new StorageIndexFieldDescriptor("Status"), new StorageIndexFieldDescriptor("DefinitionId")]),
+                        new StorageIndexDescriptor(SubStatusDefinitionIdIndexName, [new StorageIndexFieldDescriptor("SubStatus"), new StorageIndexFieldDescriptor("DefinitionId")]),
+                        new StorageIndexDescriptor(StatusSubStatusDefinitionVersionIndexName, [new StorageIndexFieldDescriptor("Status"), new StorageIndexFieldDescriptor("SubStatus"), new StorageIndexFieldDescriptor("DefinitionId"), new StorageIndexFieldDescriptor("Version")]),
+                        new StorageIndexDescriptor(IsExecutingIndexName, [new StorageIndexFieldDescriptor("IsExecuting")]),
+                        new StorageIndexDescriptor(HasIncidentsIndexName, [new StorageIndexFieldDescriptor("IncidentCount")]),
+                        new StorageIndexDescriptor(IsSystemIndexName, [new StorageIndexFieldDescriptor("IsSystem")]),
+                        new StorageIndexDescriptor(CreatedAtIndexName, [new StorageIndexFieldDescriptor("CreatedAt")]),
+                        new StorageIndexDescriptor(UpdatedAtIndexName, [new StorageIndexFieldDescriptor("UpdatedAt")]),
+                        new StorageIndexDescriptor(FinishedAtIndexName, [new StorageIndexFieldDescriptor("FinishedAt")])
+                    ])
+            ]);
+}

--- a/src/modules/Elsa.Workflows.Management.Persistence.ModularPersistence/Stores/IWorkflowInstanceMetadataStore.cs
+++ b/src/modules/Elsa.Workflows.Management.Persistence.ModularPersistence/Stores/IWorkflowInstanceMetadataStore.cs
@@ -1,0 +1,21 @@
+using Elsa.Common.Models;
+using Elsa.Workflows.Management.Filters;
+using Elsa.Workflows.Management.Models;
+using Elsa.Workflows.Management.Persistence.ModularPersistence.Storage;
+
+namespace Elsa.Workflows.Management.Persistence.ModularPersistence.Stores;
+
+public interface IWorkflowInstanceMetadataStore
+{
+    ValueTask SaveAsync(WorkflowInstanceMetadataRecord record, CancellationToken cancellationToken = default);
+
+    ValueTask SaveManyAsync(IEnumerable<WorkflowInstanceMetadataRecord> records, CancellationToken cancellationToken = default);
+
+    ValueTask<WorkflowInstanceMetadataRecord?> FindAsync(string id, string? tenantId = null, CancellationToken cancellationToken = default);
+
+    ValueTask<Page<WorkflowInstanceSummary>> SummarizeManyAsync(WorkflowInstanceFilter filter, PageArgs pageArgs, string? tenantId = null, CancellationToken cancellationToken = default);
+
+    ValueTask<Page<string>> FindManyIdsAsync(WorkflowInstanceFilter filter, PageArgs pageArgs, string? tenantId = null, CancellationToken cancellationToken = default);
+
+    ValueTask<long> CountAsync(WorkflowInstanceFilter filter, string? tenantId = null, CancellationToken cancellationToken = default);
+}

--- a/src/modules/Elsa.Workflows.Management.Persistence.ModularPersistence/Stores/ModularPersistenceWorkflowInstanceMetadataStore.cs
+++ b/src/modules/Elsa.Workflows.Management.Persistence.ModularPersistence/Stores/ModularPersistenceWorkflowInstanceMetadataStore.cs
@@ -1,0 +1,89 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Elsa.Common.Models;
+using Elsa.ModularPersistence.Documents;
+using Elsa.Workflows.Management.Filters;
+using Elsa.Workflows.Management.Models;
+using Elsa.Workflows.Management.Persistence.ModularPersistence.Storage;
+
+namespace Elsa.Workflows.Management.Persistence.ModularPersistence.Stores;
+
+public sealed class ModularPersistenceWorkflowInstanceMetadataStore(IDocumentStore documentStore) : IWorkflowInstanceMetadataStore
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    public async ValueTask SaveAsync(WorkflowInstanceMetadataRecord record, CancellationToken cancellationToken = default)
+    {
+        await using var session = await documentStore.OpenSessionAsync(cancellationToken);
+        await SaveAsync(session, record, cancellationToken);
+    }
+
+    public async ValueTask SaveManyAsync(IEnumerable<WorkflowInstanceMetadataRecord> records, CancellationToken cancellationToken = default)
+    {
+        await using var session = await documentStore.OpenSessionAsync(cancellationToken);
+
+        foreach (var record in records)
+            await SaveAsync(session, record, cancellationToken);
+    }
+
+    public async ValueTask<WorkflowInstanceMetadataRecord?> FindAsync(string id, string? tenantId = null, CancellationToken cancellationToken = default)
+    {
+        await using var session = await documentStore.OpenSessionAsync(cancellationToken);
+        var envelope = await session.LoadAsync(new DocumentKey(id, WorkflowInstanceMetadataStorageManifest.StorageUnitName, tenantId), cancellationToken);
+        return envelope == null ? null : ToRecord(envelope);
+    }
+
+    public async ValueTask<Page<WorkflowInstanceSummary>> SummarizeManyAsync(WorkflowInstanceFilter filter, PageArgs pageArgs, string? tenantId = null, CancellationToken cancellationToken = default)
+    {
+        var page = await QueryRecordsAsync(filter, pageArgs, tenantId, cancellationToken);
+        return new Page<WorkflowInstanceSummary>(page.Items.Select(x => x.ToSummary()).ToList(), page.TotalCount);
+    }
+
+    public async ValueTask<Page<string>> FindManyIdsAsync(WorkflowInstanceFilter filter, PageArgs pageArgs, string? tenantId = null, CancellationToken cancellationToken = default)
+    {
+        var page = await QueryRecordsAsync(filter, pageArgs, tenantId, cancellationToken);
+        return new Page<string>(page.Items.Select(x => x.Id).ToList(), page.TotalCount);
+    }
+
+    public async ValueTask<long> CountAsync(WorkflowInstanceFilter filter, string? tenantId = null, CancellationToken cancellationToken = default)
+    {
+        await using var session = await documentStore.OpenSessionAsync(cancellationToken);
+        var query = WorkflowInstanceMetadataQueryBuilder.Build(filter, tenantId: tenantId);
+        var results = await session.QueryAsync(query, cancellationToken);
+        return results.LongCount();
+    }
+
+    private static async ValueTask SaveAsync(IDocumentSession session, WorkflowInstanceMetadataRecord record, CancellationToken cancellationToken)
+    {
+        var key = new DocumentKey(record.Id, WorkflowInstanceMetadataStorageManifest.StorageUnitName, record.TenantId);
+        var existingEnvelope = await session.LoadAsync(key, cancellationToken);
+        var nextVersion = existingEnvelope?.Version + 1 ?? 1;
+        var expectedVersion = existingEnvelope == null ? ExpectedDocumentVersion.New : ExpectedDocumentVersion.Exact(existingEnvelope.Version);
+        await session.SaveAsync(ToEnvelope(record, nextVersion), expectedVersion, cancellationToken);
+    }
+
+    private async ValueTask<Page<WorkflowInstanceMetadataRecord>> QueryRecordsAsync(WorkflowInstanceFilter filter, PageArgs pageArgs, string? tenantId, CancellationToken cancellationToken)
+    {
+        await using var session = await documentStore.OpenSessionAsync(cancellationToken);
+
+        var countQuery = WorkflowInstanceMetadataQueryBuilder.Build(filter, tenantId: tenantId);
+        var count = (await session.QueryAsync(countQuery, cancellationToken)).LongCount();
+        var pageQuery = WorkflowInstanceMetadataQueryBuilder.Build(filter, pageArgs, tenantId);
+        var records = (await session.QueryAsync(pageQuery, cancellationToken)).Select(ToRecord).ToList();
+
+        return new Page<WorkflowInstanceMetadataRecord>(records, count);
+    }
+
+    private static DocumentEnvelope ToEnvelope(WorkflowInstanceMetadataRecord record, long documentVersion)
+    {
+        var data = JsonSerializer.Serialize(record, JsonOptions);
+        return new DocumentEnvelope(record.Id, WorkflowInstanceMetadataStorageManifest.StorageUnitName, record.TenantId, documentVersion, record.CreatedAt, record.UpdatedAt, data);
+    }
+
+    private static WorkflowInstanceMetadataRecord ToRecord(DocumentEnvelope envelope) =>
+        JsonSerializer.Deserialize<WorkflowInstanceMetadataRecord>(envelope.Data, JsonOptions)
+        ?? throw new InvalidOperationException($"Workflow instance metadata document '{envelope.Id}' could not be deserialized.");
+}

--- a/src/modules/Elsa.Workflows.Management.Persistence.ModularPersistence/Stores/WorkflowInstanceMetadataQueryBuilder.cs
+++ b/src/modules/Elsa.Workflows.Management.Persistence.ModularPersistence/Stores/WorkflowInstanceMetadataQueryBuilder.cs
@@ -1,0 +1,183 @@
+using Elsa.Common.Models;
+using Elsa.ModularPersistence.Queries;
+using Elsa.Workflows.Management.Enums;
+using Elsa.Workflows.Management.Filters;
+using Elsa.Workflows.Management.Models;
+using Elsa.Workflows.Management.Persistence.ModularPersistence.Storage;
+
+namespace Elsa.Workflows.Management.Persistence.ModularPersistence.Stores;
+
+internal static class WorkflowInstanceMetadataQueryBuilder
+{
+    public static DocumentQuery Build(WorkflowInstanceFilter filter, PageArgs? pageArgs = null, string? tenantId = null)
+    {
+        var filters = BuildFilters(filter).ToArray();
+        if (filters.Length == 0)
+            filters = [DocumentQueryFilter.IsNotNull(WorkflowInstanceMetadataStorageManifest.IdIndexName, "Id")];
+        var page = CreatePage(pageArgs);
+        var sorts = new[]
+        {
+            new DocumentQuerySort(WorkflowInstanceMetadataStorageManifest.CreatedAtIndexName, "CreatedAt")
+        };
+
+        return new DocumentQuery(
+            WorkflowInstanceMetadataStorageManifest.StorageUnitName,
+            filters,
+            sorts,
+            page,
+            tenantId);
+    }
+
+    private static IEnumerable<DocumentQueryFilter> BuildFilters(WorkflowInstanceFilter filter)
+    {
+        RejectScanOnlyFilters(filter);
+
+        if (!string.IsNullOrWhiteSpace(filter.Id))
+            yield return DocumentQueryFilter.Equal(WorkflowInstanceMetadataStorageManifest.IdIndexName, "Id", DocumentQueryValue.String(filter.Id));
+
+        if (filter.Ids?.Count > 0)
+            yield return DocumentQueryFilter.In(WorkflowInstanceMetadataStorageManifest.IdIndexName, "Id", filter.Ids.Select(DocumentQueryValue.String));
+
+        if (!string.IsNullOrWhiteSpace(filter.DefinitionId))
+            yield return DocumentQueryFilter.Equal(WorkflowInstanceMetadataStorageManifest.DefinitionIdIndexName, "DefinitionId", DocumentQueryValue.String(filter.DefinitionId));
+
+        if (!string.IsNullOrWhiteSpace(filter.DefinitionVersionId))
+            yield return DocumentQueryFilter.Equal(WorkflowInstanceMetadataStorageManifest.DefinitionVersionIdIndexName, "DefinitionVersionId", DocumentQueryValue.String(filter.DefinitionVersionId));
+
+        if (filter.DefinitionIds?.Count > 0)
+            yield return DocumentQueryFilter.In(WorkflowInstanceMetadataStorageManifest.DefinitionIdIndexName, "DefinitionId", filter.DefinitionIds.Select(DocumentQueryValue.String));
+
+        if (filter.DefinitionVersionIds?.Count > 0)
+            yield return DocumentQueryFilter.In(WorkflowInstanceMetadataStorageManifest.DefinitionVersionIdIndexName, "DefinitionVersionId", filter.DefinitionVersionIds.Select(DocumentQueryValue.String));
+
+        if (filter.Version != null)
+            yield return DocumentQueryFilter.Equal(WorkflowInstanceMetadataStorageManifest.VersionIndexName, "Version", DocumentQueryValue.Int32(filter.Version.Value));
+
+        if (filter.ParentWorkflowInstanceIds?.Count > 0)
+            yield return DocumentQueryFilter.In(WorkflowInstanceMetadataStorageManifest.ParentWorkflowInstanceIdIndexName, "ParentWorkflowInstanceId", filter.ParentWorkflowInstanceIds.Select(DocumentQueryValue.String));
+
+        if (!string.IsNullOrWhiteSpace(filter.CorrelationId))
+            yield return DocumentQueryFilter.Equal(WorkflowInstanceMetadataStorageManifest.CorrelationIdIndexName, "CorrelationId", DocumentQueryValue.String(filter.CorrelationId));
+
+        if (filter.CorrelationIds?.Count > 0)
+            yield return DocumentQueryFilter.In(WorkflowInstanceMetadataStorageManifest.CorrelationIdIndexName, "CorrelationId", filter.CorrelationIds.Select(DocumentQueryValue.String));
+
+        if (filter.Names?.Count > 0)
+            yield return DocumentQueryFilter.In(WorkflowInstanceMetadataStorageManifest.NameIndexName, "Name", filter.Names.Select(DocumentQueryValue.String));
+
+        if (filter.WorkflowStatus != null)
+            yield return DocumentQueryFilter.Equal(WorkflowInstanceMetadataStorageManifest.StatusIndexName, "Status", DocumentQueryValue.String(filter.WorkflowStatus.Value.ToString()));
+
+        if (filter.WorkflowStatuses?.Count > 0)
+            yield return DocumentQueryFilter.In(WorkflowInstanceMetadataStorageManifest.StatusIndexName, "Status", filter.WorkflowStatuses.Select(x => DocumentQueryValue.String(x.ToString())));
+
+        if (filter.WorkflowSubStatus != null)
+            yield return DocumentQueryFilter.Equal(WorkflowInstanceMetadataStorageManifest.SubStatusIndexName, "SubStatus", DocumentQueryValue.String(filter.WorkflowSubStatus.Value.ToString()));
+
+        if (filter.WorkflowSubStatuses?.Count > 0)
+            yield return DocumentQueryFilter.In(WorkflowInstanceMetadataStorageManifest.SubStatusIndexName, "SubStatus", filter.WorkflowSubStatuses.Select(x => DocumentQueryValue.String(x.ToString())));
+
+        if (filter.IsExecuting != null)
+            yield return DocumentQueryFilter.Equal(WorkflowInstanceMetadataStorageManifest.IsExecutingIndexName, "IsExecuting", DocumentQueryValue.Boolean(filter.IsExecuting.Value));
+
+        if (filter.HasIncidents != null)
+        {
+            yield return filter.HasIncidents.Value
+                ? DocumentQueryFilter.GreaterThan(WorkflowInstanceMetadataStorageManifest.HasIncidentsIndexName, "IncidentCount", DocumentQueryValue.Int32(0))
+                : DocumentQueryFilter.Equal(WorkflowInstanceMetadataStorageManifest.HasIncidentsIndexName, "IncidentCount", DocumentQueryValue.Int32(0));
+        }
+
+        if (filter.IsSystem != null)
+            yield return DocumentQueryFilter.Equal(WorkflowInstanceMetadataStorageManifest.IsSystemIndexName, "IsSystem", DocumentQueryValue.Boolean(filter.IsSystem.Value));
+
+        if (filter.BeforeLastUpdated != null)
+            yield return DocumentQueryFilter.LessThan(WorkflowInstanceMetadataStorageManifest.UpdatedAtIndexName, "UpdatedAt", DocumentQueryValue.DateTimeOffset(filter.BeforeLastUpdated.Value));
+
+        foreach (var timestampFilter in BuildTimestampFilters(filter.TimestampFilters))
+            yield return timestampFilter;
+    }
+
+    private static void RejectScanOnlyFilters(WorkflowInstanceFilter filter)
+    {
+        if (!string.IsNullOrWhiteSpace(filter.SearchTerm))
+            throw new WorkflowInstanceMetadataQueryException("Workflow instance metadata persistence does not support SearchTerm because it requires provider-specific full-text or contains scanning.");
+
+        if (!string.IsNullOrWhiteSpace(filter.Name))
+            throw new WorkflowInstanceMetadataQueryException("Workflow instance metadata persistence supports exact Names matches only. The Name contains filter is intentionally not supported by the metadata projection.");
+    }
+
+    private static IEnumerable<DocumentQueryFilter> BuildTimestampFilters(IEnumerable<TimestampFilter>? timestampFilters)
+    {
+        foreach (var error in WorkflowInstanceFilter.ValidateTimestampFilters(timestampFilters))
+            throw new WorkflowInstanceMetadataQueryException(error);
+
+        if (timestampFilters == null)
+            yield break;
+
+        foreach (var timestampFilter in timestampFilters)
+        {
+            if (!WorkflowInstanceFilter.TryNormalizeTimestampFilterColumn(timestampFilter.Column, out var column, out var error))
+                throw new WorkflowInstanceMetadataQueryException(error);
+
+            var indexName = GetTimestampIndexName(column);
+            var timestamp = timestampFilter.Timestamp;
+            var isZeroTime = timestamp.TimeOfDay == TimeSpan.Zero;
+            var startDay = new DateTimeOffset(timestamp.Date);
+            var endDay = startDay.AddDays(1);
+
+            switch (timestampFilter.Operator)
+            {
+                case TimestampFilterOperator.Is when isZeroTime:
+                    yield return DocumentQueryFilter.GreaterThanOrEqual(indexName, column, DocumentQueryValue.DateTimeOffset(startDay));
+                    yield return DocumentQueryFilter.LessThan(indexName, column, DocumentQueryValue.DateTimeOffset(endDay));
+                    break;
+                case TimestampFilterOperator.Is:
+                    yield return DocumentQueryFilter.Equal(indexName, column, DocumentQueryValue.DateTimeOffset(timestamp));
+                    break;
+                case TimestampFilterOperator.IsNot:
+                    throw new WorkflowInstanceMetadataQueryException("Workflow instance metadata persistence does not support TimestampFilterOperator.IsNot because it cannot be represented as a single portable index range.");
+                case TimestampFilterOperator.GreaterThan when isZeroTime:
+                    yield return DocumentQueryFilter.GreaterThan(indexName, column, DocumentQueryValue.DateTimeOffset(endDay));
+                    break;
+                case TimestampFilterOperator.GreaterThan:
+                    yield return DocumentQueryFilter.GreaterThan(indexName, column, DocumentQueryValue.DateTimeOffset(timestamp));
+                    break;
+                case TimestampFilterOperator.GreaterThanOrEqual when isZeroTime:
+                    yield return DocumentQueryFilter.GreaterThanOrEqual(indexName, column, DocumentQueryValue.DateTimeOffset(startDay));
+                    break;
+                case TimestampFilterOperator.GreaterThanOrEqual:
+                    yield return DocumentQueryFilter.GreaterThanOrEqual(indexName, column, DocumentQueryValue.DateTimeOffset(timestamp));
+                    break;
+                case TimestampFilterOperator.LessThan when isZeroTime:
+                    yield return DocumentQueryFilter.LessThan(indexName, column, DocumentQueryValue.DateTimeOffset(startDay));
+                    break;
+                case TimestampFilterOperator.LessThan:
+                    yield return DocumentQueryFilter.LessThan(indexName, column, DocumentQueryValue.DateTimeOffset(timestamp));
+                    break;
+                case TimestampFilterOperator.LessThanOrEqual when isZeroTime:
+                    yield return DocumentQueryFilter.LessThanOrEqual(indexName, column, DocumentQueryValue.DateTimeOffset(endDay));
+                    break;
+                case TimestampFilterOperator.LessThanOrEqual:
+                    yield return DocumentQueryFilter.LessThanOrEqual(indexName, column, DocumentQueryValue.DateTimeOffset(timestamp));
+                    break;
+            }
+        }
+    }
+
+    private static string GetTimestampIndexName(string column) =>
+        column switch
+        {
+            "CreatedAt" => WorkflowInstanceMetadataStorageManifest.CreatedAtIndexName,
+            "UpdatedAt" => WorkflowInstanceMetadataStorageManifest.UpdatedAtIndexName,
+            "FinishedAt" => WorkflowInstanceMetadataStorageManifest.FinishedAtIndexName,
+            _ => throw new WorkflowInstanceMetadataQueryException($"Unsupported timestamp column '{column}'.")
+        };
+
+    private static DocumentQueryPage? CreatePage(PageArgs? pageArgs)
+    {
+        if (pageArgs?.Limit is null)
+            return null;
+
+        return new DocumentQueryPage(pageArgs.Limit.Value, pageArgs.Offset ?? 0);
+    }
+}

--- a/src/modules/Elsa.Workflows.Management.Persistence.ModularPersistence/Stores/WorkflowInstanceMetadataQueryException.cs
+++ b/src/modules/Elsa.Workflows.Management.Persistence.ModularPersistence/Stores/WorkflowInstanceMetadataQueryException.cs
@@ -1,0 +1,8 @@
+namespace Elsa.Workflows.Management.Persistence.ModularPersistence.Stores;
+
+public sealed class WorkflowInstanceMetadataQueryException : InvalidOperationException
+{
+    public WorkflowInstanceMetadataQueryException(string message) : base(message)
+    {
+    }
+}

--- a/test/unit/Elsa.Workflows.Management.Persistence.ModularPersistence.UnitTests/Benchmarks/WorkflowInstanceMetadataBenchmarkEstimatorTests.cs
+++ b/test/unit/Elsa.Workflows.Management.Persistence.ModularPersistence.UnitTests/Benchmarks/WorkflowInstanceMetadataBenchmarkEstimatorTests.cs
@@ -1,0 +1,17 @@
+using Elsa.Workflows.Management.Persistence.ModularPersistence.Benchmarks;
+
+namespace Elsa.Workflows.Management.Persistence.ModularPersistence.UnitTests.Benchmarks;
+
+public class WorkflowInstanceMetadataBenchmarkEstimatorTests
+{
+    [Fact]
+    public void EstimateKeepsMetadataCostStableWhenWorkflowStateGrows()
+    {
+        var small = WorkflowInstanceMetadataBenchmarkEstimator.Estimate(new WorkflowInstanceMetadataBenchmarkScenario("small", 1000, 8 * 1024));
+        var large = WorkflowInstanceMetadataBenchmarkEstimator.Estimate(new WorkflowInstanceMetadataBenchmarkScenario("large", 1000, 512 * 1024));
+
+        Assert.Equal(small.MetadataOnlyBytes, large.MetadataOnlyBytes);
+        Assert.True(large.FullDocumentBytes > small.FullDocumentBytes);
+        Assert.True(large.MetadataToFullDocumentRatio < small.MetadataToFullDocumentRatio);
+    }
+}

--- a/test/unit/Elsa.Workflows.Management.Persistence.ModularPersistence.UnitTests/Elsa.Workflows.Management.Persistence.ModularPersistence.UnitTests.csproj
+++ b/test/unit/Elsa.Workflows.Management.Persistence.ModularPersistence.UnitTests/Elsa.Workflows.Management.Persistence.ModularPersistence.UnitTests.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <Include>[Elsa.Workflows.Management.Persistence.ModularPersistence]*</Include>
+        <Threshold>0</Threshold>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\src\modules\Elsa.Workflows.Management.Persistence.ModularPersistence\Elsa.Workflows.Management.Persistence.ModularPersistence.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/test/unit/Elsa.Workflows.Management.Persistence.ModularPersistence.UnitTests/Storage/WorkflowInstanceMetadataStorageManifestTests.cs
+++ b/test/unit/Elsa.Workflows.Management.Persistence.ModularPersistence.UnitTests/Storage/WorkflowInstanceMetadataStorageManifestTests.cs
@@ -1,0 +1,24 @@
+using Elsa.Workflows.Management.Persistence.ModularPersistence.Storage;
+
+namespace Elsa.Workflows.Management.Persistence.ModularPersistence.UnitTests.Storage;
+
+public class WorkflowInstanceMetadataStorageManifestTests
+{
+    [Fact]
+    public void CreateDeclaresMetadataFieldsAndIndexesOnly()
+    {
+        var manifest = WorkflowInstanceMetadataStorageManifest.Create();
+        var unit = Assert.Single(manifest.StorageUnits);
+        var fieldNames = unit.Fields.Select(x => x.Name).ToHashSet(StringComparer.Ordinal);
+        var indexNames = unit.Indexes.Select(x => x.Name).ToHashSet(StringComparer.Ordinal);
+
+        Assert.Equal(WorkflowInstanceMetadataStorageManifest.SchemaName, manifest.SchemaName);
+        Assert.Contains("Id", fieldNames);
+        Assert.Contains("DefinitionId", fieldNames);
+        Assert.Contains("Status", fieldNames);
+        Assert.Contains("UpdatedAt", fieldNames);
+        Assert.DoesNotContain("WorkflowState", fieldNames);
+        Assert.Contains(WorkflowInstanceMetadataStorageManifest.StatusSubStatusDefinitionVersionIndexName, indexNames);
+        Assert.Contains(WorkflowInstanceMetadataStorageManifest.UpdatedAtIndexName, indexNames);
+    }
+}

--- a/test/unit/Elsa.Workflows.Management.Persistence.ModularPersistence.UnitTests/Stores/ModularPersistenceWorkflowInstanceMetadataStoreTests.cs
+++ b/test/unit/Elsa.Workflows.Management.Persistence.ModularPersistence.UnitTests/Stores/ModularPersistenceWorkflowInstanceMetadataStoreTests.cs
@@ -1,0 +1,189 @@
+using Elsa.Common.Models;
+using Elsa.Workflows;
+using Elsa.Workflows.Management.Entities;
+using Elsa.Workflows.Management.Enums;
+using Elsa.Workflows.Management.Filters;
+using Elsa.Workflows.Management.Models;
+using Elsa.Workflows.Management.Persistence.ModularPersistence.Storage;
+using Elsa.Workflows.Management.Persistence.ModularPersistence.Stores;
+using Elsa.Workflows.Management.Persistence.ModularPersistence.UnitTests.Testing;
+
+namespace Elsa.Workflows.Management.Persistence.ModularPersistence.UnitTests.Stores;
+
+public class ModularPersistenceWorkflowInstanceMetadataStoreTests
+{
+    private readonly InMemoryDocumentStore _documentStore = new();
+    private readonly ModularPersistenceWorkflowInstanceMetadataStore _store;
+
+    public ModularPersistenceWorkflowInstanceMetadataStoreTests()
+    {
+        _store = new ModularPersistenceWorkflowInstanceMetadataStore(_documentStore);
+    }
+
+    [Fact]
+    public async Task SaveAsyncPersistsMetadataWithoutWorkflowState()
+    {
+        var instance = CreateInstance("instance-1", "tenant-a");
+
+        await _store.SaveAsync(WorkflowInstanceMetadataRecord.FromInstance(instance));
+
+        var document = Assert.Single(_documentStore.Documents);
+        Assert.Equal(WorkflowInstanceMetadataStorageManifest.StorageUnitName, document.Type);
+        Assert.Equal("tenant-a", document.TenantId);
+        Assert.Contains("\"DefinitionId\":\"definition-a\"", document.Data);
+        Assert.DoesNotContain("WorkflowState", document.Data);
+    }
+
+    [Fact]
+    public async Task SummarizeManyAsyncUsesIndexedMetadataFilters()
+    {
+        await SaveFixturesAsync();
+
+        var page = await _store.SummarizeManyAsync(
+            new WorkflowInstanceFilter
+            {
+                DefinitionId = "definition-a",
+                WorkflowStatus = WorkflowStatus.Running,
+                HasIncidents = true
+            },
+            PageArgs.FromRange(0, 10),
+            "tenant-a");
+
+        var summary = Assert.Single(page.Items);
+        Assert.Equal(1, page.TotalCount);
+        Assert.Equal("instance-1", summary.Id);
+        Assert.Equal(2, summary.IncidentCount);
+    }
+
+    [Fact]
+    public async Task FindManyIdsAsyncPaginatesDeclaredIndexResults()
+    {
+        await SaveFixturesAsync();
+
+        var page = await _store.FindManyIdsAsync(
+            new WorkflowInstanceFilter
+            {
+                WorkflowStatus = WorkflowStatus.Running
+            },
+            PageArgs.FromRange(1, 1),
+            "tenant-a");
+
+        Assert.Equal(2, page.TotalCount);
+        Assert.Equal("instance-2", Assert.Single(page.Items));
+    }
+
+    [Fact]
+    public async Task CountAsyncAppliesTenantScopeAndTimestampFilter()
+    {
+        await SaveFixturesAsync();
+
+        var count = await _store.CountAsync(
+            new WorkflowInstanceFilter
+            {
+                TimestampFilters =
+                [
+                    new TimestampFilter
+                    {
+                        Column = "UpdatedAt",
+                        Operator = TimestampFilterOperator.GreaterThanOrEqual,
+                        Timestamp = new DateTimeOffset(2026, 01, 02, 0, 0, 0, TimeSpan.Zero)
+                    }
+                ]
+            },
+            "tenant-a");
+
+        Assert.Equal(2, count);
+    }
+
+    [Fact]
+    public async Task CountAsyncWithoutFiltersUsesIdIndexFallback()
+    {
+        await SaveFixturesAsync();
+
+        var count = await _store.CountAsync(new WorkflowInstanceFilter(), "tenant-a");
+
+        Assert.Equal(3, count);
+    }
+
+    [Fact]
+    public async Task FindAsyncLoadsSingleMetadataRecordByTenant()
+    {
+        await SaveFixturesAsync();
+
+        var found = await _store.FindAsync("instance-1", "tenant-a");
+        var wrongTenant = await _store.FindAsync("instance-1", "tenant-c");
+
+        Assert.NotNull(found);
+        Assert.Null(wrongTenant);
+        Assert.Equal("definition-a", found.DefinitionId);
+    }
+
+    [Fact]
+    public async Task QueryRejectsSearchTermBecauseItWouldRequireScanOrProviderSpecificTextSearch()
+    {
+        await SaveFixturesAsync();
+
+        var exception = await Assert.ThrowsAsync<WorkflowInstanceMetadataQueryException>(async () =>
+            await _store.CountAsync(new WorkflowInstanceFilter { SearchTerm = "definition" }));
+
+        Assert.Contains("SearchTerm", exception.Message);
+    }
+
+    [Fact]
+    public async Task QueryRejectsContainsNameFilterButAllowsExactNames()
+    {
+        await SaveFixturesAsync();
+
+        await Assert.ThrowsAsync<WorkflowInstanceMetadataQueryException>(async () =>
+            await _store.CountAsync(new WorkflowInstanceFilter { Name = "Import" }));
+
+        var page = await _store.FindManyIdsAsync(
+            new WorkflowInstanceFilter { Names = ["Import Orders"] },
+            PageArgs.FromRange(0, 10),
+            "tenant-a");
+
+        Assert.Equal("instance-1", Assert.Single(page.Items));
+    }
+
+    private async Task SaveFixturesAsync()
+    {
+        var records = new[]
+        {
+            WorkflowInstanceMetadataRecord.FromInstance(CreateInstance("instance-1", "tenant-a", "definition-a", WorkflowStatus.Running, WorkflowSubStatus.Suspended, 2, "Import Orders", 1)),
+            WorkflowInstanceMetadataRecord.FromInstance(CreateInstance("instance-2", "tenant-a", "definition-a", WorkflowStatus.Running, WorkflowSubStatus.Pending, 0, "Archive Orders", 2)),
+            WorkflowInstanceMetadataRecord.FromInstance(CreateInstance("instance-3", "tenant-a", "definition-b", WorkflowStatus.Finished, WorkflowSubStatus.Finished, 0, "Import Customers", 3)),
+            WorkflowInstanceMetadataRecord.FromInstance(CreateInstance("instance-1", "tenant-b", "definition-a", WorkflowStatus.Running, WorkflowSubStatus.Suspended, 1, "Other Tenant", 4))
+        };
+
+        await _store.SaveManyAsync(records);
+    }
+
+    private static WorkflowInstance CreateInstance(
+        string id,
+        string? tenantId,
+        string definitionId = "definition-a",
+        WorkflowStatus status = WorkflowStatus.Running,
+        WorkflowSubStatus subStatus = WorkflowSubStatus.Pending,
+        int incidentCount = 0,
+        string name = "Import Orders",
+        int day = 1) =>
+        new()
+        {
+            Id = id,
+            TenantId = tenantId,
+            DefinitionId = definitionId,
+            DefinitionVersionId = $"{definitionId}:v1",
+            Version = 1,
+            ParentWorkflowInstanceId = "parent-1",
+            Status = status,
+            SubStatus = subStatus,
+            IsExecuting = status == WorkflowStatus.Running,
+            CorrelationId = $"correlation-{id}",
+            Name = name,
+            IncidentCount = incidentCount,
+            IsSystem = false,
+            CreatedAt = new DateTimeOffset(2026, 01, day, 0, 0, 0, TimeSpan.Zero),
+            UpdatedAt = new DateTimeOffset(2026, 01, day, 12, 0, 0, TimeSpan.Zero),
+            FinishedAt = status == WorkflowStatus.Finished ? new DateTimeOffset(2026, 01, day, 13, 0, 0, TimeSpan.Zero) : null
+        };
+}

--- a/test/unit/Elsa.Workflows.Management.Persistence.ModularPersistence.UnitTests/Testing/InMemoryDocumentStore.cs
+++ b/test/unit/Elsa.Workflows.Management.Persistence.ModularPersistence.UnitTests/Testing/InMemoryDocumentStore.cs
@@ -1,0 +1,137 @@
+using System.Text.Json;
+using Elsa.ModularPersistence.Descriptors;
+using Elsa.ModularPersistence.Documents;
+using Elsa.ModularPersistence.Queries;
+
+namespace Elsa.Workflows.Management.Persistence.ModularPersistence.UnitTests.Testing;
+
+internal sealed class InMemoryDocumentStore : IDocumentStore
+{
+    private readonly Dictionary<DocumentKey, DocumentEnvelope> _documents = new();
+
+    public IReadOnlyCollection<DocumentEnvelope> Documents => _documents.Values.ToArray();
+
+    public ValueTask<IDocumentSession> OpenSessionAsync(CancellationToken cancellationToken = default) =>
+        ValueTask.FromResult<IDocumentSession>(new Session(_documents));
+
+    private sealed class Session(Dictionary<DocumentKey, DocumentEnvelope> documents) : IDocumentSession
+    {
+        public ValueTask<DocumentEnvelope?> LoadAsync(DocumentKey key, CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult(documents.GetValueOrDefault(key));
+
+        public ValueTask<DocumentSaveResult> SaveAsync(DocumentEnvelope document, ExpectedDocumentVersion expectedVersion = default, CancellationToken cancellationToken = default)
+        {
+            documents.TryGetValue(document.Key, out var existing);
+            ValidateConcurrency(document.Key, existing?.Version, expectedVersion);
+            documents[document.Key] = document;
+            return ValueTask.FromResult(new DocumentSaveResult(document.Key, document.Version));
+        }
+
+        public ValueTask<IReadOnlyCollection<DocumentEnvelope>> QueryAsync(DocumentQuery query, CancellationToken cancellationToken = default)
+        {
+            var results = documents.Values
+                .Where(x => x.Type == query.DocumentType)
+                .Where(x => query.TenantId is null || string.Equals(x.TenantId, query.TenantId, StringComparison.Ordinal))
+                .Where(document => query.Filters.All(filter => Matches(document, filter)))
+                .ToArray();
+
+            foreach (var sort in query.Sorts.Reverse())
+                results = Sort(results, sort).ToArray();
+
+            if (query.Page != null)
+                results = results.Skip(query.Page.Offset).Take(query.Page.Limit).ToArray();
+
+            return ValueTask.FromResult<IReadOnlyCollection<DocumentEnvelope>>(results);
+        }
+
+        public ValueTask DeleteAsync(DocumentKey key, ExpectedDocumentVersion expectedVersion = default, CancellationToken cancellationToken = default)
+        {
+            documents.TryGetValue(key, out var existing);
+            ValidateConcurrency(key, existing?.Version, expectedVersion);
+            documents.Remove(key);
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+        private static IEnumerable<DocumentEnvelope> Sort(IEnumerable<DocumentEnvelope> documents, DocumentQuerySort sort) =>
+            sort.SortOrder == StorageIndexSortOrder.Descending
+                ? documents.OrderByDescending(x => GetComparableValue(x, sort.FieldName))
+                : documents.OrderBy(x => GetComparableValue(x, sort.FieldName));
+
+        private static bool Matches(DocumentEnvelope document, DocumentQueryFilter filter)
+        {
+            using var json = JsonDocument.Parse(document.Data);
+            var value = TryGetProperty(json.RootElement, filter.FieldName, out var property) ? property : default;
+
+            return filter.Operator switch
+            {
+                DocumentQueryFilterOperator.Equals => Compare(value, filter.Values.Single()) == 0,
+                DocumentQueryFilterOperator.NotEquals => Compare(value, filter.Values.Single()) != 0,
+                DocumentQueryFilterOperator.In => filter.Values.Any(queryValue => Compare(value, queryValue) == 0),
+                DocumentQueryFilterOperator.GreaterThan => Compare(value, filter.Values.Single()) > 0,
+                DocumentQueryFilterOperator.GreaterThanOrEqual => Compare(value, filter.Values.Single()) >= 0,
+                DocumentQueryFilterOperator.LessThan => Compare(value, filter.Values.Single()) < 0,
+                DocumentQueryFilterOperator.LessThanOrEqual => Compare(value, filter.Values.Single()) <= 0,
+                DocumentQueryFilterOperator.Between => Compare(value, filter.Values[0]) >= 0 && Compare(value, filter.Values[1]) < 0,
+                DocumentQueryFilterOperator.StartsWith => GetString(value)?.StartsWith(filter.Values.Single().TextValue!, StringComparison.Ordinal) == true,
+                DocumentQueryFilterOperator.IsNull => value.ValueKind is JsonValueKind.Undefined or JsonValueKind.Null,
+                DocumentQueryFilterOperator.IsNotNull => value.ValueKind is not JsonValueKind.Undefined and not JsonValueKind.Null,
+                _ => throw new NotSupportedException($"Query operator '{filter.Operator}' is not supported by the test store.")
+            };
+        }
+
+        private static IComparable? GetComparableValue(DocumentEnvelope document, string fieldName)
+        {
+            using var json = JsonDocument.Parse(document.Data);
+            if (!TryGetProperty(json.RootElement, fieldName, out var value))
+                return null;
+
+            return value.ValueKind switch
+            {
+                JsonValueKind.String when DateTimeOffset.TryParse(value.GetString(), out var dateTime) => dateTime,
+                JsonValueKind.String => value.GetString(),
+                JsonValueKind.Number => value.GetDecimal(),
+                JsonValueKind.True => true,
+                JsonValueKind.False => false,
+                _ => null
+            };
+        }
+
+        private static int Compare(JsonElement value, DocumentQueryValue queryValue)
+        {
+            if (value.ValueKind is JsonValueKind.Undefined or JsonValueKind.Null)
+                return queryValue.TextValue == null && queryValue.NumberValue == null && queryValue.BooleanValue == null && queryValue.DateTimeValue == null ? 0 : -1;
+
+            return queryValue.Type switch
+            {
+                StorageFieldType.String => string.Compare(GetString(value), queryValue.TextValue, StringComparison.Ordinal),
+                StorageFieldType.Int32 or StorageFieldType.Int64 or StorageFieldType.Decimal => value.GetDecimal().CompareTo(queryValue.NumberValue.GetValueOrDefault()),
+                StorageFieldType.Boolean => value.GetBoolean().CompareTo(queryValue.BooleanValue.GetValueOrDefault()),
+                StorageFieldType.DateTimeOffset => DateTimeOffset.Parse(value.GetString()!).CompareTo(queryValue.DateTimeValue.GetValueOrDefault()),
+                _ => throw new NotSupportedException($"Query value type '{queryValue.Type}' is not supported by the test store.")
+            };
+        }
+
+        private static string? GetString(JsonElement value) =>
+            value.ValueKind == JsonValueKind.String ? value.GetString() : value.ToString();
+
+        private static bool TryGetProperty(JsonElement root, string fieldName, out JsonElement property)
+        {
+            if (root.TryGetProperty(fieldName, out property))
+                return true;
+
+            property = default;
+            return false;
+        }
+
+        private static void ValidateConcurrency(DocumentKey key, long? currentVersion, ExpectedDocumentVersion expectedVersion)
+        {
+            if (expectedVersion.Kind == ExpectedDocumentVersionKind.New && currentVersion is not null)
+                throw new DocumentConcurrencyException(key, "Document already exists.");
+
+            if (expectedVersion.Kind == ExpectedDocumentVersionKind.Exact && currentVersion != expectedVersion.Version)
+                throw new DocumentConcurrencyException(key, "Document version did not match.");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds an experimental `Elsa.Workflows.Management.Persistence.ModularPersistence` package for workflow instance metadata projections.
- Registers a provider-neutral manifest for workflow instance metadata only, intentionally excluding `WorkflowState`.
- Adds a side-by-side `IWorkflowInstanceMetadataStore` for indexed summary, ID, and count queries over `IDocumentStore`.
- Adds a deterministic metadata-vs-state sizing model and design note for the workflow-state decision boundary.

## Validation

- `dotnet test test/unit/Elsa.Workflows.Management.Persistence.ModularPersistence.UnitTests/Elsa.Workflows.Management.Persistence.ModularPersistence.UnitTests.csproj --no-restore`
- `dotnet build src/modules/Elsa.Workflows.Management.Persistence.ModularPersistence/Elsa.Workflows.Management.Persistence.ModularPersistence.csproj --no-restore`

Both commands passed locally. They reported existing NU1900 warnings because package vulnerability feeds were unreachable from this environment.

Closes #7662
