### PR TITLE
fix: correct Oracle identifier quoting and NVARCHAR2 type cast in GenerateOracleUpsert

### DIFF
--- a/Elsa.sln
+++ b/Elsa.sln
@@ -413,6 +413,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Persistence.VNext.Runt
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Hosting.Management.UnitTests", "test\unit\Elsa.Hosting.Management.UnitTests\Elsa.Hosting.Management.UnitTests.csproj", "{39DE4EE7-0FDB-499F-9BC2-7ECC779FA5F6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Persistence.EFCore.UnitTests", "test\unit\Elsa.Persistence.EFCore.UnitTests\Elsa.Persistence.EFCore.UnitTests.csproj", "{C6EFA89A-923E-4F7A-A63B-BC8DDF44A208}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1837,6 +1839,18 @@ Global
 		{39DE4EE7-0FDB-499F-9BC2-7ECC779FA5F6}.Release|x64.Build.0 = Release|Any CPU
 		{39DE4EE7-0FDB-499F-9BC2-7ECC779FA5F6}.Release|x86.ActiveCfg = Release|Any CPU
 		{39DE4EE7-0FDB-499F-9BC2-7ECC779FA5F6}.Release|x86.Build.0 = Release|Any CPU
+		{C6EFA89A-923E-4F7A-A63B-BC8DDF44A208}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C6EFA89A-923E-4F7A-A63B-BC8DDF44A208}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C6EFA89A-923E-4F7A-A63B-BC8DDF44A208}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C6EFA89A-923E-4F7A-A63B-BC8DDF44A208}.Debug|x64.Build.0 = Debug|Any CPU
+		{C6EFA89A-923E-4F7A-A63B-BC8DDF44A208}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C6EFA89A-923E-4F7A-A63B-BC8DDF44A208}.Debug|x86.Build.0 = Debug|Any CPU
+		{C6EFA89A-923E-4F7A-A63B-BC8DDF44A208}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C6EFA89A-923E-4F7A-A63B-BC8DDF44A208}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C6EFA89A-923E-4F7A-A63B-BC8DDF44A208}.Release|x64.ActiveCfg = Release|Any CPU
+		{C6EFA89A-923E-4F7A-A63B-BC8DDF44A208}.Release|x64.Build.0 = Release|Any CPU
+		{C6EFA89A-923E-4F7A-A63B-BC8DDF44A208}.Release|x86.ActiveCfg = Release|Any CPU
+		{C6EFA89A-923E-4F7A-A63B-BC8DDF44A208}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1993,6 +2007,7 @@ Global
 		{E1607923-038B-41D6-9D23-F540FC9E6CCE} = {5BA4A8FA-F7F4-45B3-AEC8-8886D35AAC79}
 		{6E3B6948-B16D-480C-879E-B805F732649F} = {5BA4A8FA-F7F4-45B3-AEC8-8886D35AAC79}
 		{39DE4EE7-0FDB-499F-9BC2-7ECC779FA5F6} = {18453B51-25EB-4317-A4B3-B10518252E92}
+		{C6EFA89A-923E-4F7A-A63B-BC8DDF44A208} = {18453B51-25EB-4317-A4B3-B10518252E92}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D4B5CEAA-7D70-4FCB-A68E-B03FBE5E0E5E}

--- a/src/modules/Elsa.Persistence.EFCore.Common/AssemblyInfo.cs
+++ b/src/modules/Elsa.Persistence.EFCore.Common/AssemblyInfo.cs
@@ -1,3 +1,4 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Elsa.Persistence.EFCore")]
+[assembly: InternalsVisibleTo("Elsa.Persistence.EFCore.UnitTests")]

--- a/src/modules/Elsa.Persistence.EFCore.Common/Extensions/BulkUpsertExtensions.cs
+++ b/src/modules/Elsa.Persistence.EFCore.Common/Extensions/BulkUpsertExtensions.cs
@@ -16,12 +16,6 @@ public static class BulkUpsertExtensions
     /// <summary>
     /// Performs a bulk upsert operation on a list of entities in the specified database context using a key selector.
     /// </summary>
-    /// <typeparam name="TDbContext">The type of the database context.</typeparam>
-    /// <typeparam name="TEntity">The type of the entity being upserted.</typeparam>
-    /// <param name="dbContext">The database context where the bulk upsert operation will be executed.</param>
-    /// <param name="entities">The list of entities to be upserted.</param>
-    /// <param name="keySelector">An expression used to determine the key for upsert operations.</param>
-    /// <param name="cancellationToken">A token to observe while waiting for the operation to complete.</param>
     public static async Task BulkUpsertAsync<TDbContext, TEntity>(
         this TDbContext dbContext,
         IList<TEntity> entities,
@@ -36,13 +30,6 @@ public static class BulkUpsertExtensions
     /// <summary>
     /// Performs a bulk upsert operation on a list of entities in the specified database context using a key selector and optional batch size.
     /// </summary>
-    /// <typeparam name="TDbContext">The type of the database context.</typeparam>
-    /// <typeparam name="TEntity">The type of the entity being upserted.</typeparam>
-    /// <param name="dbContext">The database context where the bulk upsert operation will be executed.</param>
-    /// <param name="entities">The list of entities to be upserted.</param>
-    /// <param name="keySelector">An expression used to determine the key for upsert operations.</param>
-    /// <param name="batchSize">The size of each batch for processing the upsert operation. Defaults to 50.</param>
-    /// <param name="cancellationToken">A token to observe while waiting for the operation to complete.</param>
     /// <exception cref="NotSupportedException">Thrown if the database provider for the context is not supported.</exception>
     public static async Task BulkUpsertAsync<TDbContext, TEntity>(
         this TDbContext dbContext,
@@ -56,29 +43,28 @@ public static class BulkUpsertExtensions
         if (entities.Count == 0)
             return;
 
-        // Identify the current provider (e.g., "Microsoft.EntityFrameworkCore.SqlServer")
         var providerName = dbContext.Database.ProviderName?.ToLowerInvariant() ?? string.Empty;
 
-        // Determine the method for generating SQL based on the provider
         Func<DbContext, IList<TEntity>, Expression<Func<TEntity, string>>, (string, object[])> generateSql = providerName switch
         {
             var pn when pn.Contains("sqlserver") => GenerateSqlServerUpsert,
-            var pn when pn.Contains("sqlite") => GenerateSqliteUpsert,
-            var pn when pn.Contains("postgres") => GeneratePostgresUpsert,
-            var pn when pn.Contains("mysql") => GenerateMySqlUpsert,
-            var pn when pn.Contains("oracle") => GenerateOracleUpsert,
+            var pn when pn.Contains("sqlite")    => GenerateSqliteUpsert,
+            var pn when pn.Contains("postgres")  => GeneratePostgresUpsert,
+            var pn when pn.Contains("mysql")     => GenerateMySqlUpsert,
+            var pn when pn.Contains("oracle")    => GenerateOracleUpsert,
             _ => throw new NotSupportedException($"Provider '{providerName}' is not supported.")
         };
 
-        // Loop through batched entities
         foreach (var batch in entities.Chunk(batchSize))
         {
-            // Generate SQL and parameters
             var (sql, parameters) = generateSql(dbContext, batch, keySelector);
-
             await dbContext.Database.ExecuteSqlRawAsync(sql, parameters, cancellationToken);
         }
     }
+
+    // -------------------------------------------------------------------------
+    // SQL Server
+    // -------------------------------------------------------------------------
 
     private static (string, object[]) GenerateSqlServerUpsert<TEntity>(
         DbContext dbContext,
@@ -92,9 +78,7 @@ public static class BulkUpsertExtensions
         var props = entityType.GetProperties().ToList();
         var keyProp = entityType.FindProperty(keySelector.GetMemberAccess().Name)!;
         var keyColumnName = $"[{keyProp.GetColumnName(storeObject)}]";
-        var columnNames = props
-            .Select(p => $"[{p.GetColumnName(storeObject)}]")
-            .ToList();
+        var columnNames = props.Select(p => $"[{p.GetColumnName(storeObject)}]").ToList();
 
         var mergeSql = new StringBuilder();
         mergeSql.AppendLine($"MERGE {tableName} AS Target");
@@ -111,27 +95,21 @@ public static class BulkUpsertExtensions
             foreach (var property in props)
             {
                 var paramName = $"{{{parameterCount++}}}";
-
-                // If it's a shadow property, retrieve value via Entry(..).Property(..)
                 var value = property.IsShadowProperty()
                     ? dbContext.Entry(entity).Property(property.Name).CurrentValue
                     : property.PropertyInfo?.GetValue(entity);
-
                 var converter = property.GetTypeMapping().Converter;
-                if (converter != null)
-                    value = converter.ConvertToProvider(value)!;
+                if (converter != null) value = converter.ConvertToProvider(value)!;
 
-                // Explicitly cast null values for varbinary columns
                 if (property.GetColumnType().StartsWith("varbinary", StringComparison.OrdinalIgnoreCase) && value is null)
-                    values.Add("CAST(NULL AS varbinary(max))"); // Explicitly cast null
+                    values.Add("CAST(NULL AS varbinary(max))");
                 else
                     values.Add(paramName);
-                
+
                 parameters.Add(value!);
             }
 
-            var line = $"({string.Join(", ", values)}){(i < entities.Count - 1 ? "," : string.Empty)}";
-            mergeSql.AppendLine(line);
+            mergeSql.AppendLine($"({string.Join(", ", values)}){(i < entities.Count - 1 ? "," : string.Empty)}");
         }
 
         mergeSql.AppendLine($") AS Source ({string.Join(", ", columnNames)})");
@@ -145,6 +123,10 @@ public static class BulkUpsertExtensions
         return (mergeSql.ToString(), parameters.ToArray());
     }
 
+    // -------------------------------------------------------------------------
+    // SQLite
+    // -------------------------------------------------------------------------
+
     private static (string, object[]) GenerateSqliteUpsert<TEntity>(
         DbContext dbContext,
         IList<TEntity> entities,
@@ -157,9 +139,7 @@ public static class BulkUpsertExtensions
         var props = entityType.GetProperties().ToList();
         var keyProp = entityType.FindProperty(keySelector.GetMemberAccess().Name)!;
         var keyColumnName = keyProp.GetColumnName(storeObject);
-        var columnNames = props
-            .Select(p => p.GetColumnName(storeObject)!)
-            .ToList();
+        var columnNames = props.Select(p => p.GetColumnName(storeObject)!).ToList();
 
         var sb = new StringBuilder();
         var parameters = new List<object>();
@@ -175,35 +155,29 @@ public static class BulkUpsertExtensions
             foreach (var property in props)
             {
                 var paramName = $"{{{parameterCount++}}}";
-
                 var value = property.IsShadowProperty()
                     ? dbContext.Entry(entity).Property(property.Name).CurrentValue
                     : property.PropertyInfo?.GetValue(entity);
-
                 var converter = property.GetTypeMapping().Converter;
-                if (converter != null)
-                    value = converter.ConvertToProvider(value);
-
+                if (converter != null) value = converter.ConvertToProvider(value);
                 placeholders.Add(paramName);
                 parameters.Add(value!);
             }
 
             sb.Append($"({string.Join(", ", placeholders)})");
-            if (i < entities.Count - 1)
-                sb.Append(", ");
+            if (i < entities.Count - 1) sb.Append(", ");
         }
 
         sb.AppendLine();
         sb.AppendLine($"ON CONFLICT(\"{keyColumnName}\") DO UPDATE SET");
-
-        var updateAssignments = columnNames
-            .Where(c => c != keyColumnName)
-            .Select(c => $"\"{c}\"=excluded.\"{c}\"");
-
-        sb.AppendLine(string.Join(", ", updateAssignments) + ";");
+        sb.AppendLine(string.Join(", ", columnNames.Where(c => c != keyColumnName).Select(c => $"\"{c}\"=excluded.\"{c}\"")) + ";");
 
         return (sb.ToString(), parameters.ToArray());
     }
+
+    // -------------------------------------------------------------------------
+    // PostgreSQL
+    // -------------------------------------------------------------------------
 
     private static (string, object[]) GeneratePostgresUpsert<TEntity>(
         DbContext dbContext,
@@ -214,14 +188,10 @@ public static class BulkUpsertExtensions
         var entityType = dbContext.Model.FindEntityType(typeof(TEntity))!;
         var tableName = entityType.GetTableName();
         var storeObject = StoreObjectIdentifier.Table(tableName!, entityType.GetSchema());
-
         var props = entityType.GetProperties().ToList();
-
         var keyProp = entityType.FindProperty(keySelector.GetMemberAccess().Name)!;
         var keyColumnName = keyProp.GetColumnName(storeObject);
-        var columnNames = props
-            .Select(p => p.GetColumnName(storeObject)!)
-            .ToList();
+        var columnNames = props.Select(p => p.GetColumnName(storeObject)!).ToList();
 
         var sb = new StringBuilder();
         var parameters = new List<object>();
@@ -237,16 +207,12 @@ public static class BulkUpsertExtensions
             foreach (var property in props)
             {
                 var paramName = $"{{{parameterCount++}}}";
-
                 var value = property.IsShadowProperty()
                     ? dbContext.Entry(entity).Property(property.Name).CurrentValue
                     : property.PropertyInfo?.GetValue(entity);
-
                 var converter = property.GetTypeMapping().Converter;
-                if (converter != null)
-                    value = converter.ConvertToProvider(value);
+                if (converter != null) value = converter.ConvertToProvider(value);
 
-                // Detect json/jsonb column types and cast the parameter so PostgreSQL accepts it.
                 var columnType = property.GetColumnType();
                 if (columnType.StartsWith("jsonb", StringComparison.OrdinalIgnoreCase))
                     placeholders.Add($"CAST({paramName} AS jsonb)");
@@ -254,26 +220,24 @@ public static class BulkUpsertExtensions
                     placeholders.Add($"CAST({paramName} AS json)");
                 else
                     placeholders.Add(paramName);
-                
+
                 parameters.Add(value!);
             }
 
             sb.Append($"({string.Join(", ", placeholders)})");
-            if (i < entities.Count - 1)
-                sb.Append(", ");
+            if (i < entities.Count - 1) sb.Append(", ");
         }
 
         sb.AppendLine();
         sb.AppendLine($"ON CONFLICT (\"{keyColumnName}\") DO UPDATE SET");
-
-        var updateAssignments = columnNames
-            .Where(c => c != keyColumnName)
-            .Select(c => $"\"{c}\" = EXCLUDED.\"{c}\"");
-
-        sb.AppendLine(string.Join(", ", updateAssignments) + ";");
+        sb.AppendLine(string.Join(", ", columnNames.Where(c => c != keyColumnName).Select(c => $"\"{c}\" = EXCLUDED.\"{c}\"")) + ";");
 
         return (sb.ToString(), parameters.ToArray());
     }
+
+    // -------------------------------------------------------------------------
+    // MySQL
+    // -------------------------------------------------------------------------
 
     private static (string, object[]) GenerateMySqlUpsert<TEntity>(
         DbContext dbContext,
@@ -284,14 +248,10 @@ public static class BulkUpsertExtensions
         var entityType = dbContext.Model.FindEntityType(typeof(TEntity))!;
         var tableName = entityType.GetTableName();
         var storeObject = StoreObjectIdentifier.Table(tableName!, entityType.GetSchema());
-
         var props = entityType.GetProperties().ToList();
-
         var keyProp = entityType.FindProperty(keySelector.GetMemberAccess().Name)!;
         var keyColumnName = keyProp.GetColumnName(storeObject);
-        var columnNames = props
-            .Select(p => p.GetColumnName(storeObject)!)
-            .ToList();
+        var columnNames = props.Select(p => p.GetColumnName(storeObject)!).ToList();
 
         var sb = new StringBuilder();
         var parameters = new List<object>();
@@ -307,35 +267,29 @@ public static class BulkUpsertExtensions
             foreach (var property in props)
             {
                 var paramName = $"{{{parameterCount++}}}";
-
                 var value = property.IsShadowProperty()
                     ? dbContext.Entry(entity).Property(property.Name).CurrentValue
                     : property.PropertyInfo?.GetValue(entity);
-
                 var converter = property.GetTypeMapping().Converter;
-                if (converter != null)
-                    value = converter.ConvertToProvider(value);
-
+                if (converter != null) value = converter.ConvertToProvider(value);
                 placeholders.Add(paramName);
                 parameters.Add(value!);
             }
 
             sb.Append($"({string.Join(", ", placeholders)})");
-            if (i < entities.Count - 1)
-                sb.Append(", ");
+            if (i < entities.Count - 1) sb.Append(", ");
         }
 
         sb.AppendLine();
         sb.AppendLine("ON DUPLICATE KEY UPDATE");
-
-        var updateAssignments = columnNames
-            .Where(c => c != keyColumnName)
-            .Select(c => $"`{c}` = VALUES(`{c}`)");
-
-        sb.AppendLine(string.Join(", ", updateAssignments) + ";");
+        sb.AppendLine(string.Join(", ", columnNames.Where(c => c != keyColumnName).Select(c => $"`{c}` = VALUES(`{c}`)")) + ";");
 
         return (sb.ToString(), parameters.ToArray());
     }
+
+    // -------------------------------------------------------------------------
+    // Oracle
+    // -------------------------------------------------------------------------
 
     private static (string, object[]) GenerateOracleUpsert<TEntity>(
         DbContext dbContext,
@@ -345,18 +299,24 @@ public static class BulkUpsertExtensions
     {
         var entityType = dbContext.Model.FindEntityType(typeof(TEntity))!;
         var schema = entityType.GetSchema();
-        var tableName = entityType.GetTableName();
-        var storeObject = StoreObjectIdentifier.Table(tableName!, schema);
-        var fullName = !string.IsNullOrEmpty(schema) ? $"{schema}.{tableName}" : tableName;
+        var tableName = entityType.GetTableName()!;
+        var storeObject = StoreObjectIdentifier.Table(tableName, schema);
+
+        // Both schema and table must be quoted so Oracle treats them as
+        // case-sensitive identifiers, matching what EF Core migrations create.
+        var fullName = !string.IsNullOrEmpty(schema)
+            ? $"\"{schema}\".\"{tableName}\""
+            : $"\"{tableName}\"";
 
         var props = entityType.GetProperties().ToList();
-
         var keyProp = entityType.FindProperty(keySelector.GetMemberAccess().Name)!;
-        var keyColumnName = keyProp.GetColumnName(storeObject);
+        var keyColumnName = keyProp.GetColumnName(storeObject)!;
 
-        var columnNames = props
-            .Select(p => p.GetColumnName(storeObject)!)
+        // Pre-build quoted column name list once; reuse throughout.
+        var quotedColumnNames = props
+            .Select(p => $"\"{p.GetColumnName(storeObject)}\"")
             .ToList();
+        var quotedKeyColumnName = $"\"{keyColumnName}\"";
 
         var sb = new StringBuilder();
         var parameters = new List<object>();
@@ -384,28 +344,61 @@ public static class BulkUpsertExtensions
 
                 parameters.Add(value!);
 
-                // Oracle aliases must match the column name
-                var alias = property.GetColumnName(storeObject);
-                lineParts.Add($"{paramName} AS {alias}");
+                // Alias must be quoted so Oracle preserves case, matching the
+                // quoted references in the WHEN MATCHED / WHEN NOT MATCHED clauses.
+                var quotedAlias = $"\"{property.GetColumnName(storeObject)}\"";
+
+                // Oracle cannot infer the bind parameter type from a bare SELECT …
+                // FROM DUAL — there is no target column to derive it from. For
+                // NVARCHAR2 columns this causes ODP.NET to default to VARCHAR2,
+                // which leads to datatype mismatch errors in the MERGE. An explicit
+                // CAST restores the correct type. The length is read from the EF
+                // column type string (e.g. "NVARCHAR2(500)") so it matches the
+                // actual column definition rather than an arbitrary hardcoded value.
+                string expr;
+                var columnType = property.GetColumnType() ?? string.Empty;
+                if (columnType.StartsWith("NVARCHAR2", StringComparison.OrdinalIgnoreCase))
+                {
+                    var length = ParseNVarchar2Length(columnType);
+                    expr = $"CAST({paramName} AS NVARCHAR2({length}))";
+                }
+                else
+                {
+                    expr = paramName;
+                }
+
+                lineParts.Add($"{expr} AS {quotedAlias}");
             }
 
-            // Comma if not last
-            var suffix = (i < entities.Count - 1) ? " FROM DUAL UNION ALL SELECT" : " FROM DUAL";
+            var suffix = i < entities.Count - 1 ? " FROM DUAL UNION ALL SELECT" : " FROM DUAL";
             sb.AppendLine(string.Join(", ", lineParts) + suffix);
         }
 
-        sb.AppendLine($") Source ON (Target.{keyColumnName} = Source.{keyColumnName})");
+        sb.AppendLine($") Source ON (Target.{quotedKeyColumnName} = Source.{quotedKeyColumnName})");
         sb.AppendLine("WHEN MATCHED THEN UPDATE SET");
-
-        var updateSetClauses = columnNames
-            .Where(c => c != keyColumnName)
-            .Select(c => $"Target.{c} = Source.{c}");
-
-        sb.AppendLine(string.Join(", ", updateSetClauses));
+        sb.AppendLine(string.Join(", ", quotedColumnNames
+            .Where(c => c != quotedKeyColumnName)
+            .Select(c => $"Target.{c} = Source.{c}")));
         sb.AppendLine("WHEN NOT MATCHED THEN");
-        sb.AppendLine($"INSERT ({string.Join(", ", columnNames)})");
-        sb.AppendLine($"VALUES ({string.Join(", ", columnNames.Select(c => $"Source.{c}"))});");
+        sb.AppendLine($"INSERT ({string.Join(", ", quotedColumnNames)})");
+        sb.AppendLine($"VALUES ({string.Join(", ", quotedColumnNames.Select(c => $"Source.{c}"))});");
 
         return (sb.ToString(), parameters.ToArray());
+    }
+
+    /// <summary>
+    /// Extracts the maximum length from an Oracle NVARCHAR2 column type string.
+    /// For example, "NVARCHAR2(500)" returns 500.
+    /// Falls back to 2000 (Oracle's maximum for NVARCHAR2) if the string is malformed.
+    /// </summary>
+    private static int ParseNVarchar2Length(string columnType)
+    {
+        var open = columnType.IndexOf('(');
+        var close = columnType.IndexOf(')');
+        if (open >= 0 && close > open &&
+            int.TryParse(columnType.AsSpan(open + 1, close - open - 1), out var length))
+            return length;
+
+        return 2000;
     }
 }

--- a/src/modules/Elsa.Persistence.EFCore.Common/Extensions/BulkUpsertExtensions.cs
+++ b/src/modules/Elsa.Persistence.EFCore.Common/Extensions/BulkUpsertExtensions.cs
@@ -16,6 +16,12 @@ public static class BulkUpsertExtensions
     /// <summary>
     /// Performs a bulk upsert operation on a list of entities in the specified database context using a key selector.
     /// </summary>
+    /// <typeparam name="TDbContext">The type of the database context.</typeparam>
+    /// <typeparam name="TEntity">The type of the entity being upserted.</typeparam>
+    /// <param name="dbContext">The database context where the bulk upsert operation will be executed.</param>
+    /// <param name="entities">The list of entities to be upserted.</param>
+    /// <param name="keySelector">An expression used to determine the key for upsert operations.</param>
+    /// <param name="cancellationToken">A token to observe while waiting for the operation to complete.</param>
     public static async Task BulkUpsertAsync<TDbContext, TEntity>(
         this TDbContext dbContext,
         IList<TEntity> entities,
@@ -30,6 +36,13 @@ public static class BulkUpsertExtensions
     /// <summary>
     /// Performs a bulk upsert operation on a list of entities in the specified database context using a key selector and optional batch size.
     /// </summary>
+    /// <typeparam name="TDbContext">The type of the database context.</typeparam>
+    /// <typeparam name="TEntity">The type of the entity being upserted.</typeparam>
+    /// <param name="dbContext">The database context where the bulk upsert operation will be executed.</param>
+    /// <param name="entities">The list of entities to be upserted.</param>
+    /// <param name="keySelector">An expression used to determine the key for upsert operations.</param>
+    /// <param name="batchSize">The size of each batch for processing the upsert operation. Defaults to 50.</param>
+    /// <param name="cancellationToken">A token to observe while waiting for the operation to complete.</param>
     /// <exception cref="NotSupportedException">Thrown if the database provider for the context is not supported.</exception>
     public static async Task BulkUpsertAsync<TDbContext, TEntity>(
         this TDbContext dbContext,
@@ -43,28 +56,29 @@ public static class BulkUpsertExtensions
         if (entities.Count == 0)
             return;
 
+        // Identify the current provider (e.g., "Microsoft.EntityFrameworkCore.SqlServer")
         var providerName = dbContext.Database.ProviderName?.ToLowerInvariant() ?? string.Empty;
 
+        // Determine the method for generating SQL based on the provider
         Func<DbContext, IList<TEntity>, Expression<Func<TEntity, string>>, (string, object[])> generateSql = providerName switch
         {
             var pn when pn.Contains("sqlserver") => GenerateSqlServerUpsert,
-            var pn when pn.Contains("sqlite")    => GenerateSqliteUpsert,
-            var pn when pn.Contains("postgres")  => GeneratePostgresUpsert,
-            var pn when pn.Contains("mysql")     => GenerateMySqlUpsert,
-            var pn when pn.Contains("oracle")    => GenerateOracleUpsert,
+            var pn when pn.Contains("sqlite") => GenerateSqliteUpsert,
+            var pn when pn.Contains("postgres") => GeneratePostgresUpsert,
+            var pn when pn.Contains("mysql") => GenerateMySqlUpsert,
+            var pn when pn.Contains("oracle") => GenerateOracleUpsert,
             _ => throw new NotSupportedException($"Provider '{providerName}' is not supported.")
         };
 
+        // Loop through batched entities
         foreach (var batch in entities.Chunk(batchSize))
         {
+            // Generate SQL and parameters
             var (sql, parameters) = generateSql(dbContext, batch, keySelector);
+
             await dbContext.Database.ExecuteSqlRawAsync(sql, parameters, cancellationToken);
         }
     }
-
-    // -------------------------------------------------------------------------
-    // SQL Server
-    // -------------------------------------------------------------------------
 
     private static (string, object[]) GenerateSqlServerUpsert<TEntity>(
         DbContext dbContext,
@@ -78,7 +92,9 @@ public static class BulkUpsertExtensions
         var props = entityType.GetProperties().ToList();
         var keyProp = entityType.FindProperty(keySelector.GetMemberAccess().Name)!;
         var keyColumnName = $"[{keyProp.GetColumnName(storeObject)}]";
-        var columnNames = props.Select(p => $"[{p.GetColumnName(storeObject)}]").ToList();
+        var columnNames = props
+            .Select(p => $"[{p.GetColumnName(storeObject)}]")
+            .ToList();
 
         var mergeSql = new StringBuilder();
         mergeSql.AppendLine($"MERGE {tableName} AS Target");
@@ -95,21 +111,27 @@ public static class BulkUpsertExtensions
             foreach (var property in props)
             {
                 var paramName = $"{{{parameterCount++}}}";
+
+                // If it's a shadow property, retrieve value via Entry(..).Property(..)
                 var value = property.IsShadowProperty()
                     ? dbContext.Entry(entity).Property(property.Name).CurrentValue
                     : property.PropertyInfo?.GetValue(entity);
-                var converter = property.GetTypeMapping().Converter;
-                if (converter != null) value = converter.ConvertToProvider(value)!;
 
+                var converter = property.GetTypeMapping().Converter;
+                if (converter != null)
+                    value = converter.ConvertToProvider(value)!;
+
+                // Explicitly cast null values for varbinary columns
                 if (property.GetColumnType().StartsWith("varbinary", StringComparison.OrdinalIgnoreCase) && value is null)
-                    values.Add("CAST(NULL AS varbinary(max))");
+                    values.Add("CAST(NULL AS varbinary(max))"); // Explicitly cast null
                 else
                     values.Add(paramName);
-
+                
                 parameters.Add(value!);
             }
 
-            mergeSql.AppendLine($"({string.Join(", ", values)}){(i < entities.Count - 1 ? "," : string.Empty)}");
+            var line = $"({string.Join(", ", values)}){(i < entities.Count - 1 ? "," : string.Empty)}";
+            mergeSql.AppendLine(line);
         }
 
         mergeSql.AppendLine($") AS Source ({string.Join(", ", columnNames)})");
@@ -123,10 +145,6 @@ public static class BulkUpsertExtensions
         return (mergeSql.ToString(), parameters.ToArray());
     }
 
-    // -------------------------------------------------------------------------
-    // SQLite
-    // -------------------------------------------------------------------------
-
     private static (string, object[]) GenerateSqliteUpsert<TEntity>(
         DbContext dbContext,
         IList<TEntity> entities,
@@ -139,7 +157,9 @@ public static class BulkUpsertExtensions
         var props = entityType.GetProperties().ToList();
         var keyProp = entityType.FindProperty(keySelector.GetMemberAccess().Name)!;
         var keyColumnName = keyProp.GetColumnName(storeObject);
-        var columnNames = props.Select(p => p.GetColumnName(storeObject)!).ToList();
+        var columnNames = props
+            .Select(p => p.GetColumnName(storeObject)!)
+            .ToList();
 
         var sb = new StringBuilder();
         var parameters = new List<object>();
@@ -155,29 +175,35 @@ public static class BulkUpsertExtensions
             foreach (var property in props)
             {
                 var paramName = $"{{{parameterCount++}}}";
+
                 var value = property.IsShadowProperty()
                     ? dbContext.Entry(entity).Property(property.Name).CurrentValue
                     : property.PropertyInfo?.GetValue(entity);
+
                 var converter = property.GetTypeMapping().Converter;
-                if (converter != null) value = converter.ConvertToProvider(value);
+                if (converter != null)
+                    value = converter.ConvertToProvider(value);
+
                 placeholders.Add(paramName);
                 parameters.Add(value!);
             }
 
             sb.Append($"({string.Join(", ", placeholders)})");
-            if (i < entities.Count - 1) sb.Append(", ");
+            if (i < entities.Count - 1)
+                sb.Append(", ");
         }
 
         sb.AppendLine();
         sb.AppendLine($"ON CONFLICT(\"{keyColumnName}\") DO UPDATE SET");
-        sb.AppendLine(string.Join(", ", columnNames.Where(c => c != keyColumnName).Select(c => $"\"{c}\"=excluded.\"{c}\"")) + ";");
+
+        var updateAssignments = columnNames
+            .Where(c => c != keyColumnName)
+            .Select(c => $"\"{c}\"=excluded.\"{c}\"");
+
+        sb.AppendLine(string.Join(", ", updateAssignments) + ";");
 
         return (sb.ToString(), parameters.ToArray());
     }
-
-    // -------------------------------------------------------------------------
-    // PostgreSQL
-    // -------------------------------------------------------------------------
 
     private static (string, object[]) GeneratePostgresUpsert<TEntity>(
         DbContext dbContext,
@@ -188,10 +214,14 @@ public static class BulkUpsertExtensions
         var entityType = dbContext.Model.FindEntityType(typeof(TEntity))!;
         var tableName = entityType.GetTableName();
         var storeObject = StoreObjectIdentifier.Table(tableName!, entityType.GetSchema());
+
         var props = entityType.GetProperties().ToList();
+
         var keyProp = entityType.FindProperty(keySelector.GetMemberAccess().Name)!;
         var keyColumnName = keyProp.GetColumnName(storeObject);
-        var columnNames = props.Select(p => p.GetColumnName(storeObject)!).ToList();
+        var columnNames = props
+            .Select(p => p.GetColumnName(storeObject)!)
+            .ToList();
 
         var sb = new StringBuilder();
         var parameters = new List<object>();
@@ -207,12 +237,16 @@ public static class BulkUpsertExtensions
             foreach (var property in props)
             {
                 var paramName = $"{{{parameterCount++}}}";
+
                 var value = property.IsShadowProperty()
                     ? dbContext.Entry(entity).Property(property.Name).CurrentValue
                     : property.PropertyInfo?.GetValue(entity);
-                var converter = property.GetTypeMapping().Converter;
-                if (converter != null) value = converter.ConvertToProvider(value);
 
+                var converter = property.GetTypeMapping().Converter;
+                if (converter != null)
+                    value = converter.ConvertToProvider(value);
+
+                // Detect json/jsonb column types and cast the parameter so PostgreSQL accepts it.
                 var columnType = property.GetColumnType();
                 if (columnType.StartsWith("jsonb", StringComparison.OrdinalIgnoreCase))
                     placeholders.Add($"CAST({paramName} AS jsonb)");
@@ -220,24 +254,26 @@ public static class BulkUpsertExtensions
                     placeholders.Add($"CAST({paramName} AS json)");
                 else
                     placeholders.Add(paramName);
-
+                
                 parameters.Add(value!);
             }
 
             sb.Append($"({string.Join(", ", placeholders)})");
-            if (i < entities.Count - 1) sb.Append(", ");
+            if (i < entities.Count - 1)
+                sb.Append(", ");
         }
 
         sb.AppendLine();
         sb.AppendLine($"ON CONFLICT (\"{keyColumnName}\") DO UPDATE SET");
-        sb.AppendLine(string.Join(", ", columnNames.Where(c => c != keyColumnName).Select(c => $"\"{c}\" = EXCLUDED.\"{c}\"")) + ";");
+
+        var updateAssignments = columnNames
+            .Where(c => c != keyColumnName)
+            .Select(c => $"\"{c}\" = EXCLUDED.\"{c}\"");
+
+        sb.AppendLine(string.Join(", ", updateAssignments) + ";");
 
         return (sb.ToString(), parameters.ToArray());
     }
-
-    // -------------------------------------------------------------------------
-    // MySQL
-    // -------------------------------------------------------------------------
 
     private static (string, object[]) GenerateMySqlUpsert<TEntity>(
         DbContext dbContext,
@@ -248,10 +284,14 @@ public static class BulkUpsertExtensions
         var entityType = dbContext.Model.FindEntityType(typeof(TEntity))!;
         var tableName = entityType.GetTableName();
         var storeObject = StoreObjectIdentifier.Table(tableName!, entityType.GetSchema());
+
         var props = entityType.GetProperties().ToList();
+
         var keyProp = entityType.FindProperty(keySelector.GetMemberAccess().Name)!;
         var keyColumnName = keyProp.GetColumnName(storeObject);
-        var columnNames = props.Select(p => p.GetColumnName(storeObject)!).ToList();
+        var columnNames = props
+            .Select(p => p.GetColumnName(storeObject)!)
+            .ToList();
 
         var sb = new StringBuilder();
         var parameters = new List<object>();
@@ -267,29 +307,35 @@ public static class BulkUpsertExtensions
             foreach (var property in props)
             {
                 var paramName = $"{{{parameterCount++}}}";
+
                 var value = property.IsShadowProperty()
                     ? dbContext.Entry(entity).Property(property.Name).CurrentValue
                     : property.PropertyInfo?.GetValue(entity);
+
                 var converter = property.GetTypeMapping().Converter;
-                if (converter != null) value = converter.ConvertToProvider(value);
+                if (converter != null)
+                    value = converter.ConvertToProvider(value);
+
                 placeholders.Add(paramName);
                 parameters.Add(value!);
             }
 
             sb.Append($"({string.Join(", ", placeholders)})");
-            if (i < entities.Count - 1) sb.Append(", ");
+            if (i < entities.Count - 1)
+                sb.Append(", ");
         }
 
         sb.AppendLine();
         sb.AppendLine("ON DUPLICATE KEY UPDATE");
-        sb.AppendLine(string.Join(", ", columnNames.Where(c => c != keyColumnName).Select(c => $"`{c}` = VALUES(`{c}`)")) + ";");
+
+        var updateAssignments = columnNames
+            .Where(c => c != keyColumnName)
+            .Select(c => $"`{c}` = VALUES(`{c}`)");
+
+        sb.AppendLine(string.Join(", ", updateAssignments) + ";");
 
         return (sb.ToString(), parameters.ToArray());
     }
-
-    // -------------------------------------------------------------------------
-    // Oracle
-    // -------------------------------------------------------------------------
 
     private static (string, object[]) GenerateOracleUpsert<TEntity>(
         DbContext dbContext,
@@ -301,18 +347,19 @@ public static class BulkUpsertExtensions
         var schema = entityType.GetSchema();
         var tableName = entityType.GetTableName()!;
         var storeObject = StoreObjectIdentifier.Table(tableName, schema);
-
-        // Both schema and table must be quoted so Oracle treats them as
-        // case-sensitive identifiers, matching what EF Core migrations create.
+    
+        // Both schema and table must be quoted so Oracle treats them as case-sensitive
+        // identifiers, matching what EF Core migrations create.
         var fullName = !string.IsNullOrEmpty(schema)
             ? $"\"{schema}\".\"{tableName}\""
             : $"\"{tableName}\"";
 
         var props = entityType.GetProperties().ToList();
+
         var keyProp = entityType.FindProperty(keySelector.GetMemberAccess().Name)!;
         var keyColumnName = keyProp.GetColumnName(storeObject)!;
 
-        // Pre-build quoted column name list once; reuse throughout.
+        // Pre-build quoted column names once and reuse throughout all clauses.
         var quotedColumnNames = props
             .Select(p => $"\"{p.GetColumnName(storeObject)}\"")
             .ToList();
@@ -343,30 +390,23 @@ public static class BulkUpsertExtensions
                     value = converter.ConvertToProvider(value);
 
                 parameters.Add(value!);
-
-                // Alias must be quoted so Oracle preserves case, matching the
-                // quoted references in the WHEN MATCHED / WHEN NOT MATCHED clauses.
+                
+                // Aliases must be quoted so Oracle preserves their case, matching
+                // the quoted references in ON, UPDATE SET, and INSERT/VALUES below.
                 var quotedAlias = $"\"{property.GetColumnName(storeObject)}\"";
-
-                // Oracle cannot infer the bind parameter type from a bare SELECT …
-                // FROM DUAL — there is no target column to derive it from. For
-                // NVARCHAR2 columns this causes ODP.NET to default to VARCHAR2,
-                // which leads to datatype mismatch errors in the MERGE. An explicit
-                // CAST restores the correct type. The length is read from the EF
-                // column type string (e.g. "NVARCHAR2(500)") so it matches the
-                // actual column definition rather than an arbitrary hardcoded value.
-                string expr;
+    
+                // In a SELECT … FROM DUAL subquery, ODP.NET has no target column to
+                // derive bind parameter types from and defaults to VARCHAR2 for .NET
+                // strings. Elsa's Oracle migrations define string columns as NVARCHAR2,
+                // so an explicit CAST is required to avoid a datatype mismatch error.
+                // The full EF Core column type string (e.g. "NVARCHAR2(450 CHAR)") is
+                // used directly in the CAST so all Oracle type variants are handled
+                // correctly without any string parsing.
                 var columnType = property.GetColumnType() ?? string.Empty;
-                if (columnType.StartsWith("NVARCHAR2", StringComparison.OrdinalIgnoreCase))
-                {
-                    var length = ParseNVarchar2Length(columnType);
-                    expr = $"CAST({paramName} AS NVARCHAR2({length}))";
-                }
-                else
-                {
-                    expr = paramName;
-                }
-
+                var expr = columnType.StartsWith("NVARCHAR2", StringComparison.OrdinalIgnoreCase)
+                    ? $"CAST({paramName} AS {columnType})"
+                    : paramName;
+    
                 lineParts.Add($"{expr} AS {quotedAlias}");
             }
 
@@ -384,21 +424,5 @@ public static class BulkUpsertExtensions
         sb.AppendLine($"VALUES ({string.Join(", ", quotedColumnNames.Select(c => $"Source.{c}"))});");
 
         return (sb.ToString(), parameters.ToArray());
-    }
-
-    /// <summary>
-    /// Extracts the maximum length from an Oracle NVARCHAR2 column type string.
-    /// For example, "NVARCHAR2(500)" returns 500.
-    /// Falls back to 2000 (Oracle's maximum for NVARCHAR2) if the string is malformed.
-    /// </summary>
-    private static int ParseNVarchar2Length(string columnType)
-    {
-        var open = columnType.IndexOf('(');
-        var close = columnType.IndexOf(')');
-        if (open >= 0 && close > open &&
-            int.TryParse(columnType.AsSpan(open + 1, close - open - 1), out var length))
-            return length;
-
-        return 2000;
     }
 }

--- a/src/modules/Elsa.Persistence.EFCore.Common/Extensions/BulkUpsertExtensions.cs
+++ b/src/modules/Elsa.Persistence.EFCore.Common/Extensions/BulkUpsertExtensions.cs
@@ -1,8 +1,9 @@
+using System.Linq.Expressions;
 using System.Text;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
-using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Storage;
 
 // ReSharper disable once CheckNamespace
 namespace Elsa.Persistence.EFCore.Extensions;
@@ -337,7 +338,7 @@ public static class BulkUpsertExtensions
         return (sb.ToString(), parameters.ToArray());
     }
 
-    private static (string, object[]) GenerateOracleUpsert<TEntity>(
+    internal static (string, object[]) GenerateOracleUpsert<TEntity>(
         DbContext dbContext,
         IList<TEntity> entities,
         Expression<Func<TEntity, string>> keySelector)
@@ -347,12 +348,8 @@ public static class BulkUpsertExtensions
         var schema = entityType.GetSchema();
         var tableName = entityType.GetTableName()!;
         var storeObject = StoreObjectIdentifier.Table(tableName, schema);
-    
-        // Both schema and table must be quoted so Oracle treats them as case-sensitive
-        // identifiers, matching what EF Core migrations create.
-        var fullName = !string.IsNullOrEmpty(schema)
-            ? $"\"{schema}\".\"{tableName}\""
-            : $"\"{tableName}\"";
+        var sqlGenerationHelper = dbContext.GetService<ISqlGenerationHelper>();
+        var fullName = sqlGenerationHelper.DelimitIdentifier(tableName, schema);
 
         var props = entityType.GetProperties().ToList();
 
@@ -361,9 +358,9 @@ public static class BulkUpsertExtensions
 
         // Pre-build quoted column names once and reuse throughout all clauses.
         var quotedColumnNames = props
-            .Select(p => $"\"{p.GetColumnName(storeObject)}\"")
+            .Select(p => sqlGenerationHelper.DelimitIdentifier(p.GetColumnName(storeObject)!))
             .ToList();
-        var quotedKeyColumnName = $"\"{keyColumnName}\"";
+        var quotedKeyColumnName = sqlGenerationHelper.DelimitIdentifier(keyColumnName);
 
         var sb = new StringBuilder();
         var parameters = new List<object>();
@@ -390,23 +387,23 @@ public static class BulkUpsertExtensions
                     value = converter.ConvertToProvider(value);
 
                 parameters.Add(value!);
-                
+
                 // Aliases must be quoted so Oracle preserves their case, matching
                 // the quoted references in ON, UPDATE SET, and INSERT/VALUES below.
-                var quotedAlias = $"\"{property.GetColumnName(storeObject)}\"";
-    
+                var quotedAlias = sqlGenerationHelper.DelimitIdentifier(property.GetColumnName(storeObject)!);
+
                 // In a SELECT … FROM DUAL subquery, ODP.NET has no target column to
                 // derive bind parameter types from and defaults to VARCHAR2 for .NET
                 // strings. Elsa's Oracle migrations define string columns as NVARCHAR2,
                 // so an explicit CAST is required to avoid a datatype mismatch error.
-                // The full EF Core column type string (e.g. "NVARCHAR2(450 CHAR)") is
+                // The full EF Core column type string (e.g. "NVARCHAR2(450)") is
                 // used directly in the CAST so all Oracle type variants are handled
                 // correctly without any string parsing.
                 var columnType = property.GetColumnType() ?? string.Empty;
                 var expr = columnType.StartsWith("NVARCHAR2", StringComparison.OrdinalIgnoreCase)
                     ? $"CAST({paramName} AS {columnType})"
                     : paramName;
-    
+
                 lineParts.Add($"{expr} AS {quotedAlias}");
             }
 

--- a/test/unit/Elsa.Persistence.EFCore.UnitTests/BulkUpsertExtensionsTests.cs
+++ b/test/unit/Elsa.Persistence.EFCore.UnitTests/BulkUpsertExtensionsTests.cs
@@ -1,0 +1,63 @@
+using Elsa.Persistence.EFCore.Extensions;
+using Microsoft.EntityFrameworkCore;
+
+namespace Elsa.Persistence.EFCore.UnitTests;
+
+public class BulkUpsertExtensionsTests
+{
+    [Fact]
+    public void GenerateOracleUpsert_ProducesQuotedMergeWithNvarcharCasts()
+    {
+        using var dbContext = CreateDbContext();
+        var entities = new List<TestEntity>
+        {
+            new() { Id = "first", Name = "First", Count = 1 },
+            new() { Id = "second", Name = null, Count = 2 }
+        };
+
+        var (sql, parameters) = BulkUpsertExtensions.GenerateOracleUpsert(dbContext, entities, x => x.Id);
+
+        Assert.Contains("MERGE INTO \"Elsa\".\"ActivityExecutionRecords\" Target", sql);
+        Assert.Contains("CAST({0} AS NVARCHAR2(450)) AS \"RecordId\"", sql);
+        Assert.Contains("CAST({2} AS NVARCHAR2(2000)) AS \"DisplayName\"", sql);
+        Assert.Contains("CAST({5} AS NVARCHAR2(2000)) AS \"DisplayName\"", sql);
+        Assert.Contains("FROM DUAL UNION ALL SELECT", sql);
+        Assert.Contains("Target.\"RecordId\" = Source.\"RecordId\"", sql);
+        Assert.Contains("INSERT (\"RecordId\", \"Count\", \"DisplayName\")", sql);
+        Assert.Contains("VALUES (Source.\"RecordId\", Source.\"Count\", Source.\"DisplayName\")", sql);
+        Assert.DoesNotContain("CAST({1} AS NUMBER", sql);
+
+        var updateClause = sql[sql.IndexOf("WHEN MATCHED", StringComparison.Ordinal)..sql.IndexOf("WHEN NOT MATCHED", StringComparison.Ordinal)];
+        Assert.DoesNotContain("Target.\"RecordId\" = Source.\"RecordId\"", updateClause);
+        Assert.Contains("Target.\"DisplayName\" = Source.\"DisplayName\"", updateClause);
+        Assert.Equal(new object?[] { "first", 1, "First", "second", 2, null }, parameters);
+    }
+
+    private static TestDbContext CreateDbContext()
+    {
+        var options = new DbContextOptionsBuilder<TestDbContext>()
+            .UseOracle("Data Source=unused")
+            .Options;
+        return new TestDbContext(options);
+    }
+
+    private sealed class TestDbContext(DbContextOptions<TestDbContext> options) : DbContext(options)
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            var entity = modelBuilder.Entity<TestEntity>();
+            entity.ToTable("ActivityExecutionRecords", "Elsa");
+            entity.HasKey(x => x.Id);
+            entity.Property(x => x.Id).HasColumnName("RecordId").HasColumnType("NVARCHAR2(450)");
+            entity.Property(x => x.Count).HasColumnType("NUMBER(10)");
+            entity.Property(x => x.Name).HasColumnName("DisplayName").HasColumnType("NVARCHAR2(2000)");
+        }
+    }
+
+    private sealed class TestEntity
+    {
+        public string Id { get; set; } = null!;
+        public int Count { get; set; }
+        public string? Name { get; set; }
+    }
+}

--- a/test/unit/Elsa.Persistence.EFCore.UnitTests/Elsa.Persistence.EFCore.UnitTests.csproj
+++ b/test/unit/Elsa.Persistence.EFCore.UnitTests/Elsa.Persistence.EFCore.UnitTests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <Include>[Elsa.Persistence.EFCore]*</Include>
+        <Threshold>0</Threshold>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Oracle.EntityFrameworkCore" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\src\modules\Elsa.Persistence.EFCore.Common\Elsa.Persistence.EFCore.Common.csproj" />
+    </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Fixes #7755

## Problem

`GenerateOracleUpsert` produced a `MERGE` statement with unquoted schema, table, column, and source-alias identifiers. Oracle folds unquoted identifiers to uppercase, while Elsa Oracle migrations create quoted mixed-case objects such as `"Elsa"."ActivityExecutionRecords"` and `"Id"`. The generated statement therefore did not address the EF-created objects consistently and failed with `ORA-00904`.

A second failure occurs inside the `SELECT ... FROM DUAL` source. ODP.NET has no target column there from which to infer bind parameter types and defaults .NET strings to `VARCHAR2`, while Elsa maps string properties to `NVARCHAR2`. The resulting type mismatch causes the `MERGE` to fail even after identifier quoting is corrected.

## Changes

- Delimit the Oracle schema, table, columns, aliases, and all downstream references consistently through the provider `ISqlGenerationHelper`.
- Cast parameters mapped to `NVARCHAR2` using the EF Core column type, for example `CAST({0} AS NVARCHAR2(450))`.
- Add focused SQL-generation coverage for:
  - mixed-case Oracle schema, table, and column identifiers;
  - `NVARCHAR2(450)` and `NVARCHAR2(2000)` casts, including a null value;
  - non-string columns remaining uncast;
  - multi-row `UNION ALL SELECT` generation;
  - key exclusion from `UPDATE SET`;
  - `INSERT`/`VALUES` clauses and parameter ordering.

Only the Oracle generator behavior is changed; the other provider generators are untouched.

## Verification

- `dotnet test test/unit/Elsa.Persistence.EFCore.UnitTests/Elsa.Persistence.EFCore.UnitTests.csproj --configuration Release` — passed
- `dotnet build src/modules/Elsa.Persistence.EFCore.Oracle/Elsa.Persistence.EFCore.Oracle.csproj --configuration Release` — passed for `net8.0`, `net9.0`, and `net10.0` with zero warnings

The contributor also verified the original fix end-to-end on Oracle: workflow dispatch and persistence succeeded for workflow instances, activity execution records, workflow execution logs, bookmarks, and triggers, with no `ORA-00904` or datatype mismatch errors.

## Release target

The PR remains targeted to `main`. A maintainer previously made `release/3.8.0` conditional on intending the fix for that release, and the contributor explicitly accepted a later release. Retargeting this main-based head directly would also introduce unrelated main commits into the diverged release branch; a dedicated cherry-pick/backport is the safe route if 3.8.0 GA must include the fix.
