### PR TITLE
feat: Add an overload for WithVariable that uses a default value

### DIFF
--- a/src/modules/Elsa.Workflows.Core/Builders/WorkflowBuilder.cs
+++ b/src/modules/Elsa.Workflows.Core/Builders/WorkflowBuilder.cs
@@ -63,7 +63,7 @@ public class WorkflowBuilder(IActivityVisitor activityVisitor, IIdentityGraphSer
         DefinitionId = definitionId;
         return this;
     }
-    
+
     public IWorkflowBuilder WithId(string id)
     {
         Id = id;
@@ -84,8 +84,14 @@ public class WorkflowBuilder(IActivityVisitor activityVisitor, IIdentityGraphSer
         var variable = new Variable<T>(null!, default!);
         Variables.Add(variable);
         variable.WithWorkflowStorage();
-        variable.Id = null!; // This ensures that a deterministic ID is assigned by the builder.  
+        variable.Id = null!; // This ensures that a deterministic ID is assigned by the builder.
         return variable;
+    }
+
+    /// <inheritdoc />
+    public Variable<T> WithVariable<T>(string name)
+    {
+        return WithVariable<T>(name, default!);
     }
 
     /// <inheritdoc />

--- a/src/modules/Elsa.Workflows.Core/Contracts/IWorkflowBuilder.cs
+++ b/src/modules/Elsa.Workflows.Core/Contracts/IWorkflowBuilder.cs
@@ -13,7 +13,7 @@ public interface IWorkflowBuilder
     /// The definition ID to use for the workflow being built.
     /// </summary>
     string? DefinitionId { get; set; }
-    
+
     /// <summary>
     /// The version ID to use for the workflow being built.
     /// </summary>
@@ -28,22 +28,22 @@ public interface IWorkflowBuilder
     /// The version of the workflow being built.
     /// </summary>
     int Version { get; set; }
-    
+
     /// <summary>
     /// The name of the workflow.
     /// </summary>
     string? Name { get; set; }
-    
+
     /// <summary>
     /// A description of the workflow.
     /// </summary>
     string? Description { get; set; }
-    
+
     /// <summary>
     /// WorkflowDefinition is readonly.
     /// </summary>
     bool IsReadonly { get; set; }
-    
+
     /// <summary>
     /// WorkflowDefinition is readonly.
     /// </summary>
@@ -53,27 +53,27 @@ public interface IWorkflowBuilder
     /// Options for the workflow being built.
     /// </summary>
     WorkflowOptions WorkflowOptions { get; }
-    
+
     /// <summary>
-    /// The activity to execute when the workflow is run. 
+    /// The activity to execute when the workflow is run.
     /// </summary>
     IActivity? Root { get; set; }
-    
+
     /// <summary>
     /// The workflow variables to store with the workflow being built.
     /// </summary>
     ICollection<Variable> Variables { get; set; }
-    
+
     /// <summary>
     /// Gets or sets the inputs.
     /// </summary>
     ICollection<InputDefinition> Inputs { get; set; }
-    
+
     /// <summary>
     /// Gets or sets the outputs.
     /// </summary>
     ICollection<OutputDefinition> Outputs { get; set; }
-    
+
     /// <summary>
     /// Gets or sets the outcomes.
     /// </summary>
@@ -89,7 +89,7 @@ public interface IWorkflowBuilder
     /// </summary>
     [Obsolete("Use PropertyBag instead")]
     IDictionary<string, object> CustomProperties { get; }
-    
+
     /// <summary>
     /// A fluent method for setting the <see cref="DefinitionId"/> property.
     /// </summary>
@@ -114,78 +114,83 @@ public interface IWorkflowBuilder
     /// </summary>
     [Obsolete("Use the overload that takes a name instead. This overload will be removed in a future version.")]
     Variable<T> WithVariable<T>();
-    
+
+    /// <summary>
+    /// A fluent method for adding a variable to <see cref="Variables"/> with a default value.
+    /// </summary>
+    Variable<T> WithVariable<T>(string name);
+
     /// <summary>
     /// A fluent method for adding a variable to <see cref="Variables"/>.
     /// </summary>
     Variable<T> WithVariable<T>(string name, T value);
-    
+
     /// <summary>
     /// A fluent method for adding a variable to <see cref="Variables"/>.
     /// </summary>
     [Obsolete("Use the overload that takes a name instead. This overload will be removed in a future version.")]
     Variable<T> WithVariable<T>(T value);
-    
+
     /// <summary>
     /// A fluent method for adding a variable to <see cref="Variables"/>.
     /// </summary>
     IWorkflowBuilder WithVariable<T>(Variable<T> variable);
-    
+
     /// <summary>
     /// A fluent method for adding a variable to <see cref="Variables"/>.
     /// </summary>
     IWorkflowBuilder WithVariable(Variable variable);
-    
+
     /// <summary>
     /// A fluent method for adding a variable to <see cref="Variables"/>.
     /// </summary>
     IWorkflowBuilder WithVariables(params Variable[] variables);
-    
+
     /// <summary>
     /// A fluent method for adding an input to <see cref="Inputs"/>.
     /// </summary>
     InputDefinition WithInput<T>(string name, string? description = default);
-    
+
     /// <summary>
     /// A fluent method for adding an input to <see cref="Inputs"/>.
     /// </summary>
     InputDefinition WithInput(string name, Type type, string? description = default);
-    
+
     /// <summary>
     /// A fluent method for adding an input to <see cref="Inputs"/>.
     /// </summary>
     InputDefinition WithInput(string name, Type type, Action<InputDefinition>? setup = default);
-    
+
     /// <summary>
     /// A fluent method for adding an input to <see cref="Inputs"/>.
     /// </summary>
     InputDefinition WithInput(Action<InputDefinition> setup);
-    
+
     /// <summary>
     /// A fluent method for adding an input to <see cref="Inputs"/>.
     /// </summary>
     IWorkflowBuilder WithInput(InputDefinition inputDefinition);
-    
+
     /// <summary>
     /// A fluent method for adding an output to <see cref="Outputs"/>.
     /// </summary>
     OutputDefinition WithOutput<T>(string name, string? description = default);
-    
+
     /// <summary>
     /// A fluent method for adding an output to <see cref="Outputs"/>.
     /// </summary>
     OutputDefinition WithOutput(string name, Type type, string? description = default);
-    
+
     /// <summary>
     /// A fluent method for adding an output to <see cref="Outputs"/>.
     /// </summary>
     OutputDefinition WithOutput(string name, Type type, Action<OutputDefinition>? setup = default);
-    
+
     /// <summary>
     /// A fluent method for adding an output to <see cref="Outputs"/>.
     /// </summary>
     OutputDefinition WithOutput(Action<OutputDefinition> setup);
-    
+
     /// <summary>
     /// A fluent method for adding an output to <see cref="Outputs"/>.
     /// </summary>
@@ -205,7 +210,7 @@ public interface IWorkflowBuilder
     /// Marks the workflow as readonly.
     /// </summary>
     IWorkflowBuilder AsReadonly();
-    
+
     /// <summary>
     /// Marks the workflow as a system workflow.
     /// </summary>
@@ -215,7 +220,7 @@ public interface IWorkflowBuilder
     /// Build a new <see cref="Workflow"/> instance using the information collected in this pipelineBuilder.
     /// </summary>
     Task<Workflow> BuildWorkflowAsync(CancellationToken cancellationToken = default);
-    
+
     /// <summary>
     /// Creates a new <see cref="Workflow"/> instance using the specified <see cref="IWorkflow"/> definition.
     /// </summary>

--- a/test/integration/Elsa.Workflows.IntegrationTests/Scenarios/Composites/Workflows.cs
+++ b/test/integration/Elsa.Workflows.IntegrationTests/Scenarios/Composites/Workflows.cs
@@ -53,7 +53,7 @@ public class SumWorkflow : WorkflowBase
 {
     protected override void Build(IWorkflowBuilder workflow)
     {
-        var sum = workflow.WithVariable<int>("Sum", 0);
+        var sum = workflow.WithVariable<int>("Sum");
 
         workflow.Root = new Sequence
         {

--- a/test/integration/Elsa.Workflows.IntegrationTests/Scenarios/JsonObjectToObjectRemainsJsonObject/Workflows/TestWorkflow.cs
+++ b/test/integration/Elsa.Workflows.IntegrationTests/Scenarios/JsonObjectToObjectRemainsJsonObject/Workflows/TestWorkflow.cs
@@ -10,7 +10,7 @@ public class TestWorkflow : WorkflowBase
 {
     protected override void Build(IWorkflowBuilder builder)
     {
-        var item = builder.WithVariable<JsonObject>("item", default!);
+        var item = builder.WithVariable<JsonObject>("item");
 
         builder.Root = new Sequence
         {


### PR DESCRIPTION
## Purpose

<!-- What does this PR change? Summarize in 1–2 sentences. -->
Add an overload for `WithVariable` that requires a name but no value, creating a `Variable` with a default value.
---

## Scope

Select one primary concern:

- [ ] Bug fix (behavior change)
- [ ] Refactor (no behavior change)
- [ ] Documentation update
- [ ] Formatting / code cleanup
- [ ] Dependency / build update
- [x] New feature

> If this PR includes multiple unrelated concerns, please split it before requesting review.

---

## Description

### Problem
Is your enhancement request related to a problem? Please describe.
In the preview of 3.8.0 the overload of `WithVariable` without parameters has become obsolete. Instead we should be using an overload that specifies a name. Unfortunately there is no overload yet that only requires a name, the closest overload also requires a default value. A default value is irrelevant when the variable is used to store a value from an `Output<T>`.

### Solution
There should be an overload of `WithVariable` that only requires a name and it should assign the default value to the `Variable`.

---

## Verification

<!-- How can reviewers verify this change? -->

Steps:
1. Check the changes
2. Run the tests

Expected outcome:
All tests are green

---

## Screenshots / Recordings (if applicable)

<!-- Required for UI changes -->

---

## Commit Convention

We recommend using conventional commit prefixes:

- `fix:` – Bug fixes (behavior change)
- `feat:` – New features
- `refactor:` – Code changes without behavior change
- `docs:` – Documentation updates
- `chore:` – Maintenance, tooling, or dependency updates
- `test:` – Test additions or modifications

Clear commit messages make reviews easier and history more meaningful.

---

## Checklist

- [x] The PR is focused on a single concern
- [ ] Commit messages follow the recommended convention
- [ ] Tests added or updated (if applicable)
- [ ] Documentation updated (if applicable)
- [ ] No unrelated cleanup included
- [ ] All tests pass

Solves #7694
