### PR TITLE
Stop attaching Array.prototype to dictionary-like objects in JavaScript expressions

### DIFF
--- a/src/modules/Elsa.Expressions.JavaScript/Helpers/ObjectArrayHelper.cs
+++ b/src/modules/Elsa.Expressions.JavaScript/Helpers/ObjectArrayHelper.cs
@@ -5,6 +5,7 @@ namespace Elsa.Expressions.JavaScript.Helpers;
 /// <summary>
 /// Contains helper methods for working with object arrays.
 /// </summary>
+[Obsolete("Jint decides array-likeness itself and attaches Array.prototype to array-like wrappers when Options.Interop.AttachArrayPrototype is enabled (the default). This helper is no longer used and will be removed in a future version.")]
 public static class ObjectArrayHelper
 {
     /// <summary>

--- a/src/modules/Elsa.Expressions.JavaScript/Services/JintJavaScriptEvaluator.cs
+++ b/src/modules/Elsa.Expressions.JavaScript/Services/JintJavaScriptEvaluator.cs
@@ -4,13 +4,11 @@ using Acornima.Ast;
 using Elsa.Expressions.Helpers;
 using Elsa.Expressions.Models;
 using Elsa.Expressions.JavaScript.Contracts;
-using Elsa.Expressions.JavaScript.Helpers;
 using Elsa.Expressions.JavaScript.Notifications;
 using Elsa.Expressions.JavaScript.ObjectConverters;
 using Elsa.Expressions.JavaScript.Options;
 using Elsa.Mediator.Contracts;
 using Jint;
-using Jint.Runtime.Interop;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
@@ -70,7 +68,6 @@ public class JintJavaScriptEvaluator(IConfiguration configuration, INotification
         engineOptions.Interop.EnumConversion = EnumConversionMode.String;
 
         ConfigureClrAccess(engineOptions);
-        ConfigureObjectWrapper(engineOptions);
         ConfigureObjectConverters(engineOptions);
         ConfigureExecutionConstraints(engineOptions, cancellationToken);
 
@@ -91,19 +88,6 @@ public class JintJavaScriptEvaluator(IConfiguration configuration, INotification
     {
         if (_jintOptions.AllowClrAccess)
             options.AllowClr();
-    }
-
-    private void ConfigureObjectWrapper(Jint.Options options)
-    {
-        options.SetWrapObjectHandler((engine, target, type) =>
-        {
-            var instance = ObjectWrapper.Create(engine, target);
-
-            if (ObjectArrayHelper.DetermineIfObjectIsArrayLikeClrCollection(target.GetType()))
-                instance.Prototype = engine.Intrinsics.Array.PrototypeObject;
-
-            return instance;
-        });
     }
 
     private void ConfigureExecutionConstraints(Jint.Options options, CancellationToken cancellationToken)

--- a/test/integration/Elsa.JavaScript.IntegrationTests/ObjectWrappingTests.cs
+++ b/test/integration/Elsa.JavaScript.IntegrationTests/ObjectWrappingTests.cs
@@ -1,0 +1,79 @@
+using System.Dynamic;
+using Elsa.Expressions.JavaScript.Contracts;
+using Elsa.Expressions.Models;
+using Elsa.Testing.Shared;
+using Jint;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Elsa.JavaScript.IntegrationTests;
+
+/// <summary>
+/// Verifies how CLR objects are exposed to JavaScript: array-like collections should behave like arrays,
+/// while dictionary-like objects (such as the <c>variables</c> and <c>args</c> containers) should behave
+/// like plain objects.
+/// </summary>
+public class ObjectWrappingTests
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IJavaScriptEvaluator _evaluator;
+
+    public ObjectWrappingTests(ITestOutputHelper testOutputHelper)
+    {
+        _serviceProvider = new TestApplicationBuilder(testOutputHelper).Build();
+        _evaluator = _serviceProvider.GetRequiredService<IJavaScriptEvaluator>();
+    }
+
+    [Fact(DisplayName = "The variables container is a plain object, not an array")]
+    public async Task VariablesContainerIsNotArrayLike()
+    {
+        Assert.Equal("false", await EvaluateAsync<string>("return '' + (Object.getPrototypeOf(variables) === Array.prototype);"));
+        Assert.Equal("undefined", await EvaluateAsync<string>("return typeof variables.map;"));
+        Assert.Equal("undefined", await EvaluateAsync<string>("return typeof variables.filter;"));
+        Assert.Equal("undefined", await EvaluateAsync<string>("return typeof variables.length;"));
+    }
+
+    [Fact(DisplayName = "A dictionary-like object is a plain object, not an array")]
+    public async Task DictionaryLikeObjectsAreNotArrayLike()
+    {
+        var expando = new ExpandoObject() as IDictionary<string, object>;
+        expando["greeting"] = "hello";
+
+        Assert.Equal("undefined", await EvaluateAsync<string>("return typeof subject.map;", engine => engine.SetValue("subject", expando)));
+        Assert.Equal("hello", await EvaluateAsync<string>("return subject.greeting;", engine => engine.SetValue("subject", expando)));
+        Assert.Equal("undefined", await EvaluateAsync<string>("return typeof subject.map;", engine => engine.SetValue("subject", new Dictionary<string, object> { ["greeting"] = "hello" })));
+    }
+
+    [Theory(DisplayName = "Array-like CLR collections expose the array prototype")]
+    [InlineData("list")]
+    [InlineData("set")]
+    [InlineData("array")]
+    public async Task ArrayLikeCollectionsExposeArrayPrototype(string name)
+    {
+        Assert.Equal("function", await EvaluateAsync<string>($"return typeof {name}.map;", ConfigureCollections));
+        Assert.Equal("true", await EvaluateAsync<string>($"return '' + (Object.getPrototypeOf({name}) === Array.prototype);", ConfigureCollections));
+    }
+
+    [Theory(DisplayName = "Indexable CLR collections support array iteration methods")]
+    [InlineData("list")]
+    [InlineData("array")]
+    public async Task IndexableCollectionsSupportArrayMethods(string name)
+    {
+        Assert.Equal("2,4,6", await EvaluateAsync<string>($"return {name}.map(x => x * 2).join(',');", ConfigureCollections));
+        Assert.Equal("6", await EvaluateAsync<string>($"return '' + {name}.reduce((a, b) => a + b, 0);", ConfigureCollections));
+    }
+
+    private static void ConfigureCollections(Engine engine)
+    {
+        engine.SetValue("list", new List<int> { 1, 2, 3 });
+        engine.SetValue("set", new HashSet<int> { 1, 2, 3 });
+        engine.SetValue("array", new[] { 1, 2, 3 });
+    }
+
+    private async Task<T?> EvaluateAsync<T>(string script, Action<Engine>? configureEngine = null)
+    {
+        var expressionExecutionContext = new ExpressionExecutionContext(_serviceProvider, new());
+        return (T?)await _evaluator.EvaluateAsync(script, typeof(T), expressionExecutionContext, configureEngine: configureEngine);
+    }
+}

--- a/test/integration/Elsa.JavaScript.IntegrationTests/ObjectWrappingTests.cs
+++ b/test/integration/Elsa.JavaScript.IntegrationTests/ObjectWrappingTests.cs
@@ -37,7 +37,7 @@ public class ObjectWrappingTests
     [Fact(DisplayName = "A dictionary-like object is a plain object, not an array")]
     public async Task DictionaryLikeObjectsAreNotArrayLike()
     {
-        var expando = new ExpandoObject() as IDictionary<string, object>;
+        var expando = (IDictionary<string, object?>)new ExpandoObject();
         expando["greeting"] = "hello";
 
         Assert.Equal("undefined", await EvaluateAsync<string>("return typeof subject.map;", engine => engine.SetValue("subject", expando)));


### PR DESCRIPTION
## Problem

`JintJavaScriptEvaluator` installs a custom `WrapObjectDelegate`:

```csharp
options.SetWrapObjectHandler((engine, target, type) =>
{
    var instance = ObjectWrapper.Create(engine, target);

    if (ObjectArrayHelper.DetermineIfObjectIsArrayLikeClrCollection(target.GetType()))
        instance.Prototype = engine.Intrinsics.Array.PrototypeObject;

    return instance;
});
```

This duplicates what Jint already does, and gets it wrong in two ways.

Jint's default handler is `ObjectWrapper.Create(engine, target, type)`, and `ObjectWrapper` attaches `Array.prototype` to array-like wrappers by itself whenever `Options.Interop.AttachArrayPrototype` is enabled — which it is by default. Jint's own array-likeness test deliberately treats dictionary-like types, *including string-keyed generic dictionaries*, as plain objects.

The handler above:

* drops the declared `type` argument, so wrapper members are resolved against the runtime type rather than the declared one;
* delegates the array-likeness decision to `ObjectArrayHelper.DetermineIfObjectIsArrayLikeClrCollection`, which only excludes the **non-generic** `IDictionary`. `ExpandoObject` does not implement that interface — it implements `IDictionary<string, object>` and `ICollection<KeyValuePair<string, object>>` — so it comes out array-like.

Both the `variables` container (`ConfigureEngineWithVariables`) and the `args` container (`JavaScriptExpressionHandler`) are `ExpandoObject` instances. The observable result today:

```js
Object.getPrototypeOf(variables) === Array.prototype   // true
typeof variables.map                                   // "function"
typeof variables.filter                                // "function"
variables.length                                       // 0, rather than undefined
```

## Fix

Remove the handler. Jint's default covers every case the custom one was written for — verified against a plain engine:

| wrapped value | gets `Array.prototype` |
|---|---|
| `string[]`, `List<T>`, `HashSet<T>`, `ImmutableArray<T>`, `ImmutableList<T>`, `Queue<T>`, `Stack<T>` | yes |
| `Dictionary<string, object>`, `ExpandoObject`, a bare `IEnumerable<T>` iterator | no |

`ObjectArrayHelper` is public, so it is marked `[Obsolete]` rather than deleted.

## Tests

New `ObjectWrappingTests` covers both directions: the `variables` container and dictionary-like objects are plain objects, and array-like CLR collections still expose `Array.prototype` and still support `map`/`reduce` where the collection is indexable.

`Elsa.JavaScript.IntegrationTests` 73 → 80 passing, `Elsa.Workflows.IntegrationTests` 270 passing, both before and after.

Note for reviewers: `HashSet<T>` gets `Array.prototype` but has no integer indexer, so `set.map(...)` yields empty entries. That is unchanged by this PR — it behaves identically with and without the custom handler — so the test asserts prototype presence for sets and functional iteration only for indexable collections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179sA2T7HuRfRfSc2JirFik