### PR TITLE
Make publish-on-validation-error failure opt-in (3.6.x/3.7.x)

### DIFF
--- a/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/BulkPublish/Endpoint.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/BulkPublish/Endpoint.cs
@@ -34,6 +34,7 @@ internal class BulkPublish(IWorkflowDefinitionStore store, IWorkflowDefinitionPu
         var alreadyPublished = new List<string>();
         var skipped = new List<string>();
         var updatedConsumers = new List<string>();
+        var failed = new List<string>();
 
         var definitions = (await store.FindManyAsync(new WorkflowDefinitionFilter
         {
@@ -64,12 +65,19 @@ internal class BulkPublish(IWorkflowDefinitionStore store, IWorkflowDefinitionPu
             }
 
             var result = await workflowDefinitionPublisher.PublishAsync(definition, cancellationToken);
+
+            if (!result.Succeeded)
+            {
+                failed.Add(definitionId);
+                continue;
+            }
+
             published.Add(definitionId);
             
             if (result.AffectedWorkflows.WorkflowDefinitions.Count > 0) 
                 updatedConsumers.AddRange(result.AffectedWorkflows.WorkflowDefinitions.Select(x => x.DefinitionId));
         }
 
-        return new(published, alreadyPublished, notFound, skipped, updatedConsumers);
+        return new(published, alreadyPublished, notFound, skipped, updatedConsumers, failed);
     }
 }

--- a/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/BulkPublish/Endpoint.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/BulkPublish/Endpoint.cs
@@ -35,6 +35,7 @@ internal class BulkPublish(IWorkflowDefinitionStore store, IWorkflowDefinitionPu
         var skipped = new List<string>();
         var updatedConsumers = new List<string>();
         var failed = new List<string>();
+        var warnings = new Dictionary<string, ICollection<string>>();
 
         var definitions = (await store.FindManyAsync(new WorkflowDefinitionFilter
         {
@@ -73,11 +74,14 @@ internal class BulkPublish(IWorkflowDefinitionStore store, IWorkflowDefinitionPu
             }
 
             published.Add(definitionId);
+
+            if (result.ValidationErrors.Count > 0)
+                warnings[definitionId] = result.ValidationErrors.Select(x => x.Message).ToList();
             
             if (result.AffectedWorkflows.WorkflowDefinitions.Count > 0) 
                 updatedConsumers.AddRange(result.AffectedWorkflows.WorkflowDefinitions.Select(x => x.DefinitionId));
         }
 
-        return new(published, alreadyPublished, notFound, skipped, updatedConsumers, failed);
+        return new(published, alreadyPublished, notFound, skipped, updatedConsumers, failed, warnings);
     }
 }

--- a/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/BulkPublish/Models.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/BulkPublish/Models.cs
@@ -5,7 +5,7 @@ internal class Request
     public ICollection<string> DefinitionIds { get; set; } = default!;
 }
 
-internal class Response(ICollection<string> published, ICollection<string> alreadyPublished, ICollection<string> notFound, ICollection<string> skipped, ICollection<string> updatedConsumers, ICollection<string> failed)
+internal class Response(ICollection<string> published, ICollection<string> alreadyPublished, ICollection<string> notFound, ICollection<string> skipped, ICollection<string> updatedConsumers, ICollection<string> failed, IDictionary<string, ICollection<string>> warnings)
 {
     public ICollection<string> Published { get; } = published;
     public ICollection<string> AlreadyPublished { get; } = alreadyPublished;
@@ -13,4 +13,5 @@ internal class Response(ICollection<string> published, ICollection<string> alrea
     public ICollection<string> Skipped { get; } = skipped;
     public ICollection<string> UpdatedConsumers { get; } = updatedConsumers;
     public ICollection<string> Failed { get; } = failed;
+    public IDictionary<string, ICollection<string>> Warnings { get; } = warnings;
 }

--- a/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/BulkPublish/Models.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/BulkPublish/Models.cs
@@ -5,11 +5,12 @@ internal class Request
     public ICollection<string> DefinitionIds { get; set; } = default!;
 }
 
-internal class Response(ICollection<string> published, ICollection<string> alreadyPublished, ICollection<string> notFound, ICollection<string> skipped, ICollection<string> updatedConsumers)
+internal class Response(ICollection<string> published, ICollection<string> alreadyPublished, ICollection<string> notFound, ICollection<string> skipped, ICollection<string> updatedConsumers, ICollection<string> failed)
 {
     public ICollection<string> Published { get; } = published;
     public ICollection<string> AlreadyPublished { get; } = alreadyPublished;
     public ICollection<string> NotFound { get; } = notFound;
     public ICollection<string> Skipped { get; } = skipped;
     public ICollection<string> UpdatedConsumers { get; } = updatedConsumers;
+    public ICollection<string> Failed { get; } = failed;
 }

--- a/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/Post/Endpoint.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/Post/Endpoint.cs
@@ -107,7 +107,8 @@ internal class Post(
 
         var mappedDefinition = await linker.MapAsync(draft, cancellationToken);
         var affectedWorkflows = result?.AffectedWorkflows?.WorkflowDefinitions ?? [];
-        var response = new Response(mappedDefinition, false, affectedWorkflows.Count);
+        var validationErrors = result?.ValidationErrors.Select(e => e.Message).ToList() ?? [];
+        var response = new Response(mappedDefinition, false, affectedWorkflows.Count, validationErrors);
         await HttpContext.Response.WriteAsJsonAsync(response, serializerOptions, cancellationToken);
     }
 }

--- a/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/Post/Models.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/Post/Models.cs
@@ -2,4 +2,4 @@ using Elsa.Workflows.Api.Models;
 
 namespace Elsa.Workflows.Api.Endpoints.WorkflowDefinitions.Post;
 
-internal record Response(LinkedWorkflowDefinitionModel WorkflowDefinition, bool AlreadyPublished, int ConsumingWorkflowCount);
+internal record Response(LinkedWorkflowDefinitionModel WorkflowDefinition, bool AlreadyPublished, int ConsumingWorkflowCount, ICollection<string> ValidationErrors);

--- a/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/Publish/Endpoint.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/Publish/Endpoint.cs
@@ -55,8 +55,9 @@ internal class Publish(IWorkflowDefinitionStore store, IWorkflowDefinitionPublis
             return;
         }
 
+        var validationErrors = result?.ValidationErrors.Select(e => e.Message).ToList() ?? [];
         var mappedDefinition = await linker.MapAsync(definition, cancellationToken);
-        var response = new Response(mappedDefinition, isPublished, result?.AffectedWorkflows.WorkflowDefinitions.Count ?? 0);
+        var response = new Response(mappedDefinition, isPublished, result?.AffectedWorkflows.WorkflowDefinitions.Count ?? 0, validationErrors);
         await Send.OkAsync(response, cancellationToken);
     }
 }

--- a/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/Publish/Endpoint.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/Publish/Endpoint.cs
@@ -45,6 +45,16 @@ internal class Publish(IWorkflowDefinitionStore store, IWorkflowDefinitionPublis
 
         var isPublished = definition.IsPublished;
         var result = !isPublished ? await workflowDefinitionPublisher.PublishAsync(definition, cancellationToken) : null;
+
+        if (result is { Succeeded: false })
+        {
+            foreach (var validationError in result.ValidationErrors)
+                AddError(validationError.Message);
+
+            await Send.ErrorsAsync(400, cancellationToken);
+            return;
+        }
+
         var mappedDefinition = await linker.MapAsync(definition, cancellationToken);
         var response = new Response(mappedDefinition, isPublished, result?.AffectedWorkflows.WorkflowDefinitions.Count ?? 0);
         await Send.OkAsync(response, cancellationToken);

--- a/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/Publish/Models.cs
+++ b/src/modules/Elsa.Workflows.Api/Endpoints/WorkflowDefinitions/Publish/Models.cs
@@ -7,4 +7,4 @@ internal class Request
     public string DefinitionId { get; set; } = default!;
 }
 
-internal record Response(LinkedWorkflowDefinitionModel WorkflowDefinition, bool AlreadyPublished, int ConsumingWorkflowCount);
+internal record Response(LinkedWorkflowDefinitionModel WorkflowDefinition, bool AlreadyPublished, int ConsumingWorkflowCount, ICollection<string> ValidationErrors);

--- a/src/modules/Elsa.Workflows.Management/Features/WorkflowManagementFeature.cs
+++ b/src/modules/Elsa.Workflows.Management/Features/WorkflowManagementFeature.cs
@@ -58,6 +58,7 @@ public class WorkflowManagementFeature(IModule module) : FeatureBase(module)
     private string CompressionAlgorithm { get; set; } = nameof(None);
     private LogPersistenceMode LogPersistenceMode { get; set; } = LogPersistenceMode.Include;
     private bool IsReadOnlyMode { get; set; }
+    private bool FailOnValidationErrors { get; set; }
 
     /// <summary>
     /// A set of activity types to make available to the system. 
@@ -216,6 +217,17 @@ public class WorkflowManagementFeature(IModule module) : FeatureBase(module)
         return this;
     }
 
+    /// <summary>
+    /// Enables or disables failing workflow publication when the workflow has validation errors.
+    /// Defaults to <c>false</c> in 3.6.x and 3.7.x (publication succeeds and validation errors are returned as
+    /// warnings). Set to <c>true</c> to fail publication when validation errors are present.
+    /// </summary>
+    public WorkflowManagementFeature UseFailOnValidationErrors(bool enabled = true)
+    {
+        FailOnValidationErrors = enabled;
+        return this;
+    }
+
     public WorkflowManagementFeature UseWorkflowDefinitionPublisher(Func<IServiceProvider, IWorkflowDefinitionPublisher> workflowDefinitionPublisher)
     {
         _workflowDefinitionPublisher = workflowDefinitionPublisher;
@@ -309,6 +321,7 @@ public class WorkflowManagementFeature(IModule module) : FeatureBase(module)
             options.CompressionAlgorithm = CompressionAlgorithm;
             options.LogPersistenceMode = LogPersistenceMode;
             options.IsReadOnlyMode = IsReadOnlyMode;
+            options.FailOnValidationErrors = FailOnValidationErrors;
         });
 
         Services.Configure<HostMethodActivitiesOptions>(_ => { });

--- a/src/modules/Elsa.Workflows.Management/Options/ManagementOptions.cs
+++ b/src/modules/Elsa.Workflows.Management/Options/ManagementOptions.cs
@@ -32,4 +32,14 @@ public class ManagementOptions
     /// A mode that does not allow editing workflows.
     /// </summary>
     public bool IsReadOnlyMode { get; set; }
+
+    /// <summary>
+    /// Determines whether publishing a workflow definition fails when the workflow has validation errors.
+    /// When <c>false</c> (the default in 3.6.x and 3.7.x), publishing is allowed to succeed and any validation
+    /// errors are returned as warnings on the publish result. When <c>true</c>, publishing fails if any validation
+    /// errors are present. This restores the ability to publish workflows that intentionally leave required
+    /// properties blank (for example, an empty Cron expression used to disable a trigger). As of 3.8.0 this
+    /// defaults to <c>true</c> (opt-out) instead of being opt-in.
+    /// </summary>
+    public bool FailOnValidationErrors { get; set; }
 }

--- a/src/modules/Elsa.Workflows.Management/Services/WorkflowDefinitionPublisher.cs
+++ b/src/modules/Elsa.Workflows.Management/Services/WorkflowDefinitionPublisher.cs
@@ -8,7 +8,9 @@ using Elsa.Workflows.Management.Filters;
 using Elsa.Workflows.Management.Materializers;
 using Elsa.Workflows.Management.Models;
 using Elsa.Workflows.Management.Notifications;
+using Elsa.Workflows.Management.Options;
 using Elsa.Workflows.Models;
+using Microsoft.Extensions.Options;
 
 namespace Elsa.Workflows.Management.Services;
 
@@ -20,7 +22,8 @@ public class WorkflowDefinitionPublisher(
     IIdentityGenerator identityGenerator,
     IActivitySerializer activitySerializer,
     IMediator mediator,
-    ISystemClock systemClock)
+    ISystemClock systemClock,
+    IOptions<ManagementOptions> options)
     : IWorkflowDefinitionPublisher
 {
     /// <inheritdoc />
@@ -87,7 +90,7 @@ public class WorkflowDefinitionPublisher(
         var workflowGraph = await workflowDefinitionService.MaterializeWorkflowAsync(definition, cancellationToken);
         var validationErrors = (await workflowValidator.ValidateAsync(workflowGraph.Workflow, cancellationToken)).ToList();
 
-        if (validationErrors.Any())
+        if (validationErrors.Any() && options.Value.FailOnValidationErrors)
             return new(false, validationErrors, new([]));
 
         await mediator.SendAsync(new WorkflowDefinitionPublishing(definition), cancellationToken);

--- a/test/integration/Elsa.Workflows.IntegrationTests/Scenarios/ImportAndPublish/ImportAndPublishCronTests.cs
+++ b/test/integration/Elsa.Workflows.IntegrationTests/Scenarios/ImportAndPublish/ImportAndPublishCronTests.cs
@@ -1,4 +1,5 @@
-﻿using Elsa.Testing.Shared;
+﻿using Elsa.Extensions;
+using Elsa.Testing.Shared;
 using Elsa.Workflows.Management;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit.Abstractions;
@@ -8,10 +9,12 @@ namespace Elsa.Workflows.IntegrationTests.Scenarios.ImportAndPublish;
 public class ImportAndPublishCronTests
 {
     private readonly CapturingTextWriter _capturingTextWriter = new();
+    private readonly ITestOutputHelper _testOutputHelper;
     private readonly IServiceProvider _services;
 
     public ImportAndPublishCronTests(ITestOutputHelper testOutputHelper)
     {
+        _testOutputHelper = testOutputHelper;
         _services = new TestApplicationBuilder(testOutputHelper)
             .WithCapturingTextWriter(_capturingTextWriter)
             .Build();
@@ -35,8 +38,8 @@ public class ImportAndPublishCronTests
         Assert.Empty(result.ValidationErrors);
     }
 
-    [Fact(DisplayName = "Cron workflow imported from file should not publish successfully with bad cron expression.")]
-    public async Task ImportAndPublish_ShouldFailed_WithBadCronExpression()
+    [Fact(DisplayName = "Cron workflow with a bad cron expression publishes by default, surfacing the validation error as a warning.")]
+    public async Task ImportAndPublish_ShouldSucceedWithWarnings_WithBadCronExpression_WhenLenient()
     {
         // Populate registries.
         await _services.PopulateRegistriesAsync();
@@ -46,6 +49,30 @@ public class ImportAndPublishCronTests
 
         // Publish.
         IWorkflowDefinitionPublisher workflowDefinitionPublisher = _services.GetRequiredService<IWorkflowDefinitionPublisher>();
+        var result = await workflowDefinitionPublisher.PublishAsync(workflowDefinition);
+
+        // Assert: lenient is the default in 3.6.x/3.7.x, so publishing succeeds while still reporting the error.
+        Assert.True(result.Succeeded);
+        Assert.Single(result.ValidationErrors);
+        Assert.Equal("Error when parsing cron expression: The given cron expression has an invalid format. Seconds: Value must be a number between 0 and 59 (all inclusive).", result.ValidationErrors.Single().Message);
+    }
+
+    [Fact(DisplayName = "Cron workflow with a bad cron expression fails to publish when FailOnValidationErrors is enabled.")]
+    public async Task ImportAndPublish_ShouldFail_WithBadCronExpression_WhenStrict()
+    {
+        var services = new TestApplicationBuilder(_testOutputHelper)
+            .WithCapturingTextWriter(_capturingTextWriter)
+            .ConfigureElsa(elsa => elsa.UseWorkflowManagement(management => management.UseFailOnValidationErrors()))
+            .Build();
+
+        // Populate registries.
+        await services.PopulateRegistriesAsync();
+
+        // Import workflow.
+        var workflowDefinition = await services.ImportWorkflowDefinitionAsync($"Scenarios/ImportAndPublish/Workflows/bad-cron-expression.json");
+
+        // Publish.
+        IWorkflowDefinitionPublisher workflowDefinitionPublisher = services.GetRequiredService<IWorkflowDefinitionPublisher>();
         var result = await workflowDefinitionPublisher.PublishAsync(workflowDefinition);
 
         // Assert.

--- a/test/integration/Elsa.Workflows.IntegrationTests/Scenarios/ImportAndPublish/ImportAndPublishHttpEndpointsTests.cs
+++ b/test/integration/Elsa.Workflows.IntegrationTests/Scenarios/ImportAndPublish/ImportAndPublishHttpEndpointsTests.cs
@@ -9,10 +9,12 @@ namespace Elsa.Workflows.IntegrationTests.Scenarios.ImportAndPublish;
 public class ImportAndPublishHttpEndpointsTests
 {
     private readonly CapturingTextWriter _capturingTextWriter = new();
+    private readonly ITestOutputHelper _testOutputHelper;
     private readonly IServiceProvider _services;
 
     public ImportAndPublishHttpEndpointsTests(ITestOutputHelper testOutputHelper)
     {
+        _testOutputHelper = testOutputHelper;
         _services = new TestApplicationBuilder(testOutputHelper)
             .WithCapturingTextWriter(_capturingTextWriter)
             .ConfigureElsa(configure => configure.UseHttp())
@@ -37,8 +39,8 @@ public class ImportAndPublishHttpEndpointsTests
         Assert.Empty(result.ValidationErrors);
     }
 
-    [Fact(DisplayName = "Http endpoint workflow imported from file should not publish successfully with same path and method.")]
-    public async Task ImportAndPublish_ShouldFailed_WithTwoHttpEndpointSamePathMethod()
+    [Fact(DisplayName = "Http endpoint workflow with a duplicate path and method publishes by default, surfacing the validation error as a warning.")]
+    public async Task ImportAndPublish_ShouldSucceedWithWarnings_WithTwoHttpEndpointSamePathMethod_WhenLenient()
     {
         // Populate registries.
         await _services.PopulateRegistriesAsync();
@@ -56,6 +58,42 @@ public class ImportAndPublishHttpEndpointsTests
 
         // Import second workflow.
         workflowDefinition = await _services.ImportWorkflowDefinitionAsync($"Scenarios/ImportAndPublish/Workflows/http-workflow.json");
+
+        // Publish second workflow.
+        result = await workflowDefinitionPublisher.PublishAsync(workflowDefinition);
+
+        // Assert second workflow: lenient is the default in 3.6.x/3.7.x, so publishing succeeds while still reporting the error.
+        Assert.True(result.Succeeded);
+        Assert.Single(result.ValidationErrors);
+        Assert.Equal("The /test path and get method are already in use by another workflow!", result.ValidationErrors.Single().Message);
+    }
+
+    [Fact(DisplayName = "Http endpoint workflow with a duplicate path and method fails to publish when FailOnValidationErrors is enabled.")]
+    public async Task ImportAndPublish_ShouldFail_WithTwoHttpEndpointSamePathMethod_WhenStrict()
+    {
+        var services = new TestApplicationBuilder(_testOutputHelper)
+            .WithCapturingTextWriter(_capturingTextWriter)
+            .ConfigureElsa(configure => configure
+                .UseHttp()
+                .UseWorkflowManagement(management => management.UseFailOnValidationErrors()))
+            .Build();
+
+        // Populate registries.
+        await services.PopulateRegistriesAsync();
+
+        // Import first workflow.
+        var workflowDefinition = await services.ImportWorkflowDefinitionAsync($"Scenarios/ImportAndPublish/Workflows/http-workflow.json");
+
+        // Publish first workflow.
+        IWorkflowDefinitionPublisher workflowDefinitionPublisher = services.GetRequiredService<IWorkflowDefinitionPublisher>();
+        var result = await workflowDefinitionPublisher.PublishAsync(workflowDefinition);
+
+        // Assert first workflow.
+        Assert.True(result.Succeeded);
+        Assert.Empty(result.ValidationErrors);
+
+        // Import second workflow.
+        workflowDefinition = await services.ImportWorkflowDefinitionAsync($"Scenarios/ImportAndPublish/Workflows/http-workflow.json");
 
         // Publish second workflow.
         result = await workflowDefinitionPublisher.PublishAsync(workflowDefinition);


### PR DESCRIPTION
## Summary

Restores the pre-3.6 ability to **publish workflows that have validation errors**. As of 3.6, `WorkflowDefinitionPublisher.PublishAsync` hard-fails publication whenever any validation error is present. Several teams relied on the older behavior — e.g. leaving a required property blank (an empty `Cron` expression used to *disable* a trigger) while still being able to publish.

This makes that strict behavior **opt-in** for the 3.6.x / 3.7.x line. It will become **opt-out** (default `true`) as of 3.8.0.

## Changes

- `ManagementOptions.FailOnValidationErrors` — new flag, **default `false`** on this branch.
- `WorkflowManagementFeature.UseFailOnValidationErrors(bool = true)` — fluent toggle.
- `WorkflowDefinitionPublisher.PublishAsync` — only hard-fails when the flag is `true`. When `false`, publication proceeds and validation errors are returned as warnings on `PublishWorkflowDefinitionResult.ValidationErrors` (with `Succeeded = true`).

## Behavior

| Mode | Default on | Publishing a workflow with validation errors |
|---|---|---|
| Lenient (`FailOnValidationErrors = false`) | 3.6.x / 3.7.x | Succeeds; errors surfaced as warnings |
| Strict (`FailOnValidationErrors = true`) | 3.8.0 (planned) | Fails (current 3.6 behavior) |

Opt in to strict mode:

```csharp
elsa.UseWorkflowManagement(management => management.UseFailOnValidationErrors());
```

## API endpoint behavior changes

These endpoints previously ignored the publish result and always reported success. They now honor it, and they surface validation warnings so lenient-mode callers can see why a publish succeeded with problems:

- **`POST workflow-definitions/{id}/publish` (Publish)** — now returns **400** with the validation errors when the publish fails (strict mode). On success the response body now includes a `validationErrors` collection (populated in lenient mode when the workflow published despite errors).
- **`POST workflow-definitions` (Post, save-and-publish)** — the success response body now includes a `validationErrors` collection (lenient-mode warnings). Strict-mode validation failures continue to return 400.
- **`POST workflow-definitions/bulk-publish` (BulkPublish)** — definitions whose publish fails (strict mode) are now reported in a new `failed` bucket instead of being counted as `published`. A new `warnings` map (`definitionId` → messages) surfaces lenient-mode validation warnings for definitions that published despite errors.

These are additive response fields plus a corrected status code on the single `Publish` endpoint in strict mode; lenient mode (the default on this branch) does not change the HTTP status of a successful publish.

## Tests

Updated the existing `ImportAndPublish` integration scenarios to the new default and added strict-mode counterparts:
- Cron with a bad expression: publishes by default (warning surfaced); fails when `UseFailOnValidationErrors()`.
- Duplicate HTTP path/method: publishes by default (warning surfaced); fails when `UseFailOnValidationErrors()`.

All 7 `ImportAndPublish` tests pass.

## Notes

- Complements PR #7739 (blank/disabled Cron trigger). That PR fixes the narrow Cron domain semantics (blank = disabled trigger); this PR is the general, configurable safety net for all validation errors.
- Mirrors the API contract changes made on `main` in PR #7741, keeping the 3.6.x and 3.8 branches at parity.

Related: #7738
