### PR TITLE
chore: update patch dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -183,11 +183,11 @@
         <PackageVersion Include="StackExchange.Redis" Version="2.10.1"/>
         <PackageVersion Include="System.CommandLine" Version="2.0.0"/>
         <PackageVersion Include="System.Data.SqlClient" Version="4.9.0"/>
-		<PackageVersion Include="System.Formats.Asn1" Version="10.0.8"/>
+		<PackageVersion Include="System.Formats.Asn1" Version="10.0.9"/>
         <PackageVersion Include="System.Linq.Async" Version="7.0.1"/>
         <PackageVersion Include="System.Linq.Dynamic.Core" Version="1.7.3"/>
         <PackageVersion Include="System.Net.Http" Version="4.3.4"/>
-		<PackageVersion Include="System.Text.Json" Version="10.0.8"/>
+		<PackageVersion Include="System.Text.Json" Version="10.0.9"/>
         <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1"/>
         <PackageVersion Include="Testcontainers" Version="4.9.0"/>
         <PackageVersion Include="Testcontainers.MsSql" Version="4.9.0"/>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,39 +8,39 @@
         <PackageVersion Include="FastEndpoints" Version="7.1.1" />
         <PackageVersion Include="FastEndpoints.Security" Version="7.1.1" />
         <PackageVersion Include="FastEndpoints.Swagger" Version="7.1.1" />
-        <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="9.0.16"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components" Version="9.0.16"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.16"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.16"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="9.0.16"/>
-        <PackageVersion Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="9.0.16"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.16"/>
-        <PackageVersion Include="Microsoft.Data.Sqlite" Version="9.0.16"/>
-        <PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="9.0.16"/>
-        <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.16"/>
-        <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.16"/>
-        <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.16"/>
-        <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.16"/>
-        <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.16"/>
-        <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.16"/>
-        <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="9.0.16"/>
-        <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.16"/>
-        <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.16"/>
-        <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="9.0.16"/>
-        <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16"/>
-        <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.16"/>
-        <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="9.0.16"/>
-        <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.16"/>
-        <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.16"/>
-        <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.16"/>
-        <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="9.0.16"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="9.0.17"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Components" Version="9.0.17"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.17"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.17"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="9.0.17"/>
+        <PackageVersion Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="9.0.17"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.17"/>
+        <PackageVersion Include="Microsoft.Data.Sqlite" Version="9.0.17"/>
+        <PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="9.0.17"/>
+        <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.17"/>
+        <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.17"/>
+        <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.17"/>
+        <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.17"/>
+        <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.17"/>
+        <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.17"/>
+        <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="9.0.17"/>
+        <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.17"/>
+        <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.17"/>
+        <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="9.0.17"/>
+        <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.17"/>
+        <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.17"/>
+        <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="9.0.17"/>
+        <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.17"/>
+        <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.17"/>
+        <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.17"/>
+        <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="9.0.17"/>
         <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.10.0"/>
-        <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.16"/>
-        <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.16"/>
+        <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.17"/>
+        <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.17"/>
         <PackageVersion Include="Microsoft.Extensions.Resilience" Version="9.10.0"/>
-        <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.16"/>
-        <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.16"/>
-        <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.16"/>
+        <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.17"/>
+        <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.17"/>
+        <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.17"/>
 		<PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4"/>
         <PackageVersion Include="Oracle.EntityFrameworkCore" Version="9.23.26200"/>
         <PackageVersion Include="Scrutor" Version="6.1.0"/>
@@ -50,39 +50,39 @@
         <PackageVersion Include="FastEndpoints" Version="7.2.0" />
         <PackageVersion Include="FastEndpoints.Security" Version="7.2.0" />
         <PackageVersion Include="FastEndpoints.Swagger" Version="7.2.0" />
-        <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="10.0.8"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components" Version="10.0.8"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.8"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.8"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.8"/>
-        <PackageVersion Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="10.0.8"/>
-        <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8"/>
-        <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.8"/>
-        <PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="10.0.8"/>
-        <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.8"/>
-        <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8"/>
-        <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8"/>
-        <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.8"/>
-        <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8"/>
-        <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.8"/>
-        <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.8"/>
-        <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.8"/>
-        <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.8"/>
-        <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8"/>
-        <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8"/>
-        <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8"/>
-        <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="10.0.8"/>
-        <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.8"/>
-        <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.8"/>
-        <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.8"/>
-        <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="10.0.8"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="10.0.9"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Components" Version="10.0.9"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.9"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.9"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.9"/>
+        <PackageVersion Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="10.0.9"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9"/>
+        <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.9"/>
+        <PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="10.0.9"/>
+        <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.9"/>
+        <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9"/>
+        <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.9"/>
+        <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9"/>
+        <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9"/>
+        <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.9"/>
+        <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9"/>
+        <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.9"/>
+        <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9"/>
+        <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9"/>
+        <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9"/>
+        <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9"/>
+        <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="10.0.9"/>
+        <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.9"/>
+        <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9"/>
+        <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.9"/>
+        <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="10.0.9"/>
         <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.1.0"/>
-        <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.8"/>
-        <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.8"/>
+        <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.9"/>
+        <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9"/>
         <PackageVersion Include="Microsoft.Extensions.Resilience" Version="10.1.0"/>
-        <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.8"/>
-        <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8"/>
-        <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.8"/>
+        <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.9"/>
+        <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9"/>
+        <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.9"/>
         <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1"/>
         <PackageVersion Include="Oracle.EntityFrameworkCore" Version="10.23.26200"/>
         <PackageVersion Include="Scrutor" Version="7.0.0"/>
@@ -185,7 +185,7 @@
         <PackageVersion Include="System.Data.SqlClient" Version="4.9.0"/>
 		<PackageVersion Include="System.Formats.Asn1" Version="10.0.8"/>
         <PackageVersion Include="System.Linq.Async" Version="7.0.1"/>
-        <PackageVersion Include="System.Linq.Dynamic.Core" Version="1.7.2"/>
+        <PackageVersion Include="System.Linq.Dynamic.Core" Version="1.7.3"/>
         <PackageVersion Include="System.Net.Http" Version="4.3.4"/>
 		<PackageVersion Include="System.Text.Json" Version="10.0.8"/>
         <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1"/>


### PR DESCRIPTION
## Summary

- Update the net8/net9 Microsoft package band from 9.0.16 to 9.0.17.
- Update the net10 Microsoft package band from 10.0.8 to 10.0.9.
- Update System.Linq.Dynamic.Core from 1.7.2 to 1.7.3.

## Validation

- dotnet restore Elsa.sln --nologo
- dotnet build Elsa.sln --no-restore --nologo
- Build passed: 0 errors.

## Notes

- This is the smallest patch-only upgrade set identified from the repository current versions.
- SQLitePCLRaw.lib.e_sqlite3 remains vulnerable transitively through Microsoft.Data.Sqlite; these Microsoft patch updates do not resolve GHSA-2m69-gcr7-jv3q.
- SharpCompress 0.30.1 remains vulnerable transitively through MongoDB.Driver 3.8.1; upgrading MongoDB.Driver is deferred because it is a minor dependency change requiring persistence validation.