### PR TITLE
Stop registering colliding and unreachable type globals in JavaScript expressions

### DIFF
--- a/src/modules/Elsa.Expressions.JavaScript/Extensions/EngineExtensions.cs
+++ b/src/modules/Elsa.Expressions.JavaScript/Extensions/EngineExtensions.cs
@@ -21,10 +21,19 @@ public static class EngineExtensions
     /// Register the specified type with the engine, under its type name.
     /// </summary>
     /// <remarks>
-    /// Types whose name is not usable as a JavaScript identifier are skipped. A constructed generic type such as
-    /// <c>IDictionary&lt;string, object&gt;</c> is named <c>IDictionary`2</c> and an array type such as
-    /// <c>byte[]</c> is named <c>Byte[]</c>; neither can be referenced from a script, and every constructed
-    /// generic type of the same arity would claim the same global. Registering the same type twice is a no-op.
+    /// <para>
+    /// Types whose name cannot be written as a JavaScript identifier are skipped. A constructed generic type such
+    /// as <c>IDictionary&lt;string, object&gt;</c> is named <c>IDictionary`2</c> and an array type such as
+    /// <c>byte[]</c> is named <c>Byte[]</c>. Registered, those would only be reachable through bracket notation —
+    /// <c>globalThis['Byte[]']</c> — and every constructed generic type of the same arity would claim the same
+    /// global, so the last one registered would silently win.
+    /// </para>
+    /// <para>
+    /// A name that is already taken is left alone. Registering the same type twice is therefore a no-op, and a
+    /// global the host installed — through <c>JintOptions.RegisterType</c>, <c>JintOptions.ConfigureEngine</c> or
+    /// the per-evaluation <c>configureEngine</c> callback, all of which run before the built-in registrations —
+    /// is never replaced.
+    /// </para>
     /// </remarks>
     public static void RegisterType(this Engine engine, Type type)
     {
@@ -33,9 +42,11 @@ public static class EngineExtensions
         if (!IsUsableAsIdentifier(name))
             return;
 
-        // The type registrations are contributed by several independent handlers, which overlap: without this
-        // check, the overlapping types would each be re-created and re-assigned for every expression evaluation.
-        if (engine.GetValue(name) is TypeReference registered && registered.ReferenceType == type)
+        // The type registrations are contributed by several independent handlers, whose sets overlap, and they run
+        // after the host has configured the engine. Leaving an occupied name alone does two things: the overlapping
+        // types are no longer described through reflection again for every expression evaluation, and a global that
+        // the host - or JavaScript itself - already put there keeps its value.
+        if (engine.Global.HasOwnProperty(name))
             return;
 
         engine.SetValue(name, TypeReference.CreateTypeReference(engine, type));

--- a/src/modules/Elsa.Expressions.JavaScript/Extensions/EngineExtensions.cs
+++ b/src/modules/Elsa.Expressions.JavaScript/Extensions/EngineExtensions.cs
@@ -15,12 +15,45 @@ public static class EngineExtensions
     /// <summary>
     /// Register the specified type <c>T</c> with the engine.
     /// </summary>
-    public static void RegisterType<T>(this Engine engine) => engine.SetValue(typeof(T).Name, TypeReference.CreateTypeReference(engine, typeof(T)));
-    
+    public static void RegisterType<T>(this Engine engine) => engine.RegisterType(typeof(T));
+
     /// <summary>
-    /// Register the specified type <c>T</c> with the engine.
+    /// Register the specified type with the engine, under its type name.
     /// </summary>
-    public static void RegisterType(this Engine engine, Type type) => engine.SetValue(type.Name, TypeReference.CreateTypeReference(engine, type));
+    /// <remarks>
+    /// Types whose name is not usable as a JavaScript identifier are skipped. A constructed generic type such as
+    /// <c>IDictionary&lt;string, object&gt;</c> is named <c>IDictionary`2</c> and an array type such as
+    /// <c>byte[]</c> is named <c>Byte[]</c>; neither can be referenced from a script, and every constructed
+    /// generic type of the same arity would claim the same global. Registering the same type twice is a no-op.
+    /// </remarks>
+    public static void RegisterType(this Engine engine, Type type)
+    {
+        var name = type.Name;
+
+        if (!IsUsableAsIdentifier(name))
+            return;
+
+        // The type registrations are contributed by several independent handlers, which overlap: without this
+        // check, the overlapping types would each be re-created and re-assigned for every expression evaluation.
+        if (engine.GetValue(name) is TypeReference registered && registered.ReferenceType == type)
+            return;
+
+        engine.SetValue(name, TypeReference.CreateTypeReference(engine, type));
+    }
+
+    private static bool IsUsableAsIdentifier(string name)
+    {
+        if (string.IsNullOrEmpty(name) || (!char.IsLetter(name[0]) && name[0] != '_' && name[0] != '$'))
+            return false;
+
+        foreach (var c in name)
+        {
+            if (!char.IsLetterOrDigit(c) && c != '_' && c != '$')
+                return false;
+        }
+
+        return true;
+    }
 
     internal static void SyncVariablesContainer(this Engine engine, IOptions<JintOptions> options, string name, object? value)
     {

--- a/test/integration/Elsa.JavaScript.IntegrationTests/TypeRegistrationTests.cs
+++ b/test/integration/Elsa.JavaScript.IntegrationTests/TypeRegistrationTests.cs
@@ -1,0 +1,62 @@
+using Elsa.Expressions.JavaScript.Contracts;
+using Elsa.Expressions.Models;
+using Elsa.Extensions;
+using Elsa.Testing.Shared;
+using Jint;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Elsa.JavaScript.IntegrationTests;
+
+/// <summary>
+/// Verifies which .NET types are exposed to JavaScript and under which names.
+/// </summary>
+public class TypeRegistrationTests
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IJavaScriptEvaluator _evaluator;
+
+    public TypeRegistrationTests(ITestOutputHelper testOutputHelper)
+    {
+        _serviceProvider = new TestApplicationBuilder(testOutputHelper).Build();
+        _evaluator = _serviceProvider.GetRequiredService<IJavaScriptEvaluator>();
+    }
+
+    [Theory(DisplayName = "Common .NET types are available under their type name")]
+    [InlineData("DateTime")]
+    [InlineData("DateTimeOffset")]
+    [InlineData("TimeSpan")]
+    [InlineData("Guid")]
+    [InlineData("Random")]
+    [InlineData("LogPersistenceMode")]
+    [InlineData("ExpandoObject")]
+    [InlineData("JsonElement")]
+    [InlineData("JsonNode")]
+    [InlineData("JsonObject")]
+    [InlineData("Stream")]
+    public async Task CommonTypesAreRegistered(string typeName)
+    {
+        Assert.Equal("function", await EvaluateAsync($"return typeof {typeName};"));
+    }
+
+    [Theory(DisplayName = "Types whose name is not a JavaScript identifier are not registered")]
+    [InlineData("IDictionary`2")]
+    [InlineData("Byte[]")]
+    public async Task TypesWithUnusableNamesAreNotRegistered(string globalName)
+    {
+        Assert.Equal("undefined", await EvaluateAsync($"return typeof globalThis['{globalName}'];"));
+    }
+
+    [Fact(DisplayName = "A type registered by the host stays available after the built-in registrations run")]
+    public async Task HostRegisteredTypesSurviveTheBuiltInRegistrations()
+    {
+        Assert.Equal("function", await EvaluateAsync("return typeof Uri;", engine => engine.RegisterType<Uri>()));
+    }
+
+    private async Task<string?> EvaluateAsync(string script, Action<Engine>? configureEngine = null)
+    {
+        var context = new ExpressionExecutionContext(_serviceProvider, new());
+        return (string?)await _evaluator.EvaluateAsync(script, typeof(string), context, configureEngine: configureEngine);
+    }
+}

--- a/test/integration/Elsa.JavaScript.IntegrationTests/TypeRegistrationTests.cs
+++ b/test/integration/Elsa.JavaScript.IntegrationTests/TypeRegistrationTests.cs
@@ -3,6 +3,8 @@ using Elsa.Expressions.Models;
 using Elsa.Extensions;
 using Elsa.Testing.Shared;
 using Jint;
+using Jint.Native;
+using Jint.Runtime.Interop;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 using Xunit.Abstractions;
@@ -52,6 +54,33 @@ public class TypeRegistrationTests
     public async Task HostRegisteredTypesSurviveTheBuiltInRegistrations()
     {
         Assert.Equal("function", await EvaluateAsync("return typeof Uri;", engine => engine.RegisterType<Uri>()));
+    }
+
+    [Fact(DisplayName = "A global installed by the host wins over the built-in registration of the same name")]
+    public async Task HostGlobalsAreNotOverwrittenByTheBuiltInRegistrations()
+    {
+        // Guid is registered by both ConfigureEngineWithCommonTypes and the default variable descriptor set, and
+        // those handlers run after the configureEngine callback. The host's value has to survive them.
+        Assert.Equal("host-provided", await EvaluateAsync("return Guid;", engine => engine.SetValue("Guid", "host-provided")));
+    }
+
+    [Fact(DisplayName = "A registered type is exposed as a CLR type reference and registering it again is a no-op")]
+    public async Task RegisterTypeInstallsATypeReferenceAndIsIdempotent()
+    {
+        JsValue afterFirstRegistration = JsValue.Undefined;
+        JsValue afterSecondRegistration = JsValue.Undefined;
+
+        await EvaluateAsync("return 'done';", engine =>
+        {
+            engine.RegisterType<Uri>();
+            afterFirstRegistration = engine.GetValue("Uri");
+            engine.RegisterType<Uri>();
+            afterSecondRegistration = engine.GetValue("Uri");
+        });
+
+        var typeReference = Assert.IsType<TypeReference>(afterFirstRegistration);
+        Assert.Equal(typeof(Uri), typeReference.ReferenceType);
+        Assert.Same(afterFirstRegistration, afterSecondRegistration);
     }
 
     private async Task<string?> EvaluateAsync(string script, Action<Engine>? configureEngine = null)


### PR DESCRIPTION
## Problem

`EngineExtensions.RegisterType` exposes a .NET type to script under `Type.Name`:

```csharp
public static void RegisterType(this Engine engine, Type type) =>
    engine.SetValue(type.Name, TypeReference.CreateTypeReference(engine, type));
```

`Type.Name` is not always usable as a global name, and the registrations are contributed by several independent handlers whose sets overlap. With the default configuration, every expression evaluation performs the following:

**Two registrations claim the same global.** `IDictionary<string, string>` and `IDictionary<string, object>` are both in the default `VariableDescriptors` set, and both are named ``IDictionary`2``. The second registration silently replaces the first. Neither is reachable from a script anyway — a backtick cannot appear in an identifier.

**One registration is unreachable.** `byte[]` is named `Byte[]`.

**Five registrations are exact duplicates.** `DateTime`, `DateTimeOffset`, `TimeSpan`, `Guid` and `LogPersistenceMode` appear both in `ConfigureEngineWithCommonTypes` and in the default variable descriptor set processed by `ConfigureEngineWithWorkflowVariableTypes`, so each is described through reflection and assigned twice per evaluation.

## Change

`RegisterType` now:

* skips a type whose name cannot be written as a JavaScript identifier, and
* leaves an already-occupied global name alone.

The second rule does more than suppress the duplicates. These registrations are contributed by handlers of `EvaluatingJavaScript`, which run *after* the engine has been handed to the host — `configureEngine`, `JintOptions.ConfigureEngine` and `JintOptions.RegisterType` are all applied earlier — so a host global named after a registered type used to be silently replaced with no way to win. Now the host wins. That is the same rule #7895 arrives at from the other end, where the registrations move to engine construction and every host extension point runs after them.

Type aliases used by the TypeScript definition endpoint are unaffected — those are maintained by `ITypeAliasRegistry` (`RegisterVariableTypesWithJavaScriptHostedService`) and are independent of this registration path.

## Tests

New `TypeRegistrationTests` asserts the common types remain available under their names, that ``globalThis['IDictionary`2']`` and `globalThis['Byte[]']` are undefined, that a type registered by the host survives the built-in registrations, that a host value installed under a registered type's name (``Guid``, which both built-in handlers register) wins, and that ``RegisterType`` installs a ``TypeReference`` which a second registration leaves untouched. The two "unusable name" cases fail on `main` and pass here.

`Elsa.JavaScript.IntegrationTests` 73 → 89 passing, `Elsa.Workflows.IntegrationTests` 270 passing, both before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179sA2T7HuRfRfSc2JirFik
