### PR TITLE
[codex] Add named WithVariable overload

### DIFF
--- a/src/modules/Elsa.Workflows.Core/Builders/WorkflowBuilder.cs
+++ b/src/modules/Elsa.Workflows.Core/Builders/WorkflowBuilder.cs
@@ -89,6 +89,14 @@ public class WorkflowBuilder(IActivityVisitor activityVisitor, IIdentityGraphSer
     }
 
     /// <inheritdoc />
+    public Variable<T> WithVariable<T>(string name)
+    {
+        var variable = new Variable<T>(name, default!);
+        Variables.Add(variable);
+        return variable;
+    }
+
+    /// <inheritdoc />
     public Variable<T> WithVariable<T>(string name, T value)
     {
         var variable = new Variable<T>(name, value);

--- a/src/modules/Elsa.Workflows.Core/Contracts/IWorkflowBuilder.cs
+++ b/src/modules/Elsa.Workflows.Core/Contracts/IWorkflowBuilder.cs
@@ -118,6 +118,11 @@ public interface IWorkflowBuilder
     /// <summary>
     /// A fluent method for adding a variable to <see cref="Variables"/>.
     /// </summary>
+    Variable<T> WithVariable<T>(string name);
+    
+    /// <summary>
+    /// A fluent method for adding a variable to <see cref="Variables"/>.
+    /// </summary>
     Variable<T> WithVariable<T>(string name, T value);
     
     /// <summary>

--- a/test/integration/Elsa.Workflows.IntegrationTests/Serialization/VariableExpressions/Workflows.cs
+++ b/test/integration/Elsa.Workflows.IntegrationTests/Serialization/VariableExpressions/Workflows.cs
@@ -7,7 +7,7 @@ class SampleWorkflow : WorkflowBase
 {
     protected override void Build(IWorkflowBuilder workflow)
     {
-        var variable1 = workflow.WithVariable("Some variable");
+        var variable1 = workflow.WithVariable<string>("Some variable");
         var variable2 = workflow.WithVariable(42);
         var literal1 = new Literal<string>("Some literal");
         var literal2 = new Literal<int>(84);


### PR DESCRIPTION
## Summary
- add a `WithVariable<T>(string name)` overload to `IWorkflowBuilder`
- implement the overload in `WorkflowBuilder` without changing existing value-based overloads
- exercise the new overload in the variable expression serialization integration scenario

## Why
Issue #7694 reports that the obsolete parameterless variable overload now points users toward a named overload that still forces a default value. For output-bound variables, callers only need a typed name.

## Validation
- `dotnet test test/integration/Elsa.Workflows.IntegrationTests/Elsa.Workflows.IntegrationTests.csproj --filter FullyQualifiedName~Elsa.Workflows.IntegrationTests.Serialization.VariableExpressions.Tests`
