### PR TITLE
Add multipart/form-data HTTP content factory

### DIFF
--- a/src/modules/Elsa.Http/ContentWriters/MultipartFormDataHttpContentFactory.cs
+++ b/src/modules/Elsa.Http/ContentWriters/MultipartFormDataHttpContentFactory.cs
@@ -1,0 +1,36 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Elsa.Http.ContentWriters;
+
+/// <summary>
+/// A content writer that writes content in the multipart/form-data format.
+/// </summary>
+public class MultipartFormDataHttpContentFactory : IHttpContentFactory
+{
+    /// <inheritdoc />
+    public IEnumerable<string> SupportedContentTypes => ["multipart/form-data"];
+
+    /// <inheritdoc />
+    public HttpContent CreateHttpContent(object content, string? contentType = null)
+    {
+        var multipartContent = new MultipartFormDataContent();
+
+        foreach (var (key, value) in GetContentAsDictionary(content))
+            multipartContent.Add(new StringContent(value), key);
+
+        return multipartContent;
+    }
+
+    private static IDictionary<string, string> GetContentAsDictionary(object content)
+    {
+        if (content is IDictionary<string, object> dictionary)
+            return dictionary.ToDictionary(x => x.Key, x => x.Value.ToString() ?? string.Empty);
+
+        if (content is string or JsonObject)
+            return JsonSerializer.Deserialize<Dictionary<string, string>>(JsonSerializer.Serialize(content))!;
+
+        var jsonElement = JsonSerializer.SerializeToElement(content);
+        return jsonElement.EnumerateObject().ToDictionary(x => x.Name, x => x.Value.ToString());
+    }
+}

--- a/src/modules/Elsa.Http/Features/HttpFeature.cs
+++ b/src/modules/Elsa.Http/Features/HttpFeature.cs
@@ -194,6 +194,7 @@ public class HttpFeature(IModule module) : FeatureBase(module)
             .AddScoped<IHttpContentFactory, JsonContentFactory>()
             .AddScoped<IHttpContentFactory, XmlContentFactory>()
             .AddScoped<IHttpContentFactory, FormUrlEncodedHttpContentFactory>()
+            .AddScoped<IHttpContentFactory, MultipartFormDataHttpContentFactory>()
 
             // Activity property options providers.
             .AddScoped<IPropertyUIHandler, HttpContentTypeOptionsProvider>()

--- a/src/modules/Elsa.Http/ShellFeatures/HttpFeature.cs
+++ b/src/modules/Elsa.Http/ShellFeatures/HttpFeature.cs
@@ -164,6 +164,7 @@ public class HttpFeature : IMiddlewareShellFeature
             .AddScoped<IHttpContentFactory, JsonContentFactory>()
             .AddScoped<IHttpContentFactory, XmlContentFactory>()
             .AddScoped<IHttpContentFactory, FormUrlEncodedHttpContentFactory>()
+            .AddScoped<IHttpContentFactory, MultipartFormDataHttpContentFactory>()
 
             // Activity property options providers.
             .AddScoped<IPropertyUIHandler, HttpContentTypeOptionsProvider>()

--- a/test/unit/Elsa.Http.UnitTests/ContentWriters/ContentFactoryTests.cs
+++ b/test/unit/Elsa.Http.UnitTests/ContentWriters/ContentFactoryTests.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using System.Text.Json.Nodes;
 using Elsa.Http.ContentWriters;
 using Xunit;
 
@@ -111,5 +112,78 @@ public class ContentFactoryTests
         // Content length should match the actual UTF-8 byte count
         Assert.Equal(Encoding.UTF8.GetByteCount(content), bytes.Length);
         Assert.Equal(httpContent.Headers.ContentLength, bytes.Length);
+    }
+
+    /// <summary>
+    /// Tests that <see cref="MultipartFormDataHttpContentFactory"/> reports support for the multipart/form-data content type.
+    /// </summary>
+    [Fact]
+    public void MultipartFormDataHttpContentFactory_ShouldSupportMultipartFormData()
+    {
+        // Arrange
+        var factory = new MultipartFormDataHttpContentFactory();
+
+        // Assert
+        Assert.Contains("multipart/form-data", factory.SupportedContentTypes);
+    }
+
+    /// <summary>
+    /// Tests that <see cref="MultipartFormDataHttpContentFactory"/> produces multipart/form-data content with a boundary.
+    /// </summary>
+    [Fact]
+    public void MultipartFormDataHttpContentFactory_ShouldSetMultipartContentType()
+    {
+        // Arrange
+        var content = new Dictionary<string, object> { ["field1"] = "value1", ["field2"] = "value2" };
+        var factory = new MultipartFormDataHttpContentFactory();
+
+        // Act
+        var httpContent = factory.CreateHttpContent(content, "multipart/form-data");
+
+        // Assert
+        Assert.IsType<MultipartFormDataContent>(httpContent);
+        Assert.Equal("multipart/form-data", httpContent.Headers.ContentType?.MediaType);
+        // A boundary parameter is required for multipart content.
+        Assert.Contains(httpContent.Headers.ContentType!.Parameters, p => p.Name == "boundary");
+    }
+
+    /// <summary>
+    /// Tests that <see cref="MultipartFormDataHttpContentFactory"/> writes one part per dictionary entry.
+    /// </summary>
+    [Fact]
+    public async Task MultipartFormDataHttpContentFactory_ShouldWriteEachFieldAsPart()
+    {
+        // Arrange
+        var content = new Dictionary<string, object> { ["name"] = "Alice", ["role"] = "admin" };
+        var factory = new MultipartFormDataHttpContentFactory();
+
+        // Act
+        var httpContent = factory.CreateHttpContent(content, "multipart/form-data");
+        var body = await httpContent.ReadAsStringAsync();
+
+        // Assert
+        // Each entry becomes a form-data section carrying its value.
+        Assert.Contains("form-data", body);
+        Assert.Contains("Alice", body);
+        Assert.Contains("admin", body);
+    }
+
+    /// <summary>
+    /// Tests that <see cref="MultipartFormDataHttpContentFactory"/> accepts a <see cref="JsonObject"/> payload.
+    /// </summary>
+    [Fact]
+    public async Task MultipartFormDataHttpContentFactory_ShouldSupportJsonObjectContent()
+    {
+        // Arrange
+        var content = new JsonObject { ["field1"] = "value1", ["field2"] = "value2" };
+        var factory = new MultipartFormDataHttpContentFactory();
+
+        // Act
+        var httpContent = factory.CreateHttpContent(content, "multipart/form-data");
+        var body = await httpContent.ReadAsStringAsync();
+
+        // Assert
+        Assert.Contains("value1", body);
+        Assert.Contains("value2", body);
     }
 }


### PR DESCRIPTION
## Description

`Elsa.Http` ships `IHttpContentFactory` implementations for JSON, XML, text and `application/x-www-form-urlencoded`, but there was no writer for `multipart/form-data`. This adds `MultipartFormDataHttpContentFactory`, following the same pattern as the existing `FormUrlEncodedHttpContentFactory`.

Closes #75. The `application/x-www-form-urlencoded` half of that issue already exists via `FormUrlEncodedHttpContentFactory`; this completes the remaining `multipart/form-data` writer.

## Changes

- Add `MultipartFormDataHttpContentFactory` in `Elsa.Http/ContentWriters`, converting dictionary / `JsonObject` / object content into a `MultipartFormDataContent` with one text part per field.
- Register it in both `Features/HttpFeature.cs` and `ShellFeatures/HttpFeature.cs`, so `multipart/form-data` automatically appears in the `SendHttpRequest` activity's content-type dropdown.
- Add unit tests in `ContentFactoryTests` covering the supported content type, boundary generation, per-field parts, and `JsonObject` payloads.

## Testing

`dotnet test` for `Elsa.Http.UnitTests` (`ContentFactoryTests`) — all passing (9/9).
