### PR TITLE
Fix PublishEvent payload assertion casing

### DIFF
--- a/test/component/Elsa.Workflows.ComponentTests/Scenarios/Activities/Primitives/Event/PublishEventTests.cs
+++ b/test/component/Elsa.Workflows.ComponentTests/Scenarios/Activities/Primitives/Event/PublishEventTests.cs
@@ -74,8 +74,23 @@ public class PublishEventTests : AppComponentTest
 
         // Verify the payload structure and content
         using var payloadDocument = JsonDocument.Parse(JsonSerializer.Serialize(receivedPayload));
-        Assert.True(payloadDocument.RootElement.TryGetProperty("Status", out var status), "Received payload should contain a Status property");
+        Assert.True(TryGetProperty(payloadDocument.RootElement, "Status", out var status), "Received payload should contain a Status property");
         Assert.Equal("Shipped", status.GetString());
+    }
+
+    private static bool TryGetProperty(JsonElement element, string propertyName, out JsonElement value)
+    {
+        foreach (var property in element.EnumerateObject())
+        {
+            if (string.Equals(property.Name, propertyName, StringComparison.OrdinalIgnoreCase))
+            {
+                value = property.Value;
+                return true;
+            }
+        }
+
+        value = default;
+        return false;
     }
 
     private async Task<WorkflowInstance> GetSingleWorkflowInstanceAsync(string definitionId, string correlationId, int timeoutMs = 5000)

--- a/test/component/Elsa.Workflows.ComponentTests/Scenarios/Activities/Primitives/Event/PublishEventTests.cs
+++ b/test/component/Elsa.Workflows.ComponentTests/Scenarios/Activities/Primitives/Event/PublishEventTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Text.Json;
 using Elsa.Common.Models;
 using Elsa.Testing.Shared;
@@ -80,17 +81,13 @@ public class PublishEventTests : AppComponentTest
 
     private static bool TryGetProperty(JsonElement element, string propertyName, out JsonElement value)
     {
-        foreach (var property in element.EnumerateObject())
-        {
-            if (string.Equals(property.Name, propertyName, StringComparison.OrdinalIgnoreCase))
-            {
-                value = property.Value;
-                return true;
-            }
-        }
+        value = element
+            .EnumerateObject()
+            .Where(property => string.Equals(property.Name, propertyName, StringComparison.OrdinalIgnoreCase))
+            .Select(property => property.Value)
+            .FirstOrDefault();
 
-        value = default;
-        return false;
+        return value.ValueKind != JsonValueKind.Undefined;
     }
 
     private async Task<WorkflowInstance> GetSingleWorkflowInstanceAsync(string definitionId, string correlationId, int timeoutMs = 5000)


### PR DESCRIPTION
## Summary
- Make the `PublishEvent_WithPayload_TransmitsPayloadToConsumer` payload property assertion case-insensitive.
- Keep payload serialization behavior unchanged; the fix is scoped to the flaky component test.

## Validation
- `dotnet restore test/component/Elsa.Workflows.ComponentTests/Elsa.Workflows.ComponentTests.csproj --ignore-failed-sources`
- `dotnet test test/component/Elsa.Workflows.ComponentTests/Elsa.Workflows.ComponentTests.csproj --filter FullyQualifiedName~PublishEvent_WithPayload_TransmitsPayloadToConsumer --no-build --no-restore /p:CollectCoverage=false`

Fixes #7749