### PR TITLE
feat(bpmn): the BpmnProcess container activity

### DIFF
--- a/src/common/Elsa.Testing.Shared/ActivityTestFixture.cs
+++ b/src/common/Elsa.Testing.Shared/ActivityTestFixture.cs
@@ -1,5 +1,6 @@
 using Elsa.Common;
 using Elsa.Common.Multitenancy;
+using Elsa.Common.Serialization;
 using Elsa.Expressions.Contracts;
 using Elsa.Expressions.Services;
 using Elsa.Extensions;
@@ -11,6 +12,7 @@ using Elsa.Workflows.Management.Providers;
 using Elsa.Workflows.Management.Services;
 using Elsa.Workflows.Memory;
 using Elsa.Workflows.PortResolvers;
+using Elsa.Workflows.Serialization.Serializers;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
@@ -183,5 +185,8 @@ public class ActivityTestFixture
         services.AddSingleton<IActivityExecutionContextSchedulerStrategy, FakeActivityExecutionContextSchedulerStrategy>();
         services.AddSingleton<ITenantAccessor, DefaultTenantAccessor>();
         services.AddScoped<IWorkflowStateExtractor, WorkflowStateExtractor>();
+        services.AddOptions();
+        services.AddSingleton<ISerializationTypeRegistry, SerializationTypeRegistry>();
+        services.AddSingleton<IPayloadSerializer, JsonPayloadSerializer>();
     }
 }

--- a/src/modules/Elsa.Bpmn/Activities/BpmnProcess.cs
+++ b/src/modules/Elsa.Bpmn/Activities/BpmnProcess.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
+using System.Text.Json.Serialization;
 using Bpmn.Model;
 using Elsa.Bpmn.Hosting;
 using Elsa.Bpmn.Signals;
@@ -40,6 +41,33 @@ public class BpmnProcess : Container
     /// The BPMN process definition this scope executes.
     /// </summary>
     public BpmnProcessDefinition? Process { get; set; }
+
+    /// <summary>
+    /// Whether this scope is the root BPMN process of its workflow, and may therefore register the start triggers its
+    /// definition declares.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Off unless something says otherwise, which is the answer every nested scope needs: the start events of a
+    /// subprocess body, of an event subprocess body, and of a process composed into a <c>Flowchart</c> are internal
+    /// to the graph around them, not ways into the workflow. Root position cannot be recovered from a published
+    /// activity node — a node knows neither its parent nor how it was imported — so whoever builds the graph says so
+    /// explicitly and everything that nests a scope leaves it alone.
+    /// </para>
+    /// <para>
+    /// Backed by Elsa's own <see cref="Activity.CanStartWorkflow"/> rather than by a second flag, because
+    /// <c>TriggerIndexer</c> gates registration on that one: two flags could disagree, and the disagreement would
+    /// show up as a subprocess quietly registered as an entry point. Reading it here gives the BPMN meaning a name
+    /// and one place to document it. Trigger registration itself belongs to the issue that makes this activity an
+    /// <c>ITrigger</c>; this property is what that gate will read.
+    /// </para>
+    /// </remarks>
+    [JsonIgnore]
+    public bool IsRootScope
+    {
+        get => CanStartWorkflow;
+        set => CanStartWorkflow = value;
+    }
 
     /// <summary>
     /// Maps each binding ref the definition declares to the id of the activity in <see cref="Container.Activities"/>

--- a/src/modules/Elsa.Bpmn/Activities/BpmnProcess.cs
+++ b/src/modules/Elsa.Bpmn/Activities/BpmnProcess.cs
@@ -25,6 +25,13 @@ namespace Elsa.Bpmn.Activities;
 /// Like every container, this one never auto-completes: it completes when the interpreter returns a <c>Complete</c>
 /// continuation, and its outcome is what a conditional sequence flow in the enclosing scope selects on.
 /// </para>
+/// <para>
+/// Composing this activity into a <c>Flowchart</c>: it completes with only the interpreter's outcome name (e.g.
+/// <c>BpmnInterpreter.DoneOutcomeName</c>, and <c>CancelledOutcomeName</c> where relevant) — not with
+/// <c>Outcomes.Default</c>, which an ordinary activity's null result also produces and which additionally matches a
+/// null-port connection. A <c>Connection</c> built with the default/null-port shorthand will therefore never fire
+/// from this activity; always target an explicit outcome port.
+/// </para>
 /// </remarks>
 [Activity("Elsa", "BPMN", "Executes a BPMN process scope.")]
 [System.ComponentModel.Browsable(false)]

--- a/src/modules/Elsa.Bpmn/Hosting/BpmnCommandApplier.cs
+++ b/src/modules/Elsa.Bpmn/Hosting/BpmnCommandApplier.cs
@@ -62,6 +62,18 @@ internal sealed class BpmnCommandApplier(ActivityExecutionContext scopeContext, 
                        ?? throw new InvalidOperationException(
                            $"BPMN element '{start.ElementId}' binds work '{start.BindingRef}', which activity '{process.Id}' does not map to a child activity.");
 
+        // Starting a BPMN process as this scope's work is what makes it a nested scope, so this is where the rule
+        // that a nested scope registers no start triggers is enforced. Refusing beats quietly clearing the flag: the
+        // damage a mis-flagged subprocess does is done at publish time, when its start events were indexed as ways
+        // into the workflow, and a host that repaired the object graph at runtime would leave that trigger in place
+        // while every test went green.
+        if (activity is BpmnProcess { IsRootScope: true } nested)
+        {
+            throw new InvalidOperationException(
+                $"BPMN element '{start.ElementId}' binds process activity '{nested.Id}' as the work of scope '{process.Id}', but that activity declares itself the workflow's root scope. "
+                + "A nested scope's start events are internal to the process around it, not workflow entry points, so it must not be marked as able to start the workflow.");
+        }
+
         var workflowExecutionContext = scopeContext.WorkflowExecutionContext;
 
         // The child's context is created up front so that this scope has its id before the child ever runs, and can

--- a/src/modules/Elsa.Bpmn/Hosting/BpmnCommandApplier.cs
+++ b/src/modules/Elsa.Bpmn/Hosting/BpmnCommandApplier.cs
@@ -32,6 +32,21 @@ internal sealed class BpmnCommandApplier(ActivityExecutionContext scopeContext, 
     /// </remarks>
     public async ValueTask ApplyAsync(IReadOnlyList<BpmnHostCommand> commands)
     {
+        // Refused before anything in the batch is applied. Applying commands one at a time and refusing only once
+        // the offending StartWork is reached would leave earlier commands in the same batch already applied and
+        // saved via memory.SaveWork() below — and under ContinueWithIncidentsStrategy that throw is absorbed into
+        // an incident rather than surfaced, so the workflow would carry on with a half-applied batch and half-saved
+        // memory instead of the refusal stopping it clean.
+        foreach (var command in commands)
+        {
+            if (command is BpmnHostCommand.StartWork start && process.FindWorkActivity(start.BindingRef) is BpmnProcess { IsRootScope: true } nested)
+            {
+                throw new InvalidOperationException(
+                    $"BPMN element '{start.ElementId}' binds process activity '{nested.Id}' as the work of scope '{process.Id}', but that activity declares itself the workflow's root scope. "
+                    + "A nested scope's start events are internal to the process around it, not workflow entry points, so it must not be marked as able to start the workflow.");
+            }
+        }
+
         foreach (var command in commands)
         {
             switch (command)
@@ -62,18 +77,9 @@ internal sealed class BpmnCommandApplier(ActivityExecutionContext scopeContext, 
                        ?? throw new InvalidOperationException(
                            $"BPMN element '{start.ElementId}' binds work '{start.BindingRef}', which activity '{process.Id}' does not map to a child activity.");
 
-        // Starting a BPMN process as this scope's work is what makes it a nested scope, so this is where the rule
-        // that a nested scope registers no start triggers is enforced. Refusing beats quietly clearing the flag: the
-        // damage a mis-flagged subprocess does is done at publish time, when its start events were indexed as ways
-        // into the workflow, and a host that repaired the object graph at runtime would leave that trigger in place
-        // while every test went green.
-        if (activity is BpmnProcess { IsRootScope: true } nested)
-        {
-            throw new InvalidOperationException(
-                $"BPMN element '{start.ElementId}' binds process activity '{nested.Id}' as the work of scope '{process.Id}', but that activity declares itself the workflow's root scope. "
-                + "A nested scope's start events are internal to the process around it, not workflow entry points, so it must not be marked as able to start the workflow.");
-        }
-
+        // The rule that a nested scope registers no start triggers is enforced by ApplyAsync's pre-scan, before any
+        // command in the batch is applied — not here, where earlier commands in the same batch could already have
+        // been applied and persisted.
         var workflowExecutionContext = scopeContext.WorkflowExecutionContext;
 
         // The child's context is created up front so that this scope has its id before the child ever runs, and can

--- a/src/modules/Elsa.Bpmn/Hosting/BpmnCommandApplier.cs
+++ b/src/modules/Elsa.Bpmn/Hosting/BpmnCommandApplier.cs
@@ -37,9 +37,9 @@ internal sealed class BpmnCommandApplier(ActivityExecutionContext scopeContext, 
         // saved via memory.SaveWork() below — and under ContinueWithIncidentsStrategy that throw is absorbed into
         // an incident rather than surfaced, so the workflow would carry on with a half-applied batch and half-saved
         // memory instead of the refusal stopping it clean.
-        foreach (var command in commands)
+        foreach (var start in commands.OfType<BpmnHostCommand.StartWork>())
         {
-            if (command is BpmnHostCommand.StartWork start && process.FindWorkActivity(start.BindingRef) is BpmnProcess { IsRootScope: true } nested)
+            if (process.FindWorkActivity(start.BindingRef) is BpmnProcess { IsRootScope: true } nested)
             {
                 throw new InvalidOperationException(
                     $"BPMN element '{start.ElementId}' binds process activity '{nested.Id}' as the work of scope '{process.Id}', but that activity declares itself the workflow's root scope. "

--- a/src/modules/Elsa.Bpmn/Hosting/BpmnScopeHost.cs
+++ b/src/modules/Elsa.Bpmn/Hosting/BpmnScopeHost.cs
@@ -31,14 +31,16 @@ internal sealed class BpmnScopeHost
     /// What this host promises it can do.
     /// </summary>
     /// <remarks>
-    /// <see cref="BpmnHostCapabilities.ScopeVariables"/> is deliberately absent: reading container-scoped variables
-    /// through <see cref="IBpmnVariableReader"/> needs the three-valued reader that distinguishes "no such variable"
-    /// from "stored externally, cannot tell you", which this host does not have yet. Declaring it anyway would buy a
-    /// definition that quietly iterates zero times instead of a refusal naming the element, and a capability is a
-    /// claim rather than a wish.
+    /// Each capability is a claim, honoured elsewhere in this module: subtree cancellation by
+    /// <see cref="BpmnWorkTeardown"/>, scope signalling by <see cref="BpmnScopeSignal"/>, iteration scopes by the
+    /// applier's per-instance variables, and <see cref="BpmnHostCapabilities.ScopeVariables"/> by
+    /// <see cref="BpmnScopeVariables"/>. Spelled out rather than written as <c>BpmnHostCapabilities.Full</c> on
+    /// purpose: <c>Full</c> would silently grow to include a capability a later library version adds and this host
+    /// has never implemented, which is the one way a declaration can become a lie without anyone editing it.
+    /// The same set goes to <see cref="BpmnGraph.Build"/> and to every snapshot, which the port requires.
     /// </remarks>
     public const BpmnHostCapabilities Capabilities =
-        BpmnHostCapabilities.SubtreeCancellation | BpmnHostCapabilities.ScopeSignalling | BpmnHostCapabilities.IterationScopes;
+        BpmnHostCapabilities.SubtreeCancellation | BpmnHostCapabilities.ScopeSignalling | BpmnHostCapabilities.IterationScopes | BpmnHostCapabilities.ScopeVariables;
 
     /// <summary>
     /// The property key under which a nested scope's invocation correlation is carried on its own context.
@@ -240,7 +242,7 @@ internal sealed class BpmnScopeHost
             HasEnclosingScope: invocationCorrelation.Count > 0,
             LiveWork: memory.Work.ToLiveWork(),
             InvocationCorrelation: invocationCorrelation,
-            Variables: BpmnNoVariables.Instance,
+            Variables: new BpmnScopeVariables(_context),
             Capabilities: Capabilities);
     }
 

--- a/src/modules/Elsa.Bpmn/Hosting/BpmnScopeVariables.cs
+++ b/src/modules/Elsa.Bpmn/Hosting/BpmnScopeVariables.cs
@@ -1,0 +1,94 @@
+using System.Text.Json;
+using Bpmn.Model;
+using Bpmn.Semantics;
+using Elsa.Extensions;
+using Elsa.Workflows;
+
+namespace Elsa.Bpmn.Hosting;
+
+/// <summary>
+/// Reads a BPMN scope's container-scoped variables for the interpreter — the one callback the port makes.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The read is three-valued, and the three answers are not interchangeable. <c>false</c> says there is no such
+/// variable, and faults the element that asked. <see cref="BpmnValuePresence.Null"/> says the variable exists and
+/// holds nothing, which a collection-mode multi-instance resolves as zero instances. <see
+/// cref="BpmnValuePresence.StoredExternally"/> says the host has a value it cannot put on the wire, and faults
+/// rather than reading as empty. Collapsing any of them into another is exactly the quiet wrong answer the port's
+/// three-valued read exists to prevent.
+/// </para>
+/// <para>
+/// This host reaches <see cref="BpmnValuePresence.StoredExternally"/> by one route: a value JSON cannot carry. It
+/// deliberately does <b>not</b> report a driver-backed variable that way. <c>PersistentVariablesMiddleware</c> calls
+/// <c>IVariablePersistenceManager.LoadVariablesAsync</c> before the pipeline runs and passes no <c>excludeTags</c>,
+/// so a driver-backed value is already materialized into its memory block by the time any scope evaluates. Were a
+/// host to exclude a tag, the skipped variable would be undetectable from here: <c>VariablePersistenceManager</c>
+/// marks the block <c>IsInitialized</c> <i>before</i> testing the exclusion, so a variable whose driver was never
+/// read is indistinguishable from one whose driver returned null, and nothing else records the exclusion. Guessing
+/// between them would either fault materialized variables or quietly report unread ones as null; answering only
+/// what the block actually says is the honest option available without changing <c>Elsa.Workflows.Core</c>.
+/// </para>
+/// <para>
+/// Synchronous, which the port requires and Elsa can honour for the same reason: nothing here needs to await a
+/// driver, because the middleware already did.
+/// </para>
+/// </remarks>
+internal sealed class BpmnScopeVariables(ActivityExecutionContext context) : IBpmnVariableReader
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new(JsonSerializerDefaults.General);
+
+    /// <summary>A value this host holds but cannot represent inline.</summary>
+    private static readonly BpmnValue Unrepresentable = new(BpmnValuePresence.StoredExternally, BpmnValueTypes.Any, null);
+
+    /// <inheritdoc />
+    public bool TryRead(string name, out BpmnValue value)
+    {
+        var expressionExecutionContext = context.ExpressionExecutionContext;
+
+        // Resolution walks outward from this scope, which is both Elsa's variable scoping and BPMN's: an inner scope
+        // sees the enclosing scope's data. A name nothing in scope declares is genuinely absent, and saying so is what
+        // turns a mistyped collection variable into a fault naming the element instead of a loop that never runs.
+        if (expressionExecutionContext.GetVariable(name) is not { } variable || !expressionExecutionContext.TryGetBlock(variable, out var block))
+        {
+            value = BpmnValue.Absent;
+            return false;
+        }
+
+        value = Represent(block.Value);
+        return true;
+    }
+
+    /// <summary>
+    /// The interpreter's view of a CLR value. Values cross the port as JSON with a host-interpreted type hint, so
+    /// anything Elsa can hold that JSON cannot carry is reported as held outside the payload rather than as absent
+    /// or null.
+    /// </summary>
+    private static BpmnValue Represent(object? value)
+    {
+        if (value is null)
+            return BpmnValue.Null;
+
+        try
+        {
+            return BpmnValue.From(JsonSerializer.SerializeToElement(value, SerializerOptions), TypeHintOf(value));
+        }
+        catch (Exception exception) when (exception is JsonException or NotSupportedException)
+        {
+            // The variable is not missing and not null: this host has it, and cannot hand it over. A cyclic object
+            // graph and a type with no converter both land here. Reporting it as null or absent would resolve a
+            // collection-mode loop to zero instances and complete as though there had been nothing to do.
+            return Unrepresentable;
+        }
+    }
+
+    /// <summary>
+    /// The type hint that travels with the value. The interpreter understands two — <see cref="BpmnValueTypes.Integer"/>,
+    /// which multi-instance cardinality and loop indices use, and <see cref="BpmnValueTypes.Any"/> — and assigns no
+    /// meaning to any other.
+    /// </summary>
+    private static string TypeHintOf(object value) =>
+        value is byte or sbyte or short or ushort or int or uint or long or ulong
+            ? BpmnValueTypes.Integer
+            : BpmnValueTypes.Any;
+}

--- a/src/modules/Elsa.Bpmn/Hosting/BpmnScopeVariables.cs
+++ b/src/modules/Elsa.Bpmn/Hosting/BpmnScopeVariables.cs
@@ -36,10 +36,12 @@ namespace Elsa.Bpmn.Hosting;
 /// </remarks>
 internal sealed class BpmnScopeVariables(ActivityExecutionContext context) : IBpmnVariableReader
 {
-    private static readonly JsonSerializerOptions SerializerOptions = new(JsonSerializerDefaults.General);
-
     /// <summary>A value this host holds but cannot represent inline.</summary>
     private static readonly BpmnValue Unrepresentable = new(BpmnValuePresence.StoredExternally, BpmnValueTypes.Any, null);
+
+    // Resolved once per snapshot, not per TryRead: GetOptions() rebuilds the converter list on every call, and the
+    // interpreter calls this port once per variable it needs.
+    private readonly Lazy<JsonSerializerOptions> _serializerOptions = new(() => context.GetRequiredService<IPayloadSerializer>().GetOptions());
 
     /// <inheritdoc />
     public bool TryRead(string name, out BpmnValue value)
@@ -64,14 +66,21 @@ internal sealed class BpmnScopeVariables(ActivityExecutionContext context) : IBp
     /// anything Elsa can hold that JSON cannot carry is reported as held outside the payload rather than as absent
     /// or null.
     /// </summary>
-    private static BpmnValue Represent(object? value)
+    private BpmnValue Represent(object? value)
     {
         if (value is null)
             return BpmnValue.Null;
 
         try
         {
-            return BpmnValue.From(JsonSerializer.SerializeToElement(value, SerializerOptions), TypeHintOf(value));
+            // Serialized against the value's own runtime type, not against the declared `object`: the declared-type
+            // overload is what routes through PolymorphicObjectConverterFactory, which wraps a boxed array or scalar
+            // in Elsa's own type-tagged envelope — exactly the shape the interpreter, reading plain JSON on its own
+            // wire format, does not expect. Serializing against the runtime type keeps a plain value plain while
+            // still picking up every other converter Elsa registers (TypeJsonConverter, VariableConverterFactory,
+            // enum-as-string, and so on), and still reaches PolymorphicObjectConverterFactory for a value whose
+            // runtime type genuinely is one it claims (ExpandoObject, Dictionary<string, object>).
+            return BpmnValue.From(JsonSerializer.SerializeToElement(value, value.GetType(), _serializerOptions.Value), TypeHintOf(value));
         }
         catch (Exception exception) when (exception is JsonException or NotSupportedException)
         {

--- a/test/integration/Elsa.Bpmn.IntegrationTests/Scenarios/Composition/BpmnCompositionTests.cs
+++ b/test/integration/Elsa.Bpmn.IntegrationTests/Scenarios/Composition/BpmnCompositionTests.cs
@@ -1,0 +1,127 @@
+using Bpmn.Semantics;
+using Elsa.Bpmn.Activities;
+using Elsa.Bpmn.IntegrationTests.Scenarios.HostPort;
+using Elsa.Bpmn.IntegrationTests.Scenarios.HostPort.Activities;
+using Elsa.Common.Models;
+using Elsa.Workflows;
+using Elsa.Workflows.Activities.Flowchart.Activities;
+using Elsa.Workflows.Activities.Flowchart.Models;
+using Elsa.Workflows.IncidentStrategies;
+using Xunit.Abstractions;
+
+namespace Elsa.Bpmn.IntegrationTests.Scenarios.Composition;
+
+/// <summary>
+/// A <see cref="BpmnProcess"/> has to work wherever an activity works — nested in another BPMN scope, and (D11)
+/// composed into a <c>Flowchart</c> — and it has to stay a nested scope when it is one.
+/// </summary>
+public class BpmnCompositionTests(ITestOutputHelper testOutputHelper)
+{
+    private readonly BpmnTestHost _host = new(testOutputHelper);
+
+    [Fact(DisplayName = "A BPMN process composed into a flowchart runs, and the flowchart continues after it")]
+    public async Task BpmnProcessInsideAFlowchart_RunsAndTheFlowchartCarriesOn()
+    {
+        // The runtime machinery is the same in a flowchart as it is under another scope: the process schedules its own
+        // work, completes when the interpreter says so, and reports the outcome the flowchart selects a connection on.
+
+        // Arrange
+        var before = Work("before");
+        var process = BpmnTestProcesses.LinearTask(_host.Log);
+        var after = Work("after-process");
+
+        var flowchart = new Flowchart
+        {
+            Start = before,
+            Activities = { before, process, after },
+            Connections =
+            {
+                new Connection(new Endpoint(before, DoneOutcome), new Endpoint(process)),
+                // Selected on the BPMN outcome the scope completes with, which is the interpreter's, not Elsa's default.
+                new Connection(new Endpoint(process, BpmnInterpreter.DoneOutcomeName), new Endpoint(after))
+            }
+        };
+
+        // Act
+        var result = await _host.RunAsync(flowchart);
+
+        // Assert: the flowchart ran into the process, the process ran its own work, and the flowchart went on.
+        Assert.Equal(["executed:before", "executed:only", "executed:after-process"], _host.Log.Entries);
+        Assert.Equal(WorkflowSubStatus.Finished, result.WorkflowState.SubStatus);
+    }
+
+    [Fact(DisplayName = "A nested scope runs with the trigger opt-out off, which is its default")]
+    public async Task NestedScope_RunsWithTheTriggerOptOutOff()
+    {
+        // The direction that could be mistaken for success: this is the ordinary case, and it must stay ordinary.
+        // Every nested scope in this suite is built without touching the flag, so if the default ever moved, the
+        // refusal below would fire here and in every other nested-scope test rather than nowhere.
+
+        // Arrange
+        var process = BpmnTestProcesses.NestedSubprocess(_host.Log);
+
+        // Assert: nothing set it, and nothing inferred it.
+        Assert.False(NestedScopeOf(process).IsRootScope);
+
+        // Act
+        var result = await _host.RunAsync(process);
+
+        // Assert
+        Assert.Equal(["executed:subOnly", "executed:after"], _host.Log.Entries);
+        Assert.Equal(WorkflowSubStatus.Finished, result.WorkflowState.SubStatus);
+    }
+
+    [Fact(DisplayName = "A nested scope that claims root position is refused, naming it")]
+    public async Task NestedScopeClaimingRootPosition_IsRefused()
+    {
+        // A subprocess body marked as able to start the workflow has already had its start events indexed as ways
+        // into the workflow. The host cannot undo that, so it refuses to run the graph rather than papering over it:
+        // the alternative is a workflow that runs perfectly while a subprocess quietly answers external messages.
+
+        // Arrange
+        var process = BpmnTestProcesses.NestedSubprocess(_host.Log);
+        NestedScopeOf(process).IsRootScope = true;
+
+        // Act
+        var result = await _host.RunAsync(process, typeof(FaultStrategy));
+
+        // Assert: the scope faulted before starting the nested work...
+        Assert.DoesNotContain("executed:subOnly", _host.Log.Entries);
+        Assert.Equal(WorkflowSubStatus.Faulted, result.WorkflowState.SubStatus);
+
+        // ...and said which activity, and why.
+        var incident = Assert.Single(result.WorkflowState.Incidents);
+        Assert.Contains("sub", incident.Exception!.Message);
+        Assert.Contains("root scope", incident.Exception.Message);
+    }
+
+    [Fact(DisplayName = "A root scope that claims root position runs")]
+    public async Task RootScopeClaimingRootPosition_Runs()
+    {
+        // The refusal is about nesting, not about the flag: the root process is exactly where the flag belongs, and
+        // a guard that fired on it would make the flag unusable for what it is for.
+
+        // Arrange
+        var process = BpmnTestProcesses.NestedSubprocess(_host.Log);
+        process.IsRootScope = true;
+
+        // Act
+        var result = await _host.RunAsync(process);
+
+        // Assert
+        Assert.Equal(["executed:subOnly", "executed:after"], _host.Log.Entries);
+        Assert.Equal(WorkflowSubStatus.Finished, result.WorkflowState.SubStatus);
+    }
+
+    /// <summary>The one nested BPMN scope of the given process.</summary>
+    private static BpmnProcess NestedScopeOf(BpmnProcess process) => process.Activities.OfType<BpmnProcess>().Single();
+
+    private BpmnTestWork Work(string id) => new()
+    {
+        Id = id,
+        Log = _host.Log
+    };
+
+    /// <summary>The port an ordinary Elsa activity's completion selects.</summary>
+    private const string DoneOutcome = "Done";
+}

--- a/test/integration/Elsa.Bpmn.IntegrationTests/Scenarios/HostPort/BpmnProcessTests.cs
+++ b/test/integration/Elsa.Bpmn.IntegrationTests/Scenarios/HostPort/BpmnProcessTests.cs
@@ -107,6 +107,45 @@ public class BpmnProcessTests(ITestOutputHelper testOutputHelper)
         Assert.Equal(WorkflowSubStatus.Finished, result.WorkflowState.SubStatus);
     }
 
+    [Fact(DisplayName = "A collection-mode multi-instance runs one instance per item of a container-scoped variable")]
+    public async Task CollectionMultiInstance_ReadsTheScopeVariable()
+    {
+        // Two things at once, and both fail loudly rather than quietly. If the host did not declare ScopeVariables,
+        // BpmnGraph.Build would refuse the definition outright. If it declared the capability but its reader could
+        // not answer, the interpreter would resolve an absent or null collection to an empty loop: "each" would never
+        // run, "after" would run anyway, and the workflow would finish looking perfectly healthy.
+
+        // Act
+        var result = await _host.RunAsync(BpmnTestProcesses.CollectionMultiInstanceTask(_host.Log));
+
+        // Assert
+        Assert.Equal(3, _host.Log.Occurrences("executed:each"));
+        Assert.Equal(1, _host.Log.Occurrences("executed:after"));
+        Assert.Equal(WorkflowSubStatus.Finished, result.WorkflowState.SubStatus);
+    }
+
+    [Fact(DisplayName = "A nested scope completing with a non-Done outcome reaches its parent's completion callback with that outcome intact")]
+    public async Task CancelledTransactionSubprocess_DeliversTheCancelledOutcomeToTheEnclosingScope()
+    {
+        // The case to write first. A nested scope's outcome is not decoration: the transaction completes 'Cancelled'
+        // instead of 'Done', and the enclosing scope routes the cancel boundary event only because that name arrives
+        // intact on the completion callback. Drop it anywhere on the way — at CompleteActivityAsync, or when the
+        // callback turns the result back into outcome names — and the parent takes the ordinary sequence flow and
+        // finishes successfully, which is the shape of failure this test exists to catch.
+
+        // Act
+        var result = await _host.RunAsync(BpmnTestProcesses.CancelledTransactionSubprocess(_host.Log));
+
+        // Assert: the cancellation path ran...
+        Assert.Contains("executed:unwind", _host.Log.Entries);
+
+        // ...and the ordinary path the 'Done' outcome would have taken did not.
+        Assert.DoesNotContain("executed:after", _host.Log.Entries);
+
+        Assert.Empty(result.WorkflowState.Incidents);
+        Assert.Equal(WorkflowSubStatus.Finished, result.WorkflowState.SubStatus);
+    }
+
     [Fact(DisplayName = "An uncaught error propagates and is left to the incident strategy")]
     public async Task UncaughtError_PropagatesToTheIncidentStrategy()
     {

--- a/test/integration/Elsa.Bpmn.IntegrationTests/Scenarios/HostPort/BpmnTestProcesses.cs
+++ b/test/integration/Elsa.Bpmn.IntegrationTests/Scenarios/HostPort/BpmnTestProcesses.cs
@@ -2,6 +2,7 @@ using Bpmn.Model;
 using Elsa.Bpmn.Activities;
 using Elsa.Bpmn.IntegrationTests.Scenarios.HostPort.Activities;
 using Elsa.Workflows;
+using Elsa.Workflows.Memory;
 
 namespace Elsa.Bpmn.IntegrationTests.Scenarios.HostPort;
 
@@ -167,6 +168,88 @@ internal static class BpmnTestProcesses
         return Scope("scope", definition, Blocking("each", log), Immediate("after", log));
     }
 
+    /// <summary>
+    /// A collection-mode multi-instance task: one instance per item of a container-scoped variable, which the
+    /// interpreter reads back through <c>IBpmnVariableReader</c> while it evaluates.
+    /// </summary>
+    /// <remarks>
+    /// Three items rather than two, so the instance count cannot be confused with a declared cardinality. The
+    /// collection variable is declared on both sides — on the definition, because <c>BpmnGraph.Build</c> refuses a
+    /// loop naming a variable the process does not declare, and on the activity, because that is where the value
+    /// actually lives.
+    /// </remarks>
+    public static BpmnProcess CollectionMultiInstanceTask(BpmnTestLog log)
+    {
+        var definition = new BpmnProcessBuilder("collection-multi-instance-task")
+            .Variable(CollectionVariableName)
+            .StartEvent("start")
+            .Task(BpmnElementTypes.Task, "each", bindingRef: BindingRef("each"), loopCharacteristics: new BpmnLoopCharacteristics(isSequential: false, collectionVariable: CollectionVariableName))
+            .Task("after", bindingRef: BindingRef("after"))
+            .EndEvent("end")
+            .ConnectSequence("start", "each", "after", "end")
+            .Build();
+
+        return Scope("scope", definition, [new Variable<string[]>(CollectionVariableName, ["alpha", "beta", "gamma"])], Immediate("each", log), Immediate("after", log));
+    }
+
+    /// <summary>
+    /// A transaction subprocess that cancels itself from the inside, and a cancel boundary event on the transaction
+    /// that routes the cancellation.
+    /// </summary>
+    /// <remarks>
+    /// The nested scope completes with the <c>Cancelled</c> outcome rather than <c>Done</c>, and the enclosing scope
+    /// only reaches the boundary path if that outcome survives the trip through the parent's completion callback.
+    /// Nothing else in the process distinguishes the two: with the outcome dropped the parent simply carries on down
+    /// the ordinary sequence flow, which is a completion that looks entirely successful.
+    /// </remarks>
+    public static BpmnProcess CancelledTransactionSubprocess(BpmnTestLog log)
+    {
+        var body = new BpmnProcessBuilder("transaction-body")
+            .Transaction()
+            .StartEvent("subStart")
+            .Task("subWork", bindingRef: BindingRef("subWork"))
+            .EndEvent("subCancelled", null, Cancel())
+            .ConnectSequence("subStart", "subWork", "subCancelled")
+            .Build();
+
+        var definition = new BpmnProcessBuilder("cancelled-transaction-subprocess")
+            .StartEvent("start")
+            .SubProcess("sub", bindingRef: BindingRef("sub"), isTransaction: true)
+            .Task("after", bindingRef: BindingRef("after"))
+            .EndEvent("end")
+            .BoundaryEvent("cancelled", attachedTo: "sub", eventDefinition: Cancel())
+            .Task("unwind", bindingRef: BindingRef("unwind"))
+            .EndEvent("unwound")
+            .ConnectSequence("start", "sub", "after", "end")
+            .ConnectSequence("cancelled", "unwind", "unwound")
+            .Build();
+
+        var nested = Scope("sub", body, Immediate("subWork", log));
+
+        return Scope("scope", definition, nested, Immediate("after", log), Immediate("unwind", log));
+    }
+
+    /// <summary>An embedded subprocess with one task in it, and one task after it in the enclosing scope.</summary>
+    public static BpmnProcess NestedSubprocess(BpmnTestLog log)
+    {
+        var body = new BpmnProcessBuilder("nested-subprocess-body")
+            .StartEvent("subStart")
+            .Task("subOnly", bindingRef: BindingRef("subOnly"))
+            .EndEvent("subEnd")
+            .ConnectSequence("subStart", "subOnly", "subEnd")
+            .Build();
+
+        var definition = new BpmnProcessBuilder("nested-subprocess")
+            .StartEvent("start")
+            .SubProcess("sub", bindingRef: BindingRef("sub"))
+            .Task("after", bindingRef: BindingRef("after"))
+            .EndEvent("end")
+            .ConnectSequence("start", "sub", "after", "end")
+            .Build();
+
+        return Scope("scope", definition, Scope("sub", body, Immediate("subOnly", log)), Immediate("after", log));
+    }
+
     /// <summary>A linear process: one task between a start and an end event.</summary>
     public static BpmnProcess LinearTask(BpmnTestLog log)
     {
@@ -183,15 +266,23 @@ internal static class BpmnTestProcesses
     /// <summary>The binding ref the given element's work is declared under.</summary>
     public static string BindingRef(string elementId) => $"node-{elementId}";
 
+    /// <summary>The name of the variable <see cref="CollectionMultiInstanceTask"/> loops over.</summary>
+    public const string CollectionVariableName = "items";
+
     private static BpmnEventDefinition Timer() => new(BpmnEventDefinitionTypes.Timer);
+
+    private static BpmnEventDefinition Cancel() => new(BpmnEventDefinitionTypes.Cancel);
 
     private static BpmnEventDefinition Escalation(string code) =>
         new(BpmnEventDefinitionTypes.Escalation, new Dictionary<string, string>(StringComparer.Ordinal) { [BpmnEventDefinitionProperties.Code] = code });
 
-    private static BpmnProcess Scope(string id, BpmnProcessDefinition definition, params IActivity[] work) => new()
+    private static BpmnProcess Scope(string id, BpmnProcessDefinition definition, params IActivity[] work) => Scope(id, definition, [], work);
+
+    private static BpmnProcess Scope(string id, BpmnProcessDefinition definition, Variable[] variables, params IActivity[] work) => new()
     {
         Id = id,
         Process = definition,
+        Variables = variables.ToList(),
         Activities = work.ToList(),
         WorkBindings = work.ToDictionary(activity => BindingRef(activity.Id), activity => activity.Id, StringComparer.Ordinal)
     };

--- a/test/unit/Elsa.Bpmn.UnitTests/BpmnCommandApplierTests.cs
+++ b/test/unit/Elsa.Bpmn.UnitTests/BpmnCommandApplierTests.cs
@@ -1,0 +1,75 @@
+using System.Collections.Generic;
+using Bpmn.Semantics;
+using Elsa.Bpmn.Activities;
+using Elsa.Bpmn.Hosting;
+using Elsa.Testing.Shared;
+using Elsa.Workflows;
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Models;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Elsa.Bpmn.UnitTests;
+
+/// <summary>
+/// Covers the root-position refusal in <see cref="BpmnCommandApplier.ApplyAsync"/>: a <c>StartWork</c> command bound
+/// to a nested <see cref="BpmnProcess"/> that (mis)declares itself the workflow's root scope must be refused before
+/// any command in the same batch is applied — not mid-list, after earlier commands already mutated and saved scope
+/// memory. Under <c>ContinueWithIncidentsStrategy</c> the throw is absorbed into an incident rather than surfaced, so
+/// a partial application would otherwise leave the scope silently half-mutated.
+/// </summary>
+public class BpmnCommandApplierTests
+{
+    private const string OrdinaryActivityId = "ordinary-activity";
+    private const string NestedProcessActivityId = "nested-activity";
+
+    [Fact]
+    public async Task ApplyAsync_RefusesTheWholeBatch_WhenALaterCommandBindsARootScopeProcess()
+    {
+        var (scopeContext, process) = await BuildScopeAsync();
+        var memory = BpmnScopeMemory.Load(scopeContext);
+        var applier = new BpmnCommandApplier(scopeContext, process, memory);
+
+        var commands = new BpmnHostCommand[]
+        {
+            new BpmnHostCommand.StartWork("ordinary-binding", "ordinary-element", "token-1", "cause", new Dictionary<string, string>(), null, null),
+            new BpmnHostCommand.StartWork("nested-binding", "nested-element", "token-2", "cause", new Dictionary<string, string>(), null, null)
+        };
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => applier.ApplyAsync(commands).AsTask());
+
+        Assert.Contains(NestedProcessActivityId, exception.Message);
+
+        // The earlier command in the same batch — the ordinary StartWork — must not have been applied: no work
+        // record persisted, and no child context created for it.
+        var reloaded = BpmnScopeMemory.Load(scopeContext);
+        Assert.Empty(reloaded.Work.Records);
+        Assert.DoesNotContain(scopeContext.WorkflowExecutionContext.ActivityExecutionContexts, context => context.Activity.Id == OrdinaryActivityId);
+    }
+
+    private static async Task<(ActivityExecutionContext ScopeContext, BpmnProcess Process)> BuildScopeAsync()
+    {
+        var ordinaryActivity = new WriteLine("ordinary") { Id = OrdinaryActivityId };
+        var nestedProcess = new BpmnProcess { Id = NestedProcessActivityId, IsRootScope = true };
+        var process = new BpmnProcess
+        {
+            Id = "process-activity",
+            Activities = { ordinaryActivity, nestedProcess },
+            WorkBindings = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["ordinary-binding"] = OrdinaryActivityId,
+                ["nested-binding"] = NestedProcessActivityId
+            }
+        };
+
+        var fixture = new ActivityTestFixture(process);
+        fixture.ConfigureServices(services => services.AddSingleton<IIdentityGenerator, GuidIdentityGenerator>());
+
+        var scopeContext = await fixture.BuildAsync();
+        var workflowExecutionContext = scopeContext.WorkflowExecutionContext;
+
+        await workflowExecutionContext.ActivityRegistry.RegisterAsync(typeof(WriteLine));
+        await workflowExecutionContext.ActivityRegistry.RegisterAsync(typeof(BpmnProcess));
+
+        return (scopeContext, process);
+    }
+}

--- a/test/unit/Elsa.Bpmn.UnitTests/BpmnScopeVariablesTests.cs
+++ b/test/unit/Elsa.Bpmn.UnitTests/BpmnScopeVariablesTests.cs
@@ -1,0 +1,114 @@
+using System.Text.Json;
+using Bpmn.Model;
+using Elsa.Bpmn.Activities;
+using Elsa.Bpmn.Hosting;
+using Elsa.Testing.Shared;
+using Elsa.Workflows;
+using Elsa.Workflows.Memory;
+
+namespace Elsa.Bpmn.UnitTests;
+
+/// <summary>
+/// The one callback the interpreter makes into the host, and the three answers it distinguishes. The third —
+/// "I have it and cannot give it to you" — is the one worth having: reported as null or absent instead, a
+/// collection-mode multi-instance resolves to zero instances and the process completes as though there had been
+/// nothing to do.
+/// </summary>
+public class BpmnScopeVariablesTests
+{
+    [Fact(DisplayName = "A variable nothing in scope declares reads as absent")]
+    public async Task TryRead_ReturnsFalse_ForAnUndeclaredVariable()
+    {
+        var variables = await ReaderForAsync(new Variable<string>("declared", "value"));
+
+        Assert.False(variables.TryRead("undeclared", out var value));
+        Assert.Equal(BpmnValuePresence.Absent, value.Presence);
+    }
+
+    [Fact(DisplayName = "A declared variable holding null reads as present-and-null, not as absent")]
+    public async Task TryRead_ReturnsNull_ForADeclaredVariableHoldingNull()
+    {
+        var variables = await ReaderForAsync(new Variable<string?>("empty", null));
+
+        Assert.True(variables.TryRead("empty", out var value));
+        Assert.Equal(BpmnValuePresence.Null, value.Presence);
+    }
+
+    [Fact(DisplayName = "A declared variable holding a value reads as present, inline")]
+    public async Task TryRead_ReturnsThePayload_ForADeclaredVariableHoldingAValue()
+    {
+        var variables = await ReaderForAsync(new Variable<string[]>("items", ["alpha", "beta"]));
+
+        Assert.True(variables.TryRead("items", out var value));
+        Assert.Equal(BpmnValuePresence.Present, value.Presence);
+        Assert.True(value.HasValue);
+        Assert.Equal(JsonValueKind.Array, value.Json!.Value.ValueKind);
+        Assert.Equal(["alpha", "beta"], value.Json.Value.EnumerateArray().Select(item => item.GetString()));
+    }
+
+    [Fact(DisplayName = "An integer carries the type hint the interpreter understands")]
+    public async Task TryRead_HintsInteger_ForAWholeNumber()
+    {
+        var variables = await ReaderForAsync(new Variable<int>("count", 3));
+
+        Assert.True(variables.TryRead("count", out var value));
+        Assert.Equal(BpmnValueTypes.Integer, value.TypeHint);
+    }
+
+    [Fact(DisplayName = "A value that cannot cross the port inline reads as stored externally, not as null")]
+    public async Task TryRead_ReturnsStoredExternally_ForAValueJsonCannotCarry()
+    {
+        // A cyclic object graph is the everyday version of this: a node holding its parent. The variable is neither
+        // missing nor null, and saying either would be a quiet wrong answer — the interpreter treats
+        // StoredExternally as unreadable and faults, naming the element that asked.
+        var cyclic = new SelfReferencing();
+        cyclic.Self = cyclic;
+
+        var variables = await ReaderForAsync(new Variable<SelfReferencing>("cyclic", cyclic));
+
+        Assert.True(variables.TryRead("cyclic", out var value));
+        Assert.Equal(BpmnValuePresence.StoredExternally, value.Presence);
+        Assert.False(value.HasValue);
+    }
+
+    [Fact(DisplayName = "A variable declared by an enclosing scope is visible to the scope inside it")]
+    public async Task TryRead_WalksOutward_ForAVariableOfAnEnclosingScope()
+    {
+        // BPMN data scoping and Elsa's agree: an inner scope sees the enclosing scope's variables.
+        var outerVariable = new Variable<string>("outer", "value");
+        var inner = new BpmnProcess { Id = "inner" };
+        var outer = new BpmnProcess { Id = "outer", Variables = { outerVariable }, Activities = { inner } };
+
+        var outerContext = await new ActivityTestFixture(outer).BuildAsync();
+        outerContext.ExpressionExecutionContext.Memory.Declare(outer.Variables);
+
+        var workflowExecutionContext = outerContext.WorkflowExecutionContext;
+        await workflowExecutionContext.ActivityRegistry.RegisterAsync(typeof(BpmnProcess));
+        var innerContext = await workflowExecutionContext.CreateActivityExecutionContextAsync(inner, new() { Owner = outerContext });
+
+        Assert.True(new BpmnScopeVariables(innerContext).TryRead("outer", out var value));
+        Assert.Equal(BpmnValuePresence.Present, value.Presence);
+    }
+
+    /// <summary>
+    /// A reader over a scope declaring the given variables, exactly as <c>Container.ExecuteAsync</c> declares them
+    /// before scheduling anything.
+    /// </summary>
+    private static async Task<BpmnScopeVariables> ReaderForAsync(params Variable[] variables)
+    {
+        var process = new BpmnProcess { Id = "scope" };
+
+        foreach (var variable in variables)
+            process.Variables.Add(variable);
+
+        var context = await new ActivityTestFixture(process).BuildAsync();
+        context.ExpressionExecutionContext.Memory.Declare(process.Variables);
+
+        return new(context);
+    }
+
+    private sealed class SelfReferencing
+    {
+        public SelfReferencing? Self { get; set; }
+    }
+}

--- a/test/unit/Elsa.Bpmn.UnitTests/BpmnScopeVariablesTests.cs
+++ b/test/unit/Elsa.Bpmn.UnitTests/BpmnScopeVariablesTests.cs
@@ -71,6 +71,19 @@ public class BpmnScopeVariablesTests
         Assert.False(value.HasValue);
     }
 
+    [Fact(DisplayName = "A value bare JsonSerializerDefaults cannot serialize, but Elsa's configured serializer can, reads as present")]
+    public async Task TryRead_ReturnsThePayload_ForAValueOnlyElsasSerializerCanCarry()
+    {
+        // System.Text.Json refuses to serialize a System.Type instance under bare defaults — it throws
+        // NotSupportedException. Elsa's configured serializer carries it via TypeJsonConverter. A reader using bare
+        // defaults collapses this to StoredExternally even though Elsa can hand the value over intact.
+        var variables = await ReaderForAsync(new Variable<Type>("clrType", typeof(string)));
+
+        Assert.True(variables.TryRead("clrType", out var value));
+        Assert.Equal(BpmnValuePresence.Present, value.Presence);
+        Assert.True(value.HasValue);
+    }
+
     [Fact(DisplayName = "A variable declared by an enclosing scope is visible to the scope inside it")]
     public async Task TryRead_WalksOutward_ForAVariableOfAnEnclosingScope()
     {


### PR DESCRIPTION
Completes the `BpmnProcess` container that #7925 deliberately left minimal.

Closes #7926.

## What this adds

- **A three-valued `IBpmnVariableReader`**, and `ScopeVariables` now declared. W2 passed `BpmnNoVariables.Instance` and omitted the capability, because declaring one the host cannot honour is exactly what `BpmnGraph.Build` refuses definitions over.
- **The trigger opt-out**, reusing Elsa's existing `CanStartWorkflow` (default `false`) rather than adding a second flag that could disagree with the gate `TriggerIndexer` reads. `ITrigger` itself is #7929.
- **`Flowchart` composability (D11)**, proven end to end through `IWorkflowRunner`.
- **The non-`Done` outcome path** the issue names as the case to write first: a cancelled transaction subprocess delivering `Cancelled` to its enclosing scope, asserted through the cancel-boundary routing so only the intact outcome name can produce the observed result.

## A correction to D7

The issue justifies the third value like this:

> `LoadVariablesAsync` takes an `excludeTags` filter and a host that excluded a tag would leave those variables unmaterialized, where `StoredExternally` is the correct answer rather than "absent".

**That case is not detectable, and cannot arise on any execution path.** Both verified:

1. In `VariablePersistenceManager.LoadVariablesAsync`, `block.Metadata = metadata with { IsInitialized = true }` runs **before** both the `driver == null` check and the `excludeTags` check. A tag-excluded variable's block is therefore identical to one whose driver returned null, and nothing else records the exclusion — `excludeTags` is a parameter, not state.
2. The only caller that passes `excludeTags` is `DefaultWorkflowInstanceVariableReader`, an out-of-band management read that never runs the pipeline. `PersistentVariablesMiddleware` and `BackgroundActivityInvoker` — the two execution paths — pass none.

Detecting it would need a change to `Elsa.Workflows.Core` (recording the skip on the block), which is out of bounds here. So the reader implements the three-valued read but reaches `StoredExternally` on the one route it can honestly detect: a value this host holds and JSON cannot carry. That is the same "I have it and cannot give it to you" answer, and the port already treats it correctly — `Bpmn.Semantics`' own docs say a value held outside the inline payload produces a deterministic fault, while a null or absent collection resolves to an empty snapshot. So a collection-mode multi-instance still faults rather than silently iterating zero times, which is the whole point of the third value. The XML doc says exactly this rather than restating D7.

## Two things review caught that mattered

**Serializing with bare `JsonSerializerOptions` reintroduced the bug the reader exists to prevent.** A value Elsa can serialize fine through its own converters — polymorphic types, `ExpandoObject`, anything needing `TypeJsonConverter` — threw with bare defaults and collapsed into `StoredExternally`, faulting a multi-instance over a collection Elsa could have handed over intact. Now serialized through `IPayloadSerializer`.

There is a subtlety worth recording: serializing against the declared `object` type routes everything through `PolymorphicObjectConverterFactory`, which wraps plain arrays in Elsa's `_items`/`_type` envelope and breaks the interpreter's expectation of plain JSON. Serializing against the value's **runtime** type keeps concrete values plain while still enabling `TypeJsonConverter`, `VariableConverterFactory`, camelCase and the rest. A pre-existing array test caught the wrong version.

**The root-position refusal threw mid-batch.** It fired part-way through applying a command list, after earlier commands had been applied and persisted. That matters because of what review established on #7925: under `ContinueWithIncidentsStrategy` a throw is absorbed into an incident, so the scope would carry on with a half-applied batch and half-saved memory. The check now runs before any command in the batch is applied.

## Verification

| Command | Result |
| --- | --- |
| `dotnet build Elsa.sln` | pass |
| `dotnet test test/unit/Elsa.Bpmn.UnitTests` | pass 16/16 (was 8) |
| `dotnet test test/integration/Elsa.Bpmn.IntegrationTests` | pass 20/20 (was 14) |
| `dotnet test test/unit/Elsa.Bpmn.Interchange.UnitTests` | pass 5/5 (duplication guard) |

### Mutation testing — nine mutations, all red

| Mutation | Result |
| --- | --- |
| `TryRead` returns true for an undeclared variable | RED |
| `Represent` returns `Null` instead of `StoredExternally` | RED |
| Snapshot left passing `BpmnNoVariables.Instance` | RED |
| `IsRootScope` default flipped to true | RED — 7 tests |
| `CompleteActivityAsync()` without the outcome (outbound) | RED |
| Completion callback discards outcome names (inbound) | RED |
| Nested-root refusal disabled | RED |
| Variable serialization reverted to bare options | RED |
| Refusal moved back inline (mid-batch) | RED |

### One file outside the module, and why

`src/common/Elsa.Testing.Shared/ActivityTestFixture.cs` gained three additive service registrations (`AddOptions`, `ISerializationTypeRegistry`, `IPayloadSerializer`), mirroring `WorkflowsFeature`'s own wiring, because the reader now resolves `IPayloadSerializer` from the context. Test-only infrastructure, nothing shipped.

Since that is shared infrastructure, the targeted runs were not sufficient. Every test project that uses the fixture was run: `Elsa.Activities.UnitTests` 411, `Elsa.Workflows.Core.UnitTests` 258, `Elsa.Workflows.Runtime.UnitTests` 250, `Elsa.Workflows.IntegrationTests` 285, `Elsa.Scheduling.UnitTests` 46, `Elsa.Diagnostics.ConsoleLogs.UnitTests` 23, `Elsa.Expressions.UnitTests` 20 — **1,293 tests, all passing**.

`Elsa.Workflows.Core` itself is untouched.

## Carried past the gate as won't-fix

The root-position refusal inspects work bound directly to the enclosing BPMN scope, so a `BpmnProcess` nested via an intermediate `Flowchart` inside another `BpmnProcess` is not checked. Real, and currently unreachable in-repo since nothing sets root position except tests and the not-yet-written binder — it is the "flowchart composition sets the flag" half of #7929 and is recorded there.

Separately, `BpmnProcess` now documents an asymmetry composers need to know: it completes with the interpreter's outcome only (`Outcomes("Done")`), not `Outcomes.Default`, so a default/null-port `Connection` silently never fires from it. Adding a null outcome would leak a null outcome name into an enclosing BPMN scope's interpreter call, so this is documented rather than "fixed".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
