### PR TITLE
[codex] Fix ForEach completion from nested flowchart

### DIFF
--- a/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Activities/Flowchart.Counters.cs
+++ b/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Activities/Flowchart.Counters.cs
@@ -380,10 +380,15 @@ public partial class Flowchart
         var flowchartContext = context.ReceiverActivityExecutionContext;
         await CompleteIfNoPendingWorkAsync(flowchartContext);
         var flowchart = (Flowchart)flowchartContext.Activity;
+        var canceledActivity = context.SenderActivityExecutionContext.Activity;
+
+        if (!flowchart.Activities.Contains(canceledActivity))
+            return;
+
         var flowGraph = flowchartContext.GetFlowGraph();
         var flowScope = flowchart.GetFlowScope(flowchartContext);
 
         // Propagate canceled connections visited count by scheduling with Outcomes.Empty
-        await MaybeScheduleOutboundActivitiesAsync(flowGraph, flowScope, flowchartContext, context.SenderActivityExecutionContext.Activity, context.SenderActivityExecutionContext, Outcomes.Empty, OnChildCompletedAsync);
+        await MaybeScheduleOutboundActivitiesAsync(flowGraph, flowScope, flowchartContext, canceledActivity, context.SenderActivityExecutionContext, Outcomes.Empty, OnChildCompletedAsync);
     }
 }

--- a/src/modules/Elsa.Workflows.Core/Behaviors/BreakBehavior.cs
+++ b/src/modules/Elsa.Workflows.Core/Behaviors/BreakBehavior.cs
@@ -21,6 +21,8 @@ public class BreakBehavior : Behavior
 
     private async ValueTask OnCompleteCompositeAsync(CompleteCompositeSignal signal, SignalContext context)
     {
+        context.ReceiverActivityExecutionContext.SetIsBreaking();
+
         // Cancel each descendant to clear bookmarks and cancel jobs etc.
         await CancelDescendantsAsync(context);
 

--- a/src/modules/Elsa.Workflows.Core/Behaviors/BreakBehavior.cs
+++ b/src/modules/Elsa.Workflows.Core/Behaviors/BreakBehavior.cs
@@ -36,7 +36,7 @@ public class BreakBehavior : Behavior
         context.StopPropagation();
         
         // Set the IsBreaking property to true.
-        context.ReceiverActivityExecutionContext.SetProperty("IsBreaking", true);
+        context.ReceiverActivityExecutionContext.SetIsBreaking();
     }
     
     private async Task CancelDescendantsAsync(SignalContext context)

--- a/test/integration/Elsa.Activities.IntegrationTests/ForEachTests.cs
+++ b/test/integration/Elsa.Activities.IntegrationTests/ForEachTests.cs
@@ -286,7 +286,10 @@ public class ForEachTests(ITestOutputHelper testOutputHelper)
             }
         };
 
-        await RunAndAssertLines(forEach, new[] { "a", "b" });
+        var result = await _fixture.RunActivityAsync(forEach);
+
+        Assert.Equal(new[] { "a", "b" }, _fixture.CapturingTextWriter.Lines);
+        Assert.Equal("b", result.WorkflowState.Output["Output"]);
     }
     
     private static WriteLine WriteCurrentValue() => new(context => context.GetVariable<string>(CurrentValueVar));

--- a/test/integration/Elsa.Activities.IntegrationTests/ForEachTests.cs
+++ b/test/integration/Elsa.Activities.IntegrationTests/ForEachTests.cs
@@ -3,9 +3,11 @@ using Elsa.Testing.Shared;
 using Elsa.Workflows;
 using Elsa.Workflows.Activities;
 using Elsa.Workflows.Activities.Flowchart.Activities;
+using Elsa.Workflows.Activities.Flowchart.Extensions;
 using Elsa.Workflows.Activities.Flowchart.Models;
 using Elsa.Workflows.Management.Activities.SetOutput;
 using Elsa.Workflows.Models;
+using Elsa.Workflows.Options;
 using Xunit.Abstractions;
 
 namespace Elsa.Activities.IntegrationTests;
@@ -285,8 +287,22 @@ public class ForEachTests(ITestOutputHelper testOutputHelper)
                 }
             }
         };
+        var outerComplete = new Complete(["False"]);
+        var outerFlowchart = new Flowchart
+        {
+            Activities =
+            {
+                forEach,
+                outerComplete
+            },
+            Connections =
+            {
+                new() { Source = new(forEach, "Done"), Target = new(outerComplete) }
+            }
+        };
+        var options = new RunWorkflowOptions().WithCounterBasedFlowchart();
 
-        var result = await _fixture.RunActivityAsync(forEach);
+        var result = await _fixture.RunActivityAsync(outerFlowchart, options);
 
         Assert.Equal(new[] { "a", "b" }, _fixture.CapturingTextWriter.Lines);
         Assert.Equal("b", result.WorkflowState.Output["Output"]);

--- a/test/integration/Elsa.Activities.IntegrationTests/ForEachTests.cs
+++ b/test/integration/Elsa.Activities.IntegrationTests/ForEachTests.cs
@@ -2,6 +2,9 @@ using Elsa.Extensions;
 using Elsa.Testing.Shared;
 using Elsa.Workflows;
 using Elsa.Workflows.Activities;
+using Elsa.Workflows.Activities.Flowchart.Activities;
+using Elsa.Workflows.Activities.Flowchart.Models;
+using Elsa.Workflows.Management.Activities.SetOutput;
 using Elsa.Workflows.Models;
 using Xunit.Abstractions;
 
@@ -246,6 +249,44 @@ public class ForEachTests(ITestOutputHelper testOutputHelper)
         Assert.NotNull(forEachContext);
         Assert.Equal(ActivityStatus.Running, forEachContext.Status);
         Assert.Equal(1, forEachContext.AggregateFaultCount);
+    }
+
+    [Fact(DisplayName = "ForEach completes when a nested flowchart completes the composite")]
+    public async Task ForEach_Completes_WhenNestedFlowchartCompletesComposite()
+    {
+        var dataSource = new[]
+        {
+            "a", "b", "c"
+        };
+        var writeLine = WriteCurrentValue();
+        var decision = new FlowDecision(context => context.GetVariable<string>(CurrentValueVar) == "b");
+        var setOutput = new SetOutput
+        {
+            OutputName = new("Output"),
+            OutputValue = new(context => context.GetVariable<string>(CurrentValueVar))
+        };
+        var complete = new Complete(["True"]);
+        var forEach = new ForEach<string>(dataSource)
+        {
+            Body = new Flowchart
+            {
+                Activities =
+                {
+                    writeLine,
+                    decision,
+                    setOutput,
+                    complete
+                },
+                Connections =
+                {
+                    new() { Source = new(writeLine, "Done"), Target = new(decision) },
+                    new() { Source = new(decision, "True"), Target = new(setOutput) },
+                    new() { Source = new(setOutput, "Done"), Target = new(complete) }
+                }
+            }
+        };
+
+        await RunAndAssertLines(forEach, new[] { "a", "b" });
     }
     
     private static WriteLine WriteCurrentValue() => new(context => context.GetVariable<string>(CurrentValueVar));


### PR DESCRIPTION
## Summary
- fix counter-based flowchart cancellation propagation for cancellation signals from nested activities that are not direct nodes of the receiving flowchart
- mark loop composites as breaking when `Complete` completes them, so late child-completion callbacks do not continue iteration
- add a regression test covering a `ForEach` body flowchart that executes `Complete` after setting an output

## Why
Issue #7693 includes an exported workflow where a `Complete` activity inside a nested flowchart body of `ForEach` faults in counter-based flowchart mode with:

`Activity ... is not reachable from the flowchart graph. Unable to schedule it's outbound activities.`

The nested body flowchart is not a direct activity in the ancestor flowchart graph, so the ancestor should not process that cancellation as graph-local skip propagation. Separately, after `CompleteCompositeSignal` completes the loop, the pending body completion callback must not schedule the next iteration.

## Validation
- `dotnet test test/integration/Elsa.Activities.IntegrationTests/Elsa.Activities.IntegrationTests.csproj --filter FullyQualifiedName~Elsa.Activities.IntegrationTests.ForEachTests.ForEach_Completes_WhenNestedFlowchartCompletesComposite`
- `dotnet test test/integration/Elsa.Activities.IntegrationTests/Elsa.Activities.IntegrationTests.csproj --filter FullyQualifiedName~Elsa.Activities.IntegrationTests.ForEachTests`
- `dotnet test test/integration/Elsa.Activities.IntegrationTests/Elsa.Activities.IntegrationTests.csproj --filter FullyQualifiedName~Elsa.Activities.IntegrationTests.Flow.FlowchartCounterBasedTests`

Fixes #7693.
