### PR TITLE
Add secret name validator coverage

### DIFF
--- a/test/unit/Elsa.Secrets.UnitTests/DefaultSecretNameValidatorTests.cs
+++ b/test/unit/Elsa.Secrets.UnitTests/DefaultSecretNameValidatorTests.cs
@@ -54,14 +54,18 @@ public class DefaultSecretNameValidatorTests
     }
 
     [Fact]
-    public void IsValid_RejectsNamesLongerThanTwoHundredCharacters()
+    public void IsValid_EnforcesTwoHundredCharacterMaximum()
     {
-        var name = $"a{new string('b', 200)}";
+        var validName = $"a{new string('b', 199)}";
+        var invalidName = $"a{new string('b', 200)}";
 
-        var isValid = _validator.IsValid(name, out var error);
+        var isValid = _validator.IsValid(validName, out var validError);
+        var isInvalid = _validator.IsValid(invalidName, out var invalidError);
 
-        Assert.False(isValid);
-        Assert.NotNull(error);
+        Assert.True(isValid);
+        Assert.Null(validError);
+        Assert.False(isInvalid);
+        Assert.NotNull(invalidError);
     }
 
     [Fact]

--- a/test/unit/Elsa.Secrets.UnitTests/DefaultSecretNameValidatorTests.cs
+++ b/test/unit/Elsa.Secrets.UnitTests/DefaultSecretNameValidatorTests.cs
@@ -1,0 +1,74 @@
+using Elsa.Secrets.Services;
+using Xunit;
+
+namespace Elsa.Secrets.UnitTests;
+
+public class DefaultSecretNameValidatorTests
+{
+    private readonly DefaultSecretNameValidator _validator = new();
+
+    [Theory]
+    [InlineData("ab")]
+    [InlineData("Smtp:Password")]
+    [InlineData("secret.name-1_value:prod")]
+    public void IsValid_ReturnsTrue_ForValidTechnicalNames(string name)
+    {
+        var isValid = _validator.IsValid(name, out var error);
+
+        Assert.True(isValid);
+        Assert.Null(error);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void IsValid_ReturnsRequiredError_ForMissingTechnicalNames(string? name)
+    {
+        var isValid = _validator.IsValid(name, out var error);
+
+        Assert.False(isValid);
+        Assert.Equal("Secret name is required.", error);
+    }
+
+    [Theory]
+    [InlineData("a")]
+    [InlineData("1secret")]
+    [InlineData("secret name")]
+    [InlineData("secret/name")]
+    public void IsValid_ReturnsFormatError_ForInvalidTechnicalNames(string name)
+    {
+        var isValid = _validator.IsValid(name, out var error);
+
+        Assert.False(isValid);
+        Assert.Equal("Secret name must be 2-200 characters, start with a letter, and contain only letters, numbers, dots, dashes, underscores, and colons.", error);
+    }
+
+    [Fact]
+    public void IsValid_AcceptsTrimmedTechnicalName()
+    {
+        var isValid = _validator.IsValid("  Smtp:Password  ", out var error);
+
+        Assert.True(isValid);
+        Assert.Null(error);
+    }
+
+    [Fact]
+    public void IsValid_RejectsNamesLongerThanTwoHundredCharacters()
+    {
+        var name = $"a{new string('b', 200)}";
+
+        var isValid = _validator.IsValid(name, out var error);
+
+        Assert.False(isValid);
+        Assert.NotNull(error);
+    }
+
+    [Fact]
+    public void Normalize_TrimsAndLowercasesTechnicalName()
+    {
+        var normalized = _validator.Normalize("  Smtp:Password  ");
+
+        Assert.Equal("smtp:password", normalized);
+    }
+}

--- a/test/unit/Elsa.Secrets.UnitTests/DefaultSecretNameValidatorTests.cs
+++ b/test/unit/Elsa.Secrets.UnitTests/DefaultSecretNameValidatorTests.cs
@@ -5,6 +5,8 @@ namespace Elsa.Secrets.UnitTests;
 
 public class DefaultSecretNameValidatorTests
 {
+    private const string FormatError = "Secret name must be 2-200 characters, start with a letter, and contain only letters, numbers, dots, dashes, underscores, and colons.";
+
     private readonly DefaultSecretNameValidator _validator = new();
 
     [Theory]
@@ -41,7 +43,7 @@ public class DefaultSecretNameValidatorTests
         var isValid = _validator.IsValid(name, out var error);
 
         Assert.False(isValid);
-        Assert.Equal("Secret name must be 2-200 characters, start with a letter, and contain only letters, numbers, dots, dashes, underscores, and colons.", error);
+        Assert.Equal(FormatError, error);
     }
 
     [Fact]
@@ -65,7 +67,7 @@ public class DefaultSecretNameValidatorTests
         Assert.True(isValid);
         Assert.Null(validError);
         Assert.False(isInvalid);
-        Assert.NotNull(invalidError);
+        Assert.Equal(FormatError, invalidError);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- add direct unit coverage for DefaultSecretNameValidator valid, invalid, trim, length, and normalization paths

## Tests
- dotnet test test/unit/Elsa.Secrets.UnitTests/Elsa.Secrets.UnitTests.csproj