### PR TITLE
build: bump NuGet.Packaging to 7.9.0 to unbreak the NUKE build on SDK 10.0.400

### DIFF
--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="Nuke.Components" Version="10.1.0" />
-    <PackageReference Include="NuGet.Packaging" Version="7.6.0" />
+    <PackageReference Include="NuGet.Packaging" Version="7.9.0" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
   </ItemGroup>
 


### PR DESCRIPTION
CI is currently red on every branch, including `main`, before any test runs. One-line fix; the explanation is longer than the diff.

## Symptom

```
InvalidProjectFileException: The expression "[MSBuild]::GetTargetFrameworkIdentifier(net10.0)" cannot be evaluated.
Could not load file or assembly 'NuGet.Frameworks, Version=7.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.
The located assembly's manifest definition does not match the assembly reference. (0x80131040)
   at Nuke.Common.ProjectModel.ProjectModelTasks.ParseProject
```

The compile itself reports `0 Error(s)`; the `Test` target then throws during project evaluation and the job exits 255.

## Cause

Nothing in the repo changed. [`pr.yml`](.github/workflows/pr.yml#L39) requests `dotnet-version: 10.x`, and the hosted runner moved up an SDK band. Same branch, same workflow, ~19 hours apart:

| Commit | SDK | Result |
| --- | --- | --- |
| `d085b536f` | 10.0.302 | success |
| `a61833792` | 10.0.400 | failure |

The two SDK bands ship different `NuGet.Frameworks`, which I checked rather than assumed:

| SDK | `NuGet.Frameworks` |
| --- | --- |
| 10.0.300 / 10.0.302 | **7.6.0** |
| 10.0.400 | **7.9.0** |

`build/_build.csproj` pinned `NuGet.Packaging 7.6.0`, which drags `NuGet.Frameworks 7.6.0` into the NUKE output directory, where it shadows the SDK's own copy. The .NET loader will accept an assembly *newer* than the reference but not *older*, so the moment MSBuild started asking for `7.9.0.0` the app-local `7.6.0` stopped satisfying it. That asymmetry is also why the failure appeared spontaneously rather than gradually, and why it will not resolve itself.

## Fix

Bump the pin to `7.9.0`, matching what the current SDK ships.

Two things make this safe rather than a version shuffle:

- **The reference is unused by the build.** There are no `NuGet.*` usages anywhere in `build/*.cs`. It was added in f5dc29cdc purely as a transitive vulnerability override — the comment above the group still says "Overridden for vulnerability reasons with dependencies referencing older versions." Bumping preserves that intent; `NuGetAudit` is enabled on this project and stays enabled.
- **It keeps working on the older SDK.** By the same newer-than-reference rule that broke the old pin, app-local `7.9.0` still satisfies MSBuild on 10.0.3xx, so local development and any runner still on the older band are unaffected.

## Verification

The `ubuntu-latest` check on this PR resolves `10.x` to 10.0.400 — the exact configuration that fails on `main` right now — so this PR's own CI run is the test. I also reproduced the SDK/assembly-version pairing locally by installing 10.0.400 side by side and inspecting both `NuGet.Frameworks.dll` files, and have a full `./build.sh Compile Test` running against it as a cross-check.

## Not addressed

The floating `10.x` in `pr.yml` is what surfaced this, and it will surface the next SDK drift too. Pinning it, or adding a `global.json`, is a real question about CI reproducibility, but it is a separate concern from this fix and a different tradeoff — deliberately left alone here.

## Related

Unblocks #7913, which is currently red for this reason and for no other. Kept separate per CONTRIBUTING's one-PR-one-concern rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)