### PR TITLE
[codex] Fix HTTP workflow and activity fallback guards

### DIFF
--- a/src/modules/Elsa.Http/Middleware/HttpWorkflowsMiddleware.cs
+++ b/src/modules/Elsa.Http/Middleware/HttpWorkflowsMiddleware.cs
@@ -40,7 +40,6 @@ public class HttpWorkflowsMiddleware(RequestDelegate next)
         IHttpWorkflowLookupService httpWorkflowLookupService)
     {
         var path = httpContext.Request.Path.Value!.NormalizeRoute();
-        var matchingPath = GetMatchingRoute(serviceProvider, path).Route;
         var basePath = options.Value.BasePath?.ToString().NormalizeRoute();
 
         // If the request path does not match the configured base path to handle workflows, then skip.
@@ -53,6 +52,12 @@ public class HttpWorkflowsMiddleware(RequestDelegate next)
             }
 
             // Strip the base path.
+        }
+
+        var matchingPath = GetMatchingRoute(serviceProvider, path).Route;
+
+        if (!string.IsNullOrWhiteSpace(basePath))
+        {
             matchingPath = matchingPath[basePath.Length..];
         }
 
@@ -252,13 +257,16 @@ public class HttpWorkflowsMiddleware(RequestDelegate next)
         // Replace the original cancellation token with the combined one.
         httpContext.RequestAborted = combinedTokenSource.Token;
 
-        // Execute the action.
-        var result = await action(httpContext.RequestAborted);
-
-        // Restore the original cancellation token.
-        httpContext.RequestAborted = originalCancellationToken;
-
-        return result;
+        try
+        {
+            // Execute the action.
+            return await action(httpContext.RequestAborted);
+        }
+        finally
+        {
+            // Restore the original cancellation token.
+            httpContext.RequestAborted = originalCancellationToken;
+        }
     }
 
     private HttpRouteData GetMatchingRoute(IServiceProvider serviceProvider, string path)
@@ -359,8 +367,9 @@ public class HttpWorkflowsMiddleware(RequestDelegate next)
 
         var httpEndpointFaultHandler = serviceProvider.GetRequiredService<IHttpEndpointFaultHandler>();
         var workflowInstanceManager = serviceProvider.GetRequiredService<IWorkflowInstanceManager>();
-        var workflowState = (await workflowInstanceManager.FindByIdAsync(workflowExecutionResult.WorkflowState.Id, cancellationToken))!;
-        await httpEndpointFaultHandler.HandleAsync(new(httpContext, workflowState.WorkflowState, cancellationToken));
+        var workflowInstance = await workflowInstanceManager.FindByIdAsync(workflowExecutionResult.WorkflowState.Id, cancellationToken);
+        var workflowState = workflowInstance?.WorkflowState ?? workflowExecutionResult.WorkflowState;
+        await httpEndpointFaultHandler.HandleAsync(new(httpContext, workflowState, cancellationToken));
         return true;
     }
 

--- a/src/modules/Elsa.Workflows.Core/Serialization/Converters/ActivityJsonConverter.cs
+++ b/src/modules/Elsa.Workflows.Core/Serialization/Converters/ActivityJsonConverter.cs
@@ -42,7 +42,11 @@ public class ActivityJsonConverter(
         // If the activity type is not found, create a NotFoundActivity instead.
         if (activityDescriptor == null)
         {
-            var notFoundActivityDescriptor = activityRegistry.Find<NotFoundActivity>()!;
+            var notFoundActivityDescriptor = activityRegistry.Find<NotFoundActivity>();
+
+            if (notFoundActivityDescriptor == null)
+                throw new JsonException($"Could not deserialize activity type '{activityTypeName}' because the '{nameof(NotFoundActivity)}' descriptor is not registered.");
+
             var notFoundActivityResult = JsonActivityConstructorContextHelper.CreateActivity<NotFoundActivity>(notFoundActivityDescriptor, activityRoot, clonedOptions);
             LogExceptionsIfAny(notFoundActivityResult);
 

--- a/test/unit/Elsa.Http.UnitTests/Middleware/HttpWorkflowsMiddlewareTests.cs
+++ b/test/unit/Elsa.Http.UnitTests/Middleware/HttpWorkflowsMiddlewareTests.cs
@@ -1,14 +1,22 @@
 using System.Collections;
+using System.Reflection;
 using Elsa.Http.Bookmarks;
+using Elsa.Http.Extensions;
 using Elsa.Http.Middleware;
 using Elsa.Http.Options;
 using Elsa.Workflows;
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Management;
+using Elsa.Workflows.Management.Entities;
+using Elsa.Workflows.Models;
 using Elsa.Workflows.Runtime;
 using Elsa.Workflows.Runtime.Entities;
 using Elsa.Workflows.Runtime.Filters;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Elsa.Workflows.State;
 
 namespace Elsa.Http.UnitTests.Middleware;
 
@@ -52,6 +60,81 @@ public class HttpWorkflowsMiddlewareTests
         Assert.NotNull(_bookmarkStore.LastFilter);
         var filter = _bookmarkStore.LastFilter!;
         Assert.False(filter.TenantAgnostic);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_WithNonElsaBasePath_SkipsRouteMatching()
+    {
+        var nextCalled = false;
+        var middleware = new HttpWorkflowsMiddleware(_ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        });
+        var serviceProvider = new ServiceCollection()
+            .AddSingleton<IRouteMatcher, ThrowingRouteMatcher>()
+            .AddSingleton<IRouteTable>(new ListRouteTable([]))
+            .BuildServiceProvider();
+        var httpContext = new DefaultHttpContext
+        {
+            RequestServices = serviceProvider
+        };
+
+        httpContext.Request.Path = "/non-elsa";
+        httpContext.Request.Method = HttpMethod.Get.Method;
+
+        await middleware.InvokeAsync(
+            httpContext,
+            serviceProvider,
+            Microsoft.Extensions.Options.Options.Create(new HttpActivityOptions { BasePath = "/workflows" }),
+            new EmptyHttpWorkflowLookupService());
+
+        Assert.True(nextCalled);
+    }
+
+    [Fact]
+    public async Task ExecuteWithinTimeoutAsync_WhenActionThrows_RestoresRequestAborted()
+    {
+        var httpContext = new DefaultHttpContext();
+        using var originalCancellationTokenSource = new CancellationTokenSource();
+        httpContext.RequestAborted = originalCancellationTokenSource.Token;
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => InvokeExecuteWithinTimeoutAsync<object>(
+            _ => throw new InvalidOperationException("Boom"),
+            TimeSpan.FromSeconds(1),
+            httpContext));
+
+        Assert.Equal(originalCancellationTokenSource.Token, httpContext.RequestAborted);
+    }
+
+    [Fact]
+    public async Task HandleWorkflowFaultAsync_WhenReloadReturnsNull_FallsBackToInMemoryWorkflowState()
+    {
+        var workflowState = new WorkflowState
+        {
+            Id = "workflow-instance-1",
+            DefinitionId = "definition-1",
+            DefinitionVersionId = "definition-version-1",
+            Incidents = [new ActivityIncident()]
+        };
+        var workflowInstanceManager = Substitute.For<IWorkflowInstanceManager>();
+        var faultHandler = Substitute.For<IHttpEndpointFaultHandler>();
+        var serviceProvider = new ServiceCollection()
+            .AddSingleton(workflowInstanceManager)
+            .AddSingleton(faultHandler)
+            .BuildServiceProvider();
+        var httpContext = new DefaultHttpContext
+        {
+            RequestServices = serviceProvider
+        };
+        var result = new RunWorkflowResult(null!, workflowState, new Workflow(), null, Journal.Empty);
+
+        workflowInstanceManager.FindByIdAsync(workflowState.Id, Arg.Any<CancellationToken>()).Returns((WorkflowInstance?)null);
+
+        var handled = await InvokeHandleWorkflowFaultAsync(serviceProvider, httpContext, result, CancellationToken.None);
+
+        Assert.True(handled);
+        await faultHandler.Received(1).HandleAsync(Arg.Is<HttpEndpointFaultContext>(x => ReferenceEquals(x.WorkflowState, workflowState)));
     }
 
     private static IEnumerable<StoredBookmark> CreateCollidingHttpEndpointBookmarks()
@@ -140,6 +223,11 @@ public class HttpWorkflowsMiddlewareTests
         public RouteValueDictionary? Match(string routeTemplate, string route) => routeTemplate == route ? new() : null;
     }
 
+    private class ThrowingRouteMatcher : IRouteMatcher
+    {
+        public RouteValueDictionary? Match(string routeTemplate, string route) => throw new InvalidOperationException("Route matching should have been skipped.");
+    }
+
     private class ListRouteTable(IEnumerable<HttpRouteData> routes) : IRouteTable
     {
         private readonly ICollection<HttpRouteData> _routes = routes.ToList();
@@ -169,5 +257,18 @@ public class HttpWorkflowsMiddlewareTests
             foreach (var route in routes)
                 Remove(route);
         }
+    }
+
+    private Task<T> InvokeExecuteWithinTimeoutAsync<T>(Func<CancellationToken, Task<T>> action, TimeSpan? requestTimeout, HttpContext httpContext)
+    {
+        var method = typeof(HttpWorkflowsMiddleware).GetMethod("ExecuteWithinTimeoutAsync", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var genericMethod = method.MakeGenericMethod(typeof(T));
+        return (Task<T>)genericMethod.Invoke(_middleware, [action, requestTimeout, httpContext])!;
+    }
+
+    private Task<bool> InvokeHandleWorkflowFaultAsync(IServiceProvider serviceProvider, HttpContext httpContext, RunWorkflowResult result, CancellationToken cancellationToken)
+    {
+        var method = typeof(HttpWorkflowsMiddleware).GetMethod("HandleWorkflowFaultAsync", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        return (Task<bool>)method.Invoke(_middleware, [serviceProvider, httpContext, result, cancellationToken])!;
     }
 }

--- a/test/unit/Elsa.Workflows.Core.UnitTests/Serialization/Converters/ActivityJsonConverterTests.cs
+++ b/test/unit/Elsa.Workflows.Core.UnitTests/Serialization/Converters/ActivityJsonConverterTests.cs
@@ -72,6 +72,20 @@ public sealed class ActivityJsonConverterTests
     }
 
     [Fact]
+    public void When_DeserializeUnknownActivity_And_NotFoundDescriptorMissing_Then_ThrowsClearJsonException()
+    {
+        // Arrange
+        var activityRegistry = Substitute.For<IActivityRegistry>();
+        var sut = CreateSut(activityRegistry);
+
+        // Act
+        var exception = Assert.Throws<JsonException>(() => Execute(sut, UnknownActivityJson));
+
+        // Assert
+        Assert.Equal($"Could not deserialize activity type '{UnknownActivityTypeName}' because the '{nameof(NotFoundActivity)}' descriptor is not registered.", exception.Message);
+    }
+
+    [Fact]
     public void When_DeserializeWorkflowAsActivity_And_WorkflowDefinitionIdSpecified_Then_FindsAndInstantiatesActivity()
     {
         // Arrange


### PR DESCRIPTION
## Summary
- move the Elsa base-path gate ahead of route matching so non-Elsa requests skip route resolution
- always restore `HttpContext.RequestAborted` in the timeout wrapper, including exception and cancellation paths
- fall back to the in-memory workflow state when fault handling cannot reload the workflow instance
- replace the `NotFoundActivity` null-forgiving fallback with an explicit guard and clear deserialization error

## Root Cause
- the middleware resolved routes before confirming the request was even under the Elsa base path
- the timeout helper restored `RequestAborted` only on the success path
- fault handling assumed workflow-instance reload would always succeed
- activity deserialization assumed the `NotFoundActivity` descriptor was always registered

## Validation
- `dotnet test test/unit/Elsa.Http.UnitTests/Elsa.Http.UnitTests.csproj --filter FullyQualifiedName~HttpWorkflowsMiddlewareTests`
- `dotnet test test/unit/Elsa.Workflows.Core.UnitTests/Elsa.Workflows.Core.UnitTests.csproj --filter FullyQualifiedName~ActivityJsonConverterTests /p:CollectCoverage=false`
