### PR TITLE
Move HTTP base-path gate ahead of route matching

### DIFF
--- a/src/modules/Elsa.Http/Middleware/HttpWorkflowsMiddleware.cs
+++ b/src/modules/Elsa.Http/Middleware/HttpWorkflowsMiddleware.cs
@@ -40,21 +40,20 @@ public class HttpWorkflowsMiddleware(RequestDelegate next)
         IHttpWorkflowLookupService httpWorkflowLookupService)
     {
         var path = httpContext.Request.Path.Value!.NormalizeRoute();
-        var matchingPath = GetMatchingRoute(serviceProvider, path).Route;
         var basePath = options.Value.BasePath?.ToString().NormalizeRoute();
+        var hasBasePath = !string.IsNullOrWhiteSpace(basePath);
 
         // If the request path does not match the configured base path to handle workflows, then skip.
-        if (!string.IsNullOrWhiteSpace(basePath))
+        if (hasBasePath && !path.StartsWith(basePath, StringComparison.OrdinalIgnoreCase))
         {
-            if (!path.StartsWith(basePath, StringComparison.OrdinalIgnoreCase))
-            {
-                await next(httpContext);
-                return;
-            }
-
-            // Strip the base path.
-            matchingPath = matchingPath[basePath.Length..];
+            await next(httpContext);
+            return;
         }
+
+        var matchingPath = GetMatchingRoute(serviceProvider, path).Route;
+
+        if (hasBasePath)
+            matchingPath = matchingPath[basePath!.Length..];
 
         // Graceful-shutdown gate: when the runtime is paused or draining, we don't accept new HTTP-triggered work.
         // The ingress source registry visibility is provided by HttpTriggerIngressSource — this is the actual mechanism.

--- a/test/unit/Elsa.Http.UnitTests/Middleware/HttpWorkflowsMiddlewareTests.cs
+++ b/test/unit/Elsa.Http.UnitTests/Middleware/HttpWorkflowsMiddlewareTests.cs
@@ -115,10 +115,10 @@ public class HttpWorkflowsMiddlewareTests
         stimulusHasher ??= new CapturingStimulusHasher();
 
         return new ServiceCollection()
-            .AddSingleton(bookmarkStore)
-            .AddSingleton(routeMatcher)
-            .AddSingleton(routeTable)
-            .AddSingleton(stimulusHasher)
+            .AddSingleton<IBookmarkStore>(bookmarkStore)
+            .AddSingleton<IRouteMatcher>(routeMatcher)
+            .AddSingleton<IRouteTable>(routeTable)
+            .AddSingleton<IStimulusHasher>(stimulusHasher)
             .BuildServiceProvider();
     }
 

--- a/test/unit/Elsa.Http.UnitTests/Middleware/HttpWorkflowsMiddlewareTests.cs
+++ b/test/unit/Elsa.Http.UnitTests/Middleware/HttpWorkflowsMiddlewareTests.cs
@@ -17,41 +17,109 @@ public class HttpWorkflowsMiddlewareTests
     private const string CurrentTenantId = "tenant-a";
     private const string OtherTenantId = "tenant-b";
     private const string BookmarkHash = "http-endpoint:/colliding:get";
-
-    private readonly CapturingBookmarkStore _bookmarkStore;
-    private readonly IServiceProvider _serviceProvider;
-    private readonly HttpWorkflowsMiddleware _middleware = new(_ => Task.CompletedTask);
-
-    public HttpWorkflowsMiddlewareTests()
-    {
-        _bookmarkStore = new(CurrentTenantId, CreateCollidingHttpEndpointBookmarks());
-        _serviceProvider = new ServiceCollection()
-            .AddSingleton<IBookmarkStore>(_bookmarkStore)
-            .AddSingleton<IRouteMatcher, ExactRouteMatcher>()
-            .AddSingleton<IRouteTable>(new ListRouteTable([new(BookmarkPath)]))
-            .AddSingleton<IStimulusHasher, FixedStimulusHasher>()
-            .BuildServiceProvider();
-    }
+    private const string BookmarkPath = "/colliding";
+    private const string BasePath = "/workflows";
+    private const string WorkflowRequestPath = BasePath + BookmarkPath;
 
     [Fact]
     public async Task InvokeAsync_WithCollidingHttpEndpointBookmarks_UsesTenantScopedBookmarkLookup()
     {
-        var httpContext = new DefaultHttpContext
-        {
-            RequestServices = _serviceProvider
-        };
-        httpContext.Request.Path = BookmarkPath;
-        httpContext.Request.Method = HttpMethod.Get.Method;
+        var bookmarkStore = new CapturingBookmarkStore(CurrentTenantId, CreateCollidingHttpEndpointBookmarks());
+        var serviceProvider = CreateServiceProvider(bookmarkStore);
+        var middleware = CreateMiddleware();
+        var httpContext = CreateHttpContext(serviceProvider, BookmarkPath);
 
-        await _middleware.InvokeAsync(
+        await middleware.InvokeAsync(
             httpContext,
-            _serviceProvider,
+            serviceProvider,
             Microsoft.Extensions.Options.Options.Create(new HttpActivityOptions { BasePath = null }),
             new EmptyHttpWorkflowLookupService());
 
-        Assert.NotNull(_bookmarkStore.LastFilter);
-        var filter = _bookmarkStore.LastFilter!;
+        Assert.NotNull(bookmarkStore.LastFilter);
+        var filter = bookmarkStore.LastFilter!;
         Assert.False(filter.TenantAgnostic);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_OutsideConfiguredBasePath_SkipsRouteMatchingAndCallsNext()
+    {
+        var bookmarkStore = new CapturingBookmarkStore(CurrentTenantId, []);
+        var routeMatcher = new TrackingRouteMatcher();
+        var serviceProvider = CreateServiceProvider(bookmarkStore, routeMatcher: routeMatcher);
+        var nextCalled = false;
+        var middleware = CreateMiddleware(_ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        });
+        var httpContext = CreateHttpContext(serviceProvider, "/api/orders");
+
+        await middleware.InvokeAsync(
+            httpContext,
+            serviceProvider,
+            Microsoft.Extensions.Options.Options.Create(new HttpActivityOptions { BasePath = BasePath }),
+            new EmptyHttpWorkflowLookupService());
+
+        Assert.True(nextCalled);
+        Assert.Equal(0, routeMatcher.CallCount);
+        Assert.Null(bookmarkStore.LastFilter);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_WithinConfiguredBasePath_UsesMatchedRouteWithoutBasePathForBookmarkHash()
+    {
+        var bookmarkStore = new CapturingBookmarkStore(CurrentTenantId, []);
+        var routeMatcher = new TrackingRouteMatcher();
+        var stimulusHasher = new CapturingStimulusHasher();
+        var routeTable = new ListRouteTable([new(WorkflowRequestPath)]);
+        var serviceProvider = CreateServiceProvider(bookmarkStore, routeMatcher, routeTable, stimulusHasher);
+        var middleware = CreateMiddleware();
+        var httpContext = CreateHttpContext(serviceProvider, WorkflowRequestPath);
+
+        await middleware.InvokeAsync(
+            httpContext,
+            serviceProvider,
+            Microsoft.Extensions.Options.Options.Create(new HttpActivityOptions { BasePath = BasePath }),
+            new EmptyHttpWorkflowLookupService());
+
+        Assert.Equal(1, routeMatcher.CallCount);
+        Assert.Equal(WorkflowRequestPath, routeMatcher.LastRouteTemplate);
+        Assert.Equal(WorkflowRequestPath, routeMatcher.LastRoute);
+        Assert.NotNull(stimulusHasher.LastPayload);
+        Assert.Equal(BookmarkPath, stimulusHasher.LastPayload!.Path);
+        Assert.Equal("get", stimulusHasher.LastPayload.Method);
+        Assert.Equal(StatusCodes.Status404NotFound, httpContext.Response.StatusCode);
+    }
+
+    private static HttpWorkflowsMiddleware CreateMiddleware(RequestDelegate? next = null) => new(next ?? (_ => Task.CompletedTask));
+
+    private static DefaultHttpContext CreateHttpContext(IServiceProvider serviceProvider, string path)
+    {
+        var httpContext = new DefaultHttpContext
+        {
+            RequestServices = serviceProvider
+        };
+        httpContext.Request.Path = path;
+        httpContext.Request.Method = HttpMethod.Get.Method;
+        return httpContext;
+    }
+
+    private static IServiceProvider CreateServiceProvider(
+        IBookmarkStore bookmarkStore,
+        IRouteMatcher? routeMatcher = null,
+        IRouteTable? routeTable = null,
+        IStimulusHasher? stimulusHasher = null)
+    {
+        routeMatcher ??= new ExactRouteMatcher();
+        routeTable ??= new ListRouteTable([new(BookmarkPath)]);
+        stimulusHasher ??= new CapturingStimulusHasher();
+
+        return new ServiceCollection()
+            .AddSingleton(bookmarkStore)
+            .AddSingleton(routeMatcher)
+            .AddSingleton(routeTable)
+            .AddSingleton(stimulusHasher)
+            .BuildServiceProvider();
     }
 
     private static IEnumerable<StoredBookmark> CreateCollidingHttpEndpointBookmarks()
@@ -60,15 +128,13 @@ public class HttpWorkflowsMiddlewareTests
         yield return CreateBookmark("other-tenant-bookmark", OtherTenantId);
     }
 
-    private const string BookmarkPath = "/colliding";
-
     private static StoredBookmark CreateBookmark(string id, string tenantId) => new()
     {
         Id = id,
         TenantId = tenantId,
         Hash = BookmarkHash,
         WorkflowInstanceId = $"{id}-workflow-instance",
-        Payload = new HttpEndpointBookmarkPayload("/colliding", "get")
+        Payload = new HttpEndpointBookmarkPayload(BookmarkPath, "get")
     };
 
     private class CapturingBookmarkStore(string currentTenantId, IEnumerable<StoredBookmark> bookmarks) : IBookmarkStore
@@ -130,14 +196,35 @@ public class HttpWorkflowsMiddlewareTests
         public Task<HttpWorkflowLookupResult?> FindWorkflowAsync(string bookmarkHash, CancellationToken cancellationToken = default) => Task.FromResult<HttpWorkflowLookupResult?>(null);
     }
 
-    private class FixedStimulusHasher : IStimulusHasher
+    private class CapturingStimulusHasher : IStimulusHasher
     {
-        public string Hash(string stimulusName, object? payload = null, string? activityInstanceId = null) => BookmarkHash;
+        public HttpEndpointBookmarkPayload? LastPayload { get; private set; }
+
+        public string Hash(string stimulusName, object? payload = null, string? activityInstanceId = null)
+        {
+            LastPayload = payload as HttpEndpointBookmarkPayload;
+            return BookmarkHash;
+        }
     }
 
     private class ExactRouteMatcher : IRouteMatcher
     {
         public RouteValueDictionary? Match(string routeTemplate, string route) => routeTemplate == route ? new() : null;
+    }
+
+    private class TrackingRouteMatcher : IRouteMatcher
+    {
+        public int CallCount { get; private set; }
+        public string? LastRouteTemplate { get; private set; }
+        public string? LastRoute { get; private set; }
+
+        public RouteValueDictionary? Match(string routeTemplate, string route)
+        {
+            CallCount++;
+            LastRouteTemplate = routeTemplate;
+            LastRoute = route;
+            return routeTemplate == route ? new() : null;
+        }
     }
 
     private class ListRouteTable(IEnumerable<HttpRouteData> routes) : IRouteTable


### PR DESCRIPTION
## Summary
- skip route-table matching for requests outside the configured HTTP workflow base path
- preserve route matching behavior for requests under the base path before stripping it
- add focused middleware tests for the early-exit and in-scope matching paths

## Testing
- not run locally in this session; local shell/process startup is unavailable here

Closes #7709