### PR TITLE
fix: preserve single latest draft when saving a new identity

### DIFF
--- a/src/modules/Elsa.Workflows.Management/Services/WorkflowDefinitionPublisher.cs
+++ b/src/modules/Elsa.Workflows.Management/Services/WorkflowDefinitionPublisher.cs
@@ -223,17 +223,20 @@ public class WorkflowDefinitionPublisher(
         draft = Initialize(draft);
 
         await mediator.SendAsync(new WorkflowDefinitionDraftSaving(draft), cancellationToken);
-        await workflowDefinitionStore.SaveAsync(draft, cancellationToken);
+
+        if (lastVersion is { IsLatest: true } && lastVersion.Id != draft.Id)
+        {
+            lastVersion.IsLatest = false;
+            await workflowDefinitionStore.SaveManyAsync([lastVersion, draft], cancellationToken);
+        }
+        else
+        {
+            await workflowDefinitionStore.SaveAsync(draft, cancellationToken);
+        }
         await mediator.SendAsync(new WorkflowDefinitionDraftSaved(draft), cancellationToken);
 
         if (lastVersion is null)
             await mediator.SendAsync(new WorkflowDefinitionCreated(definition), cancellationToken);
-
-        if (lastVersion is { IsPublished: true, IsLatest: true })
-        {
-            lastVersion.IsLatest = false;
-            await workflowDefinitionStore.SaveAsync(lastVersion, cancellationToken);
-        }
 
         return draft;
     }

--- a/test/integration/Elsa.Workflows.IntegrationTests/Scenarios/WorkflowDefinitionVersioning/Tests.cs
+++ b/test/integration/Elsa.Workflows.IntegrationTests/Scenarios/WorkflowDefinitionVersioning/Tests.cs
@@ -1,0 +1,194 @@
+using Elsa.Extensions;
+using Elsa.Mediator.Contracts;
+using Elsa.Testing.Shared;
+using Elsa.Workflows.Management;
+using Elsa.Workflows.Management.Entities;
+using Elsa.Workflows.Management.Filters;
+using Elsa.Workflows.Management.Notifications;
+using Elsa.Workflows.Management.Services;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Xunit.Abstractions;
+
+namespace Elsa.Workflows.IntegrationTests.Scenarios.WorkflowDefinitionVersioning;
+
+public class Tests
+{
+    private readonly IServiceProvider _services;
+
+    public Tests(ITestOutputHelper testOutputHelper)
+    {
+        _services = new TestApplicationBuilder(testOutputHelper).Build();
+    }
+
+    [Fact]
+    public async Task SaveDraftAsync_ShouldClearLatestFlagFromPreviousUnpublishedDraft()
+    {
+        const string definitionId = "test-definition";
+        var store = _services.GetRequiredService<IWorkflowDefinitionStore>();
+        var publisher = _services.GetRequiredService<IWorkflowDefinitionPublisher>();
+        var existingDraft = new WorkflowDefinition
+        {
+            Id = "v1",
+            DefinitionId = definitionId,
+            Version = 1,
+            IsPublished = false,
+            IsLatest = true
+        };
+        var newDraft = new WorkflowDefinition
+        {
+            Id = "v2",
+            DefinitionId = definitionId
+        };
+
+        await store.SaveAsync(existingDraft);
+
+        var savedDraft = await publisher.SaveDraftAsync(newDraft);
+
+        var definitions = (await store.FindManyAsync(new WorkflowDefinitionFilter
+        {
+            DefinitionId = definitionId
+        })).ToDictionary(x => x.Id);
+        Assert.False(definitions["v1"].IsLatest);
+        Assert.True(definitions["v2"].IsLatest);
+        Assert.Single(definitions.Values, x => x.IsLatest);
+        Assert.Equal(2, definitions["v2"].Version);
+        Assert.Equal(2, savedDraft.Version);
+    }
+
+    [Fact]
+    public async Task SaveDraftAsync_ShouldKeepExistingDraftLatestWhenResaved()
+    {
+        const string definitionId = "test-definition";
+        var store = _services.GetRequiredService<IWorkflowDefinitionStore>();
+        var publisher = _services.GetRequiredService<IWorkflowDefinitionPublisher>();
+        var existingDraft = new WorkflowDefinition
+        {
+            Id = "draft-1",
+            DefinitionId = definitionId,
+            Version = 1,
+            IsPublished = false,
+            IsLatest = true
+        };
+
+        await store.SaveAsync(existingDraft);
+
+        var savedDraft = await publisher.SaveDraftAsync(existingDraft);
+
+        var definitions = (await store.FindManyAsync(new WorkflowDefinitionFilter
+        {
+            DefinitionId = definitionId
+        })).ToList();
+        var persistedDraft = Assert.Single(definitions);
+        Assert.Equal("draft-1", persistedDraft.Id);
+        Assert.Equal(1, persistedDraft.Version);
+        Assert.True(persistedDraft.IsLatest);
+        Assert.Equal(1, savedDraft.Version);
+        Assert.True(savedDraft.IsLatest);
+    }
+
+    [Theory]
+    [InlineData(BatchFailurePoint.Replacement)]
+    [InlineData(BatchFailurePoint.PreviousLatest)]
+    public async Task SaveDraftAsync_WhenReplacementBatchFails_ShouldPreserveSinglePreviousLatest(BatchFailurePoint failurePoint)
+    {
+        const string definitionId = "test-definition";
+        var persisted = new Dictionary<string, WorkflowDefinition>
+        {
+            ["v1"] = CreateDefinition("v1", definitionId, 1, true)
+        };
+        var store = CreateFailingStore(persisted, failurePoint);
+        var publisher = ActivatorUtilities.CreateInstance<WorkflowDefinitionPublisher>(_services, store);
+        var replacement = CreateDefinition("v2", definitionId, 0, false);
+
+        await Assert.ThrowsAsync<TestPersistenceException>(() => publisher.SaveDraftAsync(replacement));
+
+        var previous = Assert.Single(persisted.Values);
+        Assert.Equal("v1", previous.Id);
+        Assert.True(previous.IsLatest);
+        Assert.Single(persisted.Values, x => x.IsLatest);
+    }
+
+    [Fact]
+    public async Task SaveDraftAsync_WhenDraftSavedNotificationFails_ShouldKeepCommittedLatestStateConsistent()
+    {
+        const string definitionId = "test-definition";
+        var services = new TestApplicationBuilder(_services.GetRequiredService<ITestOutputHelper>())
+            .ConfigureServices(serviceCollection => serviceCollection.AddNotificationHandler<FailingDraftSavedHandler, WorkflowDefinitionDraftSaved>())
+            .Build();
+        var store = services.GetRequiredService<IWorkflowDefinitionStore>();
+        var publisher = services.GetRequiredService<IWorkflowDefinitionPublisher>();
+        await store.SaveAsync(CreateDefinition("v1", definitionId, 1, true));
+
+        await Assert.ThrowsAsync<TestNotificationException>(() => publisher.SaveDraftAsync(CreateDefinition("v2", definitionId, 0, false)));
+
+        var definitions = (await store.FindManyAsync(new WorkflowDefinitionFilter { DefinitionId = definitionId })).ToList();
+        Assert.Equal(2, definitions.Count);
+        Assert.False(definitions.Single(x => x.Id == "v1").IsLatest);
+        Assert.True(definitions.Single(x => x.Id == "v2").IsLatest);
+        Assert.Single(definitions, x => x.IsLatest);
+    }
+
+    private static IWorkflowDefinitionStore CreateFailingStore(
+        IDictionary<string, WorkflowDefinition> persisted,
+        BatchFailurePoint failurePoint)
+    {
+        var store = Substitute.For<IWorkflowDefinitionStore>();
+        store.FindLastVersionAsync(Arg.Any<WorkflowDefinitionFilter>(), Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromResult(persisted.Values.OrderByDescending(x => x.Version).Select(Clone).FirstOrDefault()));
+        store.SaveManyAsync(Arg.Any<IEnumerable<WorkflowDefinition>>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var definitions = callInfo.Arg<IEnumerable<WorkflowDefinition>>().ToList();
+                var snapshot = persisted.ToDictionary(x => x.Key, x => Clone(x.Value));
+
+                try
+                {
+                    foreach (var definition in definitions)
+                    {
+                        if (failurePoint == BatchFailurePoint.PreviousLatest && definition.Id == "v1")
+                            throw new TestPersistenceException();
+                        if (failurePoint == BatchFailurePoint.Replacement && definition.Id == "v2")
+                            throw new TestPersistenceException();
+
+                        persisted[definition.Id] = Clone(definition);
+                    }
+                }
+                catch
+                {
+                    persisted.Clear();
+                    foreach (var item in snapshot)
+                        persisted[item.Key] = item.Value;
+                    throw;
+                }
+
+                return Task.CompletedTask;
+            });
+        return store;
+    }
+
+    private static WorkflowDefinition CreateDefinition(string id, string definitionId, int version, bool isLatest) => new()
+    {
+        Id = id,
+        DefinitionId = definitionId,
+        Version = version,
+        IsLatest = isLatest,
+        IsPublished = false
+    };
+
+    private static WorkflowDefinition Clone(WorkflowDefinition definition) => definition.ShallowClone();
+
+    public enum BatchFailurePoint
+    {
+        Replacement,
+        PreviousLatest
+    }
+
+    private class FailingDraftSavedHandler : INotificationHandler<WorkflowDefinitionDraftSaved>
+    {
+        public Task HandleAsync(WorkflowDefinitionDraftSaved notification, CancellationToken cancellationToken) => throw new TestNotificationException();
+    }
+
+    private class TestPersistenceException : Exception;
+    private class TestNotificationException : Exception;
+}


### PR DESCRIPTION
## Purpose

Addresses #7915 by ensuring that `SaveDraftAsync` preserves a single latest workflow definition when saving a different draft identity for the same `DefinitionId`.

The change extends the existing latest-state handling to unpublished drafts while preserving the current behavior when re-saving the same draft.

---

## Scope

Select one primary concern:

- [x] Bug fix (behavior change)
- [ ] Refactor (no behavior change)
- [ ] Documentation update
- [ ] Formatting / code cleanup
- [ ] Dependency / build update
- [ ] New feature

> If this PR includes multiple unrelated concerns, please split it before requesting review.

---

## Description

### Problem

`SaveDraftAsync` sets the incoming workflow definition to `IsLatest = true`.

When a previous version exists, its `IsLatest` flag is currently cleared only when that version is both published and latest:

```csharp
if (lastVersion is { IsPublished: true, IsLatest: true })
{
    lastVersion.IsLatest = false;
    await workflowDefinitionStore.SaveAsync(lastVersion, cancellationToken);
}
```

This works for the standard published-to-draft flow.

However, when `SaveDraftAsync` receives a different draft identity for the same `DefinitionId` while the previous latest version is unpublished, the previous version is not demoted.

For example, starting with:

```text
V1
IsPublished = false
IsLatest = true
```

and saving a different draft identity creates:

```text
V1 -> IsPublished = false, IsLatest = true
V2 -> IsPublished = false, IsLatest = true
```

This leaves multiple workflow definition versions marked as latest.

### Solution

Update the condition so that the previous last version is demoted whenever:

- it is currently marked as latest, and
- the incoming draft represents a different workflow definition identity.

```csharp
if (lastVersion is { IsLatest: true } && lastVersion.Id != draft.Id)
{
    lastVersion.IsLatest = false;
    await workflowDefinitionStore.SaveAsync(lastVersion, cancellationToken);
}
```

The identity check is important because `SaveDraftAsync` also supports re-saving the same draft.

When the same draft is saved again:

```text
lastVersion.Id == draft.Id
```

the existing draft remains latest and retains its existing version number.

This results in:

```text
Different draft identity:
V1 -> IsLatest = false
V2 -> IsLatest = true

Same draft identity:
V1 -> IsLatest = true
```

No changes are made to version allocation, publication state, or persistence ordering.

---

## Verification

Steps:

1. Added `SaveDraftAsync_ShouldClearLatestFlagFromPreviousUnpublishedDraft`.
2. Verified the test fails with the previous implementation because the existing unpublished draft remains `IsLatest = true`.
3. Added `SaveDraftAsync_ShouldKeepExistingDraftLatestWhenResaved` to protect the existing same-draft behavior.
4. Updated the `SaveDraftAsync` latest-state condition.
5. Ran both focused tests.
6. Ran the complete `Elsa.Workflows.IntegrationTests` suite.

Expected outcome:

- Saving a different draft identity demotes the previous latest workflow definition.
- The newly saved draft becomes the latest version.
- Re-saving the same draft does not demote itself or create a new numeric version.
- Existing workflow management behavior remains unaffected.

Test results:

```text
Elsa.Workflows.IntegrationTests

Passed: 274
Failed: 0
Skipped: 0
```

---

## Screenshots / Recordings (if applicable)

Not applicable.

---

## Commit Convention

We recommend using conventional commit prefixes:

- `fix:` – Bug fixes (behavior change)
- `feat:` – New features
- `refactor:` – Code changes without behavior change
- `docs:` – Documentation updates
- `chore:` – Maintenance, tooling, or dependency updates
- `test:` – Test additions or modifications

Clear commit messages make reviews easier and history more meaningful.

---

## Related Issue

Closes #7915

---

## Checklist

- [x] The PR is focused on a single concern
- [x] Commit messages follow the recommended convention
- [x] Tests added or updated (if applicable)
- [ ] Documentation updated (if applicable)
- [x] No unrelated cleanup included
- [x] All tests pass