### PR TITLE
Fix WaitAny join completion after clearing blockers

### DIFF
--- a/src/core/Elsa.Core/Handlers/WriteWorkflowSuspendExecutionLog.cs
+++ b/src/core/Elsa.Core/Handlers/WriteWorkflowSuspendExecutionLog.cs
@@ -12,7 +12,11 @@ public class WriteWorkflowSuspendExecutionLog : INotificationHandler<WorkflowSus
     public Task Handle(WorkflowSuspended notification, CancellationToken cancellationToken)
     {
         var context = notification.WorkflowExecutionContext;
-        var blockingActivity = context.WorkflowInstance.BlockingActivities.First();
+        var blockingActivity = context.WorkflowInstance.BlockingActivities.FirstOrDefault();
+
+        if (blockingActivity == null)
+            return Task.CompletedTask;
+
         context.WorkflowExecutionLog.AddEntry(context.WorkflowInstance.Id, blockingActivity.ActivityId, blockingActivity.ActivityType, nameof(WorkflowStatus.Suspended), null, null, null, null);
         return Task.CompletedTask;
     }

--- a/src/core/Elsa.Core/Handlers/WriteWorkflowSuspendExecutionLog.cs
+++ b/src/core/Elsa.Core/Handlers/WriteWorkflowSuspendExecutionLog.cs
@@ -4,18 +4,29 @@ using System.Threading.Tasks;
 using Elsa.Events;
 using Elsa.Models;
 using MediatR;
+using Microsoft.Extensions.Logging;
 
 namespace Elsa.Handlers;
 
 public class WriteWorkflowSuspendExecutionLog : INotificationHandler<WorkflowSuspended>
 {
+    private readonly ILogger _logger;
+
+    public WriteWorkflowSuspendExecutionLog(ILogger<WriteWorkflowSuspendExecutionLog> logger)
+    {
+        _logger = logger;
+    }
+
     public Task Handle(WorkflowSuspended notification, CancellationToken cancellationToken)
     {
         var context = notification.WorkflowExecutionContext;
         var blockingActivity = context.WorkflowInstance.BlockingActivities.FirstOrDefault();
 
         if (blockingActivity == null)
+        {
+            _logger.LogWarning("Workflow {WorkflowInstanceId} was suspended without blocking activities; skipping suspend execution log entry", context.WorkflowInstance.Id);
             return Task.CompletedTask;
+        }
 
         context.WorkflowExecutionLog.AddEntry(context.WorkflowInstance.Id, blockingActivity.ActivityId, blockingActivity.ActivityType, nameof(WorkflowStatus.Suspended), null, null, null, null);
         return Task.CompletedTask;

--- a/src/core/Elsa.Core/Services/Workflows/WorkflowRunner.cs
+++ b/src/core/Elsa.Core/Services/Workflows/WorkflowRunner.cs
@@ -361,6 +361,8 @@ namespace Elsa.Services.Workflows
             {
                 if (workflowExecutionContext.HasBlockingActivities)
                     workflowExecutionContext.Suspend();
+                else if (workflowExecutionContext.Status == WorkflowStatus.Suspended)
+                    workflowExecutionContext.Resume();
             }
 
             if (workflowExecutionContext.Status == WorkflowStatus.Running)

--- a/src/core/Elsa.Core/Services/Workflows/WorkflowRunner.cs
+++ b/src/core/Elsa.Core/Services/Workflows/WorkflowRunner.cs
@@ -362,7 +362,11 @@ namespace Elsa.Services.Workflows
                 if (workflowExecutionContext.HasBlockingActivities)
                     workflowExecutionContext.Suspend();
                 else if (workflowExecutionContext.Status == WorkflowStatus.Suspended)
+                {
+                    var currentStatus = workflowExecutionContext.WorkflowInstance.WorkflowStatus;
                     workflowExecutionContext.Resume();
+                    await _mediator.Publish(new WorkflowStatusChanged(workflowExecutionContext.WorkflowInstance, workflowExecutionContext.WorkflowInstance.WorkflowStatus, currentStatus), cancellationToken);
+                }
             }
 
             if (workflowExecutionContext.Status == WorkflowStatus.Running)

--- a/test/integration/Elsa.Core.IntegrationTests/Workflows/ForkJoinWorkflowTests.cs
+++ b/test/integration/Elsa.Core.IntegrationTests/Workflows/ForkJoinWorkflowTests.cs
@@ -1,8 +1,11 @@
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Elsa.Activities.Console;
 using Elsa.Activities.ControlFlow;
 using Elsa.Activities.Signaling;
 using Elsa.Activities.Signaling.Models;
+using Elsa.Builders;
 using Elsa.Models;
 using Elsa.Persistence.Specifications.WorkflowExecutionLogRecords;
 using Elsa.Services.Models;
@@ -87,7 +90,7 @@ namespace Elsa.Core.IntegrationTests.Workflows
             Assert.Equal(WorkflowStatus.Finished, workflowInstance.WorkflowStatus);
             Assert.True(await GetIsFinishedAsync());
         }
-        
+
         [Fact(DisplayName = "Normal join should not eagerly clear blocking activities")]
         public async Task Test03()
         {
@@ -132,6 +135,18 @@ namespace Elsa.Core.IntegrationTests.Workflows
             Assert.Equal(2, workflowInstance.BlockingActivities.Count);
         }
 
+        [Fact(DisplayName = "WaitAny join completes when a later branch clears blocking activities from an earlier branch")]
+        public async Task Test07()
+        {
+            var workflow = new ForkJoinClearsBlockingActivityWorkflow();
+            var workflowBlueprint = WorkflowBuilder.Build(workflow);
+            var workflowResult = await WorkflowStarter.StartWorkflowAsync(workflowBlueprint);
+            var workflowInstance = workflowResult.WorkflowInstance!;
+
+            Assert.Equal(WorkflowStatus.Finished, workflowInstance.WorkflowStatus);
+            Assert.Empty(workflowInstance.BlockingActivities);
+        }
+
         private async Task<WorkflowInstance> TriggerSignalAsync(IWorkflowBlueprint workflowBlueprint, WorkflowInstance workflowInstance, string signal)
         {
             var workflowExecutionContext = new WorkflowExecutionContext(ServiceScope.ServiceProvider, workflowBlueprint, workflowInstance);
@@ -145,6 +160,22 @@ namespace Elsa.Core.IntegrationTests.Workflows
             await WorkflowStorageService.UpdateInputAsync(workflowInstance, new WorkflowInput(triggeredSignal));
             var result = await WorkflowRunner.RunWorkflowAsync(workflowBlueprint, workflowInstance, receiveSignal.ActivityBlueprint.Id);
             return result.WorkflowInstance!;
+        }
+
+        private class ForkJoinClearsBlockingActivityWorkflow : IWorkflow
+        {
+            public void Build(IWorkflowBuilder builder)
+            {
+                builder.StartWith<Fork>(
+                        activity => activity.Set(x => x.Branches, new HashSet<string>(new[] { "Blocking", "Completing" })),
+                        fork =>
+                        {
+                            fork.When("Blocking").SignalReceived("Signal1").ThenNamed("Join");
+                            fork.When("Completing").WriteLine("Completing branch executed").ThenNamed("Join");
+                        })
+                    .Add<Join>(join => join.Set(x => x.Mode, Join.JoinMode.WaitAny)).WithName("Join")
+                    .WriteLine("Finished").WithName("Finished");
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Normalize stale suspended workflow state back to running when a burst ends with no blocking activities so normal completion can run.
- Make suspend execution-log writing tolerate a malformed suspended notification with no blocking activities.
- Add a Fork/Join regression test that reproduces the Sequence contains no elements failure from issue #7718.

Fixes #7718.

## Verification
- Confirmed the new regression test fails on 2.13.x before the runtime fix with `System.InvalidOperationException: Sequence contains no elements` in `WriteWorkflowSuspendExecutionLog.Handle`.
- `dotnet restore test/integration/Elsa.Core.IntegrationTests/Elsa.Core.IntegrationTests.csproj --configfile nuget.config /p:NoWarn=NU1605 /p:TreatWarningsAsErrors=false /p:WarningsAsErrors=`
- `dotnet test test/integration/Elsa.Core.IntegrationTests/Elsa.Core.IntegrationTests.csproj --filter FullyQualifiedName~ForkJoinWorkflowTests --no-restore /p:NoWarn=NU1605 /p:TreatWarningsAsErrors=false /p:WarningsAsErrors=`

Restore required the repository NuGet config plus warning-as-error suppression because this old 2.13.x branch resolves several historical package versions to newer transitive versions under the installed SDK.