### PR TITLE
docs(wiki): point the scheduling link at StartupTasks

### DIFF
--- a/doc/wiki/http-scheduling-resilience.md
+++ b/doc/wiki/http-scheduling-resilience.md
@@ -105,7 +105,7 @@ Scheduled workflows typically create trigger or bookmark payloads that the sched
 - [Bookmarks](../../src/modules/Elsa.Scheduling/Bookmarks)
 - [Services](../../src/modules/Elsa.Scheduling/Services)
 - [Handlers](../../src/modules/Elsa.Scheduling/Handlers)
-- [HostedServices](../../src/modules/Elsa.Scheduling/HostedServices)
+- [StartupTasks](../../src/modules/Elsa.Scheduling/StartupTasks)
 - [TriggerPayloadValidators](../../src/modules/Elsa.Scheduling/TriggerPayloadValidators)
 
 The scheduler integrates with tenancy by reacting to tenant activation/deletion events.


### PR DESCRIPTION
The **Update Wiki** workflow has failed on every run since `1000d29fe` on 2026-07-28. One broken link, one line.

## Cause

```
doc/wiki/http-scheduling-resilience.md: ../../src/modules/Elsa.Scheduling/HostedServices -> missing
```

`Elsa.Scheduling/HostedServices` was removed in 8e301d4e1, where `HostedServices/CreateSchedulesBackgroundTask.cs` became `StartupTasks/CreateSchedulesStartupTask.cs`. The wiki page kept pointing at the old directory, and the link checker has been red ever since.

## Fix

Point it at `StartupTasks`, which is where that work lives now. The link sits in a list of orientation pointers under "Scheduling Concepts", so the label changes with it.

## Verification

The workflow's check only validates wiki files that changed in the push, so its silence about everything else is not evidence the rest is sound. I ran the workflow's own validator over the whole tree instead:

```
All local markdown links resolve across 22 wiki files.
```

This was the only break. The other 39 links in that page — and every link in the remaining 21 files — resolve.

## Note

This failure is unrelated to #7913 and #7919, which were merged while it was already red. It predates both by two weeks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)