### PR TITLE
fix: use last version for revert version allocation

### DIFF
--- a/src/modules/Elsa.Workflows.Management/Services/WorkflowDefinitionPublisher.cs
+++ b/src/modules/Elsa.Workflows.Management/Services/WorkflowDefinitionPublisher.cs
@@ -153,12 +153,17 @@ public class WorkflowDefinitionPublisher(
 
     public async Task<WorkflowDefinition> RevertVersionAsync(string definitionId, int version, CancellationToken cancellationToken = default)
     {
-        var filter = new WorkflowDefinitionFilter
+        var latestVersionFilter = new WorkflowDefinitionFilter
         {
             DefinitionId = definitionId,
             VersionOptions = VersionOptions.Latest
         };
-        var latestVersion = await workflowDefinitionStore.FindAsync(filter, cancellationToken);
+        var latestVersion = await workflowDefinitionStore.FindAsync(latestVersionFilter, cancellationToken);
+        var lastVersionFilter = new WorkflowDefinitionFilter
+        {
+            DefinitionId = definitionId
+        };
+        var lastVersion = await workflowDefinitionStore.FindLastVersionAsync(lastVersionFilter, cancellationToken);
 
         if (latestVersion != null)
         {
@@ -168,7 +173,7 @@ public class WorkflowDefinitionPublisher(
 
         var draft = await GetDraftAsync(definitionId, VersionOptions.SpecificVersion(version), cancellationToken);
         draft!.Id = identityGenerator.GenerateId();
-        draft.Version = (latestVersion?.Version ?? 0) + 1;
+        draft.Version = (lastVersion?.Version ?? 0) + 1;
         draft.IsLatest = true;
 
         await workflowDefinitionStore.SaveAsync(draft, cancellationToken);

--- a/test/integration/Elsa.Workflows.IntegrationTests/Scenarios/WorkflowDefinitionVersioning/Tests.cs
+++ b/test/integration/Elsa.Workflows.IntegrationTests/Scenarios/WorkflowDefinitionVersioning/Tests.cs
@@ -1,0 +1,58 @@
+using Elsa.Testing.Shared;
+using Elsa.Workflows.Management;
+using Elsa.Workflows.Management.Entities;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit.Abstractions;
+
+namespace Elsa.Workflows.IntegrationTests.Scenarios.WorkflowDefinitionVersioning;
+
+public class Tests
+{
+    private readonly IServiceProvider _services;
+
+    public Tests(ITestOutputHelper testOutputHelper)
+    {
+        _services = new TestApplicationBuilder(testOutputHelper).Build();
+    }
+
+    [Fact]
+    public async Task RevertVersionAsync_ShouldAllocateVersionAfterHighestStoredVersion()
+    {
+        const string definitionId = "test-definition";
+        var store = _services.GetRequiredService<IWorkflowDefinitionStore>();
+        var publisher = _services.GetRequiredService<IWorkflowDefinitionPublisher>();
+        var definitions = new WorkflowDefinition[]
+        {
+            new()
+            {
+                Id = "v1",
+                DefinitionId = definitionId,
+                Version = 1,
+                IsPublished = true,
+                IsLatest = false
+            },
+            new()
+            {
+                Id = "v2",
+                DefinitionId = definitionId,
+                Version = 2,
+                IsPublished = false,
+                IsLatest = true
+            },
+            new()
+            {
+                Id = "v3",
+                DefinitionId = definitionId,
+                Version = 3,
+                IsPublished = false,
+                IsLatest = false
+            }
+        };
+
+        await store.SaveManyAsync(definitions);
+
+        var revertedDefinition = await publisher.RevertVersionAsync(definitionId, 1);
+
+        Assert.Equal(4, revertedDefinition.Version);
+    }
+}


### PR DESCRIPTION
## Purpose

Addresses #7916 by using the highest stored workflow definition version when allocating the next numeric version in `RevertVersionAsync`, while keeping `VersionOptions.Latest` responsible for latest-state management.

This makes version allocation consistent with `SaveDraftAsync`.

---

## Scope

Select one primary concern:

- [x] Bug fix (behavior change)
- [ ] Refactor (no behavior change)
- [ ] Documentation update
- [ ] Formatting / code cleanup
- [ ] Dependency / build update
- [ ] New feature

> If this PR includes multiple unrelated concerns, please split it before requesting review.

---

## Description

### Problem

`RevertVersionAsync` currently determines the next numeric workflow definition version from the workflow definition resolved using `VersionOptions.Latest`.

`VersionOptions.Latest` identifies the workflow definition marked with `IsLatest = true`, while `FindLastVersionAsync` identifies the highest stored numeric version.

Although these normally point to the same workflow definition, they represent different responsibilities.

Using `VersionOptions.Latest` for numeric version allocation means that if the latest-state metadata and numeric version ordering diverge, a reverted workflow definition can be assigned a version number that is not after the highest stored version.

`SaveDraftAsync` already uses `FindLastVersionAsync` when determining the next numeric version.

### Solution

Keep the existing `VersionOptions.Latest` lookup in `RevertVersionAsync` for latest-state management.

Use `FindLastVersionAsync` separately to determine the highest stored numeric version and allocate the reverted definition's next version from it.

The responsibilities are therefore separated as:

- `VersionOptions.Latest` → identify and clear the workflow definition currently marked as latest.
- `FindLastVersionAsync` → determine the highest stored version for numeric version allocation.

A regression test was added to verify that `RevertVersionAsync` allocates the next version after the highest stored numeric version.

---

## Verification

Steps:

1. Added `RevertVersionAsync_ShouldAllocateVersionAfterHighestStoredVersion`.
2. Verified the regression test against the previous implementation, where it failed with `Expected: 4, Actual: 3`.
3. Applied the `FindLastVersionAsync` version-allocation change.
4. Re-ran the regression test successfully.
5. Ran the full `Elsa.Workflows.IntegrationTests` suite.

Expected outcome:

- The reverted workflow definition receives a numeric version after the highest stored version.
- Existing `IsLatest` state-management behavior remains unchanged.
- Existing integration tests continue to pass.

Test results:

- Passed: 273
- Failed: 0
- Skipped: 0

---

## Screenshots / Recordings (if applicable)

Not applicable.

---

## Commit Convention

We recommend using conventional commit prefixes:

- `fix:` – Bug fixes (behavior change)
- `feat:` – New features
- `refactor:` – Code changes without behavior change
- `docs:` – Documentation updates
- `chore:` – Maintenance, tooling, or dependency updates
- `test:` – Test additions or modifications

Clear commit messages make reviews easier and history more meaningful.

---

## Related Issue

Closes #7916

---

## Checklist

- [x] The PR is focused on a single concern
- [x] Commit messages follow the recommended convention
- [x] Tests added or updated (if applicable)
- [ ] Documentation updated (if applicable)
- [x] No unrelated cleanup included
- [x] All tests pass