### PR TITLE
fix(deps): consume ConsoleLogStreaming 1.1.0 from nuget.org

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -102,10 +102,10 @@
         <PackageVersion Include="Bpmn.Model" Version="0.1.1-preview.19"/>
         <PackageVersion Include="Bpmn.Semantics" Version="0.1.1-preview.19"/>
         <PackageVersion Include="ConfigureAwait.Fody" Version="3.3.2" PrivateAssets="All"/>
-        <PackageVersion Include="ConsoleLogStreaming.Contracts" Version="1.0.0-preview.13"/>
-        <PackageVersion Include="ConsoleLogStreaming.Core" Version="1.0.0-preview.13"/>
-        <PackageVersion Include="ConsoleLogStreaming.Persistence.Sqlite" Version="1.0.0-preview.13"/>
-        <PackageVersion Include="ConsoleLogStreaming.SignalR" Version="1.0.0-preview.13"/>
+        <PackageVersion Include="ConsoleLogStreaming.Contracts" Version="1.1.0"/>
+        <PackageVersion Include="ConsoleLogStreaming.Core" Version="1.1.0"/>
+        <PackageVersion Include="ConsoleLogStreaming.Persistence.Sqlite" Version="1.1.0"/>
+        <PackageVersion Include="ConsoleLogStreaming.SignalR" Version="1.1.0"/>
         <PackageVersion Include="coverlet.collector" Version="6.0.4" PrivateAssets="All"/>
         <PackageVersion Include="coverlet.msbuild" Version="6.0.4" PrivateAssets="All"/>
         <PackageVersion Include="Cronos" Version="0.11.1"/>

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -6,7 +6,6 @@
         <add key="NuGet official package source" value="https://api.nuget.org/v3/index.json" />
         <add key="cshells-feedz" value="https://f.feedz.io/sfmskywalker/cshells/nuget/index.json" />
         <add key="elsa-preview-feedz" value="https://f.feedz.io/elsa-workflows/elsa-3/nuget/index.json" />
-        <add key="valence-consolelogstream-feedz" value="https://f.feedz.io/valence-works/consolelogstream/nuget/index.json" />
         <add key="bpmn-feedz" value="https://f.feedz.io/valence-works/bpmn/nuget/index.json" />
     </packageSources>
     <packageSourceMapping>
@@ -18,10 +17,6 @@
         <packageSource key="elsa-preview-feedz">
             <package pattern="Elsa.PackageManifest.Generator" />
             <package pattern="Elsa.PackageManifests" />
-        </packageSource>
-        <packageSource key="valence-consolelogstream-feedz">
-            <package pattern="ConsoleLogStreaming" />
-            <package pattern="ConsoleLogStreaming.*" />
         </packageSource>
         <packageSource key="bpmn-feedz">
             <package pattern="Bpmn.*" />


### PR DESCRIPTION
## Problem

`Elsa.Diagnostics.ConsoleLogs` and `Elsa.Dashboard.Api` are packable and published — to the Elsa preview feed on every push to `main`, and to nuget.org on release. Both pinned `ConsoleLogStreaming.*` at `1.0.0-preview.13`, published **only** to the private `valence-works/consolelogstream` feed. That pin was baked into the shipped nuspecs:

```
<dependency id="ConsoleLogStreaming.Core" version="1.0.0-preview.13" ... />
<dependency id="ConsoleLogStreaming.SignalR" version="1.0.0-preview.13" ... />
```

Restore did **not** hard-fail for consumers. NuGet floated the `>=` constraint up to the nuget.org `1.0.0`:

```
warning NU1603: Elsa.Diagnostics.ConsoleLogs 3.8.0-preview.5422 depends on
ConsoleLogStreaming.Core (>= 1.0.0-preview.13) but ConsoleLogStreaming.Core
1.0.0-preview.13 was not found. ConsoleLogStreaming.Core 1.0.0 was resolved instead.
```

Two consequences: NU1603 is an error under `TreatWarningsAsErrors`, and — more quietly — consumers ran a different build of the library than CI compiled against.

## Fix

[ConsoleLogStreaming 1.1.0](https://github.com/valence-works/console-log-streaming/releases/tag/1.1.0) has been released publicly, carrying work that had only ever reached the private feed as previews:

- `ConsoleLogOptions.StreamReleaseInterval` — time-gates live subscription batch releases
- `InMemoryConsoleLogProvider` — flood throttling and dead-subscriber drop accounting fixes
- `SqliteConsoleLogProvider` — aligned with the stream-release gate

Pinning to `1.1.0` makes the shipped dependency both resolvable and current, so the private feed and its `packageSourceMapping` entry are no longer needed.

## Verification

- `dotnet restore Elsa.sln` — clean, no warnings
- `Elsa.Dashboard.Api` Release/net10.0 — 0 warnings, 0 errors
- **64 tests pass**: 23 `Elsa.Diagnostics.ConsoleLogs.UnitTests`, 15 `Elsa.Dashboard.Api.UnitTests`, 26 `Elsa.Diagnostics.ConsoleLogs.IntegrationTests`
- Packed nuspec declares `1.1.0` on all three TFM groups
- A clean consumer project restoring the packed output against **nuget.org + the Elsa feed only, with `TreatWarningsAsErrors=true`**, resolves `ConsoleLogStreaming.* 1.1.0` with zero warnings — the check that originally surfaced this

## Note for reviewers

Local restores in checkouts that still have the old `NuGet.Config` will fail with `NU1100` on `ConsoleLogStreaming.*` until this merges: the stale `ConsoleLogStreaming.*` → valence mapping is a longer pattern than nuget.org's `*` and wins, while this PR removes that source. Clearing the NuGet HTTP cache after merging avoids a stale flat-container index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)