### PR TITLE
Add opt-in stable application instance name to prevent ASB subscription-cap startup hangs

### DIFF
--- a/Elsa.sln
+++ b/Elsa.sln
@@ -333,6 +333,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Common.UnitTests", "te
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Tenants.UnitTests", "test\unit\Elsa.Tenants.UnitTests\Elsa.Tenants.UnitTests.csproj", "{DC476900-D836-4920-A696-CF8796668723}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Hosting.Management.UnitTests", "test\unit\Elsa.Hosting.Management.UnitTests\Elsa.Hosting.Management.UnitTests.csproj", "{39DE4EE7-0FDB-499F-9BC2-7ECC779FA5F6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -601,6 +603,10 @@ Global
 		{DC476900-D836-4920-A696-CF8796668723}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DC476900-D836-4920-A696-CF8796668723}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DC476900-D836-4920-A696-CF8796668723}.Release|Any CPU.Build.0 = Release|Any CPU
+		{39DE4EE7-0FDB-499F-9BC2-7ECC779FA5F6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{39DE4EE7-0FDB-499F-9BC2-7ECC779FA5F6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{39DE4EE7-0FDB-499F-9BC2-7ECC779FA5F6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{39DE4EE7-0FDB-499F-9BC2-7ECC779FA5F6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -705,6 +711,7 @@ Global
 		{B8006D70-1630-43DB-A043-FA89FAC70F37} = {18453B51-25EB-4317-A4B3-B10518252E92}
 		{A3C07D5B-2A30-494E-B9BC-4B1594B31ABC} = {18453B51-25EB-4317-A4B3-B10518252E92}
 		{DC476900-D836-4920-A696-CF8796668723} = {18453B51-25EB-4317-A4B3-B10518252E92}
+		{39DE4EE7-0FDB-499F-9BC2-7ECC779FA5F6} = {18453B51-25EB-4317-A4B3-B10518252E92}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D4B5CEAA-7D70-4FCB-A68E-B03FBE5E0E5E}

--- a/src/modules/Elsa.Hosting.Management/Features/ClusteringFeature.cs
+++ b/src/modules/Elsa.Hosting.Management/Features/ClusteringFeature.cs
@@ -21,15 +21,26 @@ public class ClusteringFeature : FeatureBase
     /// <summary>
     /// A factory that instantiates an <see cref="IApplicationInstanceNameProvider"/>.
     /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="ConfiguredApplicationInstanceNameProvider"/>, which honors
+    /// <see cref="ApplicationInstanceOptions"/> for a stable instance name and falls back to a random
+    /// name when none is configured (preserving the previous default behaviour).
+    /// </remarks>
     public Func<IServiceProvider, IApplicationInstanceNameProvider> InstanceNameProvider { get; set; } = sp =>
     {
-        return ActivatorUtilities.CreateInstance<RandomApplicationInstanceNameProvider>(sp);
+        return ActivatorUtilities.CreateInstance<ConfiguredApplicationInstanceNameProvider>(sp);
     };
 
     /// <summary>
     /// Represents the options for heartbeat feature.
     /// </summary>
     public Action<HeartbeatOptions> HeartbeatOptions { get; set; } = _ => { };
+
+    /// <summary>
+    /// Configures how the application instance name is determined. Set a stable name (for example from
+    /// the pod name) to avoid accumulating orphaned per-instance transport entities across restarts.
+    /// </summary>
+    public Action<ApplicationInstanceOptions> ApplicationInstanceOptions { get; set; } = _ => { };
 
     /// <inheritdoc />
     public override void ConfigureHostedServices()
@@ -42,6 +53,7 @@ public class ClusteringFeature : FeatureBase
     public override void Apply()
     {
         Services.Configure(HeartbeatOptions)
+            .Configure(ApplicationInstanceOptions)
             .AddSingleton(InstanceNameProvider)
             .AddSingleton<RandomIntIdentityGenerator>();
     }

--- a/src/modules/Elsa.Hosting.Management/Options/ApplicationInstanceOptions.cs
+++ b/src/modules/Elsa.Hosting.Management/Options/ApplicationInstanceOptions.cs
@@ -1,0 +1,35 @@
+namespace Elsa.Hosting.Management.Options;
+
+/// <summary>
+/// Options that control how the name of the current application instance is determined.
+/// </summary>
+/// <remarks>
+/// The instance name is used to name per-instance transport entities, such as the Azure Service Bus
+/// change-token subscription and queue (<c>{instanceName}-elsa-trigger-change-token-signal</c>).
+/// By default a random name is generated for every process start, which means a new entity is created
+/// on every restart. Under transports with a per-topic entity limit (for example Azure Service Bus,
+/// which caps a topic at 2,000 subscriptions), these orphaned entities can accumulate across restarts
+/// until the limit is reached and new instances can no longer start. Providing a <i>stable</i> name
+/// that is reused across restarts of the same logical instance keeps the number of entities bounded.
+///
+/// A stable name must be both stable across restarts of the same instance and unique across instances
+/// that run at the same time. In Kubernetes a StatefulSet provides exactly this (each pod keeps its
+/// ordinal hostname across restarts); for a Deployment the pod name can be projected via the Downward
+/// API (for example <c>metadata.name</c>).
+/// </remarks>
+public class ApplicationInstanceOptions
+{
+    /// <summary>
+    /// An explicit, stable, unique-per-instance name. When set, this value is used directly and takes
+    /// precedence over <see cref="InstanceNameEnvironmentVariable"/>.
+    /// </summary>
+    public string? InstanceName { get; set; }
+
+    /// <summary>
+    /// The name of an environment variable to read the instance name from when <see cref="InstanceName"/>
+    /// is not set. For example, set this to <c>HOSTNAME</c> to use the Kubernetes pod name (stable across
+    /// restarts when running as a StatefulSet). When <see langword="null"/> or empty, no environment
+    /// variable is read and a random name is generated instead.
+    /// </summary>
+    public string? InstanceNameEnvironmentVariable { get; set; }
+}

--- a/src/modules/Elsa.Hosting.Management/Options/ApplicationInstanceOptions.cs
+++ b/src/modules/Elsa.Hosting.Management/Options/ApplicationInstanceOptions.cs
@@ -23,6 +23,12 @@ public class ApplicationInstanceOptions
     /// An explicit, stable, unique-per-instance name. When set, this value is used directly and takes
     /// precedence over <see cref="InstanceNameEnvironmentVariable"/>.
     /// </summary>
+    /// <remarks>
+    /// Keep this value short enough for downstream transport entity names. For Azure Service Bus, the
+    /// change-token subscription name must fit in 50 characters, leaving 17 characters for this prefix.
+    /// Use only letters, numbers, periods, hyphens, or underscores, and start and end the value with a
+    /// letter or number.
+    /// </remarks>
     public string? InstanceName { get; set; }
 
     /// <summary>
@@ -31,5 +37,9 @@ public class ApplicationInstanceOptions
     /// restarts when running as a StatefulSet). When <see langword="null"/> or empty, no environment
     /// variable is read and a random name is generated instead.
     /// </summary>
+    /// <remarks>
+    /// The environment variable name is trimmed before lookup. The value it contains follows the same
+    /// transport entity-name length constraints as <see cref="InstanceName"/>.
+    /// </remarks>
     public string? InstanceNameEnvironmentVariable { get; set; }
 }

--- a/src/modules/Elsa.Hosting.Management/Services/ConfiguredApplicationInstanceNameProvider.cs
+++ b/src/modules/Elsa.Hosting.Management/Services/ConfiguredApplicationInstanceNameProvider.cs
@@ -1,0 +1,64 @@
+using Elsa.Hosting.Management.Contracts;
+using Elsa.Hosting.Management.Options;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Elsa.Hosting.Management.Services;
+
+/// <summary>
+/// Resolves the application instance name from <see cref="ApplicationInstanceOptions"/>, allowing a
+/// stable name to be configured so that per-instance transport entities are reused across restarts
+/// instead of accumulating. Falls back to a random name when no stable name is configured, which
+/// preserves the previous default behaviour.
+/// </summary>
+/// <remarks>
+/// Resolution order:
+/// <list type="number">
+/// <item><description><see cref="ApplicationInstanceOptions.InstanceName"/> when set.</description></item>
+/// <item><description>The environment variable named by <see cref="ApplicationInstanceOptions.InstanceNameEnvironmentVariable"/> when configured and non-empty.</description></item>
+/// <item><description>A randomly generated name (legacy behaviour).</description></item>
+/// </list>
+/// </remarks>
+public class ConfiguredApplicationInstanceNameProvider : IApplicationInstanceNameProvider
+{
+    private readonly string _instanceName;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConfiguredApplicationInstanceNameProvider"/> class.
+    /// </summary>
+    public ConfiguredApplicationInstanceNameProvider(
+        IOptions<ApplicationInstanceOptions> options,
+        RandomIntIdentityGenerator randomIdentityGenerator,
+        ILogger<ConfiguredApplicationInstanceNameProvider> logger)
+    {
+        var value = options.Value;
+
+        if (!string.IsNullOrWhiteSpace(value.InstanceName))
+        {
+            _instanceName = value.InstanceName.Trim();
+            return;
+        }
+
+        if (!string.IsNullOrWhiteSpace(value.InstanceNameEnvironmentVariable))
+        {
+            var fromEnvironment = Environment.GetEnvironmentVariable(value.InstanceNameEnvironmentVariable);
+
+            if (!string.IsNullOrWhiteSpace(fromEnvironment))
+            {
+                _instanceName = fromEnvironment.Trim();
+                return;
+            }
+
+            logger.LogWarning(
+                "The configured instance-name environment variable '{EnvironmentVariable}' is not set or empty. Falling back to a random instance name. " +
+                "A random name causes per-instance transport entities (such as the Azure Service Bus change-token subscription) to be recreated on every restart, " +
+                "which can accumulate until the transport's per-topic limit is reached.",
+                value.InstanceNameEnvironmentVariable);
+        }
+
+        _instanceName = randomIdentityGenerator.GenerateId();
+    }
+
+    /// <inheritdoc />
+    public string GetName() => _instanceName;
+}

--- a/src/modules/Elsa.Hosting.Management/Services/ConfiguredApplicationInstanceNameProvider.cs
+++ b/src/modules/Elsa.Hosting.Management/Services/ConfiguredApplicationInstanceNameProvider.cs
@@ -21,6 +21,10 @@ namespace Elsa.Hosting.Management.Services;
 /// </remarks>
 public class ConfiguredApplicationInstanceNameProvider : IApplicationInstanceNameProvider
 {
+    private const int AzureServiceBusSubscriptionNameMaxLength = 50;
+    private const string TriggerChangeTokenSignalEndpointNameSuffix = "-elsa-trigger-change-token-signal";
+    private static readonly int ConfiguredInstanceNameMaxLength = AzureServiceBusSubscriptionNameMaxLength - TriggerChangeTokenSignalEndpointNameSuffix.Length;
+
     private readonly string _instanceName;
 
     /// <summary>
@@ -35,17 +39,18 @@ public class ConfiguredApplicationInstanceNameProvider : IApplicationInstanceNam
 
         if (!string.IsNullOrWhiteSpace(value.InstanceName))
         {
-            _instanceName = value.InstanceName.Trim();
+            _instanceName = ValidateConfiguredInstanceName(value.InstanceName, $"{nameof(ApplicationInstanceOptions)}.{nameof(ApplicationInstanceOptions.InstanceName)}");
             return;
         }
 
         if (!string.IsNullOrWhiteSpace(value.InstanceNameEnvironmentVariable))
         {
-            var fromEnvironment = Environment.GetEnvironmentVariable(value.InstanceNameEnvironmentVariable);
+            var environmentVariable = value.InstanceNameEnvironmentVariable.Trim();
+            var fromEnvironment = Environment.GetEnvironmentVariable(environmentVariable);
 
             if (!string.IsNullOrWhiteSpace(fromEnvironment))
             {
-                _instanceName = fromEnvironment.Trim();
+                _instanceName = ValidateConfiguredInstanceName(fromEnvironment, $"environment variable '{environmentVariable}'");
                 return;
             }
 
@@ -53,7 +58,7 @@ public class ConfiguredApplicationInstanceNameProvider : IApplicationInstanceNam
                 "The configured instance-name environment variable '{EnvironmentVariable}' is not set or empty. Falling back to a random instance name. " +
                 "A random name causes per-instance transport entities (such as the Azure Service Bus change-token subscription) to be recreated on every restart, " +
                 "which can accumulate until the transport's per-topic limit is reached.",
-                value.InstanceNameEnvironmentVariable);
+                environmentVariable);
         }
 
         _instanceName = randomIdentityGenerator.GenerateId();
@@ -61,4 +66,34 @@ public class ConfiguredApplicationInstanceNameProvider : IApplicationInstanceNam
 
     /// <inheritdoc />
     public string GetName() => _instanceName;
+
+    private static string ValidateConfiguredInstanceName(string value, string source)
+    {
+        var instanceName = value.Trim();
+
+        if (instanceName.Length <= ConfiguredInstanceNameMaxLength)
+        {
+            if (IsValidConfiguredInstanceName(instanceName))
+                return instanceName;
+
+            throw new InvalidOperationException(
+                $"The configured application instance name from {source} contains invalid characters. " +
+                "Use only letters, numbers, periods, hyphens, or underscores, and start and end the value with a letter or number.");
+        }
+
+        throw new InvalidOperationException(
+            $"The configured application instance name from {source} is {instanceName.Length} characters long, but it must be {ConfiguredInstanceNameMaxLength} characters or fewer. " +
+            $"The value is used to create per-instance transport entities such as '{instanceName}{TriggerChangeTokenSignalEndpointNameSuffix}', which must fit within Azure Service Bus's {AzureServiceBusSubscriptionNameMaxLength}-character subscription name limit. " +
+            "Configure a shorter stable name that is still unique for each concurrently running instance.");
+    }
+
+    private static bool IsValidConfiguredInstanceName(string instanceName)
+    {
+        return IsAsciiLetterOrDigit(instanceName[0])
+            && IsAsciiLetterOrDigit(instanceName[^1])
+            && instanceName.All(c => IsAsciiLetterOrDigit(c) || c is '.' or '-' or '_');
+    }
+
+    private static bool IsAsciiLetterOrDigit(char value) =>
+        value is >= 'a' and <= 'z' or >= 'A' and <= 'Z' or >= '0' and <= '9';
 }

--- a/test/unit/Elsa.Hosting.Management.UnitTests/Elsa.Hosting.Management.UnitTests.csproj
+++ b/test/unit/Elsa.Hosting.Management.UnitTests/Elsa.Hosting.Management.UnitTests.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <Include>[Elsa.Hosting.Management]*</Include>
+        <Threshold>0</Threshold>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\..\src\common\Elsa.Testing.Shared\Elsa.Testing.Shared.csproj" />
+      <ProjectReference Include="..\..\..\src\modules\Elsa.Hosting.Management\Elsa.Hosting.Management.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/test/unit/Elsa.Hosting.Management.UnitTests/Services/ConfiguredApplicationInstanceNameProviderTests.cs
+++ b/test/unit/Elsa.Hosting.Management.UnitTests/Services/ConfiguredApplicationInstanceNameProviderTests.cs
@@ -6,6 +6,10 @@ namespace Elsa.Hosting.Management.UnitTests.Services;
 
 public class ConfiguredApplicationInstanceNameProviderTests
 {
+    private const int AzureServiceBusSubscriptionNameMaxLength = 50;
+    private const string TriggerChangeTokenSignalEndpointNameSuffix = "-elsa-trigger-change-token-signal";
+    private static readonly int ConfiguredInstanceNameMaxLength = AzureServiceBusSubscriptionNameMaxLength - TriggerChangeTokenSignalEndpointNameSuffix.Length;
+
     [Fact]
     public void ExplicitInstanceName_IsUsedDirectly()
     {
@@ -73,6 +77,27 @@ public class ConfiguredApplicationInstanceNameProviderTests
     }
 
     [Fact]
+    public void EnvironmentVariableName_IsTrimmed()
+    {
+        var variable = NewVariableName();
+        Environment.SetEnvironmentVariable(variable, "pod-7");
+
+        try
+        {
+            var provider = CreateProvider(new()
+            {
+                InstanceNameEnvironmentVariable = $"  {variable}  "
+            });
+
+            Assert.Equal("pod-7", provider.GetName());
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(variable, null);
+        }
+    }
+
+    [Fact]
     public void EnvironmentVariable_ValueIsTrimmed()
     {
         var variable = NewVariableName();
@@ -115,6 +140,58 @@ public class ConfiguredApplicationInstanceNameProviderTests
 
         Assert.False(string.IsNullOrWhiteSpace(name1));
         Assert.NotEqual(name1, name2);
+    }
+
+    [Fact]
+    public void ExplicitInstanceName_AtMaximumLength_IsAccepted()
+    {
+        var instanceName = new string('a', ConfiguredInstanceNameMaxLength);
+
+        var provider = CreateProvider(new() { InstanceName = instanceName });
+
+        Assert.Equal(instanceName, provider.GetName());
+    }
+
+    [Fact]
+    public void ExplicitInstanceName_TooLong_Throws()
+    {
+        var instanceName = new string('a', ConfiguredInstanceNameMaxLength + 1);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => CreateProvider(new() { InstanceName = instanceName }));
+
+        Assert.Contains($"{ConfiguredInstanceNameMaxLength} characters or fewer", exception.Message);
+        Assert.Contains("Azure Service Bus", exception.Message);
+    }
+
+    [Theory]
+    [InlineData("pod 0")]
+    [InlineData("pöd-0")]
+    [InlineData("-pod-0")]
+    [InlineData("pod-0-")]
+    public void ExplicitInstanceName_InvalidCharacters_Throws(string instanceName)
+    {
+        var exception = Assert.Throws<InvalidOperationException>(() => CreateProvider(new() { InstanceName = instanceName }));
+
+        Assert.Contains("contains invalid characters", exception.Message);
+    }
+
+    [Fact]
+    public void EnvironmentVariableValue_TooLong_Throws()
+    {
+        var variable = NewVariableName();
+        Environment.SetEnvironmentVariable(variable, new string('a', ConfiguredInstanceNameMaxLength + 1));
+
+        try
+        {
+            var exception = Assert.Throws<InvalidOperationException>(() => CreateProvider(new() { InstanceNameEnvironmentVariable = variable }));
+
+            Assert.Contains(variable, exception.Message);
+            Assert.Contains($"{ConfiguredInstanceNameMaxLength} characters or fewer", exception.Message);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(variable, null);
+        }
     }
 
     private static ConfiguredApplicationInstanceNameProvider CreateProvider(ApplicationInstanceOptions options)

--- a/test/unit/Elsa.Hosting.Management.UnitTests/Services/ConfiguredApplicationInstanceNameProviderTests.cs
+++ b/test/unit/Elsa.Hosting.Management.UnitTests/Services/ConfiguredApplicationInstanceNameProviderTests.cs
@@ -1,0 +1,129 @@
+using Elsa.Hosting.Management.Options;
+using Elsa.Hosting.Management.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Elsa.Hosting.Management.UnitTests.Services;
+
+public class ConfiguredApplicationInstanceNameProviderTests
+{
+    [Fact]
+    public void ExplicitInstanceName_IsUsedDirectly()
+    {
+        var provider = CreateProvider(new()
+        {
+            InstanceName = "pod-0",
+            InstanceNameEnvironmentVariable = "ELSA_TEST_INSTANCE_NAME"
+        });
+
+        Assert.Equal("pod-0", provider.GetName());
+    }
+
+    [Fact]
+    public void ExplicitInstanceName_IsTrimmed()
+    {
+        var provider = CreateProvider(new()
+        {
+            InstanceName = "  pod-0  "
+        });
+
+        Assert.Equal("pod-0", provider.GetName());
+    }
+
+    [Fact]
+    public void ExplicitInstanceName_TakesPrecedenceOverEnvironmentVariable()
+    {
+        var variable = NewVariableName();
+        Environment.SetEnvironmentVariable(variable, "from-env");
+
+        try
+        {
+            var provider = CreateProvider(new()
+            {
+                InstanceName = "explicit",
+                InstanceNameEnvironmentVariable = variable
+            });
+
+            Assert.Equal("explicit", provider.GetName());
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(variable, null);
+        }
+    }
+
+    [Fact]
+    public void EnvironmentVariable_IsUsedWhenInstanceNameNotSet()
+    {
+        var variable = NewVariableName();
+        Environment.SetEnvironmentVariable(variable, "pod-7");
+
+        try
+        {
+            var provider = CreateProvider(new()
+            {
+                InstanceNameEnvironmentVariable = variable
+            });
+
+            Assert.Equal("pod-7", provider.GetName());
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(variable, null);
+        }
+    }
+
+    [Fact]
+    public void EnvironmentVariable_ValueIsTrimmed()
+    {
+        var variable = NewVariableName();
+        Environment.SetEnvironmentVariable(variable, "  pod-7  ");
+
+        try
+        {
+            var provider = CreateProvider(new()
+            {
+                InstanceNameEnvironmentVariable = variable
+            });
+
+            Assert.Equal("pod-7", provider.GetName());
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(variable, null);
+        }
+    }
+
+    [Fact]
+    public void NoConfiguration_FallsBackToRandomName()
+    {
+        var name1 = CreateProvider(new()).GetName();
+        var name2 = CreateProvider(new()).GetName();
+
+        Assert.False(string.IsNullOrWhiteSpace(name1));
+        Assert.False(string.IsNullOrWhiteSpace(name2));
+        Assert.NotEqual(name1, name2);
+    }
+
+    [Fact]
+    public void EnvironmentVariableConfiguredButEmpty_FallsBackToRandomName()
+    {
+        var variable = NewVariableName();
+        Environment.SetEnvironmentVariable(variable, null);
+
+        var name1 = CreateProvider(new() { InstanceNameEnvironmentVariable = variable }).GetName();
+        var name2 = CreateProvider(new() { InstanceNameEnvironmentVariable = variable }).GetName();
+
+        Assert.False(string.IsNullOrWhiteSpace(name1));
+        Assert.NotEqual(name1, name2);
+    }
+
+    private static ConfiguredApplicationInstanceNameProvider CreateProvider(ApplicationInstanceOptions options)
+    {
+        return new ConfiguredApplicationInstanceNameProvider(
+            Microsoft.Extensions.Options.Options.Create(options),
+            new RandomIntIdentityGenerator(),
+            NullLogger<ConfiguredApplicationInstanceNameProvider>.Instance);
+    }
+
+    private static string NewVariableName() => "ELSA_TEST_INSTANCE_" + Guid.NewGuid().ToString("N");
+}


### PR DESCRIPTION
## Summary

**Fixes #7736** (the root cause behind #7732): under the Azure Service Bus (MassTransit) transport, app startup eventually hangs and Kubernetes crash-loops the pod once the distributed-cache **change-token topic reaches the hard ASB limit of 2,000 subscriptions per topic**.

Part of the **#7737** tracking effort.

### Why it happens

Elsa names per-instance transport entities using the application instance name, e.g. `{instanceName}-elsa-trigger-change-token-signal`. The default `RandomApplicationInstanceNameProvider` generates a **new random name on every process start**, so each restart leaks a new change-token **subscription** (plus its forwarding queue). Continuous change-token fan-out keeps those orphans non-idle, so `AutoDeleteOnIdle` (1h) never reclaims them and they accumulate across restarts. Once the topic hits 2,000 subscriptions, a fresh instance's `CreateSubscription` fails with `403 QuotaExceeded`, MassTransit retries the topology forever, and with `WaitUntilStarted=true` the host's `StartAsync` never completes → no `ApplicationStarted` → crash loop.

This was confirmed by end-to-end reproduction on a real ASB Standard namespace (details in #7732). Note: the message **backlog** on those queues is a correlated symptom, **not** the blocking mechanism — startup is flat regardless of message count or subscription count; only reaching the cap breaks it.

## What this PR does

Adds an **opt-in** stable application instance name so an instance reuses the same change-token subscription across restarts instead of leaking a new one:

- **`ApplicationInstanceOptions`** (`Elsa.Hosting.Management.Options`)
  - `InstanceName` — explicit stable name.
  - `InstanceNameEnvironmentVariable` — name of an env var to read it from (e.g. `HOSTNAME`). The env-var name is trimmed before lookup.
- **`ConfiguredApplicationInstanceNameProvider`** — resolution order:
  1. explicit `InstanceName`, when set;
  2. the configured environment variable, when present and non-empty (logs a warning and falls back when it was configured but empty);
  3. a random name otherwise — **previous behaviour, preserved**.
- Configured stable names are validated fail-fast before transport startup: they must be short enough for the ASB change-token subscription (`≤17` chars before `-elsa-trigger-change-token-signal`), use only ASCII letters/numbers/`.`/`-`/`_`, and start/end with an ASCII letter or number.
- **`ClusteringFeature`** now defaults `InstanceNameProvider` to the new provider and exposes an `ApplicationInstanceOptions` configuration hook.

### Why opt-in (and not default-stable) for a patch

When nothing is configured, behaviour is **unchanged** (random per-process name). Defaulting to a host-level identifier (HOSTNAME / MachineName) would be unsafe in a patch because some shared-process scenarios — including this repo's clustered-hosting component tests, which run multiple logical instances in one process — rely on each instance getting a distinct random name; a shared name there would collide on the per-instance change-token subscription and silently break cross-instance cache invalidation. Default-stable is better suited to a future minor/major.

## Usage

```csharp
elsa.UseApplicationCluster(cluster =>
{
    cluster.ApplicationInstanceOptions = options =>
    {
        // Stable + unique per pod (e.g. StatefulSet pod name projected into HOSTNAME):
        options.InstanceNameEnvironmentVariable = "HOSTNAME";
        // or set an explicit value:
        // options.InstanceName = "order-service-0";
    };
});
```

The instance name must be both **stable across restarts** of the same instance and **unique across instances** that run concurrently. A Kubernetes StatefulSet provides exactly this. Keep the configured value within the ASB-safe constraints above; if a projected pod name is too long, configure a shorter stable alias instead.

## Tests

New `Elsa.Hosting.Management.UnitTests` project covering the resolution order: explicit name wins, env var used when set (and trimmed), env-var key trimming, random fallback when unconfigured, random fallback when the env var is configured but empty, maximum-length acceptance, too-long names, and invalid character validation. All 15 pass.

## Follow-ups (separate PRs, noted in #7737)

- Make `WaitUntilStarted` configurable in `Elsa.ServiceBus.MassTransit` (defense-in-depth).
- Lower the default heartbeat/orphan-cleanup timeout so existing `RemoveOrphanedSubscriptions` self-healing reclaims orphans faster.
- Consider defaulting to stable naming in a future minor/major.

Fixes #7736. Relates to #7732. Part of #7737.