### PR TITLE
Bound JavaScript expression execution

### DIFF
--- a/doc/security-assessment/elsa-core-architecture-patterns.md
+++ b/doc/security-assessment/elsa-core-architecture-patterns.md
@@ -107,7 +107,7 @@
 | Deployment stamps | ❌ | No first-class multi-region stamp deployment tooling. |
 | Geode | ❌ | No geo-distribution support. |
 | Quarantine | ❌ | No quarantine/validation gate for inbound messages or data. |
-| Timeout | ✅ | `Delay`, `StartAt`, `Timer`, and `Cron` activities implement time-based waits. `CancellationToken` propagation allows workflow-level and activity-level timeout cancellation. `JintOptions` exposes a JavaScript execution timeout. |
+| Timeout | ✅ | `Delay`, `StartAt`, `Timer`, and `Cron` activities implement time-based waits. `CancellationToken` propagation allows workflow-level and activity-level timeout cancellation. `JintOptions.ExecutionTimeout` bounds how long a single JavaScript expression may run (30 seconds by default), and the ambient `CancellationToken` aborts a script that is still running; `JintOptions.MaxStatements`, `MemoryLimit` and `MaxRecursionDepth` add optional resource limits on top. |
 
 ---
 

--- a/doc/security-assessment/elsa-core-profile.md
+++ b/doc/security-assessment/elsa-core-profile.md
@@ -177,7 +177,7 @@ Elsa provides a pluggable expression evaluation system via `IExpressionHandler` 
 | ElsaScript DSL | `Elsa.Dsl.ElsaScript` | Custom regex-based parser + compiler |
 | Literal / Delegate | `Elsa.Expressions` | Native .NET |
 
-The JavaScript engine (Jint) supports optional CLR access (`AllowClrAccess`) and optional `getConfig` access for reading `IConfiguration` values; both are disabled by default for security. Python requires a Python runtime path configured via `PYTHONNET_PYDLL` or application settings.
+The JavaScript engine (Jint) supports optional CLR access (`AllowClrAccess`) and optional `getConfig` access for reading `IConfiguration` values; both are disabled by default for security. Script execution is bounded by `JintOptions.ExecutionTimeout` (30 seconds by default) and by the ambient `CancellationToken`; `MaxStatements`, `MemoryLimit` and `MaxRecursionDepth` are available as additional opt-in limits. Python requires a Python runtime path configured via `PYTHONNET_PYDLL` or application settings.
 
 ---
 

--- a/src/modules/Elsa.Expressions.JavaScript/Options/JintOptions.cs
+++ b/src/modules/Elsa.Expressions.JavaScript/Options/JintOptions.cs
@@ -33,6 +33,35 @@ public class JintOptions
     public bool AllowConfigurationAccess { get; set; }
 
     /// <summary>
+    /// The maximum wall-clock time a single JavaScript expression may run for. Set to <c>null</c> to remove the limit.
+    /// </summary>
+    /// <remarks>
+    /// Without a limit, an expression such as <c>while (true) {}</c> occupies the calling thread indefinitely.
+    /// The default is deliberately generous so that legitimate expressions are unaffected; hosts that evaluate
+    /// user-defined workflows are encouraged to lower it.
+    /// </remarks>
+    public TimeSpan? ExecutionTimeout { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// The maximum number of statements a single JavaScript expression may execute. Set to <c>null</c> (the default) to remove the limit.
+    /// </summary>
+    public int? MaxStatements { get; set; }
+
+    /// <summary>
+    /// The maximum amount of memory, in bytes, a single JavaScript expression may allocate. Set to <c>null</c> (the default) to remove the limit.
+    /// </summary>
+    public long? MemoryLimit { get; set; }
+
+    /// <summary>
+    /// The maximum recursion depth allowed within a single JavaScript expression. Set to <c>null</c> (the default) to remove the limit.
+    /// </summary>
+    /// <remarks>
+    /// Unbounded recursion in a script exhausts the CLR stack, which cannot be recovered from. Hosts that evaluate
+    /// user-defined workflows are encouraged to set a limit.
+    /// </remarks>
+    public int? MaxRecursionDepth { get; set; }
+
+    /// <summary>
     /// The timeout for script caching.
     /// </summary>
     /// <remarks>

--- a/src/modules/Elsa.Expressions.JavaScript/Services/JintJavaScriptEvaluator.cs
+++ b/src/modules/Elsa.Expressions.JavaScript/Services/JintJavaScriptEvaluator.cs
@@ -56,6 +56,7 @@ public class JintJavaScriptEvaluator(IConfiguration configuration, INotification
         ConfigureClrAccess(engineOptions);
         ConfigureObjectWrapper(engineOptions);
         ConfigureObjectConverters(engineOptions);
+        ConfigureExecutionConstraints(engineOptions, cancellationToken);
 
         await mediator.SendAsync(new CreatingJavaScriptEngine(engineOptions, context), cancellationToken);
         _jintOptions.ConfigureEngineOptionsCallback(engineOptions, context);
@@ -87,6 +88,25 @@ public class JintJavaScriptEvaluator(IConfiguration configuration, INotification
 
             return instance;
         });
+    }
+
+    private void ConfigureExecutionConstraints(Jint.Options options, CancellationToken cancellationToken)
+    {
+        // An expression that never returns would otherwise occupy the calling thread forever.
+        if (_jintOptions.ExecutionTimeout is { } executionTimeout)
+            options.TimeoutInterval(executionTimeout);
+
+        if (_jintOptions.MaxStatements is { } maxStatements)
+            options.MaxStatements(maxStatements);
+
+        if (_jintOptions.MemoryLimit is { } memoryLimit)
+            options.LimitMemory(memoryLimit);
+
+        if (_jintOptions.MaxRecursionDepth is { } maxRecursionDepth)
+            options.LimitRecursion(maxRecursionDepth);
+
+        // Cancelling the workflow should also abort a script that is still running.
+        options.CancellationToken(cancellationToken);
     }
 
     private void ConfigureObjectConverters(Jint.Options options)

--- a/test/integration/Elsa.JavaScript.IntegrationTests/ExecutionConstraintTests.cs
+++ b/test/integration/Elsa.JavaScript.IntegrationTests/ExecutionConstraintTests.cs
@@ -3,6 +3,7 @@ using Elsa.Expressions.JavaScript.Options;
 using Elsa.Expressions.Models;
 using Elsa.Extensions;
 using Elsa.Testing.Shared;
+using Jint;
 using Jint.Runtime;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -17,67 +18,117 @@ public class ExecutionConstraintTests(ITestOutputHelper testOutputHelper)
 {
     private const string InfiniteLoop = "while (true) {}";
 
+    /// <summary>
+    /// Tests whose subject is a constraint other than the timeout still register a timeout, so that a regression
+    /// in the constraint under test fails that one test instead of leaving an infinite loop running until the CI
+    /// job is killed. It is orders of magnitude longer than those constraints need — each of them aborts within
+    /// milliseconds — so it cannot itself become a source of flaky failures on a loaded machine, and
+    /// <see cref="AssertAbortedByAsync{TException}"/> reports a trip as a failsafe trip rather than as a
+    /// confusing exception type mismatch.
+    /// </summary>
+    private static readonly TimeSpan FailsafeTimeout = TimeSpan.FromSeconds(30);
+
     [Fact(DisplayName = "An expression that never returns is aborted by the execution timeout")]
     public async Task ExecutionTimeoutAbortsRunawayExpression()
     {
-        var evaluator = BuildEvaluator(options => options.ExecutionTimeout = TimeSpan.FromMilliseconds(250));
+        // No failsafe needed: the timeout is the subject here, so the test is bounded by the thing it asserts.
+        var services = BuildServices(options => options.ExecutionTimeout = TimeSpan.FromMilliseconds(250));
 
-        await Assert.ThrowsAsync<TimeoutException>(() => EvaluateAsync(evaluator, InfiniteLoop));
+        await Assert.ThrowsAsync<TimeoutException>(() => EvaluateAsync(services, InfiniteLoop));
     }
 
     [Fact(DisplayName = "An expression that never returns is aborted when the cancellation token is signalled")]
     public async Task CancellationAbortsRunawayExpression()
     {
-        var evaluator = BuildEvaluator(options => options.ExecutionTimeout = null);
-        using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromMilliseconds(250));
+        var services = BuildServices(options => options.ExecutionTimeout = FailsafeTimeout);
+        using var cancellationTokenSource = new CancellationTokenSource();
 
-        await Assert.ThrowsAsync<ExecutionCanceledException>(() => EvaluateAsync(evaluator, InfiniteLoop, cancellationTokenSource.Token));
+        // The script signals the token itself, so cancellation is guaranteed to land after the engine has been
+        // built and while the expression is running. A wall-clock timer would instead race engine construction
+        // and could fault the setup rather than the script on a loaded machine.
+        await AssertAbortedByAsync<ExecutionCanceledException>(() => EvaluateAsync(
+            services,
+            "cancel(); " + InfiniteLoop,
+            engine => engine.SetValue("cancel", (Action)cancellationTokenSource.Cancel),
+            cancellationTokenSource.Token));
     }
 
     [Fact(DisplayName = "An expression that exceeds the statement limit is aborted")]
     public async Task StatementLimitAbortsRunawayExpression()
     {
-        var evaluator = BuildEvaluator(options =>
+        var services = BuildServices(options =>
         {
-            options.ExecutionTimeout = null;
+            options.ExecutionTimeout = FailsafeTimeout;
             options.MaxStatements = 100;
         });
 
-        await Assert.ThrowsAsync<StatementsCountOverflowException>(() => EvaluateAsync(evaluator, InfiniteLoop));
+        await AssertAbortedByAsync<StatementsCountOverflowException>(() => EvaluateAsync(services, InfiniteLoop));
+    }
+
+    [Fact(DisplayName = "An expression that allocates without bound is aborted by the memory limit")]
+    public async Task MemoryLimitAbortsAllocationHeavyExpression()
+    {
+        var services = BuildServices(options =>
+        {
+            options.ExecutionTimeout = FailsafeTimeout;
+            options.MemoryLimit = 4 * 1024 * 1024;
+        });
+
+        // The limit is checked between statements, so the script has to allocate in visible steps. Doubling the
+        // string crosses any limit within a couple of dozen iterations, which keeps the test fast and bounds how
+        // far past the limit the process can get before the check fires.
+        await AssertAbortedByAsync<MemoryLimitExceededException>(() => EvaluateAsync(services, "var s = 'x'; while (true) { s += s; }"));
     }
 
     [Fact(DisplayName = "An expression that recurses without bound is aborted")]
     public async Task RecursionLimitAbortsRunawayExpression()
     {
-        var evaluator = BuildEvaluator(options =>
+        var services = BuildServices(options =>
         {
-            options.ExecutionTimeout = null;
+            options.ExecutionTimeout = FailsafeTimeout;
             options.MaxRecursionDepth = 32;
         });
 
-        await Assert.ThrowsAsync<RecursionDepthOverflowException>(() => EvaluateAsync(evaluator, "function f() { return f(); } return f();"));
+        await AssertAbortedByAsync<RecursionDepthOverflowException>(() => EvaluateAsync(services, "function f() { return f(); } return f();"));
     }
 
     [Fact(DisplayName = "A well-behaved expression is unaffected by the default constraints")]
     public async Task DefaultConstraintsDoNotAffectNormalExpressions()
     {
-        var evaluator = BuildEvaluator(_ => { });
+        var services = BuildServices(_ => { });
 
-        Assert.Equal("3", await EvaluateAsync(evaluator, "return '' + (1 + 2);"));
+        Assert.Equal("3", await EvaluateAsync(services, "return '' + (1 + 2);"));
     }
 
-    private IJavaScriptEvaluator BuildEvaluator(Action<JintOptions> configure)
+    private IServiceProvider BuildServices(Action<JintOptions> configure)
     {
-        var serviceProvider = new TestApplicationBuilder(testOutputHelper)
+        return new TestApplicationBuilder(testOutputHelper)
             .ConfigureElsa(elsa => elsa.UseJavaScript(configure))
             .Build();
-
-        return serviceProvider.GetRequiredService<IJavaScriptEvaluator>();
     }
 
-    private static async Task<string?> EvaluateAsync(IJavaScriptEvaluator evaluator, string script, CancellationToken cancellationToken = default)
+    private static async Task<string?> EvaluateAsync(IServiceProvider services, string script, Action<Engine>? configureEngine = null, CancellationToken cancellationToken = default)
     {
-        var context = new ExpressionExecutionContext(new ServiceCollection().BuildServiceProvider(), new());
-        return (string?)await evaluator.EvaluateAsync(script, typeof(string), context, cancellationToken: cancellationToken);
+        var evaluator = services.GetRequiredService<IJavaScriptEvaluator>();
+        var context = new ExpressionExecutionContext(services, new());
+
+        return (string?)await evaluator.EvaluateAsync(script, typeof(string), context, configureEngine: configureEngine, cancellationToken: cancellationToken);
+    }
+
+    /// <summary>
+    /// Asserts that the expression was aborted by <typeparamref name="TException"/>, distinguishing that outcome
+    /// from a trip of the failsafe execution timeout that guards the test against running unbounded.
+    /// </summary>
+    private static async Task AssertAbortedByAsync<TException>(Func<Task> evaluate) where TException : Exception
+    {
+        var exception = await Record.ExceptionAsync(evaluate);
+
+        if (exception is null)
+            Assert.Fail($"Expected the expression to be aborted by {typeof(TException).Name}, but it ran to completion.");
+
+        if (exception is TimeoutException)
+            Assert.Fail($"The {FailsafeTimeout.TotalSeconds:0} second failsafe execution timeout fired before {typeof(TException).Name} was thrown: the constraint under test did not abort the expression.");
+
+        Assert.IsType<TException>(exception);
     }
 }

--- a/test/integration/Elsa.JavaScript.IntegrationTests/ExecutionConstraintTests.cs
+++ b/test/integration/Elsa.JavaScript.IntegrationTests/ExecutionConstraintTests.cs
@@ -1,0 +1,83 @@
+using Elsa.Expressions.JavaScript.Contracts;
+using Elsa.Expressions.JavaScript.Options;
+using Elsa.Expressions.Models;
+using Elsa.Extensions;
+using Elsa.Testing.Shared;
+using Jint.Runtime;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Elsa.JavaScript.IntegrationTests;
+
+/// <summary>
+/// Verifies that a runaway JavaScript expression cannot occupy the calling thread indefinitely.
+/// </summary>
+public class ExecutionConstraintTests(ITestOutputHelper testOutputHelper)
+{
+    private const string InfiniteLoop = "while (true) {}";
+
+    [Fact(DisplayName = "An expression that never returns is aborted by the execution timeout")]
+    public async Task ExecutionTimeoutAbortsRunawayExpression()
+    {
+        var evaluator = BuildEvaluator(options => options.ExecutionTimeout = TimeSpan.FromMilliseconds(250));
+
+        await Assert.ThrowsAsync<TimeoutException>(() => EvaluateAsync(evaluator, InfiniteLoop));
+    }
+
+    [Fact(DisplayName = "An expression that never returns is aborted when the cancellation token is signalled")]
+    public async Task CancellationAbortsRunawayExpression()
+    {
+        var evaluator = BuildEvaluator(options => options.ExecutionTimeout = null);
+        using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromMilliseconds(250));
+
+        await Assert.ThrowsAsync<ExecutionCanceledException>(() => EvaluateAsync(evaluator, InfiniteLoop, cancellationTokenSource.Token));
+    }
+
+    [Fact(DisplayName = "An expression that exceeds the statement limit is aborted")]
+    public async Task StatementLimitAbortsRunawayExpression()
+    {
+        var evaluator = BuildEvaluator(options =>
+        {
+            options.ExecutionTimeout = null;
+            options.MaxStatements = 100;
+        });
+
+        await Assert.ThrowsAsync<StatementsCountOverflowException>(() => EvaluateAsync(evaluator, InfiniteLoop));
+    }
+
+    [Fact(DisplayName = "An expression that recurses without bound is aborted")]
+    public async Task RecursionLimitAbortsRunawayExpression()
+    {
+        var evaluator = BuildEvaluator(options =>
+        {
+            options.ExecutionTimeout = null;
+            options.MaxRecursionDepth = 32;
+        });
+
+        await Assert.ThrowsAsync<RecursionDepthOverflowException>(() => EvaluateAsync(evaluator, "function f() { return f(); } return f();"));
+    }
+
+    [Fact(DisplayName = "A well-behaved expression is unaffected by the default constraints")]
+    public async Task DefaultConstraintsDoNotAffectNormalExpressions()
+    {
+        var evaluator = BuildEvaluator(_ => { });
+
+        Assert.Equal("3", await EvaluateAsync(evaluator, "return '' + (1 + 2);"));
+    }
+
+    private IJavaScriptEvaluator BuildEvaluator(Action<JintOptions> configure)
+    {
+        var serviceProvider = new TestApplicationBuilder(testOutputHelper)
+            .ConfigureElsa(elsa => elsa.UseJavaScript(configure))
+            .Build();
+
+        return serviceProvider.GetRequiredService<IJavaScriptEvaluator>();
+    }
+
+    private static async Task<string?> EvaluateAsync(IJavaScriptEvaluator evaluator, string script, CancellationToken cancellationToken = default)
+    {
+        var context = new ExpressionExecutionContext(new ServiceCollection().BuildServiceProvider(), new());
+        return (string?)await evaluator.EvaluateAsync(script, typeof(string), context, cancellationToken: cancellationToken);
+    }
+}


### PR DESCRIPTION
## Problem

JavaScript expressions are evaluated with no execution constraints at all. `JintJavaScriptEvaluator` builds a `Jint.Options` with only `ExperimentalFeatures`, CLR access and object converters set — no timeout, no statement limit, no memory limit, no recursion limit. The ambient `CancellationToken` is already available at the call site and is already threaded through `IJavaScriptEvaluator.EvaluateAsync`, but it is never handed to Jint.

So `while (true) {}` in any JavaScript expression occupies the calling thread for the lifetime of the process, and cancelling the workflow does not stop it. Unbounded recursion exhausts the CLR stack, which cannot be recovered from.

The security assessment documents already describe a JavaScript execution timeout as present (`doc/security-assessment/elsa-core-architecture-patterns.md`, Timeout row) — `JintOptions` had no such setting.

## Change

New `JintOptions` settings:

| Setting | Default | Effect |
|---|---|---|
| `ExecutionTimeout` | 30 seconds | Wall-clock limit for a single expression. `null` removes it. |
| `MaxStatements` | `null` | Statement-count limit. |
| `MemoryLimit` | `null` | Allocation limit, in bytes. |
| `MaxRecursionDepth` | `null` | Recursion depth limit. |

Plus: the cancellation token already passed into `EvaluateAsync` is now given to Jint, so cancelling a workflow aborts a script that is still running.

Only the timeout is on by default, and deliberately generously so — the intent is that no legitimate expression is affected, while a runaway one fails instead of hanging. Hosts evaluating user-defined workflows are pointed at the tighter limits in the XML docs. Jint ignores saturated values (`MaxStatements(int.MaxValue)`, `TimeoutInterval(TimeSpan.MaxValue)` register no constraint), so these are real values rather than sentinels.

The two security assessment documents are updated to describe what is actually configurable.

## Tests

New `ExecutionConstraintTests` drives each limit and asserts the corresponding Jint exception:

| Test | Script | Asserted |
|---|---|---|
| `ExecutionTimeout` | `while (true) {}` | `TimeoutException` |
| Cancellation | `while (true) {}` | `ExecutionCanceledException` |
| `MaxStatements` | `while (true) {}` | `StatementsCountOverflowException` |
| `MemoryLimit` | a string doubled each iteration | `MemoryLimitExceededException` |
| `MaxRecursionDepth` | unbounded recursion | `RecursionDepthOverflowException` |

Plus one test that a normal expression is unaffected by the defaults.

Every test whose subject is a constraint other than the timeout still registers a generous 30 second failsafe timeout rather than disabling the timeout, so a regression in the constraint under test fails that one test instead of leaving an infinite loop running until the CI job is killed. The slowest of these constraints aborts in ~270 ms, so the failsafe has ~100× headroom and cannot itself become a flaky failure; a failsafe trip is reported as a failsafe trip rather than as an unexplained exception type mismatch. The cancellation test signals its token from inside the script through a host function, so it has no wall-clock race against engine construction. The whole class runs in under a second.

`Elsa.JavaScript.IntegrationTests` 73 → 79 passing, `Elsa.Workflows.IntegrationTests` 270 passing, both before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179sA2T7HuRfRfSc2JirFik
