### PR TITLE
[codex] Add shell feature manifest categories

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -112,7 +112,7 @@
         <PackageVersion Include="CShells.AspNetCore.Abstractions" Version="0.0.24-preview.132"/>
         <PackageVersion Include="CShells.FastEndpoints" Version="0.0.24-preview.132"/>
         <PackageVersion Include="CShells.FastEndpoints.Abstractions" Version="0.0.24-preview.132"/>
-        <PackageVersion Include="Elsa.Platform.PackageManifest.Generator" Version="0.0.1-preview.50"/>
+        <PackageVersion Include="Elsa.Platform.PackageManifest.Generator" Version="0.0.1-preview.53"/>
         <PackageVersion Include="Datadog.Trace.Bundle" Version="3.32.0"/>
         <PackageVersion Include="DistributedLock" Version="2.7.1"/>
         <PackageVersion Include="DistributedLock.Core" Version="1.0.9"/>

--- a/src/modules/Directory.Build.props
+++ b/src/modules/Directory.Build.props
@@ -5,6 +5,7 @@
   <ItemGroup Condition="Exists('$(MSBuildProjectDirectory)/ShellFeatures')">
     <PackageReference Include="Elsa.Platform.PackageManifest.Generator" PrivateAssets="all" />
     <Compile Include="$(MSBuildThisFileDirectory)PackageManifestHints.cs" Link="PackageManifestHints.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)PackageManifestCategories.cs" Link="PackageManifestCategories.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/modules/Elsa.AI.Copilot/ShellFeatures/CopilotAIFeature.cs
+++ b/src/modules/Elsa.AI.Copilot/ShellFeatures/CopilotAIFeature.cs
@@ -1,11 +1,13 @@
 using CShells.Features;
 using Elsa.AI.Copilot.Options;
 using Elsa.Extensions;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Elsa.AI.Copilot.ShellFeatures;
 
+[ManifestFeatureCategory(ManifestFeatureCategories.AI)]
 [ShellFeature(
     "CopilotAI",
     DisplayName = "Copilot AI Provider",

--- a/src/modules/Elsa.AI.Host/ShellFeatures/AIFeature.cs
+++ b/src/modules/Elsa.AI.Host/ShellFeatures/AIFeature.cs
@@ -3,11 +3,13 @@ using CShells.Features;
 using Elsa.AI.Host.Options;
 using Elsa.Extensions;
 using Elsa.ShellFeatures;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Elsa.AI.Host.ShellFeatures;
 
+[ManifestFeatureCategory(ManifestFeatureCategories.AI)]
 [ShellFeature(
     "AI",
     DisplayName = "AI Host",

--- a/src/modules/Elsa.AI.Persistence.EFCore/ShellFeatures/AIPersistenceFeature.cs
+++ b/src/modules/Elsa.AI.Persistence.EFCore/ShellFeatures/AIPersistenceFeature.cs
@@ -1,11 +1,14 @@
 using CShells.Features;
 using Elsa.Extensions;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Elsa.AI.Persistence.EFCore.ShellFeatures;
 
+[ManifestFeatureCategory(ManifestFeatureCategories.AI)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Persistence)]
 [ShellFeature(
     "AIPersistence",
     DisplayName = "AI Persistence",

--- a/src/modules/Elsa.Alterations/ShellFeatures/AlterationsFeature.cs
+++ b/src/modules/Elsa.Alterations/ShellFeatures/AlterationsFeature.cs
@@ -13,6 +13,7 @@ using Elsa.Extensions;
 using Elsa.ShellFeatures;
 using Elsa.Workflows.Options;
 using Elsa.Workflows.Runtime.ShellFeatures;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -21,6 +22,8 @@ namespace Elsa.Alterations.ShellFeatures;
 /// <summary>
 /// Adds the Elsa alterations services.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Alterations)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Workflows)]
 [ShellFeature(
     DisplayName = "Alterations",
     Description = "Provides workflow alteration capabilities for modifying running workflow instances",

--- a/src/modules/Elsa.Caching/ShellFeatures/MemoryCacheFeature.cs
+++ b/src/modules/Elsa.Caching/ShellFeatures/MemoryCacheFeature.cs
@@ -1,5 +1,6 @@
 using CShells.Features;
 using Elsa.Caching.Services;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -8,6 +9,8 @@ namespace Elsa.Caching.ShellFeatures;
 /// <summary>
 /// Configures the MemoryCache.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Caching)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Infrastructure)]
 [ShellFeature(
     DisplayName = "Memory Cache",
     Description = "Provides in-memory caching services")]

--- a/src/modules/Elsa.Common/ShellFeatures/DefaultFormattersFeature.cs
+++ b/src/modules/Elsa.Common/ShellFeatures/DefaultFormattersFeature.cs
@@ -2,10 +2,12 @@ using System.ComponentModel;
 using CShells.Features;
 using Elsa.Common.Serialization;
 using Elsa.Common.Services;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Elsa.Common.ShellFeatures;
 
+[ManifestFeatureCategory(ManifestFeatureCategories.Infrastructure)]
 [ShellFeature(
     "DefaultFormatters",
     DisplayName = "Default Formatters",

--- a/src/modules/Elsa.Common/ShellFeatures/MediatorFeature.cs
+++ b/src/modules/Elsa.Common/ShellFeatures/MediatorFeature.cs
@@ -1,6 +1,7 @@
 using CShells.Features;
 using Elsa.Common.ShellHandlers;
 using Elsa.Extensions;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -9,6 +10,7 @@ namespace Elsa.Common.ShellFeatures;
 /// <summary>
 /// Adds and configures the Mediator feature.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Infrastructure)]
 [ShellFeature(
     "Mediator",
     DisplayName = "Mediator",

--- a/src/modules/Elsa.Common/ShellFeatures/MultitenancyFeature.cs
+++ b/src/modules/Elsa.Common/ShellFeatures/MultitenancyFeature.cs
@@ -6,10 +6,12 @@ using Elsa.Common.Multitenancy.HostedServices;
 using Elsa.Common.RecurringTasks;
 using Elsa.Common.ShellHandlers;
 using Elsa.Extensions;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Elsa.Common.ShellFeatures;
 
+[ManifestFeatureCategory(ManifestFeatureCategories.Tenancy)]
 [ShellFeature(
     "Multitenancy",
     DisplayName = "Multitenancy",

--- a/src/modules/Elsa.Common/ShellFeatures/StringCompressionFeature.cs
+++ b/src/modules/Elsa.Common/ShellFeatures/StringCompressionFeature.cs
@@ -1,12 +1,14 @@
 using CShells.Features;
 using Elsa.Common.Codecs;
 using Elsa.Common.Services;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Elsa.Common.ShellFeatures;
 
 [UsedImplicitly]
+[ManifestFeatureCategory(ManifestFeatureCategories.Infrastructure)]
 [ShellFeature(
     "StringCompression",
     DisplayName = "String Compression",

--- a/src/modules/Elsa.Common/ShellFeatures/SystemClockFeature.cs
+++ b/src/modules/Elsa.Common/ShellFeatures/SystemClockFeature.cs
@@ -1,5 +1,6 @@
 using CShells.Features;
 using Elsa.Common.Services;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Elsa.Common.ShellFeatures;
@@ -7,6 +8,7 @@ namespace Elsa.Common.ShellFeatures;
 /// <summary>
 /// Configures the system clock.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Infrastructure)]
 [ShellFeature(
     "SystemClock",
     DisplayName = "System Clock",

--- a/src/modules/Elsa.Dashboard.Api/ShellFeatures/DashboardApiFeature.cs
+++ b/src/modules/Elsa.Dashboard.Api/ShellFeatures/DashboardApiFeature.cs
@@ -2,11 +2,14 @@ using CShells.FastEndpoints.Features;
 using CShells.Features;
 using Elsa.Dashboard.Api.Extensions;
 using Elsa.ShellFeatures;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Elsa.Dashboard.Api.ShellFeatures;
 
+[ManifestFeatureCategory(ManifestFeatureCategories.Dashboard)]
+[ManifestFeatureCategory(ManifestFeatureCategories.API)]
 [ShellFeature(
     DisplayName = "Dashboard API",
     Description = "Provides operational dashboard API endpoints for Elsa Studio",

--- a/src/modules/Elsa.Diagnostics.ConsoleLogs.Dashboard/ShellFeatures/ConsoleLogsDashboardFeature.cs
+++ b/src/modules/Elsa.Diagnostics.ConsoleLogs.Dashboard/ShellFeatures/ConsoleLogsDashboardFeature.cs
@@ -2,11 +2,14 @@ using CShells.Features;
 using Elsa.Dashboard.Api.ShellFeatures;
 using Elsa.Diagnostics.ConsoleLogs.Dashboard.Extensions;
 using Elsa.Diagnostics.ConsoleLogs.ShellFeatures;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Elsa.Diagnostics.ConsoleLogs.Dashboard.ShellFeatures;
 
+[ManifestFeatureCategory(ManifestFeatureCategories.Diagnostics)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Dashboard)]
 [ShellFeature(
     DisplayName = "Console Logs Dashboard",
     Description = "Provides console log dashboard contributions",

--- a/src/modules/Elsa.Diagnostics.ConsoleLogs/ShellFeatures/ConsoleLogsFeature.cs
+++ b/src/modules/Elsa.Diagnostics.ConsoleLogs/ShellFeatures/ConsoleLogsFeature.cs
@@ -5,6 +5,7 @@ using ConsoleLogStreaming.Core.Options;
 using Elsa.Diagnostics.ConsoleLogs.Extensions;
 using Elsa.ShellFeatures;
 using Elsa.Workflows.ShellFeatures;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
@@ -15,6 +16,7 @@ namespace Elsa.Diagnostics.ConsoleLogs.ShellFeatures;
 /// <summary>
 /// Provides live raw console log streaming over REST and SignalR.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Diagnostics)]
 [ShellFeature(
     DisplayName = "Console Logs",
     Description = "Provides live raw console log streaming over REST and SignalR",

--- a/src/modules/Elsa.Diagnostics.OpenTelemetry/ShellFeatures/OpenTelemetryFeature.cs
+++ b/src/modules/Elsa.Diagnostics.OpenTelemetry/ShellFeatures/OpenTelemetryFeature.cs
@@ -3,8 +3,8 @@ using CShells.FastEndpoints.Features;
 using CShells.Features;
 using Elsa.Diagnostics.OpenTelemetry.Extensions;
 using Elsa.Diagnostics.OpenTelemetry.Options;
-using Elsa.Platform.PackageManifest.Generator.Hints;
 using Elsa.ShellFeatures;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
@@ -12,6 +12,7 @@ using Microsoft.Extensions.Hosting;
 
 namespace Elsa.Diagnostics.OpenTelemetry.ShellFeatures;
 
+[ManifestFeatureCategory(ManifestFeatureCategories.Diagnostics)]
 [ShellFeature(
     DisplayName = "OpenTelemetry Diagnostics",
     Description = "Provides OpenTelemetry diagnostics collection, query services, and live updates",

--- a/src/modules/Elsa.Diagnostics.StructuredLogs.Dashboard/ShellFeatures/StructuredLogsDashboardFeature.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs.Dashboard/ShellFeatures/StructuredLogsDashboardFeature.cs
@@ -2,11 +2,14 @@ using CShells.Features;
 using Elsa.Dashboard.Api.ShellFeatures;
 using Elsa.Diagnostics.StructuredLogs.Dashboard.Extensions;
 using Elsa.Diagnostics.StructuredLogs.ShellFeatures;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Elsa.Diagnostics.StructuredLogs.Dashboard.ShellFeatures;
 
+[ManifestFeatureCategory(ManifestFeatureCategories.Diagnostics)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Dashboard)]
 [ShellFeature(
     DisplayName = "Structured Logs Dashboard",
     Description = "Provides structured log dashboard contributions",

--- a/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/ShellFeatures/StructuredLogRelationalPersistenceFeature.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Relational/ShellFeatures/StructuredLogRelationalPersistenceFeature.cs
@@ -1,5 +1,6 @@
 using CShells.Features;
 using Elsa.Diagnostics.StructuredLogs.ShellFeatures;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -8,6 +9,8 @@ namespace Elsa.Diagnostics.StructuredLogs.Persistence.Relational.ShellFeatures;
 /// <summary>
 /// Provides shared relational persistence services for diagnostics structured logs.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Diagnostics)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Persistence)]
 [ShellFeature(
     DisplayName = "Structured Log Relational Persistence",
     Description = "Provides shared relational persistence services for diagnostics structured logs",

--- a/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/ShellFeatures/SqliteStructuredLogPersistenceFeature.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite/ShellFeatures/SqliteStructuredLogPersistenceFeature.cs
@@ -10,6 +10,8 @@ namespace Elsa.Diagnostics.StructuredLogs.Persistence.Sqlite.ShellFeatures;
 /// <summary>
 /// Provides SQLite persistence for diagnostics structured logs.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Diagnostics)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Persistence)]
 [ShellFeature(
     DisplayName = "SQLite Structured Log Persistence",
     Description = "Provides SQLite persistence for diagnostics structured logs",

--- a/src/modules/Elsa.Diagnostics.StructuredLogs/ShellFeatures/StructuredLogsFeature.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs/ShellFeatures/StructuredLogsFeature.cs
@@ -3,8 +3,8 @@ using CShells.FastEndpoints.Features;
 using CShells.Features;
 using Elsa.Diagnostics.StructuredLogs.Extensions;
 using Elsa.Diagnostics.StructuredLogs.Options;
-using Elsa.Platform.PackageManifest.Generator.Hints;
 using Elsa.ShellFeatures;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
@@ -15,6 +15,7 @@ namespace Elsa.Diagnostics.StructuredLogs.ShellFeatures;
 /// <summary>
 /// Provides live structured log streaming over REST and SignalR.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Diagnostics)]
 [ShellFeature(
     DisplayName = "Structured Logs",
     Description = "Provides live structured log streaming over REST and SignalR",

--- a/src/modules/Elsa.Dsl.ElsaScript/ShellFeatures/ElsaScriptFeature.cs
+++ b/src/modules/Elsa.Dsl.ElsaScript/ShellFeatures/ElsaScriptFeature.cs
@@ -4,6 +4,7 @@ using Elsa.Dsl.ElsaScript.Contracts;
 using Elsa.Dsl.ElsaScript.Materializers;
 using Elsa.Dsl.ElsaScript.Parser;
 using Elsa.Workflows.Management;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -12,6 +13,8 @@ namespace Elsa.Dsl.ElsaScript.ShellFeatures;
 /// <summary>
 /// Feature for ElsaScript DSL support.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Scripting)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Workflows)]
 [ShellFeature(
     DisplayName = "ElsaScript DSL",
     Description = "Provides ElsaScript DSL support for defining workflows")]

--- a/src/modules/Elsa.Expressions.CSharp/ShellFeatures/CSharpFeature.cs
+++ b/src/modules/Elsa.Expressions.CSharp/ShellFeatures/CSharpFeature.cs
@@ -10,6 +10,7 @@ using Elsa.Expressions.CSharp.Services;
 using Elsa.Expressions.ShellFeatures;
 using Elsa.Extensions;
 using Elsa.Workflows;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -18,6 +19,8 @@ namespace Elsa.Expressions.CSharp.ShellFeatures;
 /// <summary>
 /// Installs C# integration.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Expressions)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Scripting)]
 [ShellFeature(
     DisplayName = "C# Expressions",
     Description = "Provides C# expression evaluation capabilities for workflows",

--- a/src/modules/Elsa.Expressions.JavaScript.Libraries/ShellFeatures/JavaScriptLibraryFeatures.cs
+++ b/src/modules/Elsa.Expressions.JavaScript.Libraries/ShellFeatures/JavaScriptLibraryFeatures.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using CShells.Features;
 using Elsa.Expressions.JavaScript.Options;
 using Elsa.Expressions.JavaScript.ShellFeatures;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -39,6 +40,8 @@ public abstract class ScriptModuleShellFeatureBase : IShellFeature
 /// <summary>
 /// Adds Lodash library support to JavaScript expressions.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Expressions)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Scripting)]
 [ShellFeature(
     DisplayName = "Lodash JavaScript Library",
     Description = "Provides Lodash utility library for JavaScript expressions",
@@ -52,6 +55,8 @@ public class LodashFeature : ScriptModuleShellFeatureBase
 /// <summary>
 /// Adds Lodash FP library support to JavaScript expressions.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Expressions)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Scripting)]
 [ShellFeature(
     DisplayName = "Lodash FP JavaScript Library",
     Description = "Provides Lodash FP (functional programming) utility library for JavaScript expressions",
@@ -65,6 +70,8 @@ public class LodashFpFeature : ScriptModuleShellFeatureBase
 /// <summary>
 /// Adds Moment.js library support to JavaScript expressions.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Expressions)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Scripting)]
 [ShellFeature(
     DisplayName = "Moment JavaScript Library",
     Description = "Provides Moment.js date/time library for JavaScript expressions",

--- a/src/modules/Elsa.Expressions.JavaScript/ShellFeatures/JavaScriptFeature.cs
+++ b/src/modules/Elsa.Expressions.JavaScript/ShellFeatures/JavaScriptFeature.cs
@@ -11,19 +11,21 @@ using Elsa.Expressions.JavaScript.TypeDefinitions.Contracts;
 using Elsa.Expressions.JavaScript.TypeDefinitions.Services;
 using Elsa.Expressions.Options;
 using Elsa.Extensions;
-using Elsa.Platform.PackageManifest.Generator.Hints;
 using Elsa.Workflows;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 using Elsa.Common.Serialization;
 using Elsa.Common.ShellFeatures;
 using Elsa.Expressions.ShellFeatures;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 
 namespace Elsa.Expressions.JavaScript.ShellFeatures;
 
 /// <summary>
 /// Installs JavaScript integration.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Expressions)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Scripting)]
 [ShellFeature(
     DisplayName = "JavaScript Expressions",
     Description = "Provides JavaScript expression evaluation capabilities for workflows",

--- a/src/modules/Elsa.Expressions.Liquid/ShellFeatures/LiquidFeature.cs
+++ b/src/modules/Elsa.Expressions.Liquid/ShellFeatures/LiquidFeature.cs
@@ -9,6 +9,7 @@ using Elsa.Expressions.Liquid.Providers;
 using Elsa.Expressions.Liquid.Services;
 using Elsa.Expressions.ShellFeatures;
 using Elsa.Extensions;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using Fluid.Filters;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
@@ -18,6 +19,8 @@ namespace Elsa.Expressions.Liquid.ShellFeatures;
 /// <summary>
 /// Configures Liquid functionality.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Expressions)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Scripting)]
 [ShellFeature(
     DisplayName = "Liquid Expressions",
     Description = "Provides Liquid template expression evaluation capabilities for workflows",

--- a/src/modules/Elsa.Expressions.Python/ShellFeatures/PythonFeature.cs
+++ b/src/modules/Elsa.Expressions.Python/ShellFeatures/PythonFeature.cs
@@ -10,6 +10,7 @@ using Elsa.Expressions.Python.Services;
 using Elsa.Expressions.ShellFeatures;
 using Elsa.Extensions;
 using Elsa.Workflows;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -18,6 +19,8 @@ namespace Elsa.Expressions.Python.ShellFeatures;
 /// <summary>
 /// Installs Python integration.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Expressions)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Scripting)]
 [ShellFeature(
     DisplayName = "Python Expressions",
     Description = "Provides Python expression evaluation capabilities for workflows",

--- a/src/modules/Elsa.Expressions/ShellFeatures/ExpressionsFeature.cs
+++ b/src/modules/Elsa.Expressions/ShellFeatures/ExpressionsFeature.cs
@@ -1,6 +1,7 @@
 using CShells.Features;
 using Elsa.Expressions.Contracts;
 using Elsa.Expressions.Services;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Elsa.Expressions.ShellFeatures;
@@ -8,6 +9,7 @@ namespace Elsa.Expressions.ShellFeatures;
 /// <summary>
 /// Installs and configures the expressions feature.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Expressions)]
 [ShellFeature(
     "Expressions",
     DisplayName = "Expressions",

--- a/src/modules/Elsa.Hosting.Management/ShellFeatures/ClusteringFeature.cs
+++ b/src/modules/Elsa.Hosting.Management/ShellFeatures/ClusteringFeature.cs
@@ -3,6 +3,7 @@ using Elsa.Hosting.Management.Contracts;
 using Elsa.Hosting.Management.HostedServices;
 using Elsa.Hosting.Management.Options;
 using Elsa.Hosting.Management.Services;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -11,6 +12,7 @@ namespace Elsa.Hosting.Management.ShellFeatures;
 /// <summary>
 /// Installs and configures the clustering feature.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Infrastructure)]
 [ShellFeature(
     DisplayName = "Clustering",
     Description = "Provides clustering and heartbeat capabilities for distributed Elsa deployments")]

--- a/src/modules/Elsa.Http/ShellFeatures/HttpCacheFeature.cs
+++ b/src/modules/Elsa.Http/ShellFeatures/HttpCacheFeature.cs
@@ -2,6 +2,7 @@ using CShells.Features;
 using Elsa.Http.Handlers;
 using Elsa.Http.Services;
 using Elsa.Workflows.Management.ShellFeatures;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -10,6 +11,8 @@ namespace Elsa.Http.ShellFeatures;
 /// <summary>
 /// Installs services related to HTTP caching.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.HTTP)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Caching)]
 [ShellFeature(
     DisplayName = "HTTP Cache",
     Description = "Provides HTTP workflow caching for improved performance",

--- a/src/modules/Elsa.Http/ShellFeatures/HttpFeature.cs
+++ b/src/modules/Elsa.Http/ShellFeatures/HttpFeature.cs
@@ -22,6 +22,7 @@ using Elsa.Resilience.ShellFeatures;
 using Elsa.Workflows.Management.Extensions;
 using Elsa.Workflows.Options;
 using Elsa.Workflows;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using FluentStorage;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Builder;
@@ -36,6 +37,8 @@ namespace Elsa.Http.ShellFeatures;
 /// <summary>
 /// Installs services related to HTTP services and activities.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.HTTP)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Workflows)]
 [ShellFeature(
     DisplayName = "HTTP",
     Description = "Provides HTTP-related activities and services for workflow execution",

--- a/src/modules/Elsa.Http/ShellFeatures/HttpJavaScriptFeature.cs
+++ b/src/modules/Elsa.Http/ShellFeatures/HttpJavaScriptFeature.cs
@@ -1,6 +1,7 @@
 using CShells.Features;
 using Elsa.Expressions.JavaScript.ShellFeatures;
 using Elsa.Http.Scripting.JavaScript;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -9,6 +10,8 @@ namespace Elsa.Http.ShellFeatures;
 /// <summary>
 /// Provides JavaScript integration for HTTP features.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.HTTP)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Scripting)]
 [ShellFeature(
     DisplayName = "HTTP JavaScript",
     Description = "Provides JavaScript integration for HTTP activities",

--- a/src/modules/Elsa.Identity/ShellFeatures/DefaultAdminUserFeature.cs
+++ b/src/modules/Elsa.Identity/ShellFeatures/DefaultAdminUserFeature.cs
@@ -11,6 +11,8 @@ namespace Elsa.Identity.ShellFeatures;
 /// <summary>
 /// Feature that initializes an admin user from configuration if provided.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Identity)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Security)]
 [ShellFeature(
     DisplayName = "Default Admin User Initialization",
     Description = "Initializes a default admin user from configuration if provided",

--- a/src/modules/Elsa.Identity/ShellFeatures/DefaultAuthenticationFeature.cs
+++ b/src/modules/Elsa.Identity/ShellFeatures/DefaultAuthenticationFeature.cs
@@ -5,8 +5,8 @@ using Elsa.Identity.Constants;
 using Elsa.Identity.Options;
 using Elsa.Identity.Providers;
 using Elsa.Options;
-using Elsa.Platform.PackageManifest.Generator.Hints;
 using Elsa.Requirements;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
@@ -17,6 +17,8 @@ namespace Elsa.Identity.ShellFeatures;
 /// <summary>
 /// Provides an authorization feature that configures the system with JWT bearer and API key authentication.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Identity)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Security)]
 [ShellFeature(
     DisplayName = "Default Authentication",
     Description = "Provides JWT bearer and API key authentication",

--- a/src/modules/Elsa.Identity/ShellFeatures/IdentityFeature.cs
+++ b/src/modules/Elsa.Identity/ShellFeatures/IdentityFeature.cs
@@ -11,6 +11,7 @@ using Elsa.Identity.Multitenancy;
 using Elsa.Identity.Options;
 using Elsa.Identity.Providers;
 using Elsa.Identity.Services;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -20,6 +21,8 @@ namespace Elsa.Identity.ShellFeatures;
 /// <summary>
 /// Provides identity feature to authenticate &amp; authorize API requests.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Identity)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Security)]
 [ShellFeature(
     DisplayName = "Identity",
     Description = "Provides identity management, authentication and authorization capabilities",

--- a/src/modules/Elsa.KeyValues/ShellFeatures/KeyValueFeature.cs
+++ b/src/modules/Elsa.KeyValues/ShellFeatures/KeyValueFeature.cs
@@ -3,6 +3,7 @@ using Elsa.Common.Services;
 using Elsa.KeyValues.Contracts;
 using Elsa.KeyValues.Entities;
 using Elsa.KeyValues.Stores;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -12,6 +13,8 @@ namespace Elsa.KeyValues.ShellFeatures;
 /// <summary>
 /// Installs and configures key-value store features.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Storage)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Infrastructure)]
 [ShellFeature(
     DisplayName = "Key-Value Store",
     Description = "Provides key-value storage capabilities for workflows")]

--- a/src/modules/Elsa.Labels/ShellFeatures/LabelsFeature.cs
+++ b/src/modules/Elsa.Labels/ShellFeatures/LabelsFeature.cs
@@ -4,6 +4,7 @@ using Elsa.Extensions;
 using Elsa.Labels.Contracts;
 using Elsa.Labels.Entities;
 using Elsa.Labels.Services;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -12,6 +13,7 @@ namespace Elsa.Labels.ShellFeatures;
 /// <summary>
 /// Enables functionality to tag workflows with labels.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Labels)]
 [ShellFeature(
     DisplayName = "Labels",
     Description = "Enables functionality to tag workflows with labels",

--- a/src/modules/Elsa.Persistence.EFCore.MySql/ShellFeatures/Alterations/MySqlAlterationsPersistenceShellFeature.cs
+++ b/src/modules/Elsa.Persistence.EFCore.MySql/ShellFeatures/Alterations/MySqlAlterationsPersistenceShellFeature.cs
@@ -13,6 +13,8 @@ namespace Elsa.Persistence.EFCore.MySql.ShellFeatures.Alterations;
 /// <summary>
 /// Configures the alterations feature to use MySql persistence.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Persistence)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Alterations)]
 [ShellFeature(
     DisplayName = "MySql Alterations Persistence",
     Description = "Provides MySql persistence for workflow alterations",

--- a/src/modules/Elsa.Persistence.EFCore.MySql/ShellFeatures/Identity/MySqlIdentityPersistenceShellFeature.cs
+++ b/src/modules/Elsa.Persistence.EFCore.MySql/ShellFeatures/Identity/MySqlIdentityPersistenceShellFeature.cs
@@ -13,6 +13,8 @@ namespace Elsa.Persistence.EFCore.MySql.ShellFeatures.Identity;
 /// <summary>
 /// Configures the identity feature to use MySql persistence.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Persistence)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Identity)]
 [ShellFeature(
     DisplayName = "MySql Identity Persistence",
     Description = "Provides MySql persistence for identity management",

--- a/src/modules/Elsa.Persistence.EFCore.MySql/ShellFeatures/Labels/MySqlLabelPersistenceShellFeature.cs
+++ b/src/modules/Elsa.Persistence.EFCore.MySql/ShellFeatures/Labels/MySqlLabelPersistenceShellFeature.cs
@@ -13,6 +13,8 @@ namespace Elsa.Persistence.EFCore.MySql.ShellFeatures.Labels;
 /// <summary>
 /// Configures the labels feature to use MySql persistence.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Persistence)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Labels)]
 [ShellFeature(
     DisplayName = "MySql Label Persistence",
     Description = "Provides MySql persistence for label management",

--- a/src/modules/Elsa.Persistence.EFCore.MySql/ShellFeatures/Management/MySqlWorkflowDefinitionPersistenceShellFeature.cs
+++ b/src/modules/Elsa.Persistence.EFCore.MySql/ShellFeatures/Management/MySqlWorkflowDefinitionPersistenceShellFeature.cs
@@ -2,8 +2,8 @@ using System.Reflection;
 using CShells.Features;
 using Elsa.Persistence.EFCore.Extensions;
 using Elsa.Persistence.EFCore.Modules.Management;
-using Elsa.Platform.PackageManifest.Generator.Hints;
 using Elsa.Workflows.Management.ShellFeatures;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -13,6 +13,8 @@ namespace Elsa.Persistence.EFCore.MySql.ShellFeatures.Management;
 /// <summary>
 /// Configures the management feature to use MySql persistence.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Persistence)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Workflows)]
 [ShellFeature(
     DisplayName = "MySql Workflow Definition Persistence",
     Description = "Provides MySql persistence for workflow definitions",

--- a/src/modules/Elsa.Persistence.EFCore.MySql/ShellFeatures/Management/MySqlWorkflowInstancePersistenceShellFeature.cs
+++ b/src/modules/Elsa.Persistence.EFCore.MySql/ShellFeatures/Management/MySqlWorkflowInstancePersistenceShellFeature.cs
@@ -2,8 +2,8 @@ using System.Reflection;
 using CShells.Features;
 using Elsa.Persistence.EFCore.Extensions;
 using Elsa.Persistence.EFCore.Modules.Management;
-using Elsa.Platform.PackageManifest.Generator.Hints;
 using Elsa.Workflows.Management.ShellFeatures;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -13,6 +13,8 @@ namespace Elsa.Persistence.EFCore.MySql.ShellFeatures.Management;
 /// <summary>
 /// Configures the management feature to use MySql persistence.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Persistence)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Workflows)]
 [ShellFeature(
     DisplayName = "MySql Workflow Instance Persistence",
     Description = "Provides MySql persistence for workflow instances",

--- a/src/modules/Elsa.Persistence.EFCore.MySql/ShellFeatures/MySqlWorkflowPersistenceShellFeature.cs
+++ b/src/modules/Elsa.Persistence.EFCore.MySql/ShellFeatures/MySqlWorkflowPersistenceShellFeature.cs
@@ -33,6 +33,8 @@ namespace Elsa.Persistence.EFCore.MySql.ShellFeatures;
 /// </code>
 /// </example>
 /// </remarks>
+[ManifestFeatureCategory(ManifestFeatureCategories.Persistence)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Workflows)]
 [ShellFeature(
     DisplayName = "MySql Workflow Persistence",
     Description = "Provides MySql persistence for workflow definitions, instances, and runtime data with unified configuration",

--- a/src/modules/Elsa.Persistence.EFCore.MySql/ShellFeatures/Runtime/MySqlWorkflowRuntimePersistenceShellFeature.cs
+++ b/src/modules/Elsa.Persistence.EFCore.MySql/ShellFeatures/Runtime/MySqlWorkflowRuntimePersistenceShellFeature.cs
@@ -2,8 +2,8 @@ using System.Reflection;
 using CShells.Features;
 using Elsa.Persistence.EFCore.Extensions;
 using Elsa.Persistence.EFCore.Modules.Runtime;
-using Elsa.Platform.PackageManifest.Generator.Hints;
 using Elsa.Workflows.Runtime.ShellFeatures;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -13,6 +13,8 @@ namespace Elsa.Persistence.EFCore.MySql.ShellFeatures.Runtime;
 /// <summary>
 /// Configures the runtime feature to use MySql persistence.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Persistence)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Workflows)]
 [ShellFeature(
     DisplayName = "MySql Workflow Runtime Persistence",
     Description = "Provides MySql persistence for workflow runtime",

--- a/src/modules/Elsa.Persistence.EFCore.MySql/ShellFeatures/Tenants/MySqlTenantPersistenceShellFeature.cs
+++ b/src/modules/Elsa.Persistence.EFCore.MySql/ShellFeatures/Tenants/MySqlTenantPersistenceShellFeature.cs
@@ -2,8 +2,8 @@ using System.Reflection;
 using CShells.Features;
 using Elsa.Persistence.EFCore.Extensions;
 using Elsa.Persistence.EFCore.Modules.Tenants;
-using Elsa.Platform.PackageManifest.Generator.Hints;
 using Elsa.Tenants.ShellFeatures;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -13,6 +13,8 @@ namespace Elsa.Persistence.EFCore.MySql.ShellFeatures.Tenants;
 /// <summary>
 /// Configures the tenants feature to use MySql persistence.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Persistence)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Tenancy)]
 [ShellFeature(
     DisplayName = "MySql Tenant Persistence",
     Description = "Provides MySql persistence for tenant management",

--- a/src/modules/Elsa.Persistence.EFCore.Oracle/ShellFeatures/Alterations/OracleAlterationsPersistenceShellFeature.cs
+++ b/src/modules/Elsa.Persistence.EFCore.Oracle/ShellFeatures/Alterations/OracleAlterationsPersistenceShellFeature.cs
@@ -12,6 +12,8 @@ namespace Elsa.Persistence.EFCore.Oracle.ShellFeatures.Alterations;
 /// <summary>
 /// Configures the alterations feature to use Oracle persistence.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Persistence)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Alterations)]
 [ShellFeature(
     DisplayName = "Oracle Alterations Persistence",
     Description = "Provides Oracle persistence for workflow alterations",

--- a/src/modules/Elsa.Persistence.EFCore.Oracle/ShellFeatures/Identity/OracleIdentityPersistenceShellFeature.cs
+++ b/src/modules/Elsa.Persistence.EFCore.Oracle/ShellFeatures/Identity/OracleIdentityPersistenceShellFeature.cs
@@ -12,6 +12,8 @@ namespace Elsa.Persistence.EFCore.Oracle.ShellFeatures.Identity;
 /// <summary>
 /// Configures the identity feature to use Oracle persistence.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Persistence)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Identity)]
 [ShellFeature(
     DisplayName = "Oracle Identity Persistence",
     Description = "Provides Oracle persistence for identity management",

--- a/src/modules/Elsa.Persistence.EFCore.Oracle/ShellFeatures/Labels/OracleLabelPersistenceShellFeature.cs
+++ b/src/modules/Elsa.Persistence.EFCore.Oracle/ShellFeatures/Labels/OracleLabelPersistenceShellFeature.cs
@@ -12,6 +12,8 @@ namespace Elsa.Persistence.EFCore.Oracle.ShellFeatures.Labels;
 /// <summary>
 /// Configures the labels feature to use Oracle persistence.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Persistence)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Labels)]
 [ShellFeature(
     DisplayName = "Oracle Label Persistence",
     Description = "Provides Oracle persistence for label management",

--- a/src/modules/Elsa.Persistence.EFCore.Oracle/ShellFeatures/Management/OracleWorkflowDefinitionPersistenceShellFeature.cs
+++ b/src/modules/Elsa.Persistence.EFCore.Oracle/ShellFeatures/Management/OracleWorkflowDefinitionPersistenceShellFeature.cs
@@ -2,8 +2,8 @@ using System.Reflection;
 using CShells.Features;
 using Elsa.Persistence.EFCore.Extensions;
 using Elsa.Persistence.EFCore.Modules.Management;
-using Elsa.Platform.PackageManifest.Generator.Hints;
 using Elsa.Workflows.Management.ShellFeatures;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
 
@@ -12,6 +12,8 @@ namespace Elsa.Persistence.EFCore.Oracle.ShellFeatures.Management;
 /// <summary>
 /// Configures the management feature to use Oracle persistence.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Persistence)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Workflows)]
 [ShellFeature(
     DisplayName = "Oracle Workflow Definition Persistence",
     Description = "Provides Oracle persistence for workflow definitions",

--- a/src/modules/Elsa.Persistence.EFCore.Oracle/ShellFeatures/Management/OracleWorkflowInstancePersistenceShellFeature.cs
+++ b/src/modules/Elsa.Persistence.EFCore.Oracle/ShellFeatures/Management/OracleWorkflowInstancePersistenceShellFeature.cs
@@ -2,8 +2,8 @@ using System.Reflection;
 using CShells.Features;
 using Elsa.Persistence.EFCore.Extensions;
 using Elsa.Persistence.EFCore.Modules.Management;
-using Elsa.Platform.PackageManifest.Generator.Hints;
 using Elsa.Workflows.Management.ShellFeatures;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
 
@@ -12,6 +12,8 @@ namespace Elsa.Persistence.EFCore.Oracle.ShellFeatures.Management;
 /// <summary>
 /// Configures the management feature to use Oracle persistence.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Persistence)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Workflows)]
 [ShellFeature(
     DisplayName = "Oracle Workflow Instance Persistence",
     Description = "Provides Oracle persistence for workflow instances",

--- a/src/modules/Elsa.Persistence.EFCore.Oracle/ShellFeatures/OracleWorkflowPersistenceShellFeature.cs
+++ b/src/modules/Elsa.Persistence.EFCore.Oracle/ShellFeatures/OracleWorkflowPersistenceShellFeature.cs
@@ -33,6 +33,8 @@ namespace Elsa.Persistence.EFCore.Oracle.ShellFeatures;
 /// </code>
 /// </example>
 /// </remarks>
+[ManifestFeatureCategory(ManifestFeatureCategories.Persistence)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Workflows)]
 [ShellFeature(
     DisplayName = "Oracle Workflow Persistence",
     Description = "Provides Oracle persistence for workflow definitions, instances, and runtime data with unified configuration",

--- a/src/modules/Elsa.Persistence.EFCore.Oracle/ShellFeatures/Runtime/OracleWorkflowRuntimePersistenceShellFeature.cs
+++ b/src/modules/Elsa.Persistence.EFCore.Oracle/ShellFeatures/Runtime/OracleWorkflowRuntimePersistenceShellFeature.cs
@@ -2,8 +2,8 @@ using System.Reflection;
 using CShells.Features;
 using Elsa.Persistence.EFCore.Extensions;
 using Elsa.Persistence.EFCore.Modules.Runtime;
-using Elsa.Platform.PackageManifest.Generator.Hints;
 using Elsa.Workflows.Runtime.ShellFeatures;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
 
@@ -12,6 +12,8 @@ namespace Elsa.Persistence.EFCore.Oracle.ShellFeatures.Runtime;
 /// <summary>
 /// Configures the runtime feature to use Oracle persistence.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Persistence)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Workflows)]
 [ShellFeature(
     DisplayName = "Oracle Workflow Runtime Persistence",
     Description = "Provides Oracle persistence for workflow runtime",

--- a/src/modules/Elsa.Persistence.EFCore.Oracle/ShellFeatures/Tenants/OracleTenantPersistenceShellFeature.cs
+++ b/src/modules/Elsa.Persistence.EFCore.Oracle/ShellFeatures/Tenants/OracleTenantPersistenceShellFeature.cs
@@ -2,8 +2,8 @@ using System.Reflection;
 using CShells.Features;
 using Elsa.Persistence.EFCore.Extensions;
 using Elsa.Persistence.EFCore.Modules.Tenants;
-using Elsa.Platform.PackageManifest.Generator.Hints;
 using Elsa.Tenants.ShellFeatures;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
 
@@ -12,6 +12,8 @@ namespace Elsa.Persistence.EFCore.Oracle.ShellFeatures.Tenants;
 /// <summary>
 /// Configures the tenants feature to use Oracle persistence.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Persistence)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Tenancy)]
 [ShellFeature(
     DisplayName = "Oracle Tenant Persistence",
     Description = "Provides Oracle persistence for tenant management",

--- a/src/modules/Elsa.Persistence.EFCore.PostgreSql/ShellFeatures/Alterations/PostgreSqlAlterationsPersistenceFeature.cs
+++ b/src/modules/Elsa.Persistence.EFCore.PostgreSql/ShellFeatures/Alterations/PostgreSqlAlterationsPersistenceFeature.cs
@@ -13,6 +13,8 @@ namespace Elsa.Persistence.EFCore.PostgreSql.ShellFeatures.Alterations;
 /// <summary>
 /// Configures the alterations feature to use PostgreSql persistence.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Persistence)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Alterations)]
 [ShellFeature(
     DisplayName = "PostgreSql Alterations Persistence",
     Description = "Provides PostgreSql persistence for workflow alterations",

--- a/src/modules/Elsa.Persistence.EFCore.PostgreSql/ShellFeatures/Identity/PostgreSqlIdentityPersistenceFeature.cs
+++ b/src/modules/Elsa.Persistence.EFCore.PostgreSql/ShellFeatures/Identity/PostgreSqlIdentityPersistenceFeature.cs
@@ -13,6 +13,8 @@ namespace Elsa.Persistence.EFCore.PostgreSql.ShellFeatures.Identity;
 /// <summary>
 /// Configures the identity feature to use PostgreSql persistence.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Persistence)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Identity)]
 [ShellFeature(
     DisplayName = "PostgreSql Identity Persistence",
     Description = "Provides PostgreSql persistence for identity management",

--- a/src/modules/Elsa.Persistence.EFCore.PostgreSql/ShellFeatures/Labels/PostgreSqlLabelPersistenceFeature.cs
+++ b/src/modules/Elsa.Persistence.EFCore.PostgreSql/ShellFeatures/Labels/PostgreSqlLabelPersistenceFeature.cs
@@ -13,6 +13,8 @@ namespace Elsa.Persistence.EFCore.PostgreSql.ShellFeatures.Labels;
 /// <summary>
 /// Configures the labels feature to use PostgreSql persistence.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Persistence)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Labels)]
 [ShellFeature(
     DisplayName = "PostgreSql Label Persistence",
     Description = "Provides PostgreSql persistence for label management",

--- a/src/modules/Elsa.Persistence.EFCore.PostgreSql/ShellFeatures/Management/PostgreSqlWorkflowDefinitionPersistenceFeature.cs
+++ b/src/modules/Elsa.Persistence.EFCore.PostgreSql/ShellFeatures/Management/PostgreSqlWorkflowDefinitionPersistenceFeature.cs
@@ -2,8 +2,8 @@ using System.Reflection;
 using CShells.Features;
 using Elsa.Persistence.EFCore.Extensions;
 using Elsa.Persistence.EFCore.Modules.Management;
-using Elsa.Platform.PackageManifest.Generator.Hints;
 using Elsa.Workflows.Management.ShellFeatures;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -13,6 +13,8 @@ namespace Elsa.Persistence.EFCore.PostgreSql.ShellFeatures.Management;
 /// <summary>
 /// Configures the management feature to use PostgreSql persistence.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Persistence)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Workflows)]
 [ShellFeature(
     DisplayName = "PostgreSql Workflow Definition Persistence",
     Description = "Provides PostgreSql persistence for workflow definitions",

--- a/src/modules/Elsa.Persistence.EFCore.PostgreSql/ShellFeatures/Management/PostgreSqlWorkflowInstancePersistenceFeature.cs
+++ b/src/modules/Elsa.Persistence.EFCore.PostgreSql/ShellFeatures/Management/PostgreSqlWorkflowInstancePersistenceFeature.cs
@@ -2,8 +2,8 @@ using System.Reflection;
 using CShells.Features;
 using Elsa.Persistence.EFCore.Extensions;
 using Elsa.Persistence.EFCore.Modules.Management;
-using Elsa.Platform.PackageManifest.Generator.Hints;
 using Elsa.Workflows.Management.ShellFeatures;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -13,6 +13,8 @@ namespace Elsa.Persistence.EFCore.PostgreSql.ShellFeatures.Management;
 /// <summary>
 /// Configures the management feature to use PostgreSql persistence.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Persistence)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Workflows)]
 [ShellFeature(
     DisplayName = "PostgreSql Workflow Instance Persistence",
     Description = "Provides PostgreSql persistence for workflow instances",

--- a/src/modules/Elsa.Persistence.EFCore.PostgreSql/ShellFeatures/PostgreSqlWorkflowPersistenceFeature.cs
+++ b/src/modules/Elsa.Persistence.EFCore.PostgreSql/ShellFeatures/PostgreSqlWorkflowPersistenceFeature.cs
@@ -1,7 +1,7 @@
 using CShells.Features;
-using Elsa.Platform.PackageManifest.Generator.Hints;
 using Elsa.Persistence.EFCore.PostgreSql.ShellFeatures.Management;
 using Elsa.Persistence.EFCore.PostgreSql.ShellFeatures.Runtime;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 
 namespace Elsa.Persistence.EFCore.PostgreSql.ShellFeatures;
@@ -32,6 +32,8 @@ namespace Elsa.Persistence.EFCore.PostgreSql.ShellFeatures;
 /// </code>
 /// </example>
 /// </remarks>
+[ManifestFeatureCategory(ManifestFeatureCategories.Persistence)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Workflows)]
 [ShellFeature(
     DisplayName = "PostgreSql Workflow Persistence",
     Description = "Provides PostgreSQL persistence for workflow definitions, instances, and runtime data with unified configuration",

--- a/src/modules/Elsa.Persistence.EFCore.PostgreSql/ShellFeatures/Runtime/PostgreSqlWorkflowRuntimePersistenceFeature.cs
+++ b/src/modules/Elsa.Persistence.EFCore.PostgreSql/ShellFeatures/Runtime/PostgreSqlWorkflowRuntimePersistenceFeature.cs
@@ -2,8 +2,8 @@ using System.Reflection;
 using CShells.Features;
 using Elsa.Persistence.EFCore.Extensions;
 using Elsa.Persistence.EFCore.Modules.Runtime;
-using Elsa.Platform.PackageManifest.Generator.Hints;
 using Elsa.Workflows.Runtime.ShellFeatures;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -13,6 +13,8 @@ namespace Elsa.Persistence.EFCore.PostgreSql.ShellFeatures.Runtime;
 /// <summary>
 /// Configures the runtime feature to use PostgreSql persistence.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Persistence)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Workflows)]
 [ShellFeature(
     DisplayName = "PostgreSql Workflow Runtime Persistence",
     Description = "Provides PostgreSql persistence for workflow runtime",

--- a/src/modules/Elsa.Persistence.EFCore.PostgreSql/ShellFeatures/Tenants/PostgreSqlTenantPersistenceFeature.cs
+++ b/src/modules/Elsa.Persistence.EFCore.PostgreSql/ShellFeatures/Tenants/PostgreSqlTenantPersistenceFeature.cs
@@ -2,8 +2,8 @@ using System.Reflection;
 using CShells.Features;
 using Elsa.Persistence.EFCore.Extensions;
 using Elsa.Persistence.EFCore.Modules.Tenants;
-using Elsa.Platform.PackageManifest.Generator.Hints;
 using Elsa.Tenants.ShellFeatures;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -13,6 +13,8 @@ namespace Elsa.Persistence.EFCore.PostgreSql.ShellFeatures.Tenants;
 /// <summary>
 /// Configures the tenants feature to use PostgreSql persistence.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Persistence)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Tenancy)]
 [ShellFeature(
     DisplayName = "PostgreSql Tenant Persistence",
     Description = "Provides PostgreSql persistence for tenant management",

--- a/src/modules/Elsa.Persistence.EFCore.SqlServer/ShellFeatures/Alterations/SqlServerAlterationsPersistenceShellFeature.cs
+++ b/src/modules/Elsa.Persistence.EFCore.SqlServer/ShellFeatures/Alterations/SqlServerAlterationsPersistenceShellFeature.cs
@@ -12,6 +12,8 @@ namespace Elsa.Persistence.EFCore.SqlServer.ShellFeatures.Alterations;
 /// <summary>
 /// Configures the alterations feature to use SqlServer persistence.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Persistence)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Alterations)]
 [ShellFeature(
     DisplayName = "SqlServer Alterations Persistence",
     Description = "Provides SqlServer persistence for workflow alterations",

--- a/src/modules/Elsa.Persistence.EFCore.SqlServer/ShellFeatures/Identity/SqlServerIdentityPersistenceShellFeature.cs
+++ b/src/modules/Elsa.Persistence.EFCore.SqlServer/ShellFeatures/Identity/SqlServerIdentityPersistenceShellFeature.cs
@@ -12,6 +12,8 @@ namespace Elsa.Persistence.EFCore.SqlServer.ShellFeatures.Identity;
 /// <summary>
 /// Configures the identity feature to use SqlServer persistence.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Persistence)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Identity)]
 [ShellFeature(
     DisplayName = "SqlServer Identity Persistence",
     Description = "Provides SqlServer persistence for identity management",

--- a/src/modules/Elsa.Persistence.EFCore.SqlServer/ShellFeatures/Labels/SqlServerLabelPersistenceShellFeature.cs
+++ b/src/modules/Elsa.Persistence.EFCore.SqlServer/ShellFeatures/Labels/SqlServerLabelPersistenceShellFeature.cs
@@ -12,6 +12,8 @@ namespace Elsa.Persistence.EFCore.SqlServer.ShellFeatures.Labels;
 /// <summary>
 /// Configures the labels feature to use SqlServer persistence.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Persistence)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Labels)]
 [ShellFeature(
     DisplayName = "SqlServer Label Persistence",
     Description = "Provides SqlServer persistence for label management",

--- a/src/modules/Elsa.Persistence.EFCore.SqlServer/ShellFeatures/Management/SqlServerWorkflowDefinitionPersistenceShellFeature.cs
+++ b/src/modules/Elsa.Persistence.EFCore.SqlServer/ShellFeatures/Management/SqlServerWorkflowDefinitionPersistenceShellFeature.cs
@@ -2,8 +2,8 @@ using System.Reflection;
 using CShells.Features;
 using Elsa.Persistence.EFCore.Extensions;
 using Elsa.Persistence.EFCore.Modules.Management;
-using Elsa.Platform.PackageManifest.Generator.Hints;
 using Elsa.Workflows.Management.ShellFeatures;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
 
@@ -12,6 +12,8 @@ namespace Elsa.Persistence.EFCore.SqlServer.ShellFeatures.Management;
 /// <summary>
 /// Configures the management feature to use SqlServer persistence.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Persistence)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Workflows)]
 [ShellFeature(
     DisplayName = "SqlServer Workflow Definition Persistence",
     Description = "Provides SqlServer persistence for workflow definitions",

--- a/src/modules/Elsa.Persistence.EFCore.SqlServer/ShellFeatures/Management/SqlServerWorkflowInstancePersistenceShellFeature.cs
+++ b/src/modules/Elsa.Persistence.EFCore.SqlServer/ShellFeatures/Management/SqlServerWorkflowInstancePersistenceShellFeature.cs
@@ -2,8 +2,8 @@ using System.Reflection;
 using CShells.Features;
 using Elsa.Persistence.EFCore.Extensions;
 using Elsa.Persistence.EFCore.Modules.Management;
-using Elsa.Platform.PackageManifest.Generator.Hints;
 using Elsa.Workflows.Management.ShellFeatures;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
 
@@ -12,6 +12,8 @@ namespace Elsa.Persistence.EFCore.SqlServer.ShellFeatures.Management;
 /// <summary>
 /// Configures the management feature to use SqlServer persistence.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Persistence)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Workflows)]
 [ShellFeature(
     DisplayName = "SqlServer Workflow Instance Persistence",
     Description = "Provides SqlServer persistence for workflow instances",

--- a/src/modules/Elsa.Persistence.EFCore.SqlServer/ShellFeatures/Runtime/SqlServerWorkflowRuntimePersistenceShellFeature.cs
+++ b/src/modules/Elsa.Persistence.EFCore.SqlServer/ShellFeatures/Runtime/SqlServerWorkflowRuntimePersistenceShellFeature.cs
@@ -2,8 +2,8 @@ using System.Reflection;
 using CShells.Features;
 using Elsa.Persistence.EFCore.Extensions;
 using Elsa.Persistence.EFCore.Modules.Runtime;
-using Elsa.Platform.PackageManifest.Generator.Hints;
 using Elsa.Workflows.Runtime.ShellFeatures;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
 
@@ -12,6 +12,8 @@ namespace Elsa.Persistence.EFCore.SqlServer.ShellFeatures.Runtime;
 /// <summary>
 /// Configures the runtime feature to use SqlServer persistence.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Persistence)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Workflows)]
 [ShellFeature(
     DisplayName = "SqlServer Workflow Runtime Persistence",
     Description = "Provides SqlServer persistence for workflow runtime",

--- a/src/modules/Elsa.Persistence.EFCore.SqlServer/ShellFeatures/SqlServerWorkflowPersistenceShellFeature.cs
+++ b/src/modules/Elsa.Persistence.EFCore.SqlServer/ShellFeatures/SqlServerWorkflowPersistenceShellFeature.cs
@@ -33,6 +33,8 @@ namespace Elsa.Persistence.EFCore.SqlServer.ShellFeatures;
 /// </code>
 /// </example>
 /// </remarks>
+[ManifestFeatureCategory(ManifestFeatureCategories.Persistence)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Workflows)]
 [ShellFeature(
     DisplayName = "SQL Server Workflow Persistence",
     Description = "Provides SQL Server persistence for workflow definitions, instances, and runtime data with unified configuration",

--- a/src/modules/Elsa.Persistence.EFCore.SqlServer/ShellFeatures/Tenants/SqlServerTenantPersistenceShellFeature.cs
+++ b/src/modules/Elsa.Persistence.EFCore.SqlServer/ShellFeatures/Tenants/SqlServerTenantPersistenceShellFeature.cs
@@ -2,8 +2,8 @@ using System.Reflection;
 using CShells.Features;
 using Elsa.Persistence.EFCore.Extensions;
 using Elsa.Persistence.EFCore.Modules.Tenants;
-using Elsa.Platform.PackageManifest.Generator.Hints;
 using Elsa.Tenants.ShellFeatures;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
 
@@ -12,6 +12,8 @@ namespace Elsa.Persistence.EFCore.SqlServer.ShellFeatures.Tenants;
 /// <summary>
 /// Configures the tenants feature to use SqlServer persistence.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Persistence)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Tenancy)]
 [ShellFeature(
     DisplayName = "SqlServer Tenant Persistence",
     Description = "Provides SqlServer persistence for tenant management",

--- a/src/modules/Elsa.Persistence.EFCore.Sqlite/ShellFeatures/Alterations/SqliteAlterationsPersistenceShellFeature.cs
+++ b/src/modules/Elsa.Persistence.EFCore.Sqlite/ShellFeatures/Alterations/SqliteAlterationsPersistenceShellFeature.cs
@@ -13,6 +13,8 @@ namespace Elsa.Persistence.EFCore.Sqlite.ShellFeatures.Alterations;
 /// <summary>
 /// Configures the alterations feature to use Sqlite persistence.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Persistence)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Alterations)]
 [ShellFeature(
     DisplayName = "Sqlite Alterations Persistence",
     Description = "Provides Sqlite persistence for workflow alterations",

--- a/src/modules/Elsa.Persistence.EFCore.Sqlite/ShellFeatures/Identity/SqliteIdentityPersistenceShellFeature.cs
+++ b/src/modules/Elsa.Persistence.EFCore.Sqlite/ShellFeatures/Identity/SqliteIdentityPersistenceShellFeature.cs
@@ -13,6 +13,8 @@ namespace Elsa.Persistence.EFCore.Sqlite.ShellFeatures.Identity;
 /// <summary>
 /// Configures the identity feature to use Sqlite persistence.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Persistence)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Identity)]
 [ShellFeature(
     DisplayName = "Sqlite Identity Persistence",
     Description = "Provides Sqlite persistence for identity management",

--- a/src/modules/Elsa.Persistence.EFCore.Sqlite/ShellFeatures/Labels/SqliteLabelPersistenceShellFeature.cs
+++ b/src/modules/Elsa.Persistence.EFCore.Sqlite/ShellFeatures/Labels/SqliteLabelPersistenceShellFeature.cs
@@ -13,6 +13,8 @@ namespace Elsa.Persistence.EFCore.Sqlite.ShellFeatures.Labels;
 /// <summary>
 /// Configures the labels feature to use Sqlite persistence.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Persistence)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Labels)]
 [ShellFeature(
     DisplayName = "Sqlite Label Persistence",
     Description = "Provides Sqlite persistence for label management",

--- a/src/modules/Elsa.Persistence.EFCore.Sqlite/ShellFeatures/Management/SqliteWorkflowDefinitionPersistenceShellFeature.cs
+++ b/src/modules/Elsa.Persistence.EFCore.Sqlite/ShellFeatures/Management/SqliteWorkflowDefinitionPersistenceShellFeature.cs
@@ -2,8 +2,8 @@ using System.Reflection;
 using CShells.Features;
 using Elsa.Persistence.EFCore.Extensions;
 using Elsa.Persistence.EFCore.Modules.Management;
-using Elsa.Platform.PackageManifest.Generator.Hints;
 using Elsa.Workflows.Management.ShellFeatures;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -13,6 +13,8 @@ namespace Elsa.Persistence.EFCore.Sqlite.ShellFeatures.Management;
 /// <summary>
 /// Configures the management feature to use Sqlite persistence.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Persistence)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Workflows)]
 [ShellFeature(
     DisplayName = "Sqlite Workflow Definition Persistence",
     Description = "Provides Sqlite persistence for workflow definitions",

--- a/src/modules/Elsa.Persistence.EFCore.Sqlite/ShellFeatures/Management/SqliteWorkflowInstancePersistenceShellFeature.cs
+++ b/src/modules/Elsa.Persistence.EFCore.Sqlite/ShellFeatures/Management/SqliteWorkflowInstancePersistenceShellFeature.cs
@@ -2,8 +2,8 @@ using System.Reflection;
 using CShells.Features;
 using Elsa.Persistence.EFCore.Extensions;
 using Elsa.Persistence.EFCore.Modules.Management;
-using Elsa.Platform.PackageManifest.Generator.Hints;
 using Elsa.Workflows.Management.ShellFeatures;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -13,6 +13,8 @@ namespace Elsa.Persistence.EFCore.Sqlite.ShellFeatures.Management;
 /// <summary>
 /// Configures the management feature to use Sqlite persistence.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Persistence)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Workflows)]
 [ShellFeature(
     DisplayName = "Sqlite Workflow Instance Persistence",
     Description = "Provides Sqlite persistence for workflow instances",

--- a/src/modules/Elsa.Persistence.EFCore.Sqlite/ShellFeatures/Runtime/SqliteWorkflowRuntimePersistenceShellFeature.cs
+++ b/src/modules/Elsa.Persistence.EFCore.Sqlite/ShellFeatures/Runtime/SqliteWorkflowRuntimePersistenceShellFeature.cs
@@ -2,8 +2,8 @@ using System.Reflection;
 using CShells.Features;
 using Elsa.Persistence.EFCore.Extensions;
 using Elsa.Persistence.EFCore.Modules.Runtime;
-using Elsa.Platform.PackageManifest.Generator.Hints;
 using Elsa.Workflows.Runtime.ShellFeatures;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -13,6 +13,8 @@ namespace Elsa.Persistence.EFCore.Sqlite.ShellFeatures.Runtime;
 /// <summary>
 /// Configures the runtime feature to use Sqlite persistence.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Persistence)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Workflows)]
 [ShellFeature(
     DisplayName = "Sqlite Workflow Runtime Persistence",
     Description = "Provides Sqlite persistence for workflow runtime",

--- a/src/modules/Elsa.Persistence.EFCore.Sqlite/ShellFeatures/SqliteWorkflowPersistenceShellFeature.cs
+++ b/src/modules/Elsa.Persistence.EFCore.Sqlite/ShellFeatures/SqliteWorkflowPersistenceShellFeature.cs
@@ -55,6 +55,8 @@ namespace Elsa.Persistence.EFCore.Sqlite.ShellFeatures;
 /// </code>
 /// </example>
 /// </remarks>
+[ManifestFeatureCategory(ManifestFeatureCategories.Persistence)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Workflows)]
 [ShellFeature(
     DisplayName = "Sqlite Workflow Persistence",
     Description = "Provides Sqlite persistence for workflow definitions, instances, and runtime data with unified configuration",

--- a/src/modules/Elsa.Persistence.EFCore.Sqlite/ShellFeatures/Tenants/SqliteTenantPersistenceShellFeature.cs
+++ b/src/modules/Elsa.Persistence.EFCore.Sqlite/ShellFeatures/Tenants/SqliteTenantPersistenceShellFeature.cs
@@ -2,8 +2,8 @@ using System.Reflection;
 using CShells.Features;
 using Elsa.Persistence.EFCore.Extensions;
 using Elsa.Persistence.EFCore.Modules.Tenants;
-using Elsa.Platform.PackageManifest.Generator.Hints;
 using Elsa.Tenants.ShellFeatures;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -13,6 +13,8 @@ namespace Elsa.Persistence.EFCore.Sqlite.ShellFeatures.Tenants;
 /// <summary>
 /// Configures the tenants feature to use Sqlite persistence.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Persistence)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Tenancy)]
 [ShellFeature(
     DisplayName = "Sqlite Tenant Persistence",
     Description = "Provides Sqlite persistence for tenant management",

--- a/src/modules/Elsa.Resilience/ShellFeatures/ResilienceFeature.cs
+++ b/src/modules/Elsa.Resilience/ShellFeatures/ResilienceFeature.cs
@@ -14,9 +14,11 @@ using Elsa.Workflows.Options;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Elsa.Common.Serialization;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 
 namespace Elsa.Resilience.ShellFeatures;
 
+[ManifestFeatureCategory(ManifestFeatureCategories.Resilience)]
 [ShellFeature(
     DisplayName = "Resilience",
     Description = "Provides workflow resilience strategies and retry attempt tracking")]

--- a/src/modules/Elsa.SasTokens/ShellFeatures/SasTokensFeature.cs
+++ b/src/modules/Elsa.SasTokens/ShellFeatures/SasTokensFeature.cs
@@ -1,5 +1,6 @@
 using CShells.Features;
 using Elsa.SasTokens.Contracts;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.DependencyInjection;
@@ -9,6 +10,7 @@ namespace Elsa.SasTokens.ShellFeatures;
 /// <summary>
 /// Adds the SAS tokens feature to the workflow runtime.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Security)]
 [ShellFeature(
     DisplayName = "SAS Tokens",
     Description = "Provides shared access signature token generation and validation")]

--- a/src/modules/Elsa.Scheduling/ShellFeatures/SchedulingFeature.cs
+++ b/src/modules/Elsa.Scheduling/ShellFeatures/SchedulingFeature.cs
@@ -12,12 +12,15 @@ using Elsa.Workflows.Management.Extensions;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 using Elsa.Common.Serialization;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 
 namespace Elsa.Scheduling.ShellFeatures;
 
 /// <summary>
 /// Provides scheduling features to the system.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Scheduling)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Workflows)]
 [ShellFeature(
     DisplayName = "Scheduling",
     Description = "Provides scheduling capabilities for workflows including cron and delay-based triggers",

--- a/src/modules/Elsa.Secrets.JavaScript/ShellFeatures/SecretsJavaScriptFeature.cs
+++ b/src/modules/Elsa.Secrets.JavaScript/ShellFeatures/SecretsJavaScriptFeature.cs
@@ -3,11 +3,14 @@ using Elsa.Expressions.JavaScript.Extensions;
 using Elsa.Expressions.JavaScript.ShellFeatures;
 using Elsa.Secrets.JavaScript.Scripting.JavaScript;
 using Elsa.Secrets.ShellFeatures;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Elsa.Secrets.JavaScript.ShellFeatures;
 
+[ManifestFeatureCategory(ManifestFeatureCategories.Secrets)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Scripting)]
 [ShellFeature(
     DisplayName = "Secrets JavaScript",
     Description = "Provides JavaScript expression functions for resolving Elsa secrets.",

--- a/src/modules/Elsa.Secrets.Persistence.EFCore.MySql/ShellFeatures/MySqlSecretsPersistenceShellFeature.cs
+++ b/src/modules/Elsa.Secrets.Persistence.EFCore.MySql/ShellFeatures/MySqlSecretsPersistenceShellFeature.cs
@@ -2,15 +2,17 @@ using System.Reflection;
 using CShells.Features;
 using Elsa.Persistence.EFCore.Extensions;
 using Elsa.Persistence.EFCore;
-using Elsa.Platform.PackageManifest.Generator.Hints;
 using Elsa.Secrets.Persistence.EFCore.ShellFeatures;
 using Elsa.Secrets.ShellFeatures;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Elsa.Secrets.Persistence.EFCore.MySql.ShellFeatures;
 
+[ManifestFeatureCategory(ManifestFeatureCategories.Secrets)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Persistence)]
 [ShellFeature(
     DisplayName = "MySql Secrets Persistence",
     Description = "Provides MySql persistence for secrets",

--- a/src/modules/Elsa.Secrets.Persistence.EFCore.Oracle/ShellFeatures/OracleSecretsPersistenceShellFeature.cs
+++ b/src/modules/Elsa.Secrets.Persistence.EFCore.Oracle/ShellFeatures/OracleSecretsPersistenceShellFeature.cs
@@ -2,15 +2,17 @@ using System.Reflection;
 using CShells.Features;
 using Elsa.Persistence.EFCore.Extensions;
 using Elsa.Persistence.EFCore;
-using Elsa.Platform.PackageManifest.Generator.Hints;
 using Elsa.Secrets.Persistence.EFCore.Oracle.Extensions;
 using Elsa.Secrets.Persistence.EFCore.ShellFeatures;
 using Elsa.Secrets.ShellFeatures;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
 
 namespace Elsa.Secrets.Persistence.EFCore.Oracle.ShellFeatures;
 
+[ManifestFeatureCategory(ManifestFeatureCategories.Secrets)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Persistence)]
 [ShellFeature(
     DisplayName = "Oracle Secrets Persistence",
     Description = "Provides Oracle persistence for secrets",

--- a/src/modules/Elsa.Secrets.Persistence.EFCore.PostgreSql/ShellFeatures/PostgreSqlSecretsPersistenceShellFeature.cs
+++ b/src/modules/Elsa.Secrets.Persistence.EFCore.PostgreSql/ShellFeatures/PostgreSqlSecretsPersistenceShellFeature.cs
@@ -2,15 +2,17 @@ using System.Reflection;
 using CShells.Features;
 using Elsa.Persistence.EFCore.Extensions;
 using Elsa.Persistence.EFCore;
-using Elsa.Platform.PackageManifest.Generator.Hints;
 using Elsa.Secrets.Persistence.EFCore.ShellFeatures;
 using Elsa.Secrets.ShellFeatures;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Elsa.Secrets.Persistence.EFCore.PostgreSql.ShellFeatures;
 
+[ManifestFeatureCategory(ManifestFeatureCategories.Secrets)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Persistence)]
 [ShellFeature(
     DisplayName = "PostgreSql Secrets Persistence",
     Description = "Provides PostgreSql persistence for secrets",

--- a/src/modules/Elsa.Secrets.Persistence.EFCore.SqlServer/ShellFeatures/SqlServerSecretsPersistenceShellFeature.cs
+++ b/src/modules/Elsa.Secrets.Persistence.EFCore.SqlServer/ShellFeatures/SqlServerSecretsPersistenceShellFeature.cs
@@ -2,14 +2,16 @@ using System.Reflection;
 using CShells.Features;
 using Elsa.Persistence.EFCore.Extensions;
 using Elsa.Persistence.EFCore;
-using Elsa.Platform.PackageManifest.Generator.Hints;
 using Elsa.Secrets.Persistence.EFCore.ShellFeatures;
 using Elsa.Secrets.ShellFeatures;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
 
 namespace Elsa.Secrets.Persistence.EFCore.SqlServer.ShellFeatures;
 
+[ManifestFeatureCategory(ManifestFeatureCategories.Secrets)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Persistence)]
 [ShellFeature(
     DisplayName = "SqlServer Secrets Persistence",
     Description = "Provides SqlServer persistence for secrets",

--- a/src/modules/Elsa.Secrets.Persistence.EFCore.Sqlite/ShellFeatures/SqliteSecretsPersistenceShellFeature.cs
+++ b/src/modules/Elsa.Secrets.Persistence.EFCore.Sqlite/ShellFeatures/SqliteSecretsPersistenceShellFeature.cs
@@ -2,15 +2,17 @@ using System.Reflection;
 using CShells.Features;
 using Elsa.Persistence.EFCore.Extensions;
 using Elsa.Persistence.EFCore;
-using Elsa.Platform.PackageManifest.Generator.Hints;
 using Elsa.Secrets.Persistence.EFCore.ShellFeatures;
 using Elsa.Secrets.ShellFeatures;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Elsa.Secrets.Persistence.EFCore.Sqlite.ShellFeatures;
 
+[ManifestFeatureCategory(ManifestFeatureCategories.Secrets)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Persistence)]
 [ShellFeature(
     DisplayName = "Sqlite Secrets Persistence",
     Description = "Provides Sqlite persistence for secrets",

--- a/src/modules/Elsa.Secrets/ShellFeatures/SecretsFeature.cs
+++ b/src/modules/Elsa.Secrets/ShellFeatures/SecretsFeature.cs
@@ -2,11 +2,14 @@ using CShells.FastEndpoints.Features;
 using CShells.Features;
 using Elsa.Secrets.Extensions;
 using Elsa.ShellFeatures;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Elsa.Secrets.ShellFeatures;
 
+[ManifestFeatureCategory(ManifestFeatureCategories.Secrets)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Security)]
 [ShellFeature(
     DisplayName = "Secrets",
     Description = "Provides named secret management, secret stores, and runtime secret resolution.",

--- a/src/modules/Elsa.Shells.Api/ShellFeatures/ShellsApiFeature.cs
+++ b/src/modules/Elsa.Shells.Api/ShellFeatures/ShellsApiFeature.cs
@@ -1,6 +1,7 @@
 using CShells.FastEndpoints.Features;
 using CShells.Features;
 using Elsa.ShellFeatures;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -13,6 +14,8 @@ namespace Elsa.Shells.Api.ShellFeatures;
 /// This feature implements <see cref="IFastEndpointsShellFeature"/> to indicate that this assembly
 /// contains FastEndpoints that should be automatically discovered and registered.
 /// </remarks>
+[ManifestFeatureCategory(ManifestFeatureCategories.Shells)]
+[ManifestFeatureCategory(ManifestFeatureCategories.API)]
 [ShellFeature(
     DisplayName = "Shells API",
     Description = "Provides REST API endpoints for shell management",

--- a/src/modules/Elsa.Tenants.AspNetCore/ShellFeatures/MultitenantHttpRoutingFeature.cs
+++ b/src/modules/Elsa.Tenants.AspNetCore/ShellFeatures/MultitenantHttpRoutingFeature.cs
@@ -1,8 +1,8 @@
 using CShells.Features;
 using Elsa.Common.Multitenancy;
-using Elsa.Platform.PackageManifest.Generator.Hints;
 using Elsa.Tenants.AspNetCore.Options;
 using Elsa.Tenants.AspNetCore.Services;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -11,6 +11,8 @@ namespace Elsa.Tenants.AspNetCore.ShellFeatures;
 /// <summary>
 /// Provides multi-tenant HTTP routing features.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Tenancy)]
+[ManifestFeatureCategory(ManifestFeatureCategories.HTTP)]
 [ShellFeature(
     DisplayName = "Multi-tenant HTTP Routing",
     Description = "Provides multi-tenant HTTP routing capabilities for workflows")]

--- a/src/modules/Elsa.Tenants/ShellFeatures/TenantManagementEndpointsFeature.cs
+++ b/src/modules/Elsa.Tenants/ShellFeatures/TenantManagementEndpointsFeature.cs
@@ -1,4 +1,5 @@
 using CShells.Features;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -7,6 +8,8 @@ namespace Elsa.Tenants.ShellFeatures;
 /// <summary>
 /// Enables tenant management endpoints.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Tenancy)]
+[ManifestFeatureCategory(ManifestFeatureCategories.API)]
 [ShellFeature(
     DisplayName = "Tenant Management Endpoints",
     Description = "Provides REST API endpoints for tenant management",

--- a/src/modules/Elsa.Tenants/ShellFeatures/TenantManagementFeature.cs
+++ b/src/modules/Elsa.Tenants/ShellFeatures/TenantManagementFeature.cs
@@ -1,6 +1,7 @@
 using CShells.Features;
 using Elsa.Common.Multitenancy;
 using Elsa.Extensions;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -9,6 +10,7 @@ namespace Elsa.Tenants.ShellFeatures;
 /// <summary>
 /// Enables tenant management capabilities.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Tenancy)]
 [ShellFeature(
     DisplayName = "Tenant Management",
     Description = "Provides tenant store and management capabilities")]

--- a/src/modules/Elsa.Tenants/ShellFeatures/TenantsFeature.cs
+++ b/src/modules/Elsa.Tenants/ShellFeatures/TenantsFeature.cs
@@ -2,6 +2,7 @@ using CShells.Features;
 using Elsa.Common.Multitenancy;
 using Elsa.Tenants.Mediator.Tasks;
 using Elsa.Tenants.Options;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -10,6 +11,7 @@ namespace Elsa.Tenants.ShellFeatures;
 /// <summary>
 /// Configures multi-tenancy features.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Tenancy)]
 [ShellFeature(
     DisplayName = "Tenants",
     Description = "Provides multi-tenancy capabilities for workflows")]

--- a/src/modules/Elsa.WorkflowProviders.BlobStorage.ElsaScript/ShellFeatures/ElsaScriptBlobStorageFeature.cs
+++ b/src/modules/Elsa.WorkflowProviders.BlobStorage.ElsaScript/ShellFeatures/ElsaScriptBlobStorageFeature.cs
@@ -3,6 +3,7 @@ using Elsa.Dsl.ElsaScript.ShellFeatures;
 using Elsa.WorkflowProviders.BlobStorage.Contracts;
 using Elsa.WorkflowProviders.BlobStorage.ElsaScript.Handlers;
 using Elsa.WorkflowProviders.BlobStorage.ShellFeatures;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -11,6 +12,9 @@ namespace Elsa.WorkflowProviders.BlobStorage.ElsaScript.ShellFeatures;
 /// <summary>
 /// A feature that enables ElsaScript support for the BlobStorage workflow provider.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Storage)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Scripting)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Workflows)]
 [ShellFeature(
     DisplayName = "ElsaScript Blob Storage",
     Description = "Provides ElsaScript format support for the BlobStorage workflow provider",

--- a/src/modules/Elsa.WorkflowProviders.BlobStorage/ShellFeatures/BlobStorageFeature.cs
+++ b/src/modules/Elsa.WorkflowProviders.BlobStorage/ShellFeatures/BlobStorageFeature.cs
@@ -5,6 +5,7 @@ using Elsa.WorkflowProviders.BlobStorage.Handlers;
 using Elsa.WorkflowProviders.BlobStorage.Providers;
 using Elsa.Workflows.Management.ShellFeatures;
 using Elsa.Workflows.Runtime;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using FluentStorage.Blobs;
 using FluentStorage;
 using JetBrains.Annotations;
@@ -15,6 +16,8 @@ namespace Elsa.WorkflowProviders.BlobStorage.ShellFeatures;
 /// <summary>
 /// A feature that enables the FluentStorage workflow definition provider.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Storage)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Workflows)]
 [ShellFeature(
     DisplayName = "Blob Storage Workflow Provider",
     Description = "Provides workflow definitions from blob storage",

--- a/src/modules/Elsa.Workflows.Api/ShellFeatures/RealTimeWorkflowUpdatesFeature.cs
+++ b/src/modules/Elsa.Workflows.Api/ShellFeatures/RealTimeWorkflowUpdatesFeature.cs
@@ -1,5 +1,6 @@
 using CShells.Features;
 using Elsa.Workflows.Api.RealTime.Handlers;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -8,6 +9,8 @@ namespace Elsa.Workflows.Api.ShellFeatures;
 /// <summary>
 /// Sets up a SignalR hub for receiving workflow events on the client.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Workflows)]
+[ManifestFeatureCategory(ManifestFeatureCategories.API)]
 [ShellFeature(
     DisplayName = "Real-Time Workflow Updates",
     Description = "Provides real-time workflow updates via SignalR")]

--- a/src/modules/Elsa.Workflows.Api/ShellFeatures/WorkflowsApiFeature.cs
+++ b/src/modules/Elsa.Workflows.Api/ShellFeatures/WorkflowsApiFeature.cs
@@ -10,6 +10,7 @@ using Elsa.Workflows.Api.Serialization;
 using Elsa.Workflows.Api.Services;
 using Elsa.Workflows.Management.ShellFeatures;
 using Elsa.Workflows.Runtime.ShellFeatures;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.DependencyInjection;
@@ -23,6 +24,8 @@ namespace Elsa.Workflows.Api.ShellFeatures;
 /// This feature implements <see cref="IFastEndpointsShellFeature"/> to indicate that this assembly
 /// contains FastEndpoints that should be automatically discovered and registered.
 /// </remarks>
+[ManifestFeatureCategory(ManifestFeatureCategories.Workflows)]
+[ManifestFeatureCategory(ManifestFeatureCategories.API)]
 [ShellFeature(
     DisplayName = "Workflows API",
     Description = "Provides REST API endpoints for workflow management",

--- a/src/modules/Elsa.Workflows.Core/ShellFeatures/CommitStrategiesFeature.cs
+++ b/src/modules/Elsa.Workflows.Core/ShellFeatures/CommitStrategiesFeature.cs
@@ -2,10 +2,12 @@ using CShells.Features;
 using Elsa.Extensions;
 using Elsa.Workflows.CommitStates;
 using Elsa.Workflows.CommitStates.Tasks;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Elsa.Workflows.ShellFeatures;
 
+[ManifestFeatureCategory(ManifestFeatureCategories.Workflows)]
 [ShellFeature(
     "CommitStrategies",
     DisplayName = "Commit Strategies",

--- a/src/modules/Elsa.Workflows.Core/ShellFeatures/FlowchartFeature.cs
+++ b/src/modules/Elsa.Workflows.Core/ShellFeatures/FlowchartFeature.cs
@@ -7,12 +7,14 @@ using Elsa.Workflows.Options;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 using Elsa.Common.Serialization;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 
 namespace Elsa.Workflows.ShellFeatures;
 
 /// <summary>
 /// Adds support for the Flowchart activity.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Workflows)]
 [ShellFeature(
     DisplayName = "Flowchart",
     Description = "Adds support for the Flowchart activity")]

--- a/src/modules/Elsa.Workflows.Core/ShellFeatures/WorkflowsFeature.cs
+++ b/src/modules/Elsa.Workflows.Core/ShellFeatures/WorkflowsFeature.cs
@@ -30,11 +30,13 @@ using Elsa.Workflows.UIHints.Dictionary;
 using Elsa.Workflows.UIHints.Dropdown;
 using Elsa.Workflows.UIHints.JsonEditor;
 using Elsa.Workflows.UIHints.RadioList;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json.Linq;
 
 namespace Elsa.Workflows.ShellFeatures;
 
+[ManifestFeatureCategory(ManifestFeatureCategories.Workflows)]
 [ShellFeature(
     DisplayName = "Workflows",
     Description = "Provides core workflow execution, activity execution, and workflow serialization services",

--- a/src/modules/Elsa.Workflows.Management/ShellFeatures/CachingWorkflowDefinitionsFeature.cs
+++ b/src/modules/Elsa.Workflows.Management/ShellFeatures/CachingWorkflowDefinitionsFeature.cs
@@ -2,6 +2,7 @@ using CShells.Features;
 using Elsa.Workflows.Management.Handlers.Notifications;
 using Elsa.Workflows.Management.Services;
 using Elsa.Workflows.Management.Stores;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -10,6 +11,8 @@ namespace Elsa.Workflows.Management.ShellFeatures;
 /// <summary>
 /// Configures workflow definition caching.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Workflows)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Caching)]
 [ShellFeature(
     DisplayName = "Caching Workflow Definitions",
     Description = "Provides caching for workflow definitions")]

--- a/src/modules/Elsa.Workflows.Management/ShellFeatures/WorkflowDefinitionsFeature.cs
+++ b/src/modules/Elsa.Workflows.Management/ShellFeatures/WorkflowDefinitionsFeature.cs
@@ -1,5 +1,6 @@
 using CShells.Features;
 using Elsa.Workflows.Management.Stores;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -8,6 +9,7 @@ namespace Elsa.Workflows.Management.ShellFeatures;
 /// <summary>
 /// Configures workflow definition storage.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Workflows)]
 [ShellFeature(
     DisplayName = "Workflow Definitions",
     Description = "Manages workflow definitions and their storage")]

--- a/src/modules/Elsa.Workflows.Management/ShellFeatures/WorkflowInstancesFeature.cs
+++ b/src/modules/Elsa.Workflows.Management/ShellFeatures/WorkflowInstancesFeature.cs
@@ -1,5 +1,6 @@
 using CShells.Features;
 using Elsa.Workflows.Management.Stores;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -8,6 +9,7 @@ namespace Elsa.Workflows.Management.ShellFeatures;
 /// <summary>
 /// Enables storage of workflow instances.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Workflows)]
 [ShellFeature(
     DisplayName = "Workflow Instances",
     Description = "Manages workflow execution instances and their persistent state")]

--- a/src/modules/Elsa.Workflows.Management/ShellFeatures/WorkflowManagementFeature.cs
+++ b/src/modules/Elsa.Workflows.Management/ShellFeatures/WorkflowManagementFeature.cs
@@ -24,6 +24,7 @@ using Elsa.Workflows.Management.Services;
 using Elsa.Workflows.Management.Stores;
 using Elsa.Workflows.Options;
 using Elsa.Workflows.Serialization.Serializers;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -32,6 +33,7 @@ namespace Elsa.Workflows.Management.ShellFeatures;
 /// <summary>
 /// Installs and configures the workflow management feature.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Workflows)]
 [ShellFeature(
     DisplayName = "Workflow Management",
     Description = "Provides comprehensive workflow definition and instance management capabilities",

--- a/src/modules/Elsa.Workflows.Runtime.Dashboard/ShellFeatures/WorkflowRuntimeDashboardFeature.cs
+++ b/src/modules/Elsa.Workflows.Runtime.Dashboard/ShellFeatures/WorkflowRuntimeDashboardFeature.cs
@@ -2,11 +2,14 @@ using CShells.Features;
 using Elsa.Dashboard.Api.ShellFeatures;
 using Elsa.Workflows.Runtime.Dashboard.Extensions;
 using Elsa.Workflows.Runtime.ShellFeatures;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Elsa.Workflows.Runtime.Dashboard.ShellFeatures;
 
+[ManifestFeatureCategory(ManifestFeatureCategories.Workflows)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Dashboard)]
 [ShellFeature(
     DisplayName = "Workflow Runtime Dashboard",
     Description = "Provides workflow runtime dashboard contributions",

--- a/src/modules/Elsa.Workflows.Runtime.Distributed/ShellFeatures/DistributedRuntimeFeature.cs
+++ b/src/modules/Elsa.Workflows.Runtime.Distributed/ShellFeatures/DistributedRuntimeFeature.cs
@@ -4,6 +4,7 @@ using Elsa.Extensions;
 using Elsa.Resilience.ShellFeatures;
 using Elsa.Workflows.Runtime.Distributed.StartupTasks;
 using Elsa.Workflows.Runtime.ShellFeatures;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.DependencyInjection;
@@ -13,6 +14,8 @@ namespace Elsa.Workflows.Runtime.Distributed.ShellFeatures;
 /// <summary>
 /// Installs and configures distributed workflow runtime features.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Workflows)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Infrastructure)]
 [ShellFeature(
     DisplayName = "Distributed Runtime",
     Description = "Provides distributed workflow runtime capabilities",

--- a/src/modules/Elsa.Workflows.Runtime/ShellFeatures/CachingWorkflowRuntimeFeature.cs
+++ b/src/modules/Elsa.Workflows.Runtime/ShellFeatures/CachingWorkflowRuntimeFeature.cs
@@ -2,6 +2,7 @@ using CShells.Features;
 using Elsa.Caching.ShellFeatures;
 using Elsa.Workflows.Runtime.Handlers;
 using Elsa.Workflows.Runtime.Stores;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -10,6 +11,8 @@ namespace Elsa.Workflows.Runtime.ShellFeatures;
 /// <summary>
 /// Installs and configures workflow runtime caching features.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Workflows)]
+[ManifestFeatureCategory(ManifestFeatureCategories.Caching)]
 [ShellFeature(
     DisplayName = "Caching Workflow Runtime",
     Description = "Provides caching for workflow runtime operations",

--- a/src/modules/Elsa.Workflows.Runtime/ShellFeatures/WorkflowRuntimeFeature.cs
+++ b/src/modules/Elsa.Workflows.Runtime/ShellFeatures/WorkflowRuntimeFeature.cs
@@ -22,6 +22,7 @@ using Elsa.Workflows.Runtime.Stores;
 using Elsa.Workflows.Runtime.Tasks;
 using Elsa.Workflows.Runtime.UIHints;
 using Elsa.Workflows.ShellFeatures;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using Medallion.Threading.FileSystem;
 using Medallion.Threading;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -33,6 +34,7 @@ namespace Elsa.Workflows.Runtime.ShellFeatures;
 /// <summary>
 /// Installs and configures workflow runtime features.
 /// </summary>
+[ManifestFeatureCategory(ManifestFeatureCategories.Workflows)]
 [ShellFeature(
     DisplayName = "Workflow Runtime",
     Description = "Provides workflow execution runtime and scheduling capabilities",

--- a/src/modules/Elsa/ShellFeatures/ElsaFeature.cs
+++ b/src/modules/Elsa/ShellFeatures/ElsaFeature.cs
@@ -1,10 +1,12 @@
 using CShells.Features;
 using Elsa.Workflows.Management.ShellFeatures;
 using Elsa.Workflows.Runtime.ShellFeatures;
+using Elsa.Platform.PackageManifest.Generator.Hints;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Elsa.ShellFeatures;
 
+[ManifestFeatureCategory(ManifestFeatureCategories.Workflows)]
 [ShellFeature(
     DisplayName = "Elsa Core",
     Description = "Core Elsa workflow system functionality",

--- a/src/modules/PackageManifestCategories.cs
+++ b/src/modules/PackageManifestCategories.cs
@@ -1,0 +1,26 @@
+namespace Elsa.Platform.PackageManifest.Generator.Hints;
+
+internal static class ManifestFeatureCategories
+{
+    public const string AI = "AI";
+    public const string Alterations = "Alterations";
+    public const string API = "API";
+    public const string Caching = "Caching";
+    public const string Dashboard = "Dashboard";
+    public const string Diagnostics = "Diagnostics";
+    public const string Expressions = "Expressions";
+    public const string HTTP = "HTTP";
+    public const string Identity = "Identity";
+    public const string Infrastructure = "Infrastructure";
+    public const string Labels = "Labels";
+    public const string Persistence = "Persistence";
+    public const string Resilience = "Resilience";
+    public const string Scheduling = "Scheduling";
+    public const string Scripting = "Scripting";
+    public const string Secrets = "Secrets";
+    public const string Security = "Security";
+    public const string Shells = "Shells";
+    public const string Storage = "Storage";
+    public const string Tenancy = "Tenancy";
+    public const string Workflows = "Workflows";
+}


### PR DESCRIPTION
## Summary

Updates `Elsa.Platform.PackageManifest.Generator` to `0.0.1-preview.53` and uses the new `ManifestFeatureCategory` hint support to classify Elsa module shell features.

## Changes

- Added shared manifest category constants for module projects.
- Linked the category constants into shell-feature module builds.
- Assigned applicable categories to all manifest-generating module shell feature classes, covering workflows, persistence, diagnostics, AI, identity/security, tenancy, HTTP, expressions/scripting, dashboards, storage, caching, and infrastructure.

## Validation

- `dotnet restore Elsa.sln`
- `dotnet build Elsa.sln --no-restore`
- Scanned generated module manifests: 312 generated feature entries, 0 without categories.

Build currently reports the pre-existing `SharpCompress` NU1902 warnings in `Elsa.Persistence.VNext.MongoDb` / related tests.