### PR TITLE
Feat: Elsa2 Enhance TypeScript generation and type utilities

### DIFF
--- a/src/scripting/Elsa.Scripting.JavaScript/Extensions/TypeExtensions.cs
+++ b/src/scripting/Elsa.Scripting.JavaScript/Extensions/TypeExtensions.cs
@@ -29,5 +29,16 @@ namespace Elsa.Scripting.JavaScript.Extensions
         {
             return type == typeof(object);
         }
+
+
+        /// <summary>
+        /// Determines whether the specified type is a nullable value type (e.g., Nullable&lt;T&gt;).
+        /// </summary>
+        /// <param name="type">The type to check.</param>
+        /// <returns>True if the type is a nullable value type; otherwise, false.</returns>
+        public static bool IsNullableType(this Type type)
+        {
+            return type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>);
+        }
     }
 }

--- a/src/scripting/Elsa.Scripting.JavaScript/Providers/DefaultActivityTypeDefinitionRenderer.cs
+++ b/src/scripting/Elsa.Scripting.JavaScript/Providers/DefaultActivityTypeDefinitionRenderer.cs
@@ -12,7 +12,7 @@ namespace Elsa.Scripting.JavaScript.Providers
 {
     public class DefaultActivityTypeDefinitionRenderer : IActivityTypeDefinitionRenderer
     {
-        public int Priority => -1;
+        public virtual int Priority => -1;
         public virtual bool GetCanRenderType(ActivityType activityType) => true;
 
         public virtual async ValueTask RenderTypeDeclarationAsync(

--- a/src/scripting/Elsa.Scripting.JavaScript/Providers/DotNetTypeScriptDefinitionProvider.cs
+++ b/src/scripting/Elsa.Scripting.JavaScript/Providers/DotNetTypeScriptDefinitionProvider.cs
@@ -5,9 +5,9 @@ using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using AutoMapper.Internal;
 using Elsa.Models;
 using Elsa.Scripting.JavaScript.Events;
+using Elsa.Scripting.JavaScript.Extensions;
 using Elsa.Scripting.JavaScript.Models;
 using Elsa.Scripting.JavaScript.Services;
 using MediatR;
@@ -113,9 +113,9 @@ namespace Elsa.Scripting.JavaScript.Providers
             var symbol = type switch
             {
                 { IsInterface: true } => "interface",
+                { IsEnum: true } => "enum", // This must come before IsValueType as IsValueType will also be true for enums
                 { IsClass: true } => "class",
                 { IsValueType: true } => "class",
-                { IsEnum: true } => "enum",
                 _ => "interface"
             };
 
@@ -125,11 +125,40 @@ namespace Elsa.Scripting.JavaScript.Providers
         private void RenderTypeDeclaration(TypeDefinitionContext context, string symbol, Type type, ISet<Type> collectedTypes, StringBuilder output)
         {
             var typeName = GetTypeScriptType(context, type, collectedTypes);
+
+            // Render enum members only if this is an enum, enums do not support properties/methods in TypeScript
+            if (symbol == "enum")
+            {
+                output.AppendLine($"declare enum {typeName} {{");
+                var names = Enum.GetNames(type);
+                var values = Enum.GetValues(type);
+
+                for (int i = 0; i < names.Length; i++)
+                {
+                    var value = Convert.ChangeType(values.GetValue(i), Enum.GetUnderlyingType(type));
+                    output.AppendLine($"  {names[i]} = {value},");
+                }
+
+                output.AppendLine("}");
+                return;
+            }
+
             var properties = type.GetProperties();
             var methods = type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static).Where(x => !x.IsSpecialName).ToList();
 
-
             output.AppendLine($"declare {symbol} {typeName} {{");
+            
+            // Add constructors for classes only
+            if (symbol == "class")
+            {
+                var constructors = type.GetConstructors(BindingFlags.Public | BindingFlags.Instance);
+                foreach (var ctor in constructors)
+                {
+                    var parameters = ctor.GetParameters()
+                        .Select(p => $"{p.Name}: {GetTypeScriptType(context, p.ParameterType, collectedTypes)}");
+                    output.AppendLine($"constructor({string.Join(", ", parameters)});");
+                }
+            }
 
             foreach (var property in properties)
             {

--- a/src/scripting/Elsa.Scripting.JavaScript/Typings/EnumTypeDefinitionProvider.cs
+++ b/src/scripting/Elsa.Scripting.JavaScript/Typings/EnumTypeDefinitionProvider.cs
@@ -1,11 +1,14 @@
-﻿using System;
+using System;
 using Elsa.Scripting.JavaScript.Services;
 
 namespace Elsa.Scripting.JavaScript.Typings
 {
     public class EnumTypeDefinitionProvider : TypeDefinitionProvider
     {
+        public override bool ShouldRenderType(TypeDefinitionContext context, Type type) => type.IsEnum;
+
         public override bool SupportsType(TypeDefinitionContext context, Type type) => type.IsEnum;
-        public override string GetTypeDefinition(TypeDefinitionContext context, Type type) => "number";
+
+        public override string GetTypeDefinition(TypeDefinitionContext context, Type type) => type.Name;
     }
 }


### PR DESCRIPTION
- Added `IsNullableType` extension method for nullable type checks.
- Made `Priority` property in `DefaultActivityTypeDefinitionRenderer` virtual to allow correct priorty to be used when subclassing
- Replaced a usage of `AutoMapper.Internal` with `Elsa.Scripting.JavaScript.Extensions`.  IsNullableType method.
- Improved `RenderTypeDeclaration` to handle enums and class constructors.
- Updated `EnumTypeDefinitionProvider` to refine enum handling and definitions.

## Purpose

This PR enhances Elsa 2's TypeScript definition generation to include .NET class constructor signatures and correctly render enums instead of treating them as plain numbers. These changes provide full IntelliSense support and autocomplete functionality for workflow authors using JavaScript expressions.

---

## Scope

Select one primary concern:

- [ ] Bug fix (behavior change)
- [ ] Refactor (no behavior change)
- [ ] Documentation update
- [ ] Formatting / code cleanup
- [ ] Dependency / build update
- [X] New feature

---

## Description

### Problem
Currently, `DotNetTypeScriptDefinitionProvider `does not display constructors for .NET classes, making it unclear which overloads are available during JavaScript type instantiation. Additionally, the `EnumDefinitionProvider` renders enums as generic numbers (e.g., DayOfWeek: number;), hiding the actual enum names and values from the editor.

### Solution

- Updated RenderTypeDeclaration and DotNetTypeScriptDefinitionProvider to enumerate public constructors and generate corresponding TypeScript constructor(...) signatures.
- Refined EnumTypeDefinitionProvider to generate proper TypeScript enum structures rather than plain numeric properties.
- Made the Priority property in DefaultActivityTypeDefinitionRenderer virtual to allow proper prioritization when subclassing.
- Replaced a AutoMapper.Internal dependency with a new IsNullableType extension method in Elsa.Scripting.JavaScript.Extensions.

---

## Verification

### Steps:

1. Open a workflow containing JavaScript expressions using the Monaco editor.
2. Attempt to instantiate a registered .NET class (e.g., new MyClass(...)) and trigger IntelliSense.
3. Reference a registered .NET enum (e.g., DayOfWeek) within a JavaScript expression and trigger IntelliSense.

### Expected outcome:

1. The editor displays available constructor overloads and parameter types.
2. Enums are fully autocompleteable with their specific name-value pairs instead of displaying as a standard number.
3. All existing automated tests continue to pass.

---

## Screenshots / Recordings (if applicable)

Target TypeScript Definition Output Example:

```
declare class MyClass {
  constructor(param1: string);
  constructor(param1: string, param2: number);
  constructor(param1: string, param2: number, param2: DayOfWeek);
}

declare enum DayOfWeek {
  Sunday = 0,
  Monday = 1,
  // ...
}
```
---

## Checklist

- [X] The PR is focused on a single concern
- [X] Commit messages follow the recommended convention
- [ ] Tests added or updated (if applicable)
- [ ] Documentation updated (if applicable)
- [X] No unrelated cleanup included
- [X] All tests pass
