### PR TITLE
Fix long scheduled instant delays

### DIFF
--- a/src/modules/Elsa.Scheduling/ScheduledTasks/ScheduledSpecificInstantTask.cs
+++ b/src/modules/Elsa.Scheduling/ScheduledTasks/ScheduledSpecificInstantTask.cs
@@ -12,6 +12,7 @@ namespace Elsa.Scheduling.ScheduledTasks;
 /// </summary>
 public class ScheduledSpecificInstantTask : IScheduledTask, IDisposable
 {
+    private static readonly TimeSpan MaxTimerInterval = TimeSpan.FromMilliseconds(int.MaxValue);
     private readonly ITask _task;
     private readonly ISystemClock _systemClock;
     private readonly IServiceScopeFactory _scopeFactory;
@@ -66,7 +67,9 @@ public class ScheduledSpecificInstantTask : IScheduledTask, IDisposable
             delay = TimeSpan.FromMilliseconds(1);
         }
 
-        _timer = new(delay.TotalMilliseconds)
+        var timerDelay = delay > MaxTimerInterval ? MaxTimerInterval : delay;
+
+        _timer = new(timerDelay.TotalMilliseconds)
         {
             Enabled = true
         };
@@ -78,6 +81,14 @@ public class ScheduledSpecificInstantTask : IScheduledTask, IDisposable
 
             // Check if disposed before proceeding
             if (_disposed) return;
+
+            // System.Timers.Timer cannot handle intervals greater than int.MaxValue milliseconds.
+            // For longer delays, keep scheduling capped intervals until the target instant arrives.
+            if (_startAt > _systemClock.UtcNow)
+            {
+                Schedule();
+                return;
+            }
 
             using var scope = _scopeFactory.CreateScope();
             var commandSender = scope.ServiceProvider.GetRequiredService<ICommandSender>();

--- a/test/unit/Elsa.Scheduling.UnitTests/ScheduledTasks/ScheduledSpecificInstantTaskTests.cs
+++ b/test/unit/Elsa.Scheduling.UnitTests/ScheduledTasks/ScheduledSpecificInstantTaskTests.cs
@@ -85,6 +85,20 @@ public class ScheduledSpecificInstantTaskTests : IDisposable
     }
 
     [Fact]
+    public void Schedule_WithDelayExceedingTimerLimit_ShouldStillSetupTimer()
+    {
+        // Arrange - System.Timers.Timer rejects intervals greater than int.MaxValue milliseconds.
+        SetupSystemClock(DefaultNow);
+        var startAt = DefaultNow.AddDays(26);
+
+        // Act
+        CreateScheduledTask(startAt: startAt);
+
+        // Assert - Verify that no error was logged (timer should be set up successfully)
+        AssertNoErrorLogged();
+    }
+
+    [Fact]
     public void Schedule_WithZeroDelay_ShouldUseMinimumDelay()
     {
         // Arrange - simulate a case where startAt is exactly now


### PR DESCRIPTION
## Summary
- cap `ScheduledSpecificInstantTask` timer intervals at `int.MaxValue` milliseconds
- reschedule capped intervals until the requested instant is reached
- add a regression test for delays beyond the `System.Timers.Timer` interval limit

Fixes #5978.

## Tests
- `dotnet test test/unit/Elsa.Scheduling.UnitTests/Elsa.Scheduling.UnitTests.csproj --filter ScheduledSpecificInstantTaskTests`
- `dotnet test test/unit/Elsa.Scheduling.UnitTests/Elsa.Scheduling.UnitTests.csproj --no-restore`