### PR TITLE
Update Jint to 4.15.3 and stop blocking the calling thread on promises

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -128,7 +128,7 @@
         <PackageVersion Include="Humanizer.Core" Version="3.0.10"/>
         <PackageVersion Include="IronCompress" Version="1.7.0"/>
         <PackageVersion Include="JetBrains.Annotations" Version="2025.2.4"/>
-        <PackageVersion Include="Jint" Version="4.4.2"/>
+        <PackageVersion Include="Jint" Version="4.15.3"/>
         <PackageVersion Include="JsonSchema.Net" Version="9.4.0"/>
         <PackageVersion Include="LinqKit.Core" Version="1.2.11"/>
         <PackageVersion Include="MailKit" Version="4.14.1"/>

--- a/src/modules/Elsa.Expressions.JavaScript/ObjectConverters/JsonElementConverter.cs
+++ b/src/modules/Elsa.Expressions.JavaScript/ObjectConverters/JsonElementConverter.cs
@@ -26,7 +26,11 @@ internal class JsonElementConverter : IObjectConverter
         {
             JsonValueKind.Object => JsValue.FromObject(engine, JsonObject.Create(element)),
             JsonValueKind.Array => JsValue.FromObject(engine, JsonArray.Create(element)),
-            JsonValueKind.String => JsValue.FromObject(engine, element.GetString()),
+            // JsString.Create is the counterpart of the JsNumber.Create and JsBoolean uses below: it produces the
+            // string value directly, where JsValue.FromObject would re-enter the whole conversion pipeline — the
+            // registered object converters, this one included, followed by the default converter's type switch —
+            // to arrive at the same call. It became public in Jint 4.15.3.
+            JsonValueKind.String => JsString.Create(element.GetString()!),
             JsonValueKind.Number => element.TryGetInt32(out var intValue) ? JsNumber.Create(intValue) : JsNumber.Create(element.GetDouble()),
             JsonValueKind.True => JsBoolean.True,
             JsonValueKind.False => JsBoolean.False,

--- a/src/modules/Elsa.Expressions.JavaScript/Services/JintJavaScriptEvaluator.cs
+++ b/src/modules/Elsa.Expressions.JavaScript/Services/JintJavaScriptEvaluator.cs
@@ -38,7 +38,7 @@ public class JintJavaScriptEvaluator(IConfiguration configuration, INotification
     {
         var engine = await GetConfiguredEngine(configureEngine, context, options, cancellationToken);
         await mediator.SendAsync(new EvaluatingJavaScript(engine, context, expression), cancellationToken);
-        var result = ExecuteExpressionAndGetResult(engine, expression);
+        var result = await ExecuteExpressionAndGetResultAsync(engine, expression, cancellationToken);
         await mediator.SendAsync(new EvaluatedJavaScript(engine, context, expression, result), cancellationToken);
 
         return result.ConvertTo(returnType);
@@ -52,6 +52,12 @@ public class JintJavaScriptEvaluator(IConfiguration configuration, INotification
         {
             ExperimentalFeatures = ExperimentalFeature.TaskInterop
         };
+
+        // Jint 4.14 changed this default to LiveView, which exposes a CLR array to script as a live view over
+        // the original array rather than as a copy. Keeping the copy semantics means a script that mutates an
+        // array does not reach back into the workflow's own data, and that an array survives a round trip as
+        // object[] the way it always has. Hosts that want the live view can opt in via ConfigureEngineOptions.
+        engineOptions.Interop.ArrayConversion = ArrayConversionMode.Copy;
 
         ConfigureClrAccess(engineOptions);
         ConfigureObjectWrapper(engineOptions);
@@ -106,11 +112,14 @@ public class JintJavaScriptEvaluator(IConfiguration configuration, INotification
             engine.SetValue("getConfig", (Func<string, object?>)(name => configuration.GetSection(name).Value));
     }
 
-    private object? ExecuteExpressionAndGetResult(Engine engine, string expression)
+    private async Task<object?> ExecuteExpressionAndGetResultAsync(Engine engine, string expression, CancellationToken cancellationToken)
     {
         var preparedScript = GetOrCreatePrepareScript(expression);
-        var result = engine.Evaluate(preparedScript);
-        return result.UnwrapIfPromise().ToObject();
+
+        // EvaluateAsync awaits a returned promise instead of blocking the calling thread on it, which matters
+        // for expressions that await a .NET Task, such as the ones calling getSecret().
+        var result = await engine.EvaluateAsync(preparedScript, cancellationToken);
+        return result.ToObject();
     }
 
     private Prepared<Script> GetOrCreatePrepareScript(string expression)

--- a/test/integration/Elsa.JavaScript.IntegrationTests/ArrayConversionTests.cs
+++ b/test/integration/Elsa.JavaScript.IntegrationTests/ArrayConversionTests.cs
@@ -1,0 +1,50 @@
+using Elsa.Expressions.JavaScript.Contracts;
+using Elsa.Expressions.Models;
+using Elsa.Testing.Shared;
+using Jint;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Elsa.JavaScript.IntegrationTests;
+
+/// <summary>
+/// Pins how CLR arrays cross into JavaScript: a script sees a copy, so mutating it does not reach back into
+/// the workflow's own data, and the value round-trips as an <c>object[]</c>.
+/// </summary>
+public class ArrayConversionTests
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IJavaScriptEvaluator _evaluator;
+
+    public ArrayConversionTests(ITestOutputHelper testOutputHelper)
+    {
+        _serviceProvider = new TestApplicationBuilder(testOutputHelper).Build();
+        _evaluator = _serviceProvider.GetRequiredService<IJavaScriptEvaluator>();
+    }
+
+    [Fact(DisplayName = "Sorting a CLR array from a script does not mutate the original array")]
+    public async Task SortingAnArrayDoesNotMutateTheOriginal()
+    {
+        var numbers = new[] { 8.0, 4.0, 2.0 };
+
+        var result = await EvaluateAsync<object>("numbers.sort((a, b) => a - b); return numbers;", engine => engine.SetValue("numbers", numbers));
+
+        Assert.Equal([2.0, 4.0, 8.0], Assert.IsType<object[]>(result).Cast<double>());
+        Assert.Equal([8.0, 4.0, 2.0], numbers);
+    }
+
+    [Fact(DisplayName = "A CLR array is readable from a script")]
+    public async Task ArraysAreReadable()
+    {
+        var numbers = new[] { 8.0, 4.0, 2.0 };
+
+        Assert.Equal("14", await EvaluateAsync<string>("return '' + numbers.reduce((a, b) => a + b, 0);", engine => engine.SetValue("numbers", numbers)));
+    }
+
+    private async Task<T?> EvaluateAsync<T>(string script, Action<Engine> configureEngine)
+    {
+        var context = new ExpressionExecutionContext(_serviceProvider, new());
+        return (T?)await _evaluator.EvaluateAsync(script, typeof(T), context, configureEngine: configureEngine);
+    }
+}

--- a/test/integration/Elsa.JavaScript.IntegrationTests/ArrayConversionTests.cs
+++ b/test/integration/Elsa.JavaScript.IntegrationTests/ArrayConversionTests.cs
@@ -42,6 +42,43 @@ public class ArrayConversionTests
         Assert.Equal("14", await EvaluateAsync<string>("return '' + numbers.reduce((a, b) => a + b, 0);", engine => engine.SetValue("numbers", numbers)));
     }
 
+    [Fact(DisplayName = "A CLR array crosses into a script through the copy lane, not the live view")]
+    public async Task ArraysCrossThroughTheCopyLane()
+    {
+        // The tests above assert the behaviour a copy produces, which a live view happens to match for a value
+        // nothing mutates. Asking the engine how many conversions of each kind it performed is what pins the
+        // lane itself, so a future change of the ArrayConversion default cannot pass unnoticed.
+        var numbers = new[] { 8.0, 4.0, 2.0 };
+        Engine? engine = null;
+
+        await EvaluateAsync<double>("return numbers.length;", e =>
+        {
+            engine = e;
+            e.SetValue("numbers", numbers);
+        });
+
+        var diagnostics = engine!.Advanced.GetInteropConversionDiagnostics();
+
+        Assert.Equal(0L, diagnostics.ArrayLiveViewConversions);
+        Assert.True(diagnostics.ArrayCopyConversions > 0, "the array should have crossed through the copy lane");
+    }
+
+    [Fact(DisplayName = "An expression that touches no CLR array converts none")]
+    public async Task ExpressionsWithoutArraysConvertNothing()
+    {
+        // Elsa converts collection-valued workflow variables itself, in ObjectConverterHelper, so an ordinary
+        // evaluation never reaches Jint's array-conversion lane at all. That is what makes the ArrayConversion
+        // setting a narrow compatibility pin rather than something every evaluation depends on.
+        Engine? engine = null;
+
+        await EvaluateAsync<double>("return 1 + 1;", e => engine = e);
+
+        var diagnostics = engine!.Advanced.GetInteropConversionDiagnostics();
+
+        Assert.Equal(0L, diagnostics.ArrayLiveViewConversions);
+        Assert.Equal(0L, diagnostics.ArrayCopyConversions);
+    }
+
     private async Task<T?> EvaluateAsync<T>(string script, Action<Engine> configureEngine)
     {
         var context = new ExpressionExecutionContext(_serviceProvider, new());


### PR DESCRIPTION
## Non-blocking promise resolution

```csharp
var result = engine.Evaluate(preparedScript);
return result.UnwrapIfPromise().ToObject();
```

`UnwrapIfPromise` blocks the calling thread while the engine's event loop drains — inside an `async` method. An expression that awaits a .NET `Task`, such as any expression calling `getSecret()`, therefore held a thread pool thread for the duration of that I/O.

`Engine.EvaluateAsync` awaits the returned promise instead, and observes the cancellation token while it does.

## Why 4.15.3 and not 4.14.0

The PR originally moved 4.4.2 → 4.14.0, the release where `EvaluateAsync` arrived. It now lands past 4.15.2 deliberately: once expressions genuinely suspend and resume instead of draining the event loop on the calling thread, they exercise the async suspension machinery 4.15.2 corrected — an `await` on a right-hand side no longer stores the suspension sentinel, async generators and `for await...of` preserve loop iteration state across a suspension, and a suspension node is unwrapped correctly. Shipping the non-blocking change on an earlier 4.14/4.15 would enable exactly the code paths those releases fixed. 4.15.3 is the current release.

## One default changed along the way

Since 4.14, `Options.Interop.ArrayConversion` defaults to `LiveView`: a CLR array reaches script as a live view over the original array rather than as a copy. That is observable, and it showed up in the existing suite —
`Scenarios/JavaScriptListsAndArrays` `Test5` ("Can sort array and list properties as mutable arrays") fails on the bare upgrade with `Cannot convert type 'double[]' to 'object[]'`, because a `double[]` now round-trips back as `double[]` rather than as a copied `object[]`. The same change also means a script calling `.sort()` on an array would reorder the workflow's own array in place.

The evaluator therefore pins the previous `Copy` semantics, so the version bump carries no behavioural change. Hosts that want the live view can opt in:

```csharp
elsa.UseJavaScript(jint => jint.ConfigureEngineOptions(options =>
    options.Interop.ArrayConversion = ArrayConversionMode.LiveView));
```

If you would rather adopt `LiveView` as the new Elsa default, that is a one-line change plus an update to `Test5` — happy to do it either way, but it seemed wrong to fold a semantic change into a version bump.

## Tests

New `ArrayConversionTests` pins the copy semantics from both sides: sorting a CLR array from a script does not mutate the original, and the value round-trips as `object[]`.

A second commit pins the *lane* rather than just its observable product, using the interop conversion counters that arrived in 4.15.1: a CLR array crosses through the copy lane and never the live view, and an ordinary evaluation converts no CLR array at all — Elsa converts collection-valued variables itself in `ObjectConverterHelper` before Jint's array lane could see them, which is what makes the `ArrayConversion` setting a narrow compatibility pin rather than something every evaluation depends on. The same commit adopts `JsString.Create` (public since 4.15.3) in `JsonElementConverter`, where the string case was the only one still routed through the whole `JsValue.FromObject` conversion pipeline to arrive at the same call the number and boolean cases beside it already make directly.

`Elsa.JavaScript.IntegrationTests`: 77 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179sA2T7HuRfRfSc2JirFik
