### PR TITLE
Add workflow state rehydration diagnostics

### DIFF
--- a/src/modules/Elsa.Workflows.Core/Services/WorkflowStateExtractor.cs
+++ b/src/modules/Elsa.Workflows.Core/Services/WorkflowStateExtractor.cs
@@ -142,7 +142,15 @@ public class WorkflowStateExtractor(ILogger<WorkflowStateExtractor> logger) : IW
 
             // Activity can be null in case the workflow instance was migrated to a newer version that no longer contains this activity.
             if (activity == null)
+            {
+                LogSkippedStateReference(
+                    state,
+                    workflowExecutionContext,
+                    "ActivityExecutionContext",
+                    activityExecutionContextState.Id,
+                    activityExecutionContextState.ScheduledActivityNodeId);
                 return null;
+            }
 
             var properties = activityExecutionContextState.Properties;
             var metadata = activityExecutionContextState.Metadata;
@@ -167,24 +175,71 @@ public class WorkflowStateExtractor(ILogger<WorkflowStateExtractor> logger) : IW
         }
     }
 
-    private static void ApplyCompletionCallbacks(WorkflowState state, WorkflowExecutionContext workflowExecutionContext)
+    private void ApplyCompletionCallbacks(WorkflowState state, WorkflowExecutionContext workflowExecutionContext)
     {
         foreach (var completionCallbackEntry in state.CompletionCallbacks)
         {
             var ownerActivityExecutionContext = workflowExecutionContext.ActivityExecutionContexts.FirstOrDefault(x => x.Id == completionCallbackEntry.OwnerInstanceId);
-            if (ownerActivityExecutionContext != null)
+            if (ownerActivityExecutionContext == null)
             {
-                var childNode = workflowExecutionContext.FindNodeById(completionCallbackEntry.ChildNodeId);
-
-                if (childNode == null)
-                    continue;
-
-                var callbackName = completionCallbackEntry.MethodName;
-                var callbackDelegate = !string.IsNullOrEmpty(callbackName) ? ownerActivityExecutionContext.Activity.GetActivityCompletionCallback(callbackName) : default;
-                var tag = completionCallbackEntry.Tag;
-                workflowExecutionContext.AddCompletionCallback(ownerActivityExecutionContext, childNode, callbackDelegate, tag);
+                LogSkippedStateReference(
+                    state,
+                    workflowExecutionContext,
+                    "CompletionCallbackOwner",
+                    completionCallbackOwnerInstanceId: completionCallbackEntry.OwnerInstanceId,
+                    completionCallbackChildNodeId: completionCallbackEntry.ChildNodeId);
+                continue;
             }
+
+            var childNode = workflowExecutionContext.FindNodeById(completionCallbackEntry.ChildNodeId);
+
+            if (childNode == null)
+            {
+                LogSkippedStateReference(
+                    state,
+                    workflowExecutionContext,
+                    "CompletionCallbackChild",
+                    completionCallbackOwnerInstanceId: completionCallbackEntry.OwnerInstanceId,
+                    completionCallbackChildNodeId: completionCallbackEntry.ChildNodeId);
+                continue;
+            }
+
+            var callbackName = completionCallbackEntry.MethodName;
+            var callbackDelegate = !string.IsNullOrEmpty(callbackName) ? ownerActivityExecutionContext.Activity.GetActivityCompletionCallback(callbackName) : default;
+            var tag = completionCallbackEntry.Tag;
+            workflowExecutionContext.AddCompletionCallback(ownerActivityExecutionContext, childNode, callbackDelegate, tag);
         }
+    }
+
+    private void LogSkippedStateReference(
+        WorkflowState state,
+        WorkflowExecutionContext workflowExecutionContext,
+        string skipKind,
+        string? activityExecutionContextId = null,
+        string? scheduledActivityNodeId = null,
+        string? completionCallbackOwnerInstanceId = null,
+        string? completionCallbackChildNodeId = null)
+    {
+        var targetIdentity = workflowExecutionContext.Workflow.Identity;
+        var isWorkflowDefinitionVersionMigration = !string.Equals(state.DefinitionVersionId, targetIdentity.Id, StringComparison.Ordinal);
+        var classification = isWorkflowDefinitionVersionMigration ? "MigrationCompatible" : "Unexpected";
+
+        logger.LogWarning(
+            "Skipping unresolved workflow state reference {WorkflowStateSkipKind} ({WorkflowStateSkipClassification}) for workflow instance {WorkflowInstanceId}. Persisted definition {PersistedWorkflowDefinitionId}/{PersistedWorkflowDefinitionVersionId}/v{PersistedWorkflowDefinitionVersion}; target definition {TargetWorkflowDefinitionId}/{TargetWorkflowDefinitionVersionId}/v{TargetWorkflowDefinitionVersion}; activity context {ActivityExecutionContextId}; scheduled activity node {ScheduledActivityNodeId}; callback owner {CompletionCallbackOwnerInstanceId}; callback child {CompletionCallbackChildNodeId}; definition version migration: {IsWorkflowDefinitionVersionMigration}.",
+            skipKind,
+            classification,
+            state.Id,
+            state.DefinitionId,
+            state.DefinitionVersionId,
+            state.DefinitionVersion,
+            targetIdentity.DefinitionId,
+            targetIdentity.Id,
+            targetIdentity.Version,
+            activityExecutionContextId,
+            scheduledActivityNodeId,
+            completionCallbackOwnerInstanceId,
+            completionCallbackChildNodeId,
+            isWorkflowDefinitionVersionMigration);
     }
 
     private void ApplyScheduledActivities(WorkflowState state, WorkflowExecutionContext workflowExecutionContext)

--- a/test/unit/Elsa.Workflows.Core.UnitTests/Services/WorkflowStateExtractorTests.cs
+++ b/test/unit/Elsa.Workflows.Core.UnitTests/Services/WorkflowStateExtractorTests.cs
@@ -5,6 +5,7 @@ using Elsa.Workflows.Options;
 using Elsa.Workflows.Services;
 using Elsa.Workflows.State;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace Elsa.Workflows.Core.UnitTests.Services;
@@ -96,5 +97,161 @@ public class WorkflowStateExtractorTests
         // Assert - The CallStackDepth should be parent depth + 1
         Assert.Equal(4, childContext.CallStackDepth);
         Assert.Equal(parentContext.Id, childContext.SchedulingActivityExecutionId);
+    }
+
+    [Theory]
+    [InlineData("1", 1, false, "Unexpected")]
+    [InlineData("persisted-version-id", 7, true, "MigrationCompatible")]
+    public async Task ApplyAsync_WhenActivityContextNodeIsMissing_LogsStructuredWarningAndSkipsContext(
+        string persistedDefinitionVersionId,
+        int persistedDefinitionVersion,
+        bool isMigration,
+        string expectedClassification)
+    {
+        // Arrange
+        var testContext = await CreateTestContextAsync();
+        var state = testContext.State;
+        state.DefinitionVersionId = persistedDefinitionVersionId;
+        state.DefinitionVersion = persistedDefinitionVersion;
+        state.ActivityExecutionContexts.Add(new()
+        {
+            Id = "missing-activity-context",
+            ScheduledActivityNodeId = "missing-activity-node"
+        });
+
+        // Act
+        await testContext.Extractor.ApplyAsync(testContext.TargetContext, state);
+
+        // Assert
+        Assert.Empty(testContext.TargetContext.ActivityExecutionContexts);
+        var warning = Assert.Single(testContext.Logger.Entries);
+        Assert.Equal(LogLevel.Warning, warning.Level);
+        Assert.Equal("ActivityExecutionContext", warning.Properties["WorkflowStateSkipKind"]);
+        Assert.Equal("missing-activity-context", warning.Properties["ActivityExecutionContextId"]);
+        Assert.Equal("missing-activity-node", warning.Properties["ScheduledActivityNodeId"]);
+        AssertDefinitionProperties(warning, state, testContext.TargetContext, isMigration, expectedClassification);
+    }
+
+    [Fact]
+    public async Task ApplyAsync_WhenCompletionCallbackOwnerIsMissing_LogsStructuredWarning()
+    {
+        // Arrange
+        var testContext = await CreateTestContextAsync();
+        var state = testContext.State;
+        state.CompletionCallbacks.Add(new("missing-owner", "child-node", null));
+
+        // Act
+        await testContext.Extractor.ApplyAsync(testContext.TargetContext, state);
+
+        // Assert
+        Assert.Empty(testContext.TargetContext.CompletionCallbacks);
+        var warning = Assert.Single(testContext.Logger.Entries);
+        Assert.Equal(LogLevel.Warning, warning.Level);
+        Assert.Equal("CompletionCallbackOwner", warning.Properties["WorkflowStateSkipKind"]);
+        Assert.Equal("missing-owner", warning.Properties["CompletionCallbackOwnerInstanceId"]);
+        Assert.Equal("child-node", warning.Properties["CompletionCallbackChildNodeId"]);
+        AssertDefinitionProperties(warning, state, testContext.TargetContext, false, "Unexpected");
+    }
+
+    [Fact]
+    public async Task ApplyAsync_WhenCompletionCallbackChildIsMissing_LogsStructuredWarning()
+    {
+        // Arrange
+        var testContext = await CreateTestContextAsync(includeActivityExecutionContext: true);
+        var state = testContext.State;
+        var ownerInstanceId = Assert.Single(state.ActivityExecutionContexts).Id;
+        state.CompletionCallbacks.Add(new(ownerInstanceId, "missing-child-node", null));
+
+        // Act
+        await testContext.Extractor.ApplyAsync(testContext.TargetContext, state);
+
+        // Assert
+        Assert.Empty(testContext.TargetContext.CompletionCallbacks);
+        var warning = Assert.Single(testContext.Logger.Entries);
+        Assert.Equal(LogLevel.Warning, warning.Level);
+        Assert.Equal("CompletionCallbackChild", warning.Properties["WorkflowStateSkipKind"]);
+        Assert.Equal(ownerInstanceId, warning.Properties["CompletionCallbackOwnerInstanceId"]);
+        Assert.Equal("missing-child-node", warning.Properties["CompletionCallbackChildNodeId"]);
+        AssertDefinitionProperties(warning, state, testContext.TargetContext, false, "Unexpected");
+    }
+
+    private static async Task<TestContext> CreateTestContextAsync(bool includeActivityExecutionContext = false)
+    {
+        var fixture = new ActivityTestFixture(new WriteLine("root"));
+        var contextRoot = await fixture.BuildAsync();
+        var sourceContext = contextRoot.WorkflowExecutionContext;
+
+        if (includeActivityExecutionContext)
+            sourceContext.AddActivityExecutionContext(contextRoot);
+
+        var logger = new CapturingLogger<WorkflowStateExtractor>();
+        var extractor = new WorkflowStateExtractor(logger);
+        var state = extractor.Extract(sourceContext);
+        var targetContext = await WorkflowExecutionContext.CreateAsync(
+            sourceContext.ServiceProvider,
+            sourceContext.WorkflowGraph,
+            state.Id,
+            CancellationToken.None);
+
+        return new(extractor, logger, state, targetContext);
+    }
+
+    private static void AssertDefinitionProperties(
+        CapturedLogEntry warning,
+        WorkflowState state,
+        WorkflowExecutionContext targetContext,
+        bool isMigration,
+        string expectedClassification)
+    {
+        var targetIdentity = targetContext.Workflow.Identity;
+        Assert.Equal(state.Id, warning.Properties["WorkflowInstanceId"]);
+        Assert.Equal(state.DefinitionId, warning.Properties["PersistedWorkflowDefinitionId"]);
+        Assert.Equal(state.DefinitionVersionId, warning.Properties["PersistedWorkflowDefinitionVersionId"]);
+        Assert.Equal(state.DefinitionVersion, warning.Properties["PersistedWorkflowDefinitionVersion"]);
+        Assert.Equal(targetIdentity.DefinitionId, warning.Properties["TargetWorkflowDefinitionId"]);
+        Assert.Equal(targetIdentity.Id, warning.Properties["TargetWorkflowDefinitionVersionId"]);
+        Assert.Equal(targetIdentity.Version, warning.Properties["TargetWorkflowDefinitionVersion"]);
+        Assert.Equal(isMigration, warning.Properties["IsWorkflowDefinitionVersionMigration"]);
+        Assert.Equal(expectedClassification, warning.Properties["WorkflowStateSkipClassification"]);
+    }
+
+    private sealed record TestContext(
+        WorkflowStateExtractor Extractor,
+        CapturingLogger<WorkflowStateExtractor> Logger,
+        WorkflowState State,
+        WorkflowExecutionContext TargetContext);
+
+    private sealed record CapturedLogEntry(LogLevel Level, string Message, IReadOnlyDictionary<string, object?> Properties);
+
+    private sealed class CapturingLogger<T> : ILogger<T>
+    {
+        public ICollection<CapturedLogEntry> Entries { get; } = new List<CapturedLogEntry>();
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            var properties = state is IEnumerable<KeyValuePair<string, object?>> values
+                ? values.ToDictionary(x => x.Key, x => x.Value)
+                : new Dictionary<string, object?>();
+
+            Entries.Add(new(logLevel, formatter(state, exception), properties));
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static NullScope Instance { get; } = new();
+
+            public void Dispose()
+            {
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

- log structured warnings when workflow-state rehydration cannot resolve an activity execution context
- log structured warnings when completion callback owners or child nodes cannot be resolved
- classify skips as migration-compatible or unexpected by comparing persisted and target definition version IDs
- include workflow, definition, context, owner, and child identifiers for querying and alerting

## Root cause

`WorkflowStateExtractor` intentionally skipped unresolved references to preserve workflow migration compatibility, but those paths emitted no diagnostics. The same silent behavior also concealed stale or inconsistent same-version state.

## Impact

Existing skip behavior remains unchanged, including intentional migration scenarios. Operators now receive structured warnings that distinguish expected migration cleanup from potentially inconsistent persisted state.

## Validation

- `dotnet test test/unit/Elsa.Workflows.Core.UnitTests/Elsa.Workflows.Core.UnitTests.csproj --no-restore` — 202 passed
- `dotnet build src/modules/Elsa.Workflows.Core/Elsa.Workflows.Core.csproj --no-restore` — succeeded for net8.0, net9.0, and net10.0 with 0 warnings/errors
- `git diff --check`

Fixes #7772