### PR TITLE
test(bpmn): prove execution state and the work ledger survive real persistence

### DIFF
--- a/test/integration/Elsa.Bpmn.IntegrationTests/Scenarios/HostPort/BpmnPersistenceTests.cs
+++ b/test/integration/Elsa.Bpmn.IntegrationTests/Scenarios/HostPort/BpmnPersistenceTests.cs
@@ -1,0 +1,89 @@
+using Bpmn.Model.State;
+using Elsa.Workflows;
+using Xunit.Abstractions;
+
+namespace Elsa.Bpmn.IntegrationTests.Scenarios.HostPort;
+
+/// <summary>
+/// What survives a suspend and a resume: the pruned <see cref="BpmnExecutionState"/> and the host-side work ledger,
+/// both persisted as JSON strings in <see cref="ActivityExecutionContext.Properties"/>.
+/// </summary>
+public class BpmnPersistenceTests(ITestOutputHelper testOutputHelper)
+{
+    private readonly BpmnTestHost _host = new(testOutputHelper);
+
+    [Fact(DisplayName = "The persisted execution state stays bounded across many evaluations of one scope")]
+    public async Task PersistedExecutionState_StaysBoundedAcrossManyEvaluations()
+    {
+        // A sequential multi-instance loop drives one evaluation per iteration, all on the same scope. Every
+        // iteration but the last consumes a token that nothing afterward can ever reference again: an interpreter
+        // state that is written without being pruned first re-serializes every one of them, so the token count
+        // grows with the iteration count instead of staying flat.
+
+        const int cardinality = 12;
+
+        // Arrange & Act: run every iteration but the last, capturing the persisted token count while the scope is
+        // still suspended and mid-loop after each one. The scope's own context stops being persisted the moment it
+        // completes, so the last iteration -- which also completes "after" and the scope itself -- is run separately.
+        await _host.RunAsync(BpmnTestProcesses.SequentialMultiInstanceTask(_host.Log, cardinality));
+
+        var maxTokenCount = 0;
+
+        for (var i = 0; i < cardinality - 1; i++)
+        {
+            await _host.FinishWorkAsync("each");
+
+            var (state, _) = _host.PersistedScopeMemory();
+            Assert.NotNull(state);
+            maxTokenCount = Math.Max(maxTokenCount, state.Tokens.Count);
+        }
+
+        await _host.FinishWorkAsync("each");
+
+        // Assert: the loop actually ran to completion...
+        Assert.Equal(cardinality, _host.Log.Occurrences("executed:each"));
+        Assert.Equal(1, _host.Log.Occurrences("executed:after"));
+
+        // ...and the persisted state's token count stayed flat rather than growing with the iteration count. Without
+        // pruning, a consumed token from every prior iteration would still be there by the time the loop is nearly
+        // done, so the count would climb toward the iteration count instead of staying near-constant.
+        Assert.True(
+            maxTokenCount < cardinality,
+            $"Expected the persisted token count to stay well below the iteration count ({cardinality}) because Prune() drops consumed tokens no active work references, but the highest observed count was {maxTokenCount}.");
+    }
+
+    [Fact(DisplayName = "A scope resumed from a JSON round trip matches each completion back to its binding through the rehydrated ledger")]
+    public async Task ResumedScope_WithTwoUnitsOfLiveWork_MatchesEachCompletionToItsBindingThroughTheRehydratedLedger()
+    {
+        // Arrange: suspend with two live units of work outstanding, both bound under the same scope.
+        await _host.RunAsync(BpmnTestProcesses.ParallelSplitAndJoinBlocking(_host.Log));
+
+        var (_, ledgerBeforeResume) = _host.PersistedScopeMemory();
+        Assert.Equal(2, ledgerBeforeResume.Records.Count);
+        Assert.Contains(ledgerBeforeResume.Records, x => x.BindingRef == BpmnTestProcesses.BindingRef("left"));
+        Assert.Contains(ledgerBeforeResume.Records, x => x.BindingRef == BpmnTestProcesses.BindingRef("right"));
+
+        // Act: round-trip the workflow state through Elsa's own serializer -- what a real persistence store would
+        // do -- and resume each branch by name, one at a time, round-tripping again between them.
+        _host.RoundTripStateThroughJson();
+
+        // Assert: the ledger the resumed scope would read from is intact before either branch is even resumed.
+        var (_, ledgerAfterResume) = _host.PersistedScopeMemory();
+        Assert.Equal(2, ledgerAfterResume.Records.Count);
+        Assert.Contains(ledgerAfterResume.Records, x => x.BindingRef == BpmnTestProcesses.BindingRef("left"));
+        Assert.Contains(ledgerAfterResume.Records, x => x.BindingRef == BpmnTestProcesses.BindingRef("right"));
+
+        await _host.FinishWorkAsync("left");
+        _host.RoundTripStateThroughJson();
+        var result = await _host.FinishWorkAsync("right");
+
+        // Assert: both branches ran, and the join fired exactly once. Neither is possible unless the resumed scope's
+        // ledger still mapped each completing child context back to its own binding: a scope with a lost or shared
+        // handle map either drops a completion outright (the join never fires and the workflow never finishes) or
+        // cannot tell the two branches apart (the join fires more than once).
+        Assert.Contains("resumed:left", _host.Log.Entries);
+        Assert.Contains("resumed:right", _host.Log.Entries);
+        Assert.Equal(1, _host.Log.Occurrences("executed:after"));
+        Assert.Equal(WorkflowSubStatus.Finished, result.WorkflowState.SubStatus);
+    }
+}

--- a/test/integration/Elsa.Bpmn.IntegrationTests/Scenarios/HostPort/BpmnPersistenceTests.cs
+++ b/test/integration/Elsa.Bpmn.IntegrationTests/Scenarios/HostPort/BpmnPersistenceTests.cs
@@ -86,4 +86,43 @@ public class BpmnPersistenceTests(ITestOutputHelper testOutputHelper)
         Assert.Equal(1, _host.Log.Occurrences("executed:after"));
         Assert.Equal(WorkflowSubStatus.Finished, result.WorkflowState.SubStatus);
     }
+
+    [Fact(DisplayName = "A nested scope resumed from a JSON round trip matches each completion back to its binding through its own rehydrated ledger")]
+    public async Task ResumedNestedScope_WithTwoUnitsOfLiveWork_MatchesEachCompletionToItsBindingThroughTheRehydratedLedger()
+    {
+        // Arrange: suspend with two live units of work outstanding inside the nested scope -- the embedded
+        // subprocess -- while the root scope's own ledger holds only the subprocess itself.
+        await _host.RunAsync(BpmnTestProcesses.NestedParallelSplitAndJoinBlocking(_host.Log));
+
+        var (_, nestedLedgerBeforeResume) = _host.PersistedScopeMemory(nested: true);
+        Assert.Equal(2, nestedLedgerBeforeResume.Records.Count);
+        Assert.Contains(nestedLedgerBeforeResume.Records, x => x.BindingRef == BpmnTestProcesses.BindingRef("subLeft"));
+        Assert.Contains(nestedLedgerBeforeResume.Records, x => x.BindingRef == BpmnTestProcesses.BindingRef("subRight"));
+
+        // Act: round-trip the workflow state through Elsa's own serializer, then resume each branch by name, one at
+        // a time, round-tripping again between them -- exactly as the root-scope test above does, but crossing into
+        // the nested scope's own ledger instead of the root's.
+        _host.RoundTripStateThroughJson();
+
+        // Assert: the nested scope's own ledger is intact before either branch is even resumed.
+        var (_, nestedLedgerAfterResume) = _host.PersistedScopeMemory(nested: true);
+        Assert.Equal(2, nestedLedgerAfterResume.Records.Count);
+        Assert.Contains(nestedLedgerAfterResume.Records, x => x.BindingRef == BpmnTestProcesses.BindingRef("subLeft"));
+        Assert.Contains(nestedLedgerAfterResume.Records, x => x.BindingRef == BpmnTestProcesses.BindingRef("subRight"));
+
+        await _host.FinishWorkAsync("subLeft");
+        _host.RoundTripStateThroughJson();
+        var result = await _host.FinishWorkAsync("subRight");
+
+        // Assert: both branches ran, the nested join fired exactly once, and the process ran all the way out to the
+        // root scope's own "after" step and completion. None of this is possible unless the resumed nested scope's
+        // ledger still mapped each completing child context back to its own binding: a nested scope with a lost or
+        // shared handle map either drops a completion outright (the nested join never fires and the process never
+        // finishes) or cannot tell the two branches apart (the nested join fires more than once).
+        Assert.Contains("resumed:subLeft", _host.Log.Entries);
+        Assert.Contains("resumed:subRight", _host.Log.Entries);
+        Assert.Equal(1, _host.Log.Occurrences("executed:subAfter"));
+        Assert.Equal(1, _host.Log.Occurrences("executed:after"));
+        Assert.Equal(WorkflowSubStatus.Finished, result.WorkflowState.SubStatus);
+    }
 }

--- a/test/integration/Elsa.Bpmn.IntegrationTests/Scenarios/HostPort/BpmnTestHost.cs
+++ b/test/integration/Elsa.Bpmn.IntegrationTests/Scenarios/HostPort/BpmnTestHost.cs
@@ -99,14 +99,19 @@ public sealed class BpmnTestHost
     }
 
     /// <summary>
-    /// The one BPMN scope's own memory, read straight off the current <see cref="WorkflowState"/> the way a
-    /// resumed scope itself sees it, rather than off any live <see cref="ActivityExecutionContext"/> the current
-    /// process happens to still hold. Only sound for a process with exactly one BPMN scope.
+    /// A BPMN scope's own memory, read straight off the current <see cref="WorkflowState"/> the way a resumed scope
+    /// itself sees it, rather than off any live <see cref="ActivityExecutionContext"/> the current process happens
+    /// to still hold. Sound for any process with exactly one BPMN scope; a process with a nested scope has two, so
+    /// <paramref name="nested"/> tells them apart by call-stack depth -- the nested scope's context is always
+    /// deeper than the root's.
     /// </summary>
-    internal (BpmnExecutionState? State, BpmnWorkLedger Work) PersistedScopeMemory()
+    internal (BpmnExecutionState? State, BpmnWorkLedger Work) PersistedScopeMemory(bool nested = false)
     {
         var state = _state ?? throw new InvalidOperationException("The workflow has not been run yet.");
-        var scopeState = state.ActivityExecutionContexts.Single(x => x.Properties.ContainsKey(BpmnScopeMemory.WorkLedgerPropertyKey));
+        var scopeStates = state.ActivityExecutionContexts.Where(x => x.Properties.ContainsKey(BpmnScopeMemory.WorkLedgerPropertyKey));
+        var scopeState = nested
+            ? scopeStates.OrderByDescending(x => x.CallStackDepth).First()
+            : scopeStates.OrderBy(x => x.CallStackDepth).First();
 
         var executionStateJson = scopeState.Properties.TryGetValue(BpmnScopeMemory.ExecutionStatePropertyKey, out var value) ? value as string : null;
         var workLedgerJson = (string)scopeState.Properties[BpmnScopeMemory.WorkLedgerPropertyKey];

--- a/test/integration/Elsa.Bpmn.IntegrationTests/Scenarios/HostPort/BpmnTestHost.cs
+++ b/test/integration/Elsa.Bpmn.IntegrationTests/Scenarios/HostPort/BpmnTestHost.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+using Bpmn.Model.State;
 using Elsa.Bpmn.Hosting;
 using Elsa.Bpmn.IntegrationTests.Scenarios.HostPort.Activities;
 using Elsa.Extensions;
@@ -81,6 +83,37 @@ public sealed class BpmnTestHost
         var ledger = BpmnScopeMemory.Read<BpmnWorkLedger>(scopeContext, BpmnScopeMemory.WorkLedgerPropertyKey) ?? new BpmnWorkLedger();
 
         return ledger.Records.Select(record => (record.BindingRef, record.IterationId)).ToList();
+    }
+
+    /// <summary>
+    /// Replaces the current <see cref="WorkflowState"/> with what a round trip through Elsa's own
+    /// <see cref="IWorkflowStateSerializer"/> hands back — what a real persistence store would return on load,
+    /// rather than the exact same in-memory object the previous run produced.
+    /// </summary>
+    public void RoundTripStateThroughJson()
+    {
+        var state = _state ?? throw new InvalidOperationException("The workflow has not been run yet.");
+        var serializer = _services.GetRequiredService<IWorkflowStateSerializer>();
+
+        _state = serializer.Deserialize(serializer.Serialize(state));
+    }
+
+    /// <summary>
+    /// The one BPMN scope's own memory, read straight off the current <see cref="WorkflowState"/> the way a
+    /// resumed scope itself sees it, rather than off any live <see cref="ActivityExecutionContext"/> the current
+    /// process happens to still hold. Only sound for a process with exactly one BPMN scope.
+    /// </summary>
+    internal (BpmnExecutionState? State, BpmnWorkLedger Work) PersistedScopeMemory()
+    {
+        var state = _state ?? throw new InvalidOperationException("The workflow has not been run yet.");
+        var scopeState = state.ActivityExecutionContexts.Single(x => x.Properties.ContainsKey(BpmnScopeMemory.WorkLedgerPropertyKey));
+
+        var executionStateJson = scopeState.Properties.TryGetValue(BpmnScopeMemory.ExecutionStatePropertyKey, out var value) ? value as string : null;
+        var workLedgerJson = (string)scopeState.Properties[BpmnScopeMemory.WorkLedgerPropertyKey];
+
+        return (
+            executionStateJson is null ? null : JsonSerializer.Deserialize<BpmnExecutionState>(executionStateJson),
+            JsonSerializer.Deserialize<BpmnWorkLedger>(workLedgerJson) ?? new BpmnWorkLedger());
     }
 
     private RunWorkflowResult Record(RunWorkflowResult result)

--- a/test/integration/Elsa.Bpmn.IntegrationTests/Scenarios/HostPort/BpmnTestProcesses.cs
+++ b/test/integration/Elsa.Bpmn.IntegrationTests/Scenarios/HostPort/BpmnTestProcesses.cs
@@ -71,26 +71,8 @@ internal static class BpmnTestProcesses
     }
 
     /// <summary>A parallel gateway split and join.</summary>
-    public static BpmnProcess ParallelSplitAndJoin(BpmnTestLog log)
-    {
-        var definition = new BpmnProcessBuilder("parallel-split-and-join")
-            .StartEvent("start")
-            .ParallelGateway("split")
-            .Task("left", bindingRef: BindingRef("left"))
-            .Task("right", bindingRef: BindingRef("right"))
-            .ParallelGateway("join")
-            .Task("after", bindingRef: BindingRef("after"))
-            .EndEvent("end")
-            .ConnectSequence("start", "split")
-            .Connect("split", "left")
-            .Connect("split", "right")
-            .Connect("left", "join")
-            .Connect("right", "join")
-            .ConnectSequence("join", "after", "end")
-            .Build();
-
-        return Scope("scope", definition, Immediate("left", log), Immediate("right", log), Immediate("after", log));
-    }
+    public static BpmnProcess ParallelSplitAndJoin(BpmnTestLog log) =>
+        ParallelSplitAndJoinTopology("parallel-split-and-join", Immediate("left", log), Immediate("right", log), log);
 
     /// <summary>A task that fails, with an error boundary event that catches it.</summary>
     public static BpmnProcess ErrorBoundaryCaught(BpmnTestLog log)
@@ -190,9 +172,16 @@ internal static class BpmnTestProcesses
     /// units of work outstanding and, once resumed, matches each completion back to its own binding through the
     /// rehydrated ledger.
     /// </summary>
-    public static BpmnProcess ParallelSplitAndJoinBlocking(BpmnTestLog log)
+    public static BpmnProcess ParallelSplitAndJoinBlocking(BpmnTestLog log) =>
+        ParallelSplitAndJoinTopology("parallel-split-and-join-blocking", Blocking("left", log), Blocking("right", log), log);
+
+    /// <summary>
+    /// The start/split/left/right/join/after/end graph shared by <see cref="ParallelSplitAndJoin"/> and
+    /// <see cref="ParallelSplitAndJoinBlocking"/>, parameterised by the work the two branches run.
+    /// </summary>
+    private static BpmnProcess ParallelSplitAndJoinTopology(string processId, IActivity leftWork, IActivity rightWork, BpmnTestLog log)
     {
-        var definition = new BpmnProcessBuilder("parallel-split-and-join-blocking")
+        var definition = new BpmnProcessBuilder(processId)
             .StartEvent("start")
             .ParallelGateway("split")
             .Task("left", bindingRef: BindingRef("left"))
@@ -208,7 +197,7 @@ internal static class BpmnTestProcesses
             .ConnectSequence("join", "after", "end")
             .Build();
 
-        return Scope("scope", definition, Blocking("left", log), Blocking("right", log), Immediate("after", log));
+        return Scope("scope", definition, leftWork, rightWork, Immediate("after", log));
     }
 
     /// <summary>
@@ -291,6 +280,42 @@ internal static class BpmnTestProcesses
             .Build();
 
         return Scope("scope", definition, Scope("sub", body, Immediate("subOnly", log)), Immediate("after", log));
+    }
+
+    /// <summary>
+    /// A parallel split and join, blocking on both branches, nested inside an embedded subprocess. Used to prove
+    /// a <em>nested</em> scope's own ledger -- not just a root scope's -- matches each completion back to its
+    /// binding after a round trip through Elsa's own serializer.
+    /// </summary>
+    public static BpmnProcess NestedParallelSplitAndJoinBlocking(BpmnTestLog log)
+    {
+        var body = new BpmnProcessBuilder("nested-parallel-split-and-join-body")
+            .StartEvent("subStart")
+            .ParallelGateway("subSplit")
+            .Task("subLeft", bindingRef: BindingRef("subLeft"))
+            .Task("subRight", bindingRef: BindingRef("subRight"))
+            .ParallelGateway("subJoin")
+            .Task("subAfter", bindingRef: BindingRef("subAfter"))
+            .EndEvent("subEnd")
+            .ConnectSequence("subStart", "subSplit")
+            .Connect("subSplit", "subLeft")
+            .Connect("subSplit", "subRight")
+            .Connect("subLeft", "subJoin")
+            .Connect("subRight", "subJoin")
+            .ConnectSequence("subJoin", "subAfter", "subEnd")
+            .Build();
+
+        var definition = new BpmnProcessBuilder("nested-parallel-split-and-join-blocking")
+            .StartEvent("start")
+            .SubProcess("sub", bindingRef: BindingRef("sub"))
+            .Task("after", bindingRef: BindingRef("after"))
+            .EndEvent("end")
+            .ConnectSequence("start", "sub", "after", "end")
+            .Build();
+
+        var nested = Scope("sub", body, Blocking("subLeft", log), Blocking("subRight", log), Immediate("subAfter", log));
+
+        return Scope("scope", definition, nested, Immediate("after", log));
     }
 
     /// <summary>A linear process: one task between a start and an end event.</summary>

--- a/test/integration/Elsa.Bpmn.IntegrationTests/Scenarios/HostPort/BpmnTestProcesses.cs
+++ b/test/integration/Elsa.Bpmn.IntegrationTests/Scenarios/HostPort/BpmnTestProcesses.cs
@@ -169,6 +169,49 @@ internal static class BpmnTestProcesses
     }
 
     /// <summary>
+    /// A sequential multi-instance task: one instance at a time, each blocking until a test finishes it. Used to
+    /// drive many evaluations of one scope so a persisted blob that is not pruned is observable as unbounded growth.
+    /// </summary>
+    public static BpmnProcess SequentialMultiInstanceTask(BpmnTestLog log, int cardinality)
+    {
+        var definition = new BpmnProcessBuilder("sequential-multi-instance-task")
+            .StartEvent("start")
+            .Task(BpmnElementTypes.Task, "each", bindingRef: BindingRef("each"), loopCharacteristics: new BpmnLoopCharacteristics(isSequential: true, cardinality: cardinality))
+            .Task("after", bindingRef: BindingRef("after"))
+            .EndEvent("end")
+            .ConnectSequence("start", "each", "after", "end")
+            .Build();
+
+        return Scope("scope", definition, Blocking("each", log), Immediate("after", log));
+    }
+
+    /// <summary>
+    /// A parallel split into two branches that both block, and a join. Used to prove a scope suspends with two live
+    /// units of work outstanding and, once resumed, matches each completion back to its own binding through the
+    /// rehydrated ledger.
+    /// </summary>
+    public static BpmnProcess ParallelSplitAndJoinBlocking(BpmnTestLog log)
+    {
+        var definition = new BpmnProcessBuilder("parallel-split-and-join-blocking")
+            .StartEvent("start")
+            .ParallelGateway("split")
+            .Task("left", bindingRef: BindingRef("left"))
+            .Task("right", bindingRef: BindingRef("right"))
+            .ParallelGateway("join")
+            .Task("after", bindingRef: BindingRef("after"))
+            .EndEvent("end")
+            .ConnectSequence("start", "split")
+            .Connect("split", "left")
+            .Connect("split", "right")
+            .Connect("left", "join")
+            .Connect("right", "join")
+            .ConnectSequence("join", "after", "end")
+            .Build();
+
+        return Scope("scope", definition, Blocking("left", log), Blocking("right", log), Immediate("after", log));
+    }
+
+    /// <summary>
     /// A collection-mode multi-instance task: one instance per item of a container-scoped variable, which the
     /// interpreter reads back through <c>IBpmnVariableReader</c> while it evaluates.
     /// </summary>


### PR DESCRIPTION
Proves that BPMN execution state and the host's work ledger survive real persistence. **This PR changes no production code**, and that is the finding rather than a shortcut.

Closes #7928.

## Why there is no production change

Everything #7928 asks for in its implementation half was already delivered by #7925:

- both `Bpmn:ExecutionState` and `Bpmn:WorkLedger` go into `ActivityExecutionContext.Properties` as **serialized JSON strings**, never as live objects — `BpmnScopeMemory.Write<T>` always serializes, `Read<T>` only accepts `value is string`;
- `Prune()` is called before **every** persisted write, at `BpmnScopeHost.cs:155` and `:188` — the shared evaluate path and the fault path, the only two `memory.State =` assignments in the module;
- the handle→context map lives in the ledger, keyed on the child `ActivityExecutionContext.Id`, forced there by the `Tag` trap.

I originally reported on the issue that `Prune()` was never called. That was wrong — I grepped `BpmnScopeMemory.cs` and missed that it is invoked at the call site. Corrected on the issue.

What was genuinely missing is the issue's **Verification** section.

## The gap that was actually there

The existing suites resume via `IWorkflowRunner.RunAsync(workflow, state, options)`, passing the **in-memory** `WorkflowState` object between runs. That rehydrates contexts, but it never crosses the serializer boundary — precisely the boundary #7926 showed can silently mangle values that look fine in memory.

These tests round-trip through Elsa's own `IWorkflowStateSerializer`, the same interface `WorkflowInstanceManager` and `WorkflowInstanceStore` use for real persistence.

Three tests:

1. **Pruning keeps the payload bounded** across many evaluations of a sequential multi-instance loop, deserializing the persisted property on every iteration.
2. **A root scope with two live units of work outstanding** — asserted live *before* the round trip, so the case cannot pass vacuously — resumed after serialization, matching each completion back to its binding through the rehydrated ledger.
3. **A nested scope with two live units of work outstanding.** Added on review, and the most valuable of the three: it is the intersection of the two things that have actually broken in this module. The `Tag` trap failed *only* in nested scopes while every single-scope probe passed, and no nested-scope test had ever crossed the serializer boundary. Nested rehydration turns out to be correct — the test passes with production code untouched.

## Verification

| Command | Result |
| --- | --- |
| `dotnet build Elsa.sln` | pass |
| `dotnet test test/unit/Elsa.Bpmn.UnitTests` | pass 16/16 |
| `dotnet test test/integration/Elsa.Bpmn.IntegrationTests` | pass 23/23 (was 20) |
| `dotnet test test/unit/Elsa.Bpmn.Interchange.UnitTests` | pass 5/5 |
| `dotnet test test/integration/Elsa.Bpmn.Interchange.IntegrationTests` | pass 25/25 |

Mutations, each red then restored green:

- **`Prune()` removed** from the persistence path → the token count runs past the multi-instance cardinality and test 1 fails.
- **`BpmnScopeMemory.Load` returning a fresh empty ledger** → all three persistence tests fail; the bookmark lookup finds nothing and the join never fires.

## Two claims checked rather than inherited

**`Prune()`'s contract**, by decompiling `Bpmn.Model` 0.1.1-preview.19 rather than trusting the issue text: it returns `this with { Tokens, Diagnostics }` — a new record, so nothing the interpreter handed us is mutated, satisfying port invariant 6 — never touches `Sequence`, drops only `Consumed` tokens unreferenced by `ActiveWork` plus diagnostics past the 200 cap, and leaves `Canceled` tokens structurally exempt. Every claim in the issue holds.

**No `AddTypeAlias<T>` registration is needed.** Because both halves enter the property bag as **strings**, `PolymorphicObjectConverter` treats them as primitives and never routes them through its type-tagging machinery — so the silent type-loss trap that bites complex objects does not apply here. Confirmed by a real serializer round-trip, not by reasoning.

## Also in this PR

The `ParallelSplitAndJoin` / `ParallelSplitAndJoinBlocking` fixtures shared a verbatim start/split/left/right/join/after/end topology; it is now built once and parameterised by the branch work. Both public factories keep their signatures.

## Known and not covered

A scope that **faults** after a resume is not exercised across the serializer boundary. Not an issue requirement, and flagged rather than silently left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
