### PR TITLE
fix(core): a throwing FaultSignal handler must not escape the middleware

### DIFF
--- a/src/modules/Elsa.Workflows.Core/Middleware/Activities/ExceptionHandlingMiddleware.cs
+++ b/src/modules/Elsa.Workflows.Core/Middleware/Activities/ExceptionHandlingMiddleware.cs
@@ -37,13 +37,45 @@ public class ExceptionHandlingMiddleware(ActivityMiddlewareDelegate next, IIncid
 
             // Give the ancestor chain a chance to handle the fault. See FaultSignal for the contract: the handler owns
             // terminalizing the faulted activity, and recovering the fault bookkeeping is ours alone to do, exactly once.
-            if (await context.TrySendSignalAsync(new FaultSignal(e, context)))
+            if (await TryHandOffToAncestorsAsync(context, e))
             {
                 context.RecoverFromFault();
                 return;
             }
 
             await HandleIncidentAsync(context);
+        }
+    }
+
+    /// <summary>
+    /// Offers the fault to the ancestor chain, and reports whether one of them claimed it.
+    /// </summary>
+    /// <remarks>
+    /// A handler that throws is treated as not having handled the fault, so the incident strategy runs exactly as it
+    /// would if no handler existed. This is the one place where swallowing an exception is right: the send happens
+    /// inside the <c>catch</c> whose entire job is to stop exceptions escaping the activity pipeline, so letting a
+    /// handler's failure through would defeat the middleware and lose the original fault along with it. Falling through
+    /// to the incident strategy is also the conservative direction: a handler that failed part way through may have left
+    /// the faulted activity in any state, and surfacing that as an incident is better than reporting success. Both
+    /// exceptions are logged, the handler's at error level, because a broken fault handler is a defect in its own right
+    /// rather than a workflow outcome.
+    /// </remarks>
+    private async Task<bool> TryHandOffToAncestorsAsync(ActivityExecutionContext context, Exception fault)
+    {
+        try
+        {
+            return await context.TrySendSignalAsync(new FaultSignal(fault, context));
+        }
+        catch (Exception handlerException)
+        {
+            logger.LogError(
+                handlerException,
+                "A {SignalType} handler threw while an ancestor of activity {ActivityId} of type {ActivityType} was being offered its fault. Treating the fault as unhandled",
+                nameof(FaultSignal),
+                context.Activity.Id,
+                context.Activity.Type);
+
+            return false;
         }
     }
 

--- a/src/modules/Elsa.Workflows.Core/Middleware/Activities/ExceptionHandlingMiddleware.cs
+++ b/src/modules/Elsa.Workflows.Core/Middleware/Activities/ExceptionHandlingMiddleware.cs
@@ -59,6 +59,13 @@ public class ExceptionHandlingMiddleware(ActivityMiddlewareDelegate next, IIncid
     /// the faulted activity in any state, and surfacing that as an incident is better than reporting success. Both
     /// exceptions are logged, the handler's at error level, because a broken fault handler is a defect in its own right
     /// rather than a workflow outcome.
+    /// <para>
+    /// Cancellation is deliberately excluded. An <see cref="OperationCanceledException"/> from a handler means the host
+    /// is tearing the run down, not that the handler is broken, and this repository consistently keeps the two apart:
+    /// the workflow-level exception middleware cancels and rethrows before its general catch, and
+    /// <c>WorkflowRunner</c> declines to record cancellation as the workflow's exception. Swallowing it here would
+    /// convert a deliberate cancellation into a faulted workflow.
+    /// </para>
     /// </remarks>
     private async Task<bool> TryHandOffToAncestorsAsync(ActivityExecutionContext context, Exception fault)
     {
@@ -66,7 +73,7 @@ public class ExceptionHandlingMiddleware(ActivityMiddlewareDelegate next, IIncid
         {
             return await context.TrySendSignalAsync(new FaultSignal(fault, context));
         }
-        catch (Exception handlerException)
+        catch (Exception handlerException) when (handlerException is not OperationCanceledException)
         {
             logger.LogError(
                 handlerException,

--- a/src/modules/Elsa.Workflows.Core/Signals/FaultSignal.cs
+++ b/src/modules/Elsa.Workflows.Core/Signals/FaultSignal.cs
@@ -74,6 +74,13 @@ namespace Elsa.Workflows.Signals;
 ///     its own right rather than a workflow outcome.
 ///     </description>
 ///   </item>
+///   <item>
+///     <description>
+///     <b>Cancellation is the exception to that.</b> An <see cref="OperationCanceledException"/> from a handler
+///     propagates, because it means the host is tearing the run down rather than that the handler is broken. Treating
+///     it as a handler failure would turn a deliberate cancellation into a faulted workflow.
+///     </description>
+///   </item>
 /// </list>
 /// <para>
 /// <b>Completing the faulted activity takes one extra step.</b> <c>CompleteActivityAsync</c> returns immediately unless

--- a/src/modules/Elsa.Workflows.Core/Signals/FaultSignal.cs
+++ b/src/modules/Elsa.Workflows.Core/Signals/FaultSignal.cs
@@ -63,6 +63,17 @@ namespace Elsa.Workflows.Signals;
 ///     <b>The handler must not</b> call <c>RecoverFromFault()</c>.
 ///     </description>
 ///   </item>
+///   <item>
+///     <description>
+///     <b>A handler that throws is treated as not having handled the fault.</b> Its exception does not escape, because
+///     this signal is sent from inside the <c>catch</c> whose whole job is to stop exceptions escaping the activity
+///     pipeline; letting a handler's failure through would defeat that and lose the original fault with it. The incident
+///     strategy then runs exactly as it would with no handler present, which is the conservative direction: a handler
+///     that failed part way through may have left the faulted activity in any state, and an incident is a better answer
+///     than silence. The handler's own exception is logged at error level, because a broken fault handler is a defect in
+///     its own right rather than a workflow outcome.
+///     </description>
+///   </item>
 /// </list>
 /// <para>
 /// <b>Completing the faulted activity takes one extra step.</b> <c>CompleteActivityAsync</c> returns immediately unless

--- a/test/integration/Elsa.Workflows.IntegrationTests/Scenarios/FaultSignals/FaultSignalTests.cs
+++ b/test/integration/Elsa.Workflows.IntegrationTests/Scenarios/FaultSignals/FaultSignalTests.cs
@@ -1,3 +1,4 @@
+using Elsa.Common.Models;
 using Elsa.Extensions;
 using Elsa.Testing.Shared;
 using Elsa.Testing.Shared.Activities;
@@ -5,6 +6,8 @@ using Elsa.Workflows.Activities;
 using Elsa.Workflows.IncidentStrategies;
 using Elsa.Workflows.IntegrationTests.Scenarios.FaultSignals.Activities;
 using Elsa.Workflows.Models;
+using Elsa.Workflows.Runtime;
+using Microsoft.Extensions.DependencyInjection;
 using Elsa.Workflows.Signals;
 using Xunit.Abstractions;
 
@@ -291,6 +294,34 @@ public class FaultSignalTests(ITestOutputHelper testOutputHelper)
         // Assert: the workflow-level middleware cancelled the run, so it ends Cancelled rather than Faulted. Swallowing
         // the cancellation here would instead hand the fault to FaultStrategy and finish Faulted.
         Assert.Equal(WorkflowSubStatus.Cancelled, result.WorkflowState.SubStatus);
+    }
+
+    [Fact(DisplayName = "A handled fault still leaves the failure in the execution log")]
+    public async Task HandledFault_StillRecordsTheFailureInTheJournal()
+    {
+        // The whole justification for dropping the incident is that the journal keeps the evidence, so that claim is
+        // asserted rather than assumed. ExecutionLogMiddleware writes the entry from a catch that rethrows, and it sits
+        // inside ExceptionHandlingMiddleware in the activity pipeline, so the entry is written before the fault is ever
+        // offered to an ancestor. Reordering those two would silently make a handled failure invisible.
+
+        // Arrange
+        var container = ContainerAround(_faultingActivity, ClaimAndCancelChildAsync);
+
+        // Act
+        var result = await RunAsync(container);
+
+        // Assert: no incident, but the failure is still on the record.
+        Assert.Empty(result.WorkflowState.Incidents);
+
+        var journal = await _fixture.Services.GetRequiredService<IWorkflowExecutionLogStore>().FindManyAsync(new()
+        {
+            WorkflowInstanceId = result.WorkflowState.Id,
+            ActivityId = _faultingActivity.Id,
+            EventName = "Faulted"
+        }, PageArgs.All);
+
+        var entry = Assert.Single(journal.Items);
+        Assert.Equal(_faultingActivity.Id, entry.ActivityId);
     }
 
     /// <summary>

--- a/test/integration/Elsa.Workflows.IntegrationTests/Scenarios/FaultSignals/FaultSignalTests.cs
+++ b/test/integration/Elsa.Workflows.IntegrationTests/Scenarios/FaultSignals/FaultSignalTests.cs
@@ -273,6 +273,26 @@ public class FaultSignalTests(ITestOutputHelper testOutputHelper)
         AssertFaultCounts(result, expected: 1);
     }
 
+    [Fact(DisplayName = "Cancellation from a handler propagates instead of becoming an incident")]
+    public async Task HandlerThatCancels_PropagatesRatherThanFaulting()
+    {
+        // The guard above deliberately does not cover OperationCanceledException. Cancellation means the host is tearing
+        // the run down, not that the handler is broken, and this repository keeps the two apart: the workflow-level
+        // exception middleware cancels and rethrows before its general catch, and WorkflowRunner declines to record
+        // cancellation as the workflow's exception. Swallowing it here would turn a deliberate cancellation into a
+        // faulted workflow.
+
+        // Arrange
+        var container = ContainerAround(_faultingActivity, (_, _) => throw new OperationCanceledException());
+
+        // Act
+        var result = await RunAsync(container, typeof(FaultStrategy));
+
+        // Assert: the workflow-level middleware cancelled the run, so it ends Cancelled rather than Faulted. Swallowing
+        // the cancellation here would instead hand the fault to FaultStrategy and finish Faulted.
+        Assert.Equal(WorkflowSubStatus.Cancelled, result.WorkflowState.SubStatus);
+    }
+
     /// <summary>
     /// The canonical handler: claim the fault, terminalize the faulted child, and wind the container up.
     /// </summary>

--- a/test/integration/Elsa.Workflows.IntegrationTests/Scenarios/FaultSignals/FaultSignalTests.cs
+++ b/test/integration/Elsa.Workflows.IntegrationTests/Scenarios/FaultSignals/FaultSignalTests.cs
@@ -237,6 +237,42 @@ public class FaultSignalTests(ITestOutputHelper testOutputHelper)
         Assert.Equal(ActivityStatus.Canceled, result.GetActivityStatus(_faultingActivity));
     }
 
+    [Theory(DisplayName = "A handler that throws is treated as not having handled the fault")]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task HandlerThatThrows_FallsThroughToTheIncidentStrategy(bool stopPropagationFirst)
+    {
+        // The signal is sent from inside the catch that exists to stop exceptions escaping the activity pipeline, so a
+        // handler's failure must not escape either: it would defeat the middleware and lose the original fault with it.
+        // Both cases are covered, because a handler that already claimed the fault before throwing is the one that could
+        // plausibly have been mistaken for a successful handling.
+
+        // Arrange
+        var container = ContainerAround(_faultingActivity, (_, context) =>
+        {
+            if (stopPropagationFirst)
+                context.StopPropagation();
+
+            throw new InvalidOperationException("The handler is broken");
+        });
+
+        // Act: this must not throw. If the handler's exception escaped, it would surface here.
+        var result = await RunAsync(container, typeof(FaultStrategy));
+
+        // Assert: the fault is unhandled, so it lands exactly where it would with no handler at all.
+        Assert.Equal(1, container.FaultsSeen);
+        Assert.Equal(WorkflowSubStatus.Faulted, result.WorkflowState.SubStatus);
+        Assert.Equal(ActivityStatus.Faulted, result.GetActivityStatus(_faultingActivity));
+
+        // The original fault is the incident, not the handler's failure: recovery never ran, so nothing removed it.
+        // Asserted on identity rather than message text, because the incident carries the thrown exception's message
+        // and a broken handler must not be able to substitute its own.
+        var incident = Assert.Single(result.WorkflowState.Incidents);
+        Assert.Equal(_faultingActivity.Id, incident.ActivityId);
+        Assert.DoesNotContain("The handler is broken", incident.Message, StringComparison.Ordinal);
+        AssertFaultCounts(result, expected: 1);
+    }
+
     /// <summary>
     /// The canonical handler: claim the fault, terminalize the faulted child, and wind the container up.
     /// </summary>


### PR DESCRIPTION
Closes F4 from the review on #7911.

**Stacked on #7923** (`claude/faultsignal-recovery-removes-incident`), because both touch `FaultSignalTests.cs`. Merge that one first; this branch contains its commit.

## The problem

`FaultSignal` is sent from inside `ExceptionHandlingMiddleware`'s `catch`, and neither the middleware nor `TrySendSignalAsync` guarded the dispatch. A handler that threw went straight through the middleware whose entire job is to stop exceptions escaping the activity pipeline: no incident, no strategy, and the original fault lost along with it.

## The change

The send is guarded. A handler that throws is treated as not having handled the fault, so the incident strategy runs exactly as it would with no handler present.

That direction is deliberate rather than convenient. A handler that failed part way through may have left the faulted activity in any state, so surfacing an incident is a better answer than reporting success. The handler's own exception is logged at error level, since a broken fault handler is a defect in its own right rather than a workflow outcome.

The guard is in the middleware, not in `TrySendSignalAsync`. Every other signal send sits in ordinary control flow where an exception should propagate to this middleware normally; the fault path is the one place where it cannot.

The contract on `FaultSignal` now states it, alongside the existing responsibilities.

## Tests

A theory covering both shapes, because a handler that already called `StopPropagation()` before throwing is the case that could plausibly have been mistaken for a successful handling. Both assert the fault lands exactly where it would with no handler at all, and that the incident on record is the original fault rather than the handler's failure, asserted on activity identity rather than message text so a broken handler cannot substitute its own.

I mutation-tested them: reverting the guard turns both red.

## Verification

- `Elsa.Workflows.IntegrationTests` FaultSignal scenarios: 13/13.
- Mutation check: guard removed, both new tests fail; guard restored, all pass.

## On F3, which I raised and am now withdrawing

I also reported that the merged docs did not explain that a handler's "is this mine?" guard is load-bearing, given the signal reaches the faulting activity before its ancestors.

That was wrong. #7913 already documents it thoroughly, under **"The faulting activity is itself a receiver"**, including the `SignalContext.IsSelf` alternative and a dedicated integration test pinning the dispatch order. I reviewed my own spec and asserted a fact about the implementation without reading it, which is the same mistake the review was meant to catch. No change needed, and nothing here touches it.
