### PR TITLE
Enhancement: Elsa 2 - EFCore persistence, better support for net10 (excludes MySql - Pomelo)

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
 
     mongodb:
@@ -19,8 +17,8 @@ services:
         volumes:
             - pgdata:/var/lib/postgresql/data
           
-    mysql:
-        image: mysql:5.7
+    mysql-v8:
+        image: mysql:8
         restart: always
         environment:
             MYSQL_DATABASE: 'elsa'
@@ -28,20 +26,7 @@ services:
             MYSQL_PASSWORD: 'password'
             MYSQL_ROOT_PASSWORD: 'password'
         ports:
-            - '3306:3306'
-        expose:
-            - '3306'
-                
-    mysql-arm:
-        image: arm64v8/mysql:8
-        restart: always
-        environment:
-            MYSQL_DATABASE: 'Elsa'
-            MYSQL_USER: 'user'
-            MYSQL_PASSWORD: 'password'
-            MYSQL_ROOT_PASSWORD: 'password'
-        ports:
-            - '3306:3306'
+            - '3306:3306' 
         expose:
             - '3306'
                 
@@ -58,8 +43,14 @@ services:
         ports:
             - "1433:1433"
 
+    # Azurite (Official Microsoft Local Emulator)
     azureblobstorage:
-        image: mcr.microsoft.com/azure-blob-storage
+        image: mcr.microsoft.com/azure-storage/azurite
+        restart: always
+        ports:
+            - "10000:10000" # Blob service port
+            - "10001:10001" # Queue service port
+            - "10002:10002" # Table service port
 
     redis:
         image: redis

--- a/src/activities/Elsa.Activities.Http.OpenApi/Elsa.Activities.Http.OpenApi.csproj
+++ b/src/activities/Elsa.Activities.Http.OpenApi/Elsa.Activities.Http.OpenApi.csproj
@@ -19,17 +19,22 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.3.0" />
-    </ItemGroup>
-
-    <ItemGroup>
       <ProjectReference Include="..\Elsa.Activities.Http\Elsa.Activities.Http.csproj" />
     </ItemGroup>
 
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0'">
+        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.3.0" />
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0'">
+        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.3.0" />
+    </ItemGroup>
+
     <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0'">
-        <PackageReference Include="System.Linq.Async" Version="6.0.1">
-            <ExcludeAssets>compile</ExcludeAssets>
-        </PackageReference>
+      <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.1.7" />
+      <PackageReference Include="System.Linq.Async" Version="6.0.1">
+          <ExcludeAssets>compile</ExcludeAssets>
+      </PackageReference>
     </ItemGroup>
 
 

--- a/src/activities/Elsa.Activities.Http.OpenApi/Elsa.Activities.Http.OpenApi.csproj
+++ b/src/activities/Elsa.Activities.Http.OpenApi/Elsa.Activities.Http.OpenApi.csproj
@@ -31,7 +31,7 @@
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0'">
-      <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.1.7" />
+      <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.2.3" />
       <PackageReference Include="System.Linq.Async" Version="6.0.1">
           <ExcludeAssets>compile</ExcludeAssets>
       </PackageReference>

--- a/src/activities/Elsa.Activities.Http.OpenApi/HttpEndpointDocumentFilter.cs
+++ b/src/activities/Elsa.Activities.Http.OpenApi/HttpEndpointDocumentFilter.cs
@@ -1,4 +1,4 @@
-﻿using System.Runtime.CompilerServices;
+using System.Runtime.CompilerServices;
 using Elsa.Activities.Http.Bookmarks;
 using Elsa.Activities.Http.Options;
 using Elsa.Models;
@@ -7,7 +7,11 @@ using Elsa.Services.Models;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+#if NET10_0_OR_GREATER
+using Microsoft.OpenApi;
+#else
 using Microsoft.OpenApi.Models;
+#endif
 using Open.Linq.AsyncExtensions;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
@@ -31,12 +35,16 @@ public class HttpEndpointDocumentFilter : IDocumentFilter
 
     public void Apply(OpenApiDocument swaggerDoc, DocumentFilterContext context)
     {
+#if NET10_0_OR_GREATER
+        swaggerDoc.Tags ??= new HashSet<OpenApiTag>();
+#else
         swaggerDoc.Tags ??= new List<OpenApiTag>();
+#endif
 
         var tag = new OpenApiTag
         {
             Name = "Workflow Endpoints",
-            Description = "A collection of HTTP endpoints exposed by workflows",
+            Description = "A collection of HTTP endpoints exposed by workflows"
         };
 
         var schemaRepository = context.SchemaRepository;
@@ -55,17 +63,21 @@ public class HttpEndpointDocumentFilter : IDocumentFilter
                 Description = first.Description,
                 Operations = grouping.ToDictionary(GetOperationType, httpEndpoint =>
                 {
-                    var operation = new OpenApiOperation
-                    {
-                        Tags = { tag },
-                    };
+                    var operation = new OpenApiOperation();
 
-                    if (httpEndpoint.TargetType != null || httpEndpoint.JsonSchema != null)
+#if NET10_0_OR_GREATER
+                    operation.Tags ??= new HashSet<OpenApiTagReference>();
+                    operation.Tags.Add(new OpenApiTagReference(tag.Name, swaggerDoc));
+#else
+                    operation.Tags.Add(tag);
+#endif
+
+                    if (httpEndpoint.TargetType != null || !string.IsNullOrWhiteSpace(httpEndpoint.JsonSchema))
                     {
                         operation.RequestBody = new OpenApiRequestBody
                         {
                             Required = true,
-                            Content =
+                            Content = new Dictionary<string, OpenApiMediaType>
                             {
                                 ["Unspecified"] = new OpenApiMediaType
                                 {
@@ -126,6 +138,21 @@ public class HttpEndpointDocumentFilter : IDocumentFilter
         return new HttpEndpointDescriptor(activityId, path, method, displayName, description, targetType, schema);
     }
 
+#if NET10_0_OR_GREATER
+    private HttpMethod GetOperationType(HttpEndpointDescriptor httpEndpoint) =>
+        httpEndpoint.Method switch
+        {
+            { } s when s.Equals(HttpMethods.Get, StringComparison.OrdinalIgnoreCase) => HttpMethod.Get,
+            { } s when s.Equals(HttpMethods.Post, StringComparison.OrdinalIgnoreCase) => HttpMethod.Post,
+            { } s when s.Equals(HttpMethods.Patch, StringComparison.OrdinalIgnoreCase) => HttpMethod.Patch,
+            { } s when s.Equals(HttpMethods.Delete, StringComparison.OrdinalIgnoreCase) => HttpMethod.Delete,
+            { } s when s.Equals(HttpMethods.Put, StringComparison.OrdinalIgnoreCase) => HttpMethod.Put,
+            { } s when s.Equals(HttpMethods.Options, StringComparison.OrdinalIgnoreCase) => HttpMethod.Options,
+            { } s when s.Equals(HttpMethods.Head, StringComparison.OrdinalIgnoreCase) => HttpMethod.Head,
+            { } s when s.Equals(HttpMethods.Trace, StringComparison.OrdinalIgnoreCase) => HttpMethod.Trace,
+            _ => HttpMethod.Get
+        };
+#else
     private OperationType GetOperationType(HttpEndpointDescriptor httpEndpoint) =>
         httpEndpoint.Method switch
         {
@@ -133,12 +160,13 @@ public class HttpEndpointDocumentFilter : IDocumentFilter
             { } s when s.Equals(HttpMethods.Post, StringComparison.OrdinalIgnoreCase) => OperationType.Post,
             { } s when s.Equals(HttpMethods.Patch, StringComparison.OrdinalIgnoreCase) => OperationType.Patch,
             { } s when s.Equals(HttpMethods.Delete, StringComparison.OrdinalIgnoreCase) => OperationType.Delete,
-            { } s when s.Equals(HttpMethods.Put, StringComparison.OrdinalIgnoreCase) => OperationType.Patch,
+            { } s when s.Equals(HttpMethods.Put, StringComparison.OrdinalIgnoreCase) => OperationType.Put,
             { } s when s.Equals(HttpMethods.Options, StringComparison.OrdinalIgnoreCase) => OperationType.Options,
             { } s when s.Equals(HttpMethods.Head, StringComparison.OrdinalIgnoreCase) => OperationType.Head,
             { } s when s.Equals(HttpMethods.Trace, StringComparison.OrdinalIgnoreCase) => OperationType.Trace,
             _ => OperationType.Get
         };
+#endif
 }
 
 internal record HttpEndpointDescriptor(string Id, string Path, string Method, string? DisplayName, string? Description, Type? TargetType, string? JsonSchema);

--- a/src/activities/Elsa.Activities.Telnyx/Elsa.Activities.Telnyx.csproj
+++ b/src/activities/Elsa.Activities.Telnyx/Elsa.Activities.Telnyx.csproj
@@ -28,7 +28,7 @@
         <PackageReference Include="Refit" Version="8.0.0" />
         <PackageReference Include="Refit.HttpClientFactory" Version="6.0.94" />
         <PackageReference Include="Refit.Newtonsoft.Json" Version="6.0.94" />
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0'">

--- a/src/activities/Elsa.Activities.Temporal.Quartz/Elsa.Activities.Temporal.Quartz.csproj
+++ b/src/activities/Elsa.Activities.Temporal.Quartz/Elsa.Activities.Temporal.Quartz.csproj
@@ -12,7 +12,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.16" />
         <PackageReference Include="Quartz" Version="3.5.0" />
         <PackageReference Include="Quartz.Extensions.DependencyInjection" Version="3.5.0" />
         <PackageReference Include="Quartz.Extensions.Hosting" Version="3.5.0" />

--- a/src/activities/webhooks/Elsa.Activities.Webhooks/Elsa.Activities.Webhooks.csproj
+++ b/src/activities/webhooks/Elsa.Activities.Webhooks/Elsa.Activities.Webhooks.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <Import Project="..\..\..\..\common.props" />
     <Import Project="..\..\..\..\configureawait.props" />
@@ -13,8 +13,8 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/activities/webhooks/Elsa.Webhooks.Persistence.EntityFramework.MySql/Elsa.Webhooks.Persistence.EntityFramework.MySql.csproj
+++ b/src/activities/webhooks/Elsa.Webhooks.Persistence.EntityFramework.MySql/Elsa.Webhooks.Persistence.EntityFramework.MySql.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\..\configureawait.props" />
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
         <Description>
             Elsa is a set of workflow libraries and tools that enable lean and mean workflowing capabilities in any .NET Core application.
             This package provides the MySql EF Core provider for Webhook persistence.
@@ -17,7 +17,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.0-beta.2" />
+        <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.3" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0'">
@@ -25,15 +25,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="9.0.0-preview.2.efcore.9.0.0" />
-    </ItemGroup>
-
-    <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0'">
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.1">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="9.0.0-preview.2.efcore.9.0.0" />
+        <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="9.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/activities/webhooks/Elsa.Webhooks.Persistence.EntityFramework.PostgreSql/Elsa.Webhooks.Persistence.EntityFramework.PostgreSql.csproj
+++ b/src/activities/webhooks/Elsa.Webhooks.Persistence.EntityFramework.PostgreSql/Elsa.Webhooks.Persistence.EntityFramework.PostgreSql.csproj
@@ -29,7 +29,7 @@
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0'">
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/activities/webhooks/Elsa.Webhooks.Persistence.EntityFramework.SqlServer/Elsa.Webhooks.Persistence.EntityFramework.SqlServer.csproj
+++ b/src/activities/webhooks/Elsa.Webhooks.Persistence.EntityFramework.SqlServer/Elsa.Webhooks.Persistence.EntityFramework.SqlServer.csproj
@@ -29,7 +29,7 @@
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0'">
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/activities/webhooks/Elsa.Webhooks.Persistence.EntityFramework.Sqlite/Elsa.Webhooks.Persistence.EntityFramework.Sqlite.csproj
+++ b/src/activities/webhooks/Elsa.Webhooks.Persistence.EntityFramework.Sqlite/Elsa.Webhooks.Persistence.EntityFramework.Sqlite.csproj
@@ -29,7 +29,7 @@
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0'">
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/clients/Elsa.Client/Elsa.Client.csproj
+++ b/src/clients/Elsa.Client/Elsa.Client.csproj
@@ -13,7 +13,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="NodaTime" Version="3.0.9" />
         <PackageReference Include="NodaTime.Serialization.JsonNet" Version="3.0.0" />
         <PackageReference Include="Refit" Version="8.0.0" />

--- a/src/core/Elsa.Abstractions/Elsa.Abstractions.csproj
+++ b/src/core/Elsa.Abstractions/Elsa.Abstractions.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <Import Project="..\..\..\common.props" />
     <Import Project="..\..\..\configureawait.props" />
@@ -18,17 +18,18 @@
         <PackageReference Include="LinqKit.Core" Version="1.2.5" />
         <PackageReference Include="MediatR" Version="12.4.1" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.1" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.16" />
         <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="8.0.1" />
         <PackageReference Include="Microsoft.Extensions.Primitives" Version="6.0.0" />
         <PackageReference Include="NodaTime" Version="3.0.9" />
         <PackageReference Include="NodaTime.Serialization.JsonNet" Version="3.0.0" />
         <PackageReference Include="Open.Linq.AsyncExtensions" Version="1.2.0" />
-        <PackageReference Include="Rebus" Version="8.7.1" />
+        <PackageReference Include="Rebus" Version="8.9.2" />
         <PackageReference Include="System.Linq.Async" Version="5.1.0" />
-        <PackageReference Include="System.Text.Json" Version="9.0.1" />
-        <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
+        <PackageReference Include="System.Text.Json" Version="10.0.8" />
+        <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
     </ItemGroup>
 
 </Project>

--- a/src/core/Elsa.Core/Elsa.Core.csproj
+++ b/src/core/Elsa.Core/Elsa.Core.csproj
@@ -23,12 +23,11 @@
         <PackageReference Include="MediatR" Version="12.4.1" />
         <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="9.0.1" />
         <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.1" />
         <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
         <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.0" />
         <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16" />
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.1" />
         <PackageReference Include="Microsoft.Extensions.Localization" Version="9.0.1" />
         <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
@@ -36,8 +35,8 @@
         <PackageReference Include="netbox" Version="2.5.3" />
         <PackageReference Include="NodaTime.Serialization.JsonNet" Version="3.0.0" />
         <PackageReference Include="Open.Linq.AsyncExtensions" Version="1.2.0" />
-        <PackageReference Include="Rebus.Microsoft.Extensions.Logging" Version="5.1.0" />
-        <PackageReference Include="Rebus.ServiceProvider" Version="10.3.0" />
+        <PackageReference Include="Rebus.Microsoft.Extensions.Logging" Version="5.2.0" />
+        <PackageReference Include="Rebus.ServiceProvider" Version="10.7.2" />
         <PackageReference Include="Scrutor" Version="3.3.0" />
         <PackageReference Include="System.Linq.Async" Version="5.1.0" />
         <PackageReference Include="System.Threading.Channels" Version="9.0.0" />

--- a/src/core/Elsa.Core/HostedServices/StartupRunnerHostedService.cs
+++ b/src/core/Elsa.Core/HostedServices/StartupRunnerHostedService.cs
@@ -1,24 +1,48 @@
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 using Elsa.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Elsa.HostedServices
 {
-    public class StartupRunnerHostedService : IHostedService
+    /// <summary>
+    /// A background service that executes the startup runner when the application starts.
+    /// </summary>
+    public class StartupRunnerHostedService : BackgroundService
     {
         private readonly IServiceProvider _serviceProvider;
-        public StartupRunnerHostedService(IServiceProvider serviceProvider) => _serviceProvider = serviceProvider;
+        private readonly ILogger<StartupRunnerHostedService> _logger;
 
-        public async Task StartAsync(CancellationToken cancellationToken)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StartupRunnerHostedService"/> class.
+        /// </summary>
+        /// <param name="serviceProvider">The service provider used to resolve the startup runner.</param>
+        /// <param name="logger">The logger for logging startup task execution and errors.</param>
+        public StartupRunnerHostedService(IServiceProvider serviceProvider, ILogger<StartupRunnerHostedService> logger)
         {
-            using var scope = _serviceProvider.CreateScope();
-            var startupRunner = scope.ServiceProvider.GetRequiredService<IStartupRunner>();
-            await startupRunner.StartupAsync(cancellationToken);
+            _serviceProvider = serviceProvider;
+            _logger = logger;
         }
 
-        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        /// <summary>
+        /// Executes the startup runner to perform application initialization tasks.
+        /// </summary>
+        /// <param name="stoppingToken">A cancellation token that is triggered when the application is shutting down.</param>
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            try
+            {
+                await using var scope = _serviceProvider.CreateAsyncScope();
+                var startupRunner = scope.ServiceProvider.GetRequiredService<IStartupRunner>();
+                await startupRunner.StartupAsync(stoppingToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "An error occurred while executing startup tasks");
+            }
+        }
     }
 }

--- a/src/core/Elsa.Core/Runtime/StartupRunner.cs
+++ b/src/core/Elsa.Core/Runtime/StartupRunner.cs
@@ -1,11 +1,11 @@
+using Elsa.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Elsa.Services;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 
 namespace Elsa.Runtime
 {
@@ -25,13 +25,14 @@ namespace Elsa.Runtime
         public async Task StartupAsync(CancellationToken cancellationToken = default)
         {
             // TODO: Register Startup Types the same way Activity Types are registered.
-            
+
             foreach (var startupTaskType in _startupTaskTypes)
             {
                 await using var scope = _scopeFactory.CreateAsyncScope();
                 var startupTask = (IStartupTask)scope.ServiceProvider.GetRequiredService(startupTaskType);
                 _logger.LogInformation("Running startup task {StartupTaskName}", startupTaskType.Name);
                 await startupTask.ExecuteAsync(cancellationToken);
+                _logger.LogInformation("Completed startup task {StartupTaskName}", startupTaskType.Name);
             }
         }
     }

--- a/src/core/Elsa/Elsa.csproj
+++ b/src/core/Elsa/Elsa.csproj
@@ -20,7 +20,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
+      <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.16" />
     </ItemGroup>
 
 </Project>

--- a/src/designer/elsa-workflows-studio/src/globals/tailwind.css
+++ b/src/designer/elsa-workflows-studio/src/globals/tailwind.css
@@ -2510,6 +2510,10 @@ select {
   left: 0.5rem;
 }
 
+.elsa-top-10 {
+  top: 2.5rem;
+}
+
 .elsa-bottom-10 {
   bottom: 2.5rem;
 }
@@ -2653,12 +2657,16 @@ select {
   margin-top: 4rem;
 }
 
-.elsa--mt-2 {
-  margin-top: -0.5rem;
-}
-
 .elsa-mb-2 {
   margin-bottom: 0.5rem;
+}
+
+.-elsa-mr-1 {
+  margin-right: -0.25rem;
+}
+
+.elsa--mt-2 {
+  margin-top: -0.5rem;
 }
 
 .-elsa-ml-0\.5 {
@@ -2675,10 +2683,6 @@ select {
 
 .elsa-ml-0 {
   margin-left: 0px;
-}
-
-.-elsa-mr-1 {
-  margin-right: -0.25rem;
 }
 
 .elsa-ml-3\.5 {
@@ -12427,10 +12431,6 @@ svg.jtk-connector.jtk-hover path {
 
   .sm\:elsa-w-full {
     width: 100%;
-  }
-
-  .sm\:elsa-max-w-4xl {
-    max-width: 56rem;
   }
 
   .sm\:elsa-max-w-md {

--- a/src/indexing/Elsa.Indexing.Elasticsearch/Elsa.Indexing.Elasticsearch.csproj
+++ b/src/indexing/Elsa.Indexing.Elasticsearch/Elsa.Indexing.Elasticsearch.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
     <Import Project="..\..\..\common.props" />
     <Import Project="..\..\..\configureawait.props" />
     
@@ -18,7 +18,7 @@
 
     <ItemGroup>
       <PackageReference Include="NEST" Version="7.14.1" />
-      <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+      <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
 </Project>

--- a/src/modules/secrets/Elsa.Secrets.Api/Endpoints/OAuth2/Callback.cs
+++ b/src/modules/secrets/Elsa.Secrets.Api/Endpoints/OAuth2/Callback.cs
@@ -1,11 +1,12 @@
-using System.Threading;
-using System.Threading.Tasks;
 using Elsa.Secrets.Extensions;
 using Elsa.Secrets.Http.Services;
 using Elsa.Secrets.Manager;
 using Elsa.Secrets.Persistence;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Elsa.Secrets.Api.Endpoints.OAuth2
 {
@@ -13,6 +14,7 @@ namespace Elsa.Secrets.Api.Endpoints.OAuth2
     [ApiVersion("1")]
     [Route("v{apiVersion:apiVersion}/oauth2/callback")]
     [Produces("application/json")]
+    [Tags("Secrets")]
     public class SetAuthCodeCallback : Controller
     {
         private readonly ISecretsManager _secretsManager;

--- a/src/modules/secrets/Elsa.Secrets.Api/Endpoints/OAuth2/GetUrl.cs
+++ b/src/modules/secrets/Elsa.Secrets.Api/Endpoints/OAuth2/GetUrl.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Net.Mime;
 using System.Threading;
@@ -16,6 +16,7 @@ namespace Elsa.Secrets.Api.Endpoints.OAuth2;
 [ApiVersion("1")]
 [Route("v{apiVersion:apiVersion}/oauth2/url/{secretId}")]
 [Produces(MediaTypeNames.Application.Json)]
+[Tags("Secrets")]
 public class GetUrl : Controller
 {
 	private readonly ISecretsManager _secretsManager;

--- a/src/modules/secrets/Elsa.Secrets.Api/Endpoints/Secrets/Delete.cs
+++ b/src/modules/secrets/Elsa.Secrets.Api/Endpoints/Secrets/Delete.cs
@@ -11,6 +11,7 @@ namespace Elsa.Secrets.Api.Endpoints.Secrets
     [ApiVersion("1")]
     [Route("v{apiVersion:apiVersion}/secrets/{id}")]
     [Produces("application/json")]
+    [Tags("Secrets")]
     public class Delete : Controller
     {
         private readonly ISecretsStore _secretsStore;

--- a/src/modules/secrets/Elsa.Secrets.Api/Endpoints/Secrets/List.cs
+++ b/src/modules/secrets/Elsa.Secrets.Api/Endpoints/Secrets/List.cs
@@ -15,6 +15,7 @@ namespace Elsa.Secrets.Api.Endpoints.Secrets
     [ApiVersion("1")]
     [Route("v{apiVersion:apiVersion}/secrets")]
     [Produces(MediaTypeNames.Application.Json)]
+    [Tags("Secrets")]
     public class List : Controller
     {
         private readonly ISecretsManager _secretsManager;

--- a/src/modules/secrets/Elsa.Secrets.Api/Endpoints/Secrets/Save.cs
+++ b/src/modules/secrets/Elsa.Secrets.Api/Endpoints/Secrets/Save.cs
@@ -1,10 +1,11 @@
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Elsa.Secrets.Api.Models;
 using Elsa.Secrets.Manager;
 using Elsa.Secrets.Models;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Elsa.Secrets.Api.Endpoints.Secrets
 {
@@ -12,6 +13,7 @@ namespace Elsa.Secrets.Api.Endpoints.Secrets
     [ApiVersion("1")]
     [Route("v{apiVersion:apiVersion}/secrets")]
     [Produces("application/json")]
+    [Tags("Secrets")]
     public class Save : Controller
     {
         private readonly ISecretsManager _secretsManager;

--- a/src/modules/secrets/Elsa.Secrets.Http/Elsa.Secrets.Http.csproj
+++ b/src/modules/secrets/Elsa.Secrets.Http/Elsa.Secrets.Http.csproj
@@ -12,7 +12,7 @@
     </PropertyGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0'">
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.1" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.16" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0'">

--- a/src/modules/secrets/Elsa.Secrets.Persistence.EntityFramework.MySql/Elsa.Secrets.Persistence.EntityFramework.MySql.csproj
+++ b/src/modules/secrets/Elsa.Secrets.Persistence.EntityFramework.MySql/Elsa.Secrets.Persistence.EntityFramework.MySql.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\..\configureawait.props"/>
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
         <Description>
             Elsa Secrets Entity Framework MySql is an optional part of Elsa Workflows.
         </Description>
@@ -20,13 +20,6 @@
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0'">
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.1">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
-
-    <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0'">
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/modules/secrets/Elsa.Secrets.Persistence.EntityFramework.SqlServer/Elsa.Secrets.Persistence.EntityFramework.SqlServer.csproj
+++ b/src/modules/secrets/Elsa.Secrets.Persistence.EntityFramework.SqlServer/Elsa.Secrets.Persistence.EntityFramework.SqlServer.csproj
@@ -25,7 +25,7 @@
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0'">
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/modules/secrets/Elsa.Secrets.Persistence.EntityFramework.Sqlite/Elsa.Secrets.Persistence.EntityFramework.Sqlite.csproj
+++ b/src/modules/secrets/Elsa.Secrets.Persistence.EntityFramework.Sqlite/Elsa.Secrets.Persistence.EntityFramework.Sqlite.csproj
@@ -28,7 +28,7 @@
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0'">
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/modules/secrets/Elsa.Secrets.Sql/Elsa.Secrets.Sql.csproj
+++ b/src/modules/secrets/Elsa.Secrets.Sql/Elsa.Secrets.Sql.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient" Version="3.1.7" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.16" />
     <PackageReference Include="Npgsql" Version="6.0.11" />
   </ItemGroup>
 

--- a/src/modules/secrets/Elsa.Secrets/Elsa.Secrets.csproj
+++ b/src/modules/secrets/Elsa.Secrets/Elsa.Secrets.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.16" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/modules/workflowsettings/Elsa.WorkflowSettings.Persistence.EntityFramework.MySql/Elsa.WorkflowSettings.Persistence.EntityFramework.MySql.csproj
+++ b/src/modules/workflowsettings/Elsa.WorkflowSettings.Persistence.EntityFramework.MySql/Elsa.WorkflowSettings.Persistence.EntityFramework.MySql.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\..\configureawait.props" />
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
         <Description>
             Elsa Workflow Settings is an optional part of Elsa Workflows.
             This package provides Entity Framework Core migrations for the MySql database provider.
@@ -21,13 +21,6 @@
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0'">
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.1">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
-
-    <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0'">
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/modules/workflowsettings/Elsa.WorkflowSettings.Persistence.EntityFramework.PostgreSql/Elsa.WorkflowSettings.Persistence.EntityFramework.PostgreSql.csproj
+++ b/src/modules/workflowsettings/Elsa.WorkflowSettings.Persistence.EntityFramework.PostgreSql/Elsa.WorkflowSettings.Persistence.EntityFramework.PostgreSql.csproj
@@ -29,7 +29,7 @@
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0'">
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/modules/workflowsettings/Elsa.WorkflowSettings.Persistence.EntityFramework.SqlServer/Elsa.WorkflowSettings.Persistence.EntityFramework.SqlServer.csproj
+++ b/src/modules/workflowsettings/Elsa.WorkflowSettings.Persistence.EntityFramework.SqlServer/Elsa.WorkflowSettings.Persistence.EntityFramework.SqlServer.csproj
@@ -29,7 +29,7 @@
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0'">
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/modules/workflowsettings/Elsa.WorkflowSettings.Persistence.EntityFramework.Sqlite/Elsa.WorkflowSettings.Persistence.EntityFramework.Sqlite.csproj
+++ b/src/modules/workflowsettings/Elsa.WorkflowSettings.Persistence.EntityFramework.Sqlite/Elsa.WorkflowSettings.Persistence.EntityFramework.Sqlite.csproj
@@ -29,7 +29,7 @@
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0'">
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/modules/workflowsettings/Elsa.WorkflowSettings/Elsa.WorkflowSettings.csproj
+++ b/src/modules/workflowsettings/Elsa.WorkflowSettings/Elsa.WorkflowSettings.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <Import Project="..\..\..\..\common.props" />
     <Import Project="..\..\..\..\configureawait.props" />
@@ -13,7 +13,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/Elsa.Persistence.EntityFramework.Core.csproj
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Core/Elsa.Persistence.EntityFramework.Core.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\..\configureawait.props" />
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.1;net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.1;net8.0;net9.0;net10.0</TargetFrameworks>
         <Description>
             Elsa is a set of workflow libraries and tools that enable lean and mean workflowing capabilities in any .NET Core application.
             This package provides Entity Framework Core entities used by the various Elsa persistence EF Core providers.
@@ -28,8 +28,8 @@
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0'">
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.MySql/Elsa.Persistence.EntityFramework.MySql.csproj
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.MySql/Elsa.Persistence.EntityFramework.MySql.csproj
@@ -4,7 +4,7 @@
     <Import Project="..\..\..\..\configureawait.props" />
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
         <Description>
             Elsa is a set of workflow libraries and tools that enable lean and mean workflowing capabilities in any .NET Core application.
             This package provides Entity Framework Core migrations for the MySql database provider.
@@ -21,7 +21,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.0-beta.2" />
+        <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.3" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0'">
@@ -29,15 +29,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="9.0.0-preview.2.efcore.9.0.0" />
-    </ItemGroup>
-
-    <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0'">
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.1">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="9.0.0-preview.2.efcore.9.0.0" />
+        <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="9.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Oracle/Elsa.Persistence.EntityFramework.Oracle.csproj
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Oracle/Elsa.Persistence.EntityFramework.Oracle.csproj
@@ -33,11 +33,11 @@
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0'">
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Oracle.EntityFrameworkCore" Version="10.0.0" />
+        <PackageReference Include="Oracle.EntityFrameworkCore" Version="10.23.26000" />
     </ItemGroup>
 
 </Project>

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.PostgreSql/Elsa.Persistence.EntityFramework.PostgreSql.csproj
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.PostgreSql/Elsa.Persistence.EntityFramework.PostgreSql.csproj
@@ -33,7 +33,7 @@
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0'">
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.SqlServer/Elsa.Persistence.EntityFramework.SqlServer.csproj
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.SqlServer/Elsa.Persistence.EntityFramework.SqlServer.csproj
@@ -29,7 +29,7 @@
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0'">
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Sqlite/Elsa.Persistence.EntityFramework.Sqlite.csproj
+++ b/src/persistence/Elsa.Persistence.EntityFramework/Elsa.Persistence.EntityFramework.Sqlite/Elsa.Persistence.EntityFramework.Sqlite.csproj
@@ -33,7 +33,7 @@
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0'">
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/samples/aspnet/Elsa.Samples.ContextualWorkflowHttp/Elsa.Samples.ContextualWorkflowHttp.csproj
+++ b/src/samples/aspnet/Elsa.Samples.ContextualWorkflowHttp/Elsa.Samples.ContextualWorkflowHttp.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/aspnet/Elsa.Samples.CorrelationHttp/Elsa.Samples.CorrelationHttp.csproj
+++ b/src/samples/aspnet/Elsa.Samples.CorrelationHttp/Elsa.Samples.CorrelationHttp.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/aspnet/Elsa.Samples.CustomActivities/Elsa.Samples.CustomActivities.csproj
+++ b/src/samples/aspnet/Elsa.Samples.CustomActivities/Elsa.Samples.CustomActivities.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/aspnet/Elsa.Samples.DocumentApproval/Elsa.Samples.DocumentApproval.csproj
+++ b/src/samples/aspnet/Elsa.Samples.DocumentApproval/Elsa.Samples.DocumentApproval.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/aspnet/Elsa.Samples.ExtendHttpEndpoint/Elsa.Samples.ExtendHttpEndpoint.csproj
+++ b/src/samples/aspnet/Elsa.Samples.ExtendHttpEndpoint/Elsa.Samples.ExtendHttpEndpoint.csproj
@@ -16,7 +16,6 @@
         <ProjectReference Include="..\..\..\designer\bindings\aspnet\Elsa.Designer.Components.Web\Elsa.Designer.Components.Web.csproj" />
         <ProjectReference Include="..\..\..\persistence\Elsa.Persistence.EntityFramework\Elsa.Persistence.EntityFramework.Sqlite\Elsa.Persistence.EntityFramework.Sqlite.csproj" />
         <ProjectReference Include="..\..\..\server\Elsa.Server.Api\Elsa.Server.Api.csproj" />
-        <ProjectReference Include="..\..\persistence\Elsa.Samples.Persistence.EntityFramework\Elsa.Samples.Persistence.EntityFramework.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/samples/aspnet/Elsa.Samples.ExtendHttpEndpoint/Elsa.Samples.ExtendHttpEndpoint.csproj
+++ b/src/samples/aspnet/Elsa.Samples.ExtendHttpEndpoint/Elsa.Samples.ExtendHttpEndpoint.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/aspnet/Elsa.Samples.FaultyWorkflows/Elsa.Samples.FaultyWorkflows.csproj
+++ b/src/samples/aspnet/Elsa.Samples.FaultyWorkflows/Elsa.Samples.FaultyWorkflows.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/aspnet/Elsa.Samples.ForkJoinTimerAndSignalHttp/Elsa.Samples.ForkJoinTimerAndSignalHttp.csproj
+++ b/src/samples/aspnet/Elsa.Samples.ForkJoinTimerAndSignalHttp/Elsa.Samples.ForkJoinTimerAndSignalHttp.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -6,7 +6,7 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/aspnet/Elsa.Samples.HelloWorldHttp/Elsa.Samples.HelloWorldHttp.csproj
+++ b/src/samples/aspnet/Elsa.Samples.HelloWorldHttp/Elsa.Samples.HelloWorldHttp.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/aspnet/Elsa.Samples.HttpEndpointSecurity/Elsa.Samples.HttpEndpointSecurity.csproj
+++ b/src/samples/aspnet/Elsa.Samples.HttpEndpointSecurity/Elsa.Samples.HttpEndpointSecurity.csproj
@@ -1,12 +1,12 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
     </PropertyGroup>
     
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.16" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/aspnet/Elsa.Samples.InfiniteLoopDetection/Elsa.Samples.InfiniteLoopDetection.csproj
+++ b/src/samples/aspnet/Elsa.Samples.InfiniteLoopDetection/Elsa.Samples.InfiniteLoopDetection.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/aspnet/Elsa.Samples.Interrupts/Elsa.Samples.Interrupts.csproj
+++ b/src/samples/aspnet/Elsa.Samples.Interrupts/Elsa.Samples.Interrupts.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/aspnet/Elsa.Samples.InvokeWorkflowFromController/Elsa.Samples.InvokeWorkflowFromController.csproj
+++ b/src/samples/aspnet/Elsa.Samples.InvokeWorkflowFromController/Elsa.Samples.InvokeWorkflowFromController.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/aspnet/Elsa.Samples.MassTransitRabbitMq/Elsa.Samples.MassTransitRabbitMq.csproj
+++ b/src/samples/aspnet/Elsa.Samples.MassTransitRabbitMq/Elsa.Samples.MassTransitRabbitMq.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -14,7 +14,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+      <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
 </Project>

--- a/src/samples/aspnet/Elsa.Samples.NestedForks/Elsa.Samples.NestedForks.csproj
+++ b/src/samples/aspnet/Elsa.Samples.NestedForks/Elsa.Samples.NestedForks.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/aspnet/Elsa.Samples.ReadModelHttp/Elsa.Samples.ReadModelHttp.csproj
+++ b/src/samples/aspnet/Elsa.Samples.ReadModelHttp/Elsa.Samples.ReadModelHttp.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/aspnet/Elsa.Samples.SendHttp/Elsa.Samples.SendHttp.csproj
+++ b/src/samples/aspnet/Elsa.Samples.SendHttp/Elsa.Samples.SendHttp.csproj
@@ -1,11 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/samples/aspnet/Elsa.Samples.SignalApi/Elsa.Samples.SignalApi.csproj
+++ b/src/samples/aspnet/Elsa.Samples.SignalApi/Elsa.Samples.SignalApi.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/aspnet/Elsa.Samples.UniqueCorrelatedWorkflows/Elsa.Samples.UniqueCorrelatedWorkflows.csproj
+++ b/src/samples/aspnet/Elsa.Samples.UniqueCorrelatedWorkflows/Elsa.Samples.UniqueCorrelatedWorkflows.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/console/Elsa.Samples.BuildAndDispatchConsole/Elsa.Samples.BuildAndDispatchConsole.csproj
+++ b/src/samples/console/Elsa.Samples.BuildAndDispatchConsole/Elsa.Samples.BuildAndDispatchConsole.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/console/Elsa.Samples.CompensationConsole/Elsa.Samples.CompensationConsole.csproj
+++ b/src/samples/console/Elsa.Samples.CompensationConsole/Elsa.Samples.CompensationConsole.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/console/Elsa.Samples.CustomActivityOutcomes/Elsa.Samples.CustomActivityOutcomes.csproj
+++ b/src/samples/console/Elsa.Samples.CustomActivityOutcomes/Elsa.Samples.CustomActivityOutcomes.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/console/Elsa.Samples.CustomOutcomeActivityConsole/Elsa.Samples.CustomOutcomeActivityConsole.csproj
+++ b/src/samples/console/Elsa.Samples.CustomOutcomeActivityConsole/Elsa.Samples.CustomOutcomeActivityConsole.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/console/Elsa.Samples.DeclarativeCompositeActivitiesConsole/Elsa.Samples.DeclarativeCompositeActivitiesConsole.csproj
+++ b/src/samples/console/Elsa.Samples.DeclarativeCompositeActivitiesConsole/Elsa.Samples.DeclarativeCompositeActivitiesConsole.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/console/Elsa.Samples.Elasticsearch/Elsa.Samples.Elasticsearch.csproj
+++ b/src/samples/console/Elsa.Samples.Elasticsearch/Elsa.Samples.Elasticsearch.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/console/Elsa.Samples.EntityChanged/Elsa.Samples.EntityChanged.csproj
+++ b/src/samples/console/Elsa.Samples.EntityChanged/Elsa.Samples.EntityChanged.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -8,8 +8,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/console/Elsa.Samples.FileBasedWorkflow/Elsa.Samples.FileBasedWorkflow.csproj
+++ b/src/samples/console/Elsa.Samples.FileBasedWorkflow/Elsa.Samples.FileBasedWorkflow.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/console/Elsa.Samples.ForEachLoopConsole/Elsa.Samples.ForEachLoopConsole.csproj
+++ b/src/samples/console/Elsa.Samples.ForEachLoopConsole/Elsa.Samples.ForEachLoopConsole.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/console/Elsa.Samples.ForLoopConsole/Elsa.Samples.ForLoopConsole.csproj
+++ b/src/samples/console/Elsa.Samples.ForLoopConsole/Elsa.Samples.ForLoopConsole.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/console/Elsa.Samples.Forks/Elsa.Samples.Forks.csproj
+++ b/src/samples/console/Elsa.Samples.Forks/Elsa.Samples.Forks.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/console/Elsa.Samples.HappinessConsole/Elsa.Samples.HappinessConsole.csproj
+++ b/src/samples/console/Elsa.Samples.HappinessConsole/Elsa.Samples.HappinessConsole.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -8,8 +8,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/console/Elsa.Samples.HelloWorldConsole/Elsa.Samples.HelloWorldConsole.csproj
+++ b/src/samples/console/Elsa.Samples.HelloWorldConsole/Elsa.Samples.HelloWorldConsole.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/console/Elsa.Samples.IfThenElse/Elsa.Samples.IfThenElse.csproj
+++ b/src/samples/console/Elsa.Samples.IfThenElse/Elsa.Samples.IfThenElse.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/console/Elsa.Samples.ProgrammaticCompositeActivitiesConsole/Elsa.Samples.ProgrammaticCompositeActivitiesConsole.csproj
+++ b/src/samples/console/Elsa.Samples.ProgrammaticCompositeActivitiesConsole/Elsa.Samples.ProgrammaticCompositeActivitiesConsole.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -7,9 +7,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.16" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/console/Elsa.Samples.ReadLineEchoConsole/Elsa.Samples.ReadLineEchoConsole.csproj
+++ b/src/samples/console/Elsa.Samples.ReadLineEchoConsole/Elsa.Samples.ReadLineEchoConsole.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/console/Elsa.Samples.ReadLineToFile/Elsa.Samples.ReadLineToFile.csproj
+++ b/src/samples/console/Elsa.Samples.ReadLineToFile/Elsa.Samples.ReadLineToFile.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/console/Elsa.Samples.RpaWebConsole/Elsa.Samples.RpaWebConsole.csproj
+++ b/src/samples/console/Elsa.Samples.RpaWebConsole/Elsa.Samples.RpaWebConsole.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/console/Elsa.Samples.Serialization/Elsa.Samples.Serialization.csproj
+++ b/src/samples/console/Elsa.Samples.Serialization/Elsa.Samples.Serialization.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.16" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/console/Elsa.Samples.SignalingConsole/Elsa.Samples.SignalingConsole.csproj
+++ b/src/samples/console/Elsa.Samples.SignalingConsole/Elsa.Samples.SignalingConsole.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/console/Elsa.Samples.SwitchConsole/Elsa.Samples.SwitchConsole.csproj
+++ b/src/samples/console/Elsa.Samples.SwitchConsole/Elsa.Samples.SwitchConsole.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -8,8 +8,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/console/Elsa.Samples.UserTaskConsole/Elsa.Samples.UserTaskConsole.csproj
+++ b/src/samples/console/Elsa.Samples.UserTaskConsole/Elsa.Samples.UserTaskConsole.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -8,8 +8,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/console/Elsa.Samples.WhileLoopConsole/Elsa.Samples.WhileLoopConsole.csproj
+++ b/src/samples/console/Elsa.Samples.WhileLoopConsole/Elsa.Samples.WhileLoopConsole.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/dashboard/aspnetcore/ElsaDashboard.Samples.AspNetCore.Monolith/ElsaDashboard.Samples.AspNetCore.Monolith.csproj
+++ b/src/samples/dashboard/aspnetcore/ElsaDashboard.Samples.AspNetCore.Monolith/ElsaDashboard.Samples.AspNetCore.Monolith.csproj
@@ -1,17 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <UserSecretsId>a3259a33-fe85-4d27-b041-b92a506390f5</UserSecretsId>
     </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.Identity.Client" Version="4.67.2" />
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0'">
+        <PackageReference Include="Microsoft.Identity.Client" Version="4.73.1" />
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0'">
         <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Identity.Client" Version="4.67.2" />
     </ItemGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\..\..\..\activities\Elsa.Activities.Email\Elsa.Activities.Email.csproj" />
+        <ProjectReference Include="..\..\..\..\activities\Elsa.Activities.Http.OpenApi\Elsa.Activities.Http.OpenApi.csproj" />
         <ProjectReference Include="..\..\..\..\activities\Elsa.Activities.Http\Elsa.Activities.Http.csproj" />
         <ProjectReference Include="..\..\..\..\activities\Elsa.Activities.Temporal.Quartz\Elsa.Activities.Temporal.Quartz.csproj" />
         <ProjectReference Include="..\..\..\..\activities\Elsa.Activities.UserTask\Elsa.Activities.UserTask.csproj" />
@@ -28,7 +33,6 @@
         <ProjectReference Include="..\..\..\..\persistence\Elsa.Persistence.EntityFramework\Elsa.Persistence.EntityFramework.Sqlite\Elsa.Persistence.EntityFramework.Sqlite.csproj" />
         <ProjectReference Include="..\..\..\..\server\Elsa.Server.Api\Elsa.Server.Api.csproj" />
         <ProjectReference Include="..\..\..\..\servicebus\Elsa.Rebus.AzureServiceBus\Elsa.Rebus.AzureServiceBus.csproj" />
-        <ProjectReference Include="..\..\..\persistence\Elsa.Samples.Persistence.EntityFramework\Elsa.Samples.Persistence.EntityFramework.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/samples/dashboard/aspnetcore/ElsaDashboard.Samples.AspNetCore.Monolith/ElsaDashboard.Samples.AspNetCore.Monolith.csproj
+++ b/src/samples/dashboard/aspnetcore/ElsaDashboard.Samples.AspNetCore.Monolith/ElsaDashboard.Samples.AspNetCore.Monolith.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -7,7 +7,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Identity.Client" Version="4.67.2" />
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/dashboard/aspnetcore/ElsaDashboard.Samples.AspNetCore.SubPath/ElsaDashboard.Samples.AspNetCore.SubPath.csproj
+++ b/src/samples/dashboard/aspnetcore/ElsaDashboard.Samples.AspNetCore.SubPath/ElsaDashboard.Samples.AspNetCore.SubPath.csproj
@@ -16,7 +16,6 @@
         <ProjectReference Include="..\..\..\..\designer\bindings\aspnet\Elsa.Designer.Components.Web\Elsa.Designer.Components.Web.csproj" />
         <ProjectReference Include="..\..\..\..\persistence\Elsa.Persistence.EntityFramework\Elsa.Persistence.EntityFramework.Sqlite\Elsa.Persistence.EntityFramework.Sqlite.csproj" />
         <ProjectReference Include="..\..\..\..\server\Elsa.Server.Api\Elsa.Server.Api.csproj" />
-        <ProjectReference Include="..\..\..\persistence\Elsa.Samples.Persistence.EntityFramework\Elsa.Samples.Persistence.EntityFramework.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/samples/dashboard/aspnetcore/ElsaDashboard.Samples.AspNetCore.SubPath/ElsaDashboard.Samples.AspNetCore.SubPath.csproj
+++ b/src/samples/dashboard/aspnetcore/ElsaDashboard.Samples.AspNetCore.SubPath/ElsaDashboard.Samples.AspNetCore.SubPath.csproj
@@ -1,11 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/persistence/Elsa.Samples.Persistence.EntityFramework/Elsa.Samples.Persistence.EntityFramework.csproj
+++ b/src/samples/persistence/Elsa.Samples.Persistence.EntityFramework/Elsa.Samples.Persistence.EntityFramework.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
@@ -11,8 +11,12 @@
       <ProjectReference Include="..\..\..\persistence\Elsa.Persistence.EntityFramework\Elsa.Persistence.EntityFramework.Core\Elsa.Persistence.EntityFramework.Core.csproj" />
       <ProjectReference Include="..\..\..\persistence\Elsa.Persistence.EntityFramework\Elsa.Persistence.EntityFramework.PostgreSql\Elsa.Persistence.EntityFramework.PostgreSql.csproj" />
       <ProjectReference Include="..\..\..\persistence\Elsa.Persistence.EntityFramework\Elsa.Persistence.EntityFramework.Sqlite\Elsa.Persistence.EntityFramework.Sqlite.csproj" />
-      <ProjectReference Include="..\..\..\persistence\Elsa.Persistence.EntityFramework\Elsa.Persistence.EntityFramework.SqlServer\Elsa.Persistence.EntityFramework.SqlServer.csproj" />      
-      <ProjectReference Include="..\..\..\persistence\Elsa.Persistence.EntityFramework\Elsa.Persistence.EntityFramework.MySql\Elsa.Persistence.EntityFramework.MySql.csproj" />
+      <ProjectReference Include="..\..\..\persistence\Elsa.Persistence.EntityFramework\Elsa.Persistence.EntityFramework.SqlServer\Elsa.Persistence.EntityFramework.SqlServer.csproj" />
+    </ItemGroup>
+
+    <!-- MySql not supported until Pomelo has support for Net10 -->
+    <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+        <ProjectReference Include="..\..\..\persistence\Elsa.Persistence.EntityFramework\Elsa.Persistence.EntityFramework.MySql\Elsa.Persistence.EntityFramework.MySql.csproj" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0'">
@@ -21,10 +25,6 @@
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0'">
         <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
-    </ItemGroup>
-
-    <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0'">
-        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.0" />
     </ItemGroup>
 
 </Project>

--- a/src/samples/persistence/Elsa.Samples.Persistence.EntityFramework/Elsa.Samples.Persistence.EntityFramework.csproj
+++ b/src/samples/persistence/Elsa.Samples.Persistence.EntityFramework/Elsa.Samples.Persistence.EntityFramework.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -16,11 +16,11 @@
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0'">
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.16" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0'">
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0'">

--- a/src/samples/persistence/Elsa.Samples.Persistence.EntityFramework/Program.cs
+++ b/src/samples/persistence/Elsa.Samples.Persistence.EntityFramework/Program.cs
@@ -2,10 +2,16 @@ using System;
 using System.Threading.Tasks;
 using Elsa.Persistence;
 using Elsa.Persistence.EntityFramework.Core.Extensions;
+using Elsa.Persistence.EntityFramework.Sqlite;
+#if NET9_0
+// Currently not supported in net10 until Pomelo supports it
+//using Elsa.Persistence.EntityFramework.MySql;
+#endif
+//using Elsa.Persistence.EntityFramework.PostgreSql;
+//using Elsa.Persistence.EntityFramework.SqlServer;
 using Elsa.Persistence.Specifications.WorkflowInstances;
 using Elsa.Services;
 using Microsoft.Extensions.DependencyInjection;
-using Elsa.Persistence.EntityFramework.SqlServer;
 
 namespace Elsa.Samples.Persistence.EntityFramework
 {
@@ -19,13 +25,14 @@ namespace Elsa.Samples.Persistence.EntityFramework
                     // Configure Elsa to use the Entity Framework Core persistence provider using one of the three available providers 
                     .UseEntityFrameworkPersistence(ef =>
                     {
-                        //ef.UseSqlite();
-                        
-                        //ef.UsePostgreSql("Server=127.0.0.1;Port=5432;Database=elsa;User Id=postgres;Password=password;");
+                        ef.UseSqlite();
 
+                        //ef.UsePostgreSql("Server=127.0.0.1;Port=5432;Database=elsa;User Id=root;Password=Password12!;");
+#if NET9_0
+                        // Currently not supported in net10 until Pomelo supports it
                         //ef.UseMySql("Server=localhost;Port=3306;Database=elsa;User=root;Password=password;");
-
-                        ef.UseSqlServer("Server=localhost;Database=Elsa;Integrated Security=true");
+#endif
+                        //ef.UseSqlServer("Server=localhost,1433;Database=Elsa;User Id=SA;Password=:8jNZdK7cK;TrustServerCertificate=True");
                     })
                     .AddConsoleActivities()
                     .AddWorkflow<HelloWorld>())

--- a/src/samples/persistence/Elsa.Samples.Persistence.YesSql/Elsa.Samples.Persistence.YesSql.csproj
+++ b/src/samples/persistence/Elsa.Samples.Persistence.YesSql/Elsa.Samples.Persistence.YesSql.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/worker/Elsa.Samples.AzureServiceBusWorker/Elsa.Samples.AzureServiceBusWorker.csproj
+++ b/src/samples/worker/Elsa.Samples.AzureServiceBusWorker/Elsa.Samples.AzureServiceBusWorker.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Worker">
+﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -6,8 +6,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.16" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/worker/Elsa.Samples.BreakLoop/Elsa.Samples.BreakLoop.csproj
+++ b/src/samples/worker/Elsa.Samples.BreakLoop/Elsa.Samples.BreakLoop.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Worker">
+﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -6,8 +6,8 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.16" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/worker/Elsa.Samples.CustomAttributesChildWorker/Elsa.Samples.CustomAttributesChildWorker.csproj
+++ b/src/samples/worker/Elsa.Samples.CustomAttributesChildWorker/Elsa.Samples.CustomAttributesChildWorker.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Worker">
+﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.16" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/worker/Elsa.Samples.DistributedLock/Elsa.Samples.DistributedLock.csproj
+++ b/src/samples/worker/Elsa.Samples.DistributedLock/Elsa.Samples.DistributedLock.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -7,9 +7,9 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.16" />
         <PackageReference Include="DistributedLock.Redis" Version="1.0.1" />
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/worker/Elsa.Samples.Faulting/Elsa.Samples.Faulting.csproj
+++ b/src/samples/worker/Elsa.Samples.Faulting/Elsa.Samples.Faulting.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Worker">
+﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -7,8 +7,8 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Data.SqlClient" Version="3.1.7" />
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.16" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/worker/Elsa.Samples.MqttWorker/Elsa.Samples.MqttWorker.csproj
+++ b/src/samples/worker/Elsa.Samples.MqttWorker/Elsa.Samples.MqttWorker.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
+      <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.16" />
       <PackageReference Include="MQTTnet" Version="4.2.0.706" />
     </ItemGroup>
 

--- a/src/samples/worker/Elsa.Samples.MultiTenantChildWorker/Elsa.Samples.MultiTenantChildWorker.csproj
+++ b/src/samples/worker/Elsa.Samples.MultiTenantChildWorker/Elsa.Samples.MultiTenantChildWorker.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Worker">
+﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -6,8 +6,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.16" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/worker/Elsa.Samples.RabbitMqWorker/Elsa.Samples.RabbitMqWorker.csproj
+++ b/src/samples/worker/Elsa.Samples.RabbitMqWorker/Elsa.Samples.RabbitMqWorker.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -8,8 +8,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.16" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/worker/Elsa.Samples.RebusErrorWorker/Elsa.Samples.RebusErrorWorker.csproj
+++ b/src/samples/worker/Elsa.Samples.RebusErrorWorker/Elsa.Samples.RebusErrorWorker.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Worker">
+﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -6,9 +6,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.16" />
         <PackageReference Include="Rebus.AzureServiceBus" Version="10.2.0" />
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/worker/Elsa.Samples.RebusWorker/Elsa.Samples.RebusWorker.csproj
+++ b/src/samples/worker/Elsa.Samples.RebusWorker/Elsa.Samples.RebusWorker.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Worker">
+﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -6,9 +6,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.16" />
         <PackageReference Include="Rebus.AzureServiceBus" Version="10.2.0" />
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/worker/Elsa.Samples.RunChildWorkflowWorker/Elsa.Samples.RunChildWorkflowWorker.csproj
+++ b/src/samples/worker/Elsa.Samples.RunChildWorkflowWorker/Elsa.Samples.RunChildWorkflowWorker.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Worker">
+﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -6,8 +6,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.16" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/worker/Elsa.Samples.Timers.Hangfire/Elsa.Samples.Timers.Hangfire.csproj
+++ b/src/samples/worker/Elsa.Samples.Timers.Hangfire/Elsa.Samples.Timers.Hangfire.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -9,8 +9,8 @@
 
     <ItemGroup>
         <PackageReference Include="Hangfire.SqlServer" Version="1.8.5" />
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.16" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/worker/Elsa.Samples.Timers.Quartz/Elsa.Samples.Timers.Quartz.csproj
+++ b/src/samples/worker/Elsa.Samples.Timers.Quartz/Elsa.Samples.Timers.Quartz.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Worker">
+﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -8,8 +8,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.16" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/worker/Elsa.Samples.WatchDirectoryWorker/Elsa.Samples.WatchDirectoryWorker.csproj
+++ b/src/samples/worker/Elsa.Samples.WatchDirectoryWorker/Elsa.Samples.WatchDirectoryWorker.csproj
@@ -17,8 +17,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.16" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/worker/Elsa.Samples.WhileLoopWorker/Elsa.Samples.WhileLoopWorker.csproj
+++ b/src/samples/worker/Elsa.Samples.WhileLoopWorker/Elsa.Samples.WhileLoopWorker.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Worker">
+﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -7,8 +7,8 @@
     
     <ItemGroup>
         <PackageReference Include="Microsoft.Data.SqlClient" Version="3.1.7" />
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.16" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/scripting/Elsa.Scripting.JavaScript/Converters/Jint/ByteArrayConverter.cs
+++ b/src/scripting/Elsa.Scripting.JavaScript/Converters/Jint/ByteArrayConverter.cs
@@ -11,14 +11,15 @@ namespace Elsa.Scripting.JavaScript.Converters.Jint
     {
         public bool TryConvert(Engine engine, object value, out JsValue result)
         {
-            result = JsValue.Null;
-            
-            if (value is not byte[] buffer)
-                return false;
+            if (value is byte[] bytes)
+            {
+                var buffer = engine.Intrinsics.ArrayBuffer.Construct(bytes);
+                result = buffer;
+                return true;
+            }
 
-            result = new ObjectWrapper(engine, buffer);
-            
-            return true;
+            result = JsValue.Null;
+            return false;
         }
     }
 }

--- a/src/scripting/Elsa.Scripting.JavaScript/Elsa.Scripting.JavaScript.csproj
+++ b/src/scripting/Elsa.Scripting.JavaScript/Elsa.Scripting.JavaScript.csproj
@@ -14,11 +14,15 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Jint" Version="3.0.0-beta-2037" />
+        <PackageReference Include="Jint" Version="4.9.2" />
     </ItemGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\..\core\Elsa.Core\Elsa.Core.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <InternalsVisibleTo Include="Elsa.UnitTests" />
     </ItemGroup>
     
 </Project>

--- a/src/scripting/Elsa.Scripting.JavaScript/Extensions/TypeExtensions.cs
+++ b/src/scripting/Elsa.Scripting.JavaScript/Extensions/TypeExtensions.cs
@@ -29,5 +29,16 @@ namespace Elsa.Scripting.JavaScript.Extensions
         {
             return type == typeof(object);
         }
+
+
+        /// <summary>
+        /// Determines whether the specified type is a nullable value type (e.g., Nullable&lt;T&gt;).
+        /// </summary>
+        /// <param name="type">The type to check.</param>
+        /// <returns>True if the type is a nullable value type; otherwise, false.</returns>
+        public static bool IsNullableType(this Type type)
+        {
+            return type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>);
+        }
     }
 }

--- a/src/scripting/Elsa.Scripting.JavaScript/Providers/DefaultActivityTypeDefinitionRenderer.cs
+++ b/src/scripting/Elsa.Scripting.JavaScript/Providers/DefaultActivityTypeDefinitionRenderer.cs
@@ -12,7 +12,7 @@ namespace Elsa.Scripting.JavaScript.Providers
 {
     public class DefaultActivityTypeDefinitionRenderer : IActivityTypeDefinitionRenderer
     {
-        public int Priority => -1;
+        public virtual int Priority => -1;
         public virtual bool GetCanRenderType(ActivityType activityType) => true;
 
         public virtual async ValueTask RenderTypeDeclarationAsync(

--- a/src/scripting/Elsa.Scripting.JavaScript/Providers/DotNetTypeScriptDefinitionProvider.cs
+++ b/src/scripting/Elsa.Scripting.JavaScript/Providers/DotNetTypeScriptDefinitionProvider.cs
@@ -5,9 +5,9 @@ using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using AutoMapper.Internal;
 using Elsa.Models;
 using Elsa.Scripting.JavaScript.Events;
+using Elsa.Scripting.JavaScript.Extensions;
 using Elsa.Scripting.JavaScript.Models;
 using Elsa.Scripting.JavaScript.Services;
 using MediatR;
@@ -113,9 +113,9 @@ namespace Elsa.Scripting.JavaScript.Providers
             var symbol = type switch
             {
                 { IsInterface: true } => "interface",
+                { IsEnum: true } => "enum", // This must come before IsValueType as IsValueType will also be true for enums
                 { IsClass: true } => "class",
                 { IsValueType: true } => "class",
-                { IsEnum: true } => "enum",
                 _ => "interface"
             };
 
@@ -125,11 +125,40 @@ namespace Elsa.Scripting.JavaScript.Providers
         private void RenderTypeDeclaration(TypeDefinitionContext context, string symbol, Type type, ISet<Type> collectedTypes, StringBuilder output)
         {
             var typeName = GetTypeScriptType(context, type, collectedTypes);
+
+            // Render enum members only if this is an enum, enums do not support properties/methods in TypeScript
+            if (symbol == "enum")
+            {
+                output.AppendLine($"declare enum {typeName} {{");
+                var names = Enum.GetNames(type);
+                var values = Enum.GetValues(type);
+
+                for (int i = 0; i < names.Length; i++)
+                {
+                    var value = Convert.ChangeType(values.GetValue(i), Enum.GetUnderlyingType(type));
+                    output.AppendLine($"  {names[i]} = {value},");
+                }
+
+                output.AppendLine("}");
+                return;
+            }
+
             var properties = type.GetProperties();
             var methods = type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static).Where(x => !x.IsSpecialName).ToList();
 
-
             output.AppendLine($"declare {symbol} {typeName} {{");
+            
+            // Add constructors for classes only
+            if (symbol == "class")
+            {
+                var constructors = type.GetConstructors(BindingFlags.Public | BindingFlags.Instance);
+                foreach (var ctor in constructors)
+                {
+                    var parameters = ctor.GetParameters()
+                        .Select(p => $"{p.Name}: {GetTypeScriptType(context, p.ParameterType, collectedTypes)}");
+                    output.AppendLine($"constructor({string.Join(", ", parameters)});");
+                }
+            }
 
             foreach (var property in properties)
             {

--- a/src/scripting/Elsa.Scripting.JavaScript/Typings/EnumTypeDefinitionProvider.cs
+++ b/src/scripting/Elsa.Scripting.JavaScript/Typings/EnumTypeDefinitionProvider.cs
@@ -1,11 +1,14 @@
-﻿using System;
+using System;
 using Elsa.Scripting.JavaScript.Services;
 
 namespace Elsa.Scripting.JavaScript.Typings
 {
     public class EnumTypeDefinitionProvider : TypeDefinitionProvider
     {
+        public override bool ShouldRenderType(TypeDefinitionContext context, Type type) => type.IsEnum;
+
         public override bool SupportsType(TypeDefinitionContext context, Type type) => type.IsEnum;
-        public override string GetTypeDefinition(TypeDefinitionContext context, Type type) => "number";
+
+        public override string GetTypeDefinition(TypeDefinitionContext context, Type type) => type.Name;
     }
 }

--- a/src/server/Elsa.Server.Api/Elsa.Server.Api.csproj
+++ b/src/server/Elsa.Server.Api/Elsa.Server.Api.csproj
@@ -34,10 +34,10 @@
         <PackageReference Include="System.Linq.Async" Version="6.0.1">
             <ExcludeAssets>compile</ExcludeAssets>
         </PackageReference>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
-        <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.1.7" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
+        <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.2.3" />
         <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="10.0.1" />
-        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.1.7" />
+        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.2.3" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/server/Elsa.Server.Api/Elsa.Server.Api.csproj
+++ b/src/server/Elsa.Server.Api/Elsa.Server.Api.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <Import Project="..\..\..\common.props" />
     <Import Project="..\..\..\configureawait.props" />
@@ -15,10 +15,18 @@
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0'">
         <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.1" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.3.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="7.0.2" />
+        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.3.0" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0'">
         <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="9.0.1" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.3.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="7.0.2" />
+        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.3.0" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0'">
@@ -35,13 +43,9 @@
     <ItemGroup>
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
         <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="NodaTime.Serialization.SystemTextJson" Version="1.0.0" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.0" />
-        <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.3.0" />
-        <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="7.0.2" />
-        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.3.0" />
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/server/Elsa.Server.Api/Extensions/DocumentFilters/RemoveEmptyControllerTagsFilter .cs
+++ b/src/server/Elsa.Server.Api/Extensions/DocumentFilters/RemoveEmptyControllerTagsFilter .cs
@@ -1,0 +1,73 @@
+#if NET10_0_OR_GREATER
+using Microsoft.OpenApi;
+#else
+using Microsoft.OpenApi.Models;
+#endif
+using Swashbuckle.AspNetCore.SwaggerGen;
+using System.Linq;
+
+namespace Elsa.Server.Api.Extensions.DocumentFilters
+{
+    /// <summary>
+    /// Removes any top-level tag definitions from the OpenAPI document that aren't actually assigned to any endpoint operations.
+    /// This helps to keep the generated documentation clean and focused on relevant tags.
+    /// </summary>
+    /// /// <remarks>
+    /// <para>
+    /// <b>Root Cause:</b> Swashbuckle's annotation engine bypasses its custom tag selection rules 
+    /// when using <c>[SwaggerOperation(Tags = ...)]</c>. This leaves behind "ghost" controller-named tags 
+    /// at the root level of the generated OpenAPI document that contain zero active endpoints.
+    /// See Swashbuckle Issue #2618 (https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/2618).
+    /// </para>
+    /// <para>
+    /// <b>.NET 10 Conflict:</b> In .NET 10, the native <c>Microsoft.AspNetCore.OpenApi</c> pipeline 
+    /// implicitly pushes default metadata tags down the <c>ApiExplorer</c> framework prior to Swashbuckle 
+    /// evaluation. This renders internal interception strategies like <c>TagActionsBy</c> ineffective.
+    /// </para>
+    /// <para>
+    /// <b>Resolution:</b> This filter executes exactly once per document build. It scans all actively mapped 
+    /// operations, compiles a list of utilized tags, and purges any unmapped root-level tag headers to preserve 
+    /// clean layout grouping in the Swagger UI.
+    /// </para>
+    /// </remarks>
+    public class RemoveEmptyControllerTagsFilter : IDocumentFilter
+    {
+        public void Apply(OpenApiDocument swaggerDoc, DocumentFilterContext context)
+        {
+            // 1. Find all tags that are actually assigned to at least one endpoint operation
+#if NET10_0_OR_GREATER
+            // In .NET 10, operation.Tags is ISet<OpenApiTagReference>
+            var activeTags = swaggerDoc.Paths.Values
+                .SelectMany(path => path.Operations?.Values ?? Enumerable.Empty<OpenApiOperation>())
+                .SelectMany(op => op.Tags?.Select(t => t.Reference?.Id) ?? Enumerable.Empty<string?>())
+                .Where(id => !string.IsNullOrEmpty(id))
+                .ToHashSet();
+#else
+            // In .NET 8/9, operation.Tags is IList<OpenApiTag>
+            var activeTags = swaggerDoc.Paths.Values
+                .SelectMany(path => path.Operations?.Values ?? Enumerable.Empty<OpenApiOperation>())
+                .SelectMany(op => op.Tags?.Select(t => t.Name) ?? Enumerable.Empty<string?>())
+                .Where(name => !string.IsNullOrEmpty(name))
+                .ToHashSet();
+#endif
+
+            // 2. Remove any top-level tag definitions that aren't actively used by an operation
+            if (swaggerDoc.Tags != null)
+            {
+#if NET10_0_OR_GREATER
+                // In .NET 10, swaggerDoc.Tags is ISet<OpenApiTag>
+                var tagsToRemove = swaggerDoc.Tags.Where(tag => !activeTags.Contains(tag.Name)).ToList();
+                foreach (var tag in tagsToRemove)
+                {
+                    swaggerDoc.Tags.Remove(tag);
+                }
+#else
+                // In .NET 8/9, swaggerDoc.Tags is IList<OpenApiTag>
+                swaggerDoc.Tags = swaggerDoc.Tags
+                    .Where(tag => activeTags.Contains(tag.Name))
+                    .ToList();
+#endif
+            }
+        }
+    }
+}

--- a/src/server/Elsa.Server.Api/Extensions/DocumentFilters/RemoveEmptyControllerTagsFilter.cs
+++ b/src/server/Elsa.Server.Api/Extensions/DocumentFilters/RemoveEmptyControllerTagsFilter.cs
@@ -12,7 +12,7 @@ namespace Elsa.Server.Api.Extensions.DocumentFilters
     /// Removes any top-level tag definitions from the OpenAPI document that aren't actually assigned to any endpoint operations.
     /// This helps to keep the generated documentation clean and focused on relevant tags.
     /// </summary>
-    /// /// <remarks>
+    /// <remarks>
     /// <para>
     /// <b>Root Cause:</b> Swashbuckle's annotation engine bypasses its custom tag selection rules 
     /// when using <c>[SwaggerOperation(Tags = ...)]</c>. This leaves behind "ghost" controller-named tags 

--- a/src/server/Elsa.Server.Api/Extensions/ServiceCollectionExtensions.cs
+++ b/src/server/Elsa.Server.Api/Extensions/ServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using Elsa;
 using Elsa.Models;
 using Elsa.Server.Api;
 using Elsa.Server.Api.Extensions;
+using Elsa.Server.Api.Extensions.DocumentFilters;
 using Elsa.Server.Api.Extensions.SchemaFilters;
 using Elsa.Server.Api.Mapping;
 using Elsa.Server.Api.Services;
@@ -103,6 +104,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
                     //Allow enums to be displayed
                     c.SchemaFilter<XEnumNamesSchemaFilter>();
+                    c.DocumentFilter<RemoveEmptyControllerTagsFilter>();
                     configure?.Invoke(c);
                 });
     }

--- a/test/component/Elsa.ComponentTests/Elsa.ComponentTests.csproj
+++ b/test/component/Elsa.ComponentTests/Elsa.ComponentTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -8,7 +8,7 @@
     
     <ItemGroup>
         <PackageReference Include="AutoFixture" Version="4.18.1" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.1" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.16" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
         <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
         <PackageReference Include="xunit" Version="2.9.3" />

--- a/test/integration/Elsa.Core.IntegrationTests/Elsa.Core.IntegrationTests.csproj
+++ b/test/integration/Elsa.Core.IntegrationTests/Elsa.Core.IntegrationTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -13,7 +13,7 @@
         <PackageReference Include="Moq" Version="4.16.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
         <PackageReference Include="NodaTime.Testing" Version="3.0.9" />
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="XunitXml.TestLogger" Version="5.0.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
@@ -27,7 +27,7 @@
         <PackageReference Include="YesSql.Core" Version="3.0.7" />
         <PackageReference Include="YesSql.Provider.Sqlite" Version="3.0.7" />
         <PackageReference Include="YesSql.Provider.PostgreSql" Version="3.0.7" />
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.16" />
         <PackageReference Include="Hangfire.AspNetCore" Version="1.8.5" />
         <PackageReference Include="Hangfire.InMemory" Version="0.5.1" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.1" />

--- a/test/shared/Elsa.Testing.Shared/Elsa.Testing.Shared.csproj
+++ b/test/shared/Elsa.Testing.Shared/Elsa.Testing.Shared.csproj
@@ -12,13 +12,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1"/>
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.16"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.1"/>
         <PackageReference Include="AutoFixture" Version="4.18.1"/>
         <PackageReference Include="Autofixture.AutoMoq" Version="4.18.1"/>
         <PackageReference Include="AutoFixture.Xunit2" Version="4.18.1"/>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1"/>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.1"/>        
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.16"/>        
         <PackageReference Include="NodaTime" Version="3.2.0"/>
         <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0"/>
         <PackageReference Include="xunit.extensibility.core" Version="2.9.1"/>

--- a/test/unit/Elsa.UnitTests/Elsa.UnitTests.csproj
+++ b/test/unit/Elsa.UnitTests/Elsa.UnitTests.csproj
@@ -22,7 +22,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="System.Text.Encodings.Web" Version="9.0.1" />
+        <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/unit/Elsa.UnitTests/Scripting/JavaScript/Services/JintJavaScriptEvaluatorTests.cs
+++ b/test/unit/Elsa.UnitTests/Scripting/JavaScript/Services/JintJavaScriptEvaluatorTests.cs
@@ -1,10 +1,16 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using AutoFixture.Xunit2;
+using Elsa.Scripting.JavaScript.Converters.Jint;
 using Elsa.Scripting.JavaScript.Messages;
 using Elsa.Services.Models;
 using Elsa.Testing.Shared;
 using Elsa.Testing.Shared.AutoFixture.Attributes;
+using Jint;
+using Jint.Native;
 using MediatR;
 using Moq;
 using Xunit;
@@ -128,6 +134,100 @@ namespace Elsa.Scripting.JavaScript.Services
             var result = await sut.EvaluateAsync("duration1.Plus(duration2)", typeof(NodaTime.Duration), context1);
 
             Assert.Equal(NodaTime.Duration.FromHours(36), result);
+        }
+
+        [Theory(DisplayName = "ByteArrayConverter: The EvaluateAsync method should expose a byte array as an ArrayBuffer and preserve its values"), AutoMoqData]
+        public async Task EvaluateAsync_ShouldExposeByteArrayAsArrayBufferWithCorrectValues(
+            [Frozen] IMediator mediator,
+            [JintEvaluatorWithConverter] JintJavaScriptEvaluator sut,
+            [StubActivityExecutionContext] ActivityExecutionContext context1)
+        {
+            var bytes = new byte[] { 1, 2, 3, 4 };
+            object returnedValue = null;
+
+            Mock.Get(mediator)
+                .Setup(x => x.Publish(It.Is<EvaluatingJavaScriptExpression>(e => e.ActivityExecutionContext == context1), It.IsAny<CancellationToken>()))
+                .Callback((EvaluatingJavaScriptExpression expression, CancellationToken t) => { expression.Engine.SetValue("MyVariable", returnedValue); });
+
+            returnedValue = bytes;
+
+            // Check length
+            var lengthResult = await sut.EvaluateAsync("MyVariable.byteLength", typeof(object), context1);
+            Assert.Equal((double)bytes.Length, lengthResult);
+
+            // Check values
+            var jsArray = await sut.EvaluateAsync("Array.from(new Uint8Array(MyVariable))", typeof(object), context1);
+            var resultArray = ((IEnumerable<object>)jsArray).Select(Convert.ToByte).ToArray();
+            Assert.Equal(bytes, resultArray);
+        }
+
+        [Fact(DisplayName = "ByteArrayConverter: Should return false and JsValue.Null for null input")]
+        public void TryConvert_ShouldReturnFalse_ForNull()
+        {
+            var converter = new ByteArrayConverter();
+            var engine = new Engine();
+            var result = JsValue.Undefined;
+
+            var success = converter.TryConvert(engine, null, out result);
+
+            Assert.False(success);
+            Assert.Equal(JsValue.Null, result);
+        }
+
+        [Fact(DisplayName = "ByteArrayConverter: Should return false for non-byte array input")]
+        public void TryConvert_ShouldReturnFalse_ForNonByteArray()
+        {
+            var converter = new ByteArrayConverter();
+            var engine = new Engine();
+            var result = JsValue.Undefined;
+
+            var success = converter.TryConvert(engine, new int[] { 1, 2, 3 }, out result);
+
+            Assert.False(success);
+            Assert.Equal(JsValue.Null, result);
+        }
+
+        [Theory(DisplayName = "ByteArrayConverter: Should roundtrip a byte array from .NET to JS and back"), AutoMoqData]
+        public async Task EvaluateAsync_ShouldRoundtripByteArray(
+            [Frozen] IMediator mediator,
+            [JintEvaluatorWithConverter] JintJavaScriptEvaluator sut,
+            [StubActivityExecutionContext] ActivityExecutionContext context1)
+        {
+            var bytes = new byte[] { 10, 20, 30, 40 };
+            object returnedValue = null;
+
+            Mock.Get(mediator)
+                .Setup(x => x.Publish(It.Is<EvaluatingJavaScriptExpression>(e => e.ActivityExecutionContext == context1), It.IsAny<CancellationToken>()))
+                .Callback((EvaluatingJavaScriptExpression expression, CancellationToken t) => { expression.Engine.SetValue("MyVariable", returnedValue); });
+
+            returnedValue = bytes;
+            var jsArray = await sut.EvaluateAsync("Array.from(new Uint8Array(MyVariable))", typeof(object), context1);
+
+            var resultArray = ((IEnumerable<object>)jsArray).Select(x => Convert.ToByte(x)).ToArray();
+            Assert.Equal(bytes, resultArray);
+        }
+
+        [Theory(DisplayName = "ByteArrayConverter: Should reflect mutation of ArrayBuffer in JS when read back in .NET"), AutoMoqData]
+        public async Task EvaluateAsync_ShouldReflectJsMutation(
+            [Frozen] IMediator mediator,
+            [JintEvaluatorWithConverter] JintJavaScriptEvaluator sut,
+            [StubActivityExecutionContext] ActivityExecutionContext context1)
+        {
+            var bytes = new byte[] { 1, 2, 3, 4 };
+            object returnedValue = null;
+
+            Mock.Get(mediator)
+                .Setup(x => x.Publish(It.Is<EvaluatingJavaScriptExpression>(e => e.ActivityExecutionContext == context1), It.IsAny<CancellationToken>()))
+                .Callback((EvaluatingJavaScriptExpression expression, CancellationToken t) => { expression.Engine.SetValue("MyVariable", returnedValue); });
+            
+            returnedValue = bytes;
+
+            await sut.EvaluateAsync("new Uint8Array(MyVariable)[0] = 99", typeof(object), context1);
+            var jsArray = await sut.EvaluateAsync("Array.from(new Uint8Array(MyVariable))", typeof(object), context1);
+
+            var resultArray = ((IEnumerable<object>)jsArray).Select(x => Convert.ToByte(x)).ToArray();
+            var expected = new byte[] { 99, 2, 3, 4 };
+            Assert.Equal(expected, resultArray);
         }
     }
 }


### PR DESCRIPTION
## Purpose

Add .NET 10 multi-targeting support to Entity Framework Core projects while maintaining compatibility with providers that do not yet support EF Core 10.

---

## Scope

Select one primary concern:

- [ ] Bug fix (behavior change)  
- [ ] Refactor (no behavior change)  
- [ ] Documentation update  
- [ ] Formatting / code cleanup  
- [ ] Dependency / build update  
- [x] New feature  
---

## Description

### Problem

Entity Framework Core projects needed .NET 10 support for testing and compatibility. However, `Pomelo.EntityFrameworkCore.MySql` does not yet support EF Core 10.x, which blocks full .NET 10 adoption across all database providers.

### Solution

Introduce .NET 10 multi-targeting for EF Core projects while applying conditional support for providers.

### Entity Framework Core .NET 10 Support

#### Core Projects
- Add `net10.0` to TargetFrameworks in `Elsa.Persistence.EntityFramework.Core.csproj`  
  - Now targets: `netstandard2.1;net8.0;net9.0;net10.0`
- Add conditional ItemGroup for .NET 10:
  - `Microsoft.EntityFrameworkCore` 10.0.8  
  - `Microsoft.EntityFrameworkCore.Relational` 10.0.8  
- Enables SQL Server, PostgreSQL, and SQLite providers to fully support .NET 10

#### MySQL Provider Limitation
- Restrict MySQL provider to `.NET 8` and `.NET 9`:
  - Update `Elsa.Persistence.EntityFramework.MySql.csproj`
  - Remove `.NET 10` target and related dependencies

**Root Cause**
```
Microsoft.EntityFrameworkCore.Relational >= 9.0.0 && <= 9.0.999
```

**Impact**
- MySql provider cannot be used in a .net10 project as it would try to pull in EFCore 10 which is not compatible  
- NuGet resolves the `net9.0` build automatically  
- Potential version conflicts when mixing providers requiring EF Core 10  

**Workaround**
- Prefer SQL Server, PostgreSQL, or SQLite providers for .NET 10  

**Future**
- Add .NET 10 support once Pomelo releases a compatible version  

---

### Sample Projects - Multi-Targeting for Testing

- Update `ElsaDashboard.Samples.AspNetCore.Monolith.csproj`
- Update `Elsa.Samples.Persistence.EntityFramework.csproj`
- Add:
  ```
  net10.0
  ```

- Enables:
  - Cross-framework validation  
  - EF Core migration testing  
  - Provider compatibility verification  

---

### Connection Updates

Update SQL Server connection as they were not matching docker:
```csharp
"Server=localhost,1433;Database=Elsa;User Id=SA;Password=:8jNZdK7cK;TrustServerCertificate=True"
```

Disable MySQL in .NET 10 samples:
```csharp
// ef.UseMySql(...); // Currently not supported until Pomelo supports net10
```

---

## Docker Infrastructure Updates

### docker-compose.yaml
- Replace `mysql-arm` with `mysql:8`
- Ensures broader platform compatibility
- Removed MySql 5 container as it conflicted with ports for MySql 8

### Azurite Update
- Use: `mcr.microsoft.com/azure-storage/azurite`
- Expose ports:
  - 10000 (Blob)
  - 10001 (Queue)
  - 10002 (Table)

---

## Dependency Version Summary

| Package | .NET 8 | .NET 9 | .NET 10 |
|--------|--------|--------|---------|
| Microsoft.EntityFrameworkCore | 8.0.1 | 9.0.1 | 10.0.8 |
| Microsoft.EntityFrameworkCore.Relational | 8.0.1 | 9.0.1 | 10.0.8 |
| Pomelo.EntityFrameworkCore.MySql | 8.0.3 | 9.0.0 | ❌ Not Supported |
| Npgsql.EntityFrameworkCore.PostgreSQL | 8.0.0 | 9.0.2 | 10.0.0 |
| Oracle.EntityFrameworkCore | 8.21.121 | 9.23.60 | 10.23.26000 |
| Microsoft.EntityFrameworkCore.Sqlite | 8.0.1 | 9.0.1 | 10.0.0 |
| Microsoft.EntityFrameworkCore.SqlServer | 8.0.1 | 9.0.1 | 10.0.0 |

---

## Breaking Changes

- None for existing .NET 8/9 consumers  
- MySQL limitation:
  - Any users that use `Elsa.Persistence.EntityFramework.MySql` provider cannot upgrade to .Net10 as it will fail to build
  - Microsoft.EntityFrameworkCore.Relational >= 9.0.0 && <= 9.0.999

---

## Notes

- Architecture allows providers to differ in framework support  
- MySQL support will be revisited when Pomelo releases an update for EFCore 10

---

## Verification

Steps:
1. Build and run the following projects targeting `net9.0`, and `net10.0`
 - Run `ElsaDashboard.Samples.AspNetCore.Monolith.csproj`
 - Run `Elsa.Samples.Persistence.EntityFramework.csproj`
3. Run EF Core migrations across providers
4. Run sample projects using Docker services

Expected outcome:

- ✅ All frameworks compile successfully  
- ✅ EF Core migrations execute correctly  
- ✅ SQL Server, PostgreSQL, SQLite work on .NET 10  
- ✅ MySQL works on .NET 8/9  
- ✅ Sample projects run across all configurations  

---

## Screenshots / Recordings (if applicable)

N/A

---

## Checklist

- [x] The PR is focused on a single concern  
- [x] Commit messages follow the recommended convention  
- [ ] Tests added or updated (if applicable)  
- [ ] Documentation updated (if applicable)  
- [x] No unrelated cleanup included  
- [x] All tests pass  
``