### PR TITLE
fix(runtime): let a trigger index payloads under per-payload stimulus names

### DIFF
--- a/src/modules/Elsa.Workflows.Core/Contexts/TriggerIndexingContext.cs
+++ b/src/modules/Elsa.Workflows.Core/Contexts/TriggerIndexingContext.cs
@@ -10,6 +10,15 @@ public class TriggerIndexingContext(WorkflowIndexingContext workflowIndexingCont
     public ExpressionExecutionContext ExpressionExecutionContext { get; } = expressionExecutionContext;
     public ITrigger Trigger { get; } = trigger;
     public CancellationToken CancellationToken { get; } = cancellationToken;
+
+    /// <summary>
+    /// The default stimulus name applied to the payloads returned by the trigger being indexed. Defaults to the activity type name.
+    /// </summary>
+    /// <remarks>
+    /// This is a single value shared by every payload of the trigger: when it is assigned more than once, the last write applies to all of them.
+    /// A trigger that needs to register payloads under more than one stimulus name should return <see cref="NamedTriggerPayload"/> instances instead,
+    /// which carry a name per payload and take precedence over this property.
+    /// </remarks>
     public string TriggerName { get; set; } = trigger.Type;
 
     public T? Get<T>(Input<T>? input) => ExpressionExecutionContext.Get(input);

--- a/src/modules/Elsa.Workflows.Core/Contracts/ITrigger.cs
+++ b/src/modules/Elsa.Workflows.Core/Contracts/ITrigger.cs
@@ -1,3 +1,5 @@
+using Elsa.Workflows.Models;
+
 namespace Elsa.Workflows;
 
 /// <summary>
@@ -8,5 +10,9 @@ public interface ITrigger : IActivity
     /// <summary>
     /// Implementors should return a list of objects where each object represents a bookmark datum. For each datum, a trigger is created.
     /// </summary>
+    /// <remarks>
+    /// Each returned object is stored under the stimulus name held by <see cref="TriggerIndexingContext.TriggerName"/>, which is shared by all payloads.
+    /// To register payloads under more than one stimulus name, return <see cref="NamedTriggerPayload"/> instances: each carries the name for its own payload.
+    /// </remarks>
     ValueTask<IEnumerable<object>> GetTriggerPayloadsAsync(TriggerIndexingContext context);
 }

--- a/src/modules/Elsa.Workflows.Core/Models/NamedTriggerPayload.cs
+++ b/src/modules/Elsa.Workflows.Core/Models/NamedTriggerPayload.cs
@@ -1,0 +1,36 @@
+namespace Elsa.Workflows.Models;
+
+/// <summary>
+/// A trigger payload that carries its own stimulus name.
+/// </summary>
+/// <remarks>
+/// Return instances of this type from <see cref="ITrigger.GetTriggerPayloadsAsync"/> when a single trigger needs to register payloads under
+/// more than one stimulus name. The wrapper is unwrapped during indexing: the stored trigger's name and hash are derived from <see cref="Name"/>
+/// and its payload from <see cref="Payload"/>. Payloads that are not wrapped are named using <see cref="TriggerIndexingContext.TriggerName"/>.
+/// </remarks>
+public record NamedTriggerPayload
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NamedTriggerPayload"/> class.
+    /// </summary>
+    /// <param name="name">The stimulus name to register the payload under.</param>
+    /// <param name="payload">The payload to register.</param>
+    public NamedTriggerPayload(string name, object payload)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("A stimulus name is required.", nameof(name));
+
+        Name = name;
+        Payload = payload;
+    }
+
+    /// <summary>
+    /// The stimulus name to register the payload under. Publishers of this stimulus compute their hash from this same name.
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// The payload to register. This is what gets stored; the wrapper itself never is.
+    /// </summary>
+    public object Payload { get; }
+}

--- a/src/modules/Elsa.Workflows.Core/Models/NamedTriggerPayload.cs
+++ b/src/modules/Elsa.Workflows.Core/Models/NamedTriggerPayload.cs
@@ -20,6 +20,9 @@ public record NamedTriggerPayload
         if (string.IsNullOrWhiteSpace(name))
             throw new ArgumentException("A stimulus name is required.", nameof(name));
 
+        if (payload is NamedTriggerPayload)
+            throw new ArgumentException("A NamedTriggerPayload cannot wrap another NamedTriggerPayload.", nameof(payload));
+
         Name = name;
         Payload = payload;
     }
@@ -30,7 +33,8 @@ public record NamedTriggerPayload
     public string Name { get; }
 
     /// <summary>
-    /// The payload to register. This is what gets stored; the wrapper itself never is.
+    /// The payload to register. This is what gets stored; the wrapper itself never is, since the constructor refuses to wrap another
+    /// <see cref="NamedTriggerPayload"/>.
     /// </summary>
     public object Payload { get; }
 }

--- a/src/modules/Elsa.Workflows.Runtime/Services/TriggerIndexer.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Services/TriggerIndexer.cs
@@ -7,6 +7,7 @@ using Elsa.Workflows.Activities;
 using Elsa.Workflows.Helpers;
 using Elsa.Workflows.Management;
 using Elsa.Workflows.Management.Entities;
+using Elsa.Workflows.Models;
 using Elsa.Workflows.Runtime.Comparers;
 using Elsa.Workflows.Runtime.Entities;
 using Elsa.Workflows.Runtime.Filters;
@@ -198,20 +199,29 @@ public class TriggerIndexer : ITriggerIndexer
         var expressionExecutionContext = await trigger.CreateExpressionExecutionContextAsync(triggerDescriptor, _serviceProvider, context, _expressionEvaluator, _logger);
         var triggerIndexingContext = new TriggerIndexingContext(context, expressionExecutionContext, trigger, cancellationToken);
         var triggerData = await TryGetTriggerDataAsync(trigger, triggerIndexingContext);
-        var triggerName = triggerIndexingContext.TriggerName;
+        var defaultTriggerName = triggerIndexingContext.TriggerName;
 
         // If no trigger payloads were returned, create a null payload.
         if (!triggerData.Any()) triggerData.Add(null!);
 
-        var triggers = triggerData.Select(payload => new StoredTrigger
+        var triggers = triggerData.Select(payload =>
         {
-            Id = _identityGenerator.GenerateId(),
-            WorkflowDefinitionId = workflow.Identity.DefinitionId,
-            WorkflowDefinitionVersionId = workflow.Identity.Id,
-            Name = triggerName,
-            ActivityId = trigger.Id,
-            Hash = _hasher.Hash(triggerName, payload),
-            Payload = payload
+            // A payload can carry its own stimulus name. If it does not, the trigger's shared name applies.
+            // Name and payload are always taken from the same source so that the hash matches the name stored alongside it.
+            var namedPayload = payload as NamedTriggerPayload;
+            var triggerName = namedPayload != null ? namedPayload.Name : defaultTriggerName;
+            var stimulus = namedPayload != null ? namedPayload.Payload : payload;
+
+            return new StoredTrigger
+            {
+                Id = _identityGenerator.GenerateId(),
+                WorkflowDefinitionId = workflow.Identity.DefinitionId,
+                WorkflowDefinitionVersionId = workflow.Identity.Id,
+                Name = triggerName,
+                ActivityId = trigger.Id,
+                Hash = _hasher.Hash(triggerName, stimulus),
+                Payload = stimulus
+            };
         });
 
         return triggers.ToList();

--- a/test/integration/Elsa.Workflows.IntegrationTests/Scenarios/TriggerIndexing/ExistingTriggerKindsTests.cs
+++ b/test/integration/Elsa.Workflows.IntegrationTests/Scenarios/TriggerIndexing/ExistingTriggerKindsTests.cs
@@ -1,0 +1,175 @@
+using Elsa.Extensions;
+using Elsa.Http;
+using Elsa.Http.Bookmarks;
+using Elsa.Scheduling;
+using Elsa.Scheduling.Activities;
+using Elsa.Scheduling.Bookmarks;
+using Elsa.Testing.Shared;
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Models;
+using Elsa.Workflows.Runtime;
+using Elsa.Workflows.Runtime.Activities;
+using Elsa.Workflows.Runtime.Entities;
+using Elsa.Workflows.Runtime.Stimuli;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit.Abstractions;
+using Timer = Elsa.Scheduling.Activities.Timer;
+
+namespace Elsa.Workflows.IntegrationTests.Scenarios.TriggerIndexing;
+
+/// <summary>
+/// Characterises how the trigger kinds that ship with Elsa are indexed, so that a change to the indexer that alters any of their rows is visible.
+/// The invariant asserted for every row: its hash is the one a publisher computes from that row's own name and payload.
+/// </summary>
+public class ExistingTriggerKindsTests
+{
+    private readonly IServiceProvider _services;
+    private readonly ITriggerIndexer _triggerIndexer;
+    private readonly IStimulusHasher _stimulusHasher;
+
+    public ExistingTriggerKindsTests(ITestOutputHelper testOutputHelper)
+    {
+        _services = new TestApplicationBuilder(testOutputHelper)
+            .ConfigureElsa(elsa => elsa.UseHttp().AddActivity<MultiStimulusTrigger>())
+            .Build();
+
+        _triggerIndexer = _services.GetRequiredService<ITriggerIndexer>();
+        _stimulusHasher = _services.GetRequiredService<IStimulusHasher>();
+    }
+
+    [Fact(DisplayName = "Each built-in trigger kind indexes one row per payload under its own stimulus name")]
+    public async Task GetTriggersAsync_BuiltInTriggerKinds_IndexUnderTheirOwnStimulusName()
+    {
+        var startAt = new DateTimeOffset(2035, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var interval = TimeSpan.FromHours(3);
+        var triggers = await IndexAsync(
+            new Event("order-received")
+            {
+                Id = "event"
+            },
+            new Timer(interval)
+            {
+                Id = "timer"
+            },
+            new Cron
+            {
+                Id = "cron",
+                CronExpression = new("0 0 * * *")
+            },
+            new StartAt(startAt)
+            {
+                Id = "start-at"
+            },
+            new HttpEndpoint
+            {
+                Id = "http-endpoint",
+                Path = new("/orders"),
+                SupportedMethods = new(new[]
+                {
+                    "GET",
+                    "POST"
+                })
+            });
+
+        // Event: names its payload through the shared trigger name.
+        var eventTrigger = Assert.Single(triggers["event"]);
+        AssertMatchable(eventTrigger, RuntimeStimulusNames.Event);
+        Assert.Equal(new EventStimulus("order-received"), eventTrigger.Payload);
+
+        // Timer: names its payload through the shared trigger name. Its start time is relative to the clock, so only the interval is pinned.
+        var timerTrigger = Assert.Single(triggers["timer"]);
+        AssertMatchable(timerTrigger, SchedulingStimulusNames.Timer);
+        Assert.Equal(interval, Assert.IsType<TimerTriggerPayload>(timerTrigger.Payload).Interval);
+
+        // Cron and StartAt: never assign a trigger name, so they fall back to the activity type name.
+        var cronTrigger = Assert.Single(triggers["cron"]);
+        AssertMatchable(cronTrigger, SchedulingStimulusNames.Cron);
+        Assert.Equal(new CronTriggerPayload("0 0 * * *"), cronTrigger.Payload);
+
+        var startAtTrigger = Assert.Single(triggers["start-at"]);
+        AssertMatchable(startAtTrigger, SchedulingStimulusNames.StartAt);
+        Assert.Equal(new StartAtPayload(startAt), startAtTrigger.Payload);
+
+        // HttpEndpoint: one row per supported method, all sharing a single trigger name.
+        var httpTriggers = triggers["http-endpoint"];
+        Assert.Equal(2, httpTriggers.Count);
+        Assert.All(httpTriggers, trigger => AssertMatchable(trigger, HttpStimulusNames.HttpEndpoint));
+        Assert.Equal(
+            [
+                ("/orders", "get"),
+                ("/orders", "post")
+            ],
+            httpTriggers.Select(x => Assert.IsType<HttpEndpointBookmarkPayload>(x.Payload)).Select(x => (x.Path, x.Method)).OrderBy(x => x.Method));
+    }
+
+    [Fact(DisplayName = "A trigger that contributes named payloads indexes each of them under its own stimulus name")]
+    public async Task GetTriggersAsync_NamedPayloads_IndexUnderTheirOwnStimulusName()
+    {
+        var triggers = await IndexAsync(new MultiStimulusTrigger
+        {
+            Id = "multi"
+        });
+
+        // Both rows must be matchable: the event by a published event, the timer by the trigger scheduler.
+        var rows = triggers["multi"];
+        Assert.Equal(2, rows.Count);
+
+        var eventRow = rows.Single(x => x.Name == RuntimeStimulusNames.Event);
+        AssertMatchable(eventRow, RuntimeStimulusNames.Event);
+        Assert.Equal(new EventStimulus(MultiStimulusTrigger.EventName), eventRow.Payload);
+        Assert.Equal(_stimulusHasher.Hash(RuntimeStimulusNames.Event, new EventStimulus(MultiStimulusTrigger.EventName)), eventRow.Hash);
+
+        var timerRow = rows.Single(x => x.Name == SchedulingStimulusNames.Timer);
+        AssertMatchable(timerRow, SchedulingStimulusNames.Timer);
+        Assert.Equal(MultiStimulusTrigger.Interval, Assert.IsType<TimerTriggerPayload>(timerRow.Payload).Interval);
+
+        // The name is also what DefaultTriggerScheduler filters on, so the timer row is schedulable without any trigger-specific machinery.
+        Assert.Single(rows.Filter<Timer>());
+    }
+
+    private async Task<IDictionary<string, IList<StoredTrigger>>> IndexAsync(params IActivity[] activities)
+    {
+        await _services.PopulateRegistriesAsync();
+
+        foreach (var activity in activities)
+            activity.SetCanStartWorkflow(true);
+
+        var workflow = new Workflow(new Sequence
+        {
+            Activities = activities
+        })
+        {
+            Identity = new("triggers", 1, "triggers:1")
+        };
+
+        // Assign identities the way workflow materialization does, so that activity inputs resolve during indexing.
+        var workflowGraph = await _services.GetRequiredService<IWorkflowGraphBuilder>().BuildAsync(workflow);
+        var triggers = await _triggerIndexer.GetTriggersAsync(workflowGraph.Workflow, default);
+        return triggers.GroupBy(x => x.ActivityId).ToDictionary(x => x.Key, IList<StoredTrigger> (x) => x.ToList());
+    }
+
+    private void AssertMatchable(StoredTrigger trigger, string expectedName)
+    {
+        Assert.Equal(expectedName, trigger.Name);
+        Assert.Equal(_stimulusHasher.Hash(expectedName, trigger.Payload), trigger.Hash);
+    }
+}
+
+/// <summary>
+/// A trigger that registers an event stimulus and a timer stimulus, reusing the existing stimulus extension methods.
+/// </summary>
+public class MultiStimulusTrigger : Trigger
+{
+    public const string EventName = "bpmn-message-start";
+    public static readonly TimeSpan Interval = TimeSpan.FromMinutes(15);
+
+    protected override IEnumerable<object> GetTriggerPayloads(TriggerIndexingContext context)
+    {
+        // Each extension method assigns the shared trigger name as a side effect; the payload's own name is what counts.
+        var eventStimulus = context.GetEventStimulus(EventName);
+        yield return new NamedTriggerPayload(RuntimeStimulusNames.Event, eventStimulus);
+
+        var timerStimulus = context.GetTimerTriggerStimulus(Interval);
+        yield return new NamedTriggerPayload(SchedulingStimulusNames.Timer, timerStimulus);
+    }
+}

--- a/test/unit/Elsa.Workflows.Runtime.UnitTests/Services/TriggerIndexerTests.cs
+++ b/test/unit/Elsa.Workflows.Runtime.UnitTests/Services/TriggerIndexerTests.cs
@@ -1,0 +1,218 @@
+using Elsa.Common.DistributedHosting;
+using Elsa.Common.Serialization;
+using Elsa.Expressions.Contracts;
+using Elsa.Extensions;
+using Elsa.Mediator.Contracts;
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Helpers;
+using Elsa.Workflows.Management;
+using Elsa.Workflows.Models;
+using Elsa.Workflows.Runtime.Entities;
+using Medallion.Threading;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Elsa.Workflows.Runtime.UnitTests.Services;
+
+/// <summary>
+/// Characterises how <see cref="TriggerIndexer"/> turns the payloads of an <see cref="ITrigger"/> into stored triggers.
+/// The invariant under test: every stored row's <see cref="StoredTrigger.Hash"/> equals the hash a publisher computes from the row's own
+/// <see cref="StoredTrigger.Name"/> and <see cref="StoredTrigger.Payload"/>, where that name is the one the trigger associated with that payload.
+/// </summary>
+public class TriggerIndexerTests
+{
+    private const string EventStimulusName = "Test.Event";
+    private const string TimerStimulusName = "Test.Timer";
+
+    private readonly IStimulusHasher _hasher;
+    private readonly TriggerIndexer _indexer;
+
+    public TriggerIndexerTests()
+    {
+        var typeRegistry = SerializationTypeRegistry.CreateDefault();
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        var activityRegistry = Substitute.For<IActivityRegistry>();
+        var identityGenerator = Substitute.For<IIdentityGenerator>();
+
+        activityRegistry.Find(Arg.Any<string>(), Arg.Any<int>()).Returns(new ActivityDescriptor());
+        identityGenerator.GenerateId().Returns(_ => Guid.NewGuid().ToString("N"));
+        _hasher = new StimulusHasher(new Hasher(typeRegistry));
+
+        _indexer = new(
+            new ActivityVisitor([], serviceProvider),
+            Substitute.For<IWorkflowDefinitionService>(),
+            Substitute.For<IExpressionEvaluator>(),
+            identityGenerator,
+            Substitute.For<ITriggerStore>(),
+            activityRegistry,
+            Substitute.For<INotificationSender>(),
+            serviceProvider,
+            _hasher,
+            Substitute.For<IDistributedLockProvider>(),
+            typeRegistry,
+            Microsoft.Extensions.Options.Options.Create(new DistributedLockingOptions()),
+            NullLogger<TriggerIndexer>.Instance);
+    }
+
+    [Fact(DisplayName = "A payload without a name of its own is indexed under the activity type name")]
+    public async Task GetTriggersAsync_PayloadWithoutName_UsesActivityTypeName()
+    {
+        var payload = new TestStimulus("a");
+        var triggers = await IndexAsync(_ => [payload]);
+
+        var trigger = Assert.Single(triggers);
+        Assert.Equal(ActivityTypeNameHelper.GenerateTypeName<TestTrigger>(), trigger.Name);
+        AssertMatchable(trigger, ActivityTypeNameHelper.GenerateTypeName<TestTrigger>(), payload);
+    }
+
+    [Fact(DisplayName = "An assigned trigger name applies to every payload the trigger returns")]
+    public async Task GetTriggersAsync_AssignedTriggerName_AppliesToEveryPayload()
+    {
+        var first = new TestStimulus("a");
+        var second = new TestStimulus("b");
+        var triggers = await IndexAsync(context =>
+        {
+            context.TriggerName = EventStimulusName;
+            return [first, second];
+        });
+
+        Assert.Collection(triggers,
+            trigger => AssertMatchable(trigger, EventStimulusName, first),
+            trigger => AssertMatchable(trigger, EventStimulusName, second));
+    }
+
+    [Fact(DisplayName = "The last assignment of the trigger name wins for payloads that do not carry a name")]
+    public async Task GetTriggersAsync_TriggerNameAssignedTwice_LastWriteWinsForUnnamedPayloads()
+    {
+        var first = new TestStimulus("a");
+        var second = new TestStimulus("b");
+        var triggers = await IndexAsync(context =>
+        {
+            context.TriggerName = EventStimulusName;
+            context.TriggerName = TimerStimulusName;
+            return [first, second];
+        });
+
+        // Pinned deliberately: the shared field keeps its existing semantics. Payloads that need their own name must say so.
+        Assert.Collection(triggers,
+            trigger => AssertMatchable(trigger, TimerStimulusName, first),
+            trigger => AssertMatchable(trigger, TimerStimulusName, second));
+    }
+
+    [Fact(DisplayName = "Each named payload is indexed under its own name, and each is matchable")]
+    public async Task GetTriggersAsync_NamedPayloads_AreEachIndexedUnderTheirOwnName()
+    {
+        var eventStimulus = new TestStimulus("order-received");
+        var timerStimulus = new TestStimulus("every-hour");
+        var triggers = await IndexAsync(context =>
+        {
+            // Mirrors the stimulus extension methods, which each assign the shared name as a side effect.
+            context.TriggerName = EventStimulusName;
+            context.TriggerName = TimerStimulusName;
+            return
+            [
+                new NamedTriggerPayload(EventStimulusName, eventStimulus),
+                new NamedTriggerPayload(TimerStimulusName, timerStimulus)
+            ];
+        });
+
+        Assert.Collection(triggers,
+            trigger => AssertMatchable(trigger, EventStimulusName, eventStimulus),
+            trigger => AssertMatchable(trigger, TimerStimulusName, timerStimulus));
+    }
+
+    [Fact(DisplayName = "Named and unnamed payloads can be mixed on a single trigger")]
+    public async Task GetTriggersAsync_MixedPayloads_NameEachPayloadIndependently()
+    {
+        var named = new TestStimulus("named");
+        var unnamed = new TestStimulus("unnamed");
+        var triggers = await IndexAsync(context =>
+        {
+            context.TriggerName = TimerStimulusName;
+            return [new NamedTriggerPayload(EventStimulusName, named), unnamed];
+        });
+
+        Assert.Collection(triggers,
+            trigger => AssertMatchable(trigger, EventStimulusName, named),
+            trigger => AssertMatchable(trigger, TimerStimulusName, unnamed));
+    }
+
+    [Fact(DisplayName = "A named payload is stored unwrapped")]
+    public async Task GetTriggersAsync_NamedPayload_StoresTheInnerPayload()
+    {
+        var payload = new TestStimulus("a");
+        var triggers = await IndexAsync(_ => [new NamedTriggerPayload(EventStimulusName, payload)]);
+
+        // Storing the wrapper would produce a self-consistent but unmatchable row, and would hand the wrapper to payload validators.
+        var trigger = Assert.Single(triggers);
+        Assert.Same(payload, trigger.Payload);
+        Assert.IsType<TestStimulus>(trigger.Payload);
+    }
+
+    [Fact(DisplayName = "A trigger returning no payloads still produces a single placeholder row")]
+    public async Task GetTriggersAsync_NoPayloads_ProducesPlaceholderRow()
+    {
+        var triggers = await IndexAsync(_ => []);
+
+        var trigger = Assert.Single(triggers);
+        Assert.Null(trigger.Payload);
+        Assert.Equal(ActivityTypeNameHelper.GenerateTypeName<TestTrigger>(), trigger.Name);
+        Assert.Equal(_hasher.Hash(trigger.Name!, null), trigger.Hash);
+    }
+
+    [Fact(DisplayName = "A trigger that throws produces a single placeholder row")]
+    public async Task GetTriggersAsync_ThrowingTrigger_ProducesPlaceholderRow()
+    {
+        var triggers = await IndexAsync(_ => throw new InvalidOperationException("Cannot resolve payloads."));
+
+        var trigger = Assert.Single(triggers);
+        Assert.Null(trigger.Payload);
+        Assert.Equal(ActivityTypeNameHelper.GenerateTypeName<TestTrigger>(), trigger.Name);
+    }
+
+    [Theory(DisplayName = "A named payload requires a stimulus name")]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void NamedTriggerPayload_BlankName_Throws(string name)
+    {
+        Assert.Throws<ArgumentException>(() => new NamedTriggerPayload(name, new TestStimulus("a")));
+    }
+
+    private async Task<ICollection<StoredTrigger>> IndexAsync(Func<TriggerIndexingContext, IEnumerable<object>> payloadsFactory)
+    {
+        var trigger = new TestTrigger
+        {
+            PayloadsFactory = payloadsFactory
+        };
+        trigger.SetCanStartWorkflow(true);
+        var workflow = new Workflow(trigger)
+        {
+            Identity = new("definition-1", 1, "definition-1:1")
+        };
+        return (await _indexer.GetTriggersAsync(workflow, default)).ToList();
+    }
+
+    /// <summary>
+    /// Asserts that the row carries the expected name and payload, and that its hash is the one a publisher of that same stimulus name computes.
+    /// Also asserts that the hash is not the one that would result from labelling the payload with the other stimulus name in play.
+    /// </summary>
+    private void AssertMatchable(StoredTrigger trigger, string expectedName, object expectedPayload)
+    {
+        var otherName = expectedName == EventStimulusName ? TimerStimulusName : EventStimulusName;
+
+        Assert.Equal(expectedName, trigger.Name);
+        Assert.Same(expectedPayload, trigger.Payload);
+        Assert.Equal(_hasher.Hash(expectedName, expectedPayload), trigger.Hash);
+        Assert.NotEqual(_hasher.Hash(otherName, expectedPayload), trigger.Hash);
+    }
+}
+
+public record TestStimulus(string Value);
+
+public class TestTrigger : Trigger
+{
+    public Func<TriggerIndexingContext, IEnumerable<object>> PayloadsFactory { get; set; } = _ => [];
+
+    protected override IEnumerable<object> GetTriggerPayloads(TriggerIndexingContext context) => PayloadsFactory(context);
+}

--- a/test/unit/Elsa.Workflows.Runtime.UnitTests/Services/TriggerIndexerTests.cs
+++ b/test/unit/Elsa.Workflows.Runtime.UnitTests/Services/TriggerIndexerTests.cs
@@ -179,6 +179,14 @@ public class TriggerIndexerTests
         Assert.Throws<ArgumentException>(() => new NamedTriggerPayload(name, new TestStimulus("a")));
     }
 
+    [Fact(DisplayName = "A named payload refuses to wrap another named payload")]
+    public void NamedTriggerPayload_NestedPayload_Throws()
+    {
+        var inner = new NamedTriggerPayload(EventStimulusName, new TestStimulus("a"));
+
+        Assert.Throws<ArgumentException>(() => new NamedTriggerPayload(TimerStimulusName, inner));
+    }
+
     private async Task<ICollection<StoredTrigger>> IndexAsync(Func<TriggerIndexingContext, IEnumerable<object>> payloadsFactory)
     {
         var trigger = new TestTrigger


### PR DESCRIPTION
Lets one `ITrigger` register payloads under more than one stimulus name. **Isolated into its own PR because it changes how every trigger in the runtime is indexed**, and shared-runtime changes deserve review on their own merits rather than as a rider on a feature.

Closes #7949. Unblocks #7929 (BPMN start triggers).

## The defect

`TriggerIndexingContext.TriggerName` is a single settable property, and `TriggerIndexer.CreateWorkflowTriggersAsync` read it **once** after all payloads were collected, then applied it to every row:

```csharp
var triggerName = triggerIndexingContext.TriggerName;
...
Name = triggerName,
Hash = _hasher.Hash(triggerName, payload),
```

So an `ITrigger` could only ever register under one stimulus name. Set it twice — which the stimulus extensions do, since `GetEventStimulus` and `GetTimerTriggerStimulus` each assign it — and the last write won for every row.

That is not just a wrong label. `Hash` derives from the same name, so the earlier payloads were stored under a hash no publisher would ever compute. **Silently unmatchable.**

Nothing in the existing trigger set hit this, because each emits exactly one stimulus kind. The constraint was invisible rather than absent. A BPMN process with a message start *and* a recurring timer start is the first thing that needs it.

## The change

Additive and opt-in. A `NamedTriggerPayload` wrapper returned through the existing `IEnumerable<object>`; the indexer unwraps it and derives `Name`, `Hash` and `Payload` from **one source per row**:

```csharp
var namedPayload = payload as NamedTriggerPayload;
var triggerName = namedPayload != null ? namedPayload.Name : defaultTriggerName;
var stimulus    = namedPayload != null ? namedPayload.Payload : payload;
```

`ITrigger`'s signature is untouched — it gained an XML doc remark only. `TriggerName` keeps working exactly as before for anything that does not opt in.

Written as an explicit ternary rather than `namedPayload?.Payload ?? payload` on purpose: the null-coalescing form would silently store the *wrapper* if an inner payload were ever null.

**Why a wrapper rather than `(name, payload)` pairs on the context**, which the issue suggested: an identity-keyed map fails silently when a trigger registers a name for a payload instance it does not return — you get a row under the wrong name with no signal. The wrapper makes that mis-association structurally impossible and preserves order.

## Backwards compatibility, proven rather than asserted

This is the part that matters for a change at this level. The characterisation tests were run against the **pre-change** `TriggerIndexer` (via `git checkout HEAD -- TriggerIndexer.cs`) and they pass identically there — only the new named-payload tests fail. Same assertions, both sides.

They exercise the real built-in kinds — `Event`, `Timer`, `Cron`, `StartAt`, `HttpEndpoint` — through the real DI-registered `IStimulusHasher` and `ITriggerIndexer`, asserting `Name`, `Hash`, `Payload` and row count per kind. Not mocks.

## Two invariants made structural

**The wrapper is never persisted.** Review found the doc asserted this but only one level was unwrapped, so a double-wrapped payload would reach `StoredTrigger.Payload` — breaking `ValidateWorkflowRequestHandler`, which reflects on `Payload.GetType()` to resolve `ITriggerPayloadValidator<TPayload>`, and `WorkflowTriggerEqualityComparer`, which serialises by runtime type for the definition-refresh diff. The constructor now refuses to nest, so the guarantee holds by construction rather than by documentation.

**A blank stimulus name is refused at construction**, rather than storing a row hashed under an empty name.

## Verification

| Suite | Result |
| --- | --- |
| `dotnet build Elsa.sln` | pass |
| `Elsa.Workflows.Runtime.UnitTests` | 271 |
| `Elsa.Workflows.Core.UnitTests` | 267 |
| `Elsa.Scheduling.UnitTests` | 50 |
| `Elsa.Activities.UnitTests` | 411 |
| `Elsa.Workflows.IntegrationTests` | 289 |
| `Elsa.Bpmn*` (four projects) | 16 / 5 / 23 / 25, unchanged |

Also run and green: `Elsa.Http.UnitTests`, `Elsa.Http.IntegrationTests`, `Elsa.Alterations.IntegrationTests`, `Elsa.Workflows.Management.UnitTests` — all of which contain trigger implementations.

Mutations, each red then restored green:
- per-payload name falls back to the shared field → both multi-name tests fail;
- the nesting guard removed → the nested-wrapper test fails.

## Left alone deliberately

The `Payload = null` placeholder row that gets inserted for any trigger returning an empty list is unchanged, and is now **pinned by characterisation tests** (empty list, and a throwing trigger) so a future change to it is visible.

For the record, since anyone touching that method should know: it is inert for matching — `WorkflowMatcher` and `TriggerBoundWorkflowService` key purely on `Hash`, and nothing hashes to `(triggerType, null)`. But it does make `ValidateWorkflowRequestHandler` emit a "trigger should have a payload" validation error for any activity that legitimately declines to register. That is worth its own issue rather than a rider on this one.

Also noted and unchanged: `Cron`, `StartAt`, `WebhookEventReceived` and `AlterationPlanCompleted` never assign `TriggerName`, so they index under the activity type name and only coincidentally match `SchedulingStimulusNames.Cron`/`StartAt`. That coupling is now pinned by the integration test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
