### PR TITLE
Restore RequestAborted after timed HTTP workflow failures

### DIFF
--- a/src/modules/Elsa.Http/Middleware/HttpWorkflowsMiddleware.cs
+++ b/src/modules/Elsa.Http/Middleware/HttpWorkflowsMiddleware.cs
@@ -252,13 +252,15 @@ public class HttpWorkflowsMiddleware(RequestDelegate next)
         // Replace the original cancellation token with the combined one.
         httpContext.RequestAborted = combinedTokenSource.Token;
 
-        // Execute the action.
-        var result = await action(httpContext.RequestAborted);
-
-        // Restore the original cancellation token.
-        httpContext.RequestAborted = originalCancellationToken;
-
-        return result;
+        try
+        {
+            return await action(httpContext.RequestAborted);
+        }
+        finally
+        {
+            // Restore the original cancellation token even when execution faults or is canceled.
+            httpContext.RequestAborted = originalCancellationToken;
+        }
     }
 
     private HttpRouteData GetMatchingRoute(IServiceProvider serviceProvider, string path)

--- a/test/unit/Elsa.Http.UnitTests/Middleware/HttpWorkflowsMiddlewareTests.cs
+++ b/test/unit/Elsa.Http.UnitTests/Middleware/HttpWorkflowsMiddlewareTests.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Reflection;
 using Elsa.Http.Bookmarks;
 using Elsa.Http.Middleware;
 using Elsa.Http.Options;
@@ -14,6 +15,7 @@ namespace Elsa.Http.UnitTests.Middleware;
 
 public class HttpWorkflowsMiddlewareTests
 {
+    private static readonly MethodInfo ExecuteWithinTimeoutAsyncMethod = typeof(HttpWorkflowsMiddleware).GetMethod("ExecuteWithinTimeoutAsync", BindingFlags.Instance | BindingFlags.NonPublic)!;
     private const string CurrentTenantId = "tenant-a";
     private const string OtherTenantId = "tenant-b";
     private const string BookmarkHash = "http-endpoint:/colliding:get";
@@ -52,6 +54,63 @@ public class HttpWorkflowsMiddlewareTests
         Assert.NotNull(_bookmarkStore.LastFilter);
         var filter = _bookmarkStore.LastFilter!;
         Assert.False(filter.TenantAgnostic);
+    }
+
+    [Fact]
+    public async Task ExecuteWithinTimeoutAsync_RestoresRequestAbortedAfterSuccess()
+    {
+        using var requestAbortedSource = new CancellationTokenSource();
+        var httpContext = new DefaultHttpContext { RequestAborted = requestAbortedSource.Token };
+        var observedToken = CancellationToken.None;
+
+        var result = await ExecuteWithinTimeoutAsync(async cancellationToken =>
+        {
+            observedToken = cancellationToken;
+            Assert.Equal(cancellationToken, httpContext.RequestAborted);
+            await Task.CompletedTask;
+            return 42;
+        }, TimeSpan.FromSeconds(1), httpContext);
+
+        Assert.Equal(42, result);
+        Assert.NotEqual(requestAbortedSource.Token, observedToken);
+        Assert.Equal(requestAbortedSource.Token, httpContext.RequestAborted);
+    }
+
+    [Fact]
+    public async Task ExecuteWithinTimeoutAsync_RestoresRequestAbortedAfterFault()
+    {
+        using var requestAbortedSource = new CancellationTokenSource();
+        var httpContext = new DefaultHttpContext { RequestAborted = requestAbortedSource.Token };
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => ExecuteWithinTimeoutAsync<int>(_ => throw new InvalidOperationException("Boom"), TimeSpan.FromSeconds(1), httpContext));
+
+        Assert.Equal(requestAbortedSource.Token, httpContext.RequestAborted);
+    }
+
+    [Fact]
+    public async Task ExecuteWithinTimeoutAsync_RestoresRequestAbortedAfterCancellation()
+    {
+        using var requestAbortedSource = new CancellationTokenSource();
+        requestAbortedSource.Cancel();
+
+        var httpContext = new DefaultHttpContext { RequestAborted = requestAbortedSource.Token };
+        var observedToken = CancellationToken.None;
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => ExecuteWithinTimeoutAsync<int>(cancellationToken =>
+        {
+            observedToken = cancellationToken;
+            return Task.FromCanceled<int>(cancellationToken);
+        }, TimeSpan.FromSeconds(1), httpContext));
+
+        Assert.True(observedToken.IsCancellationRequested);
+        Assert.Equal(requestAbortedSource.Token, httpContext.RequestAborted);
+    }
+
+    private async Task<T> ExecuteWithinTimeoutAsync<T>(Func<CancellationToken, Task<T>> action, TimeSpan? requestTimeout, HttpContext httpContext)
+    {
+        var method = ExecuteWithinTimeoutAsyncMethod.MakeGenericMethod(typeof(T));
+        var task = (Task<T>)method.Invoke(_middleware, [action, requestTimeout, httpContext])!;
+        return await task;
     }
 
     private static IEnumerable<StoredBookmark> CreateCollidingHttpEndpointBookmarks()


### PR DESCRIPTION
## Summary
- restore `HttpContext.RequestAborted` with `try/finally` in `ExecuteWithinTimeoutAsync`
- add focused unit tests for success, fault, and cancellation paths around timeout token replacement
- keep the change scoped to the HTTP middleware slice for `#7706`

Fixes #7706.

## Testing
- unable to run local `dotnet test` in this Codex session because process startup is failing for all shell commands
- relying on targeted unit coverage in the PR plus GitHub validation
