### PR TITLE
Skip HTTP workflow route matching outside base path

### DIFF
--- a/src/modules/Elsa.Http/Middleware/HttpWorkflowsMiddleware.cs
+++ b/src/modules/Elsa.Http/Middleware/HttpWorkflowsMiddleware.cs
@@ -40,7 +40,6 @@ public class HttpWorkflowsMiddleware(RequestDelegate next)
         IHttpWorkflowLookupService httpWorkflowLookupService)
     {
         var path = httpContext.Request.Path.Value!.NormalizeRoute();
-        var matchingPath = GetMatchingRoute(serviceProvider, path).Route;
         var basePath = options.Value.BasePath?.ToString().NormalizeRoute();
 
         // If the request path does not match the configured base path to handle workflows, then skip.
@@ -51,10 +50,13 @@ public class HttpWorkflowsMiddleware(RequestDelegate next)
                 await next(httpContext);
                 return;
             }
-
-            // Strip the base path.
-            matchingPath = matchingPath[basePath.Length..];
         }
+
+        var matchingPath = GetMatchingRoute(serviceProvider, path).Route;
+
+        // Strip the base path.
+        if (!string.IsNullOrWhiteSpace(basePath))
+            matchingPath = matchingPath[basePath.Length..];
 
         // Graceful-shutdown gate: when the runtime is paused or draining, we don't accept new HTTP-triggered work.
         // The ingress source registry visibility is provided by HttpTriggerIngressSource — this is the actual mechanism.

--- a/test/unit/Elsa.Http.UnitTests/Middleware/HttpWorkflowsMiddlewareTests.cs
+++ b/test/unit/Elsa.Http.UnitTests/Middleware/HttpWorkflowsMiddlewareTests.cs
@@ -63,6 +63,60 @@ public class HttpWorkflowsMiddlewareTests
     }
 
     [Fact]
+    public async Task InvokeAsync_WithConfiguredBasePathAndNonMatchingPath_SkipsRouteMatchingAndCallsNext()
+    {
+        var nextCalled = false;
+        var middleware = new HttpWorkflowsMiddleware(_ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        });
+        var serviceProvider = new ServiceCollection().BuildServiceProvider();
+        var httpContext = new DefaultHttpContext
+        {
+            RequestServices = serviceProvider
+        };
+        httpContext.Request.Path = "/health";
+
+        await middleware.InvokeAsync(
+            httpContext,
+            serviceProvider,
+            Microsoft.Extensions.Options.Options.Create(new HttpActivityOptions { BasePath = "/workflows" }),
+            new EmptyHttpWorkflowLookupService());
+
+        Assert.True(nextCalled);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_WithConfiguredBasePathAndMatchingPath_StillResolvesRoute()
+    {
+        var routeMatcher = Substitute.For<IRouteMatcher>();
+        routeMatcher.Match("/workflows/colliding", "/workflows/colliding").Returns(new RouteValueDictionary());
+        var bookmarkStore = new CapturingBookmarkStore(CurrentTenantId, CreateCollidingHttpEndpointBookmarks());
+        var serviceProvider = new ServiceCollection()
+            .AddSingleton<IBookmarkStore>(bookmarkStore)
+            .AddSingleton(routeMatcher)
+            .AddSingleton<IRouteTable>(new ListRouteTable([new("/workflows/colliding")]))
+            .AddSingleton<IStimulusHasher, FixedStimulusHasher>()
+            .BuildServiceProvider();
+        var httpContext = new DefaultHttpContext
+        {
+            RequestServices = serviceProvider
+        };
+        httpContext.Request.Path = "/workflows/colliding";
+        httpContext.Request.Method = HttpMethod.Get.Method;
+
+        await _middleware.InvokeAsync(
+            httpContext,
+            serviceProvider,
+            Microsoft.Extensions.Options.Options.Create(new HttpActivityOptions { BasePath = "/workflows" }),
+            new EmptyHttpWorkflowLookupService());
+
+        routeMatcher.Received(1).Match("/workflows/colliding", "/workflows/colliding");
+        Assert.NotNull(bookmarkStore.LastFilter);
+    }
+
+    [Fact]
     public async Task HandleWorkflowFaultAsync_UsesReloadedWorkflowState_WhenAvailable()
     {
         var workflowState = CreateFaultedWorkflowState("workflow-1");


### PR DESCRIPTION
## Summary
- Short-circuit HTTP workflow middleware before route matching when the request is outside the configured base path.
- Preserve route matching and base-path stripping for requests inside the base path.
- Add middleware unit coverage for both outside-base-path bypass and inside-base-path route resolution.

Fixes #7709

## Tests
- dotnet test test/unit/Elsa.Http.UnitTests/Elsa.Http.UnitTests.csproj