### PR TITLE
feat(bpmn): interchange endpoints (analyze, import, export)

### DIFF
--- a/doc/wiki/bpmn-workflows.md
+++ b/doc/wiki/bpmn-workflows.md
@@ -80,6 +80,46 @@ An exported `.bpmn` is self-contained: all binding configuration, including inpu
 
 **The names in this format are a compatibility surface.** Changing `NamespaceUri`, `BindingElementName`, `ActivityTypeAttributeName`, `InputElementName`, or `InputNameAttributeName` breaks every previously exported `.bpmn` file. Studio and any other tooling that reads or writes this extension must agree on these constants.
 
+## REST Endpoints
+
+`Elsa.Bpmn.Interchange` registers three routes, all under `bpmn/`:
+
+| Method & route | Permission | What it does |
+| --- | --- | --- |
+| `POST bpmn/analyze` | `read:workflow-definitions` | Uploads a single `.bpmn` file (multipart) and returns the Info/Degraded/Dropped findings a read would produce, without persisting anything. |
+| `POST bpmn/import` | `write:workflow-definitions` | Uploads a single `.bpmn` file and persists it as a new or updated workflow definition (as a draft; it is not published). Optional form fields: `DefinitionId` (update an existing definition instead of creating one), `Name`, `ProcessId` (required when the document declares more than one process). |
+| `GET bpmn/definitions/{definitionId}/export` | `read:workflow-definitions` | Writes the workflow definition's BPMN source back out as `.bpmn` XML. Optional `VersionOptions` query parameter (`Latest`, `Published`, or a specific version), defaulting to `Latest`. |
+
+Both `Analyze` and `Import` require exactly one uploaded file; zero or more than one returns `400 Bad Request`.
+
+### Capability refusal at import
+
+A BPMN document can declare behaviour (e.g. certain multi-instance or event-subprocess shapes) that needs a host
+capability this deployment's runtime does not implement. `Import` checks this — for the whole document, including
+nested processes — before persisting anything, and refuses with `422 Unprocessable Entity` naming the missing
+capabilities and the offending element ids, rather than persisting a definition that only fails the first time it
+runs. `Analyze` never performs this check, since it does not persist; a document that `Analyze` reports cleanly can
+still be refused by `Import` on capability grounds.
+
+### Export's limitation
+
+`Export` does not reconstruct a `.bpmn` document from the Elsa activity graph a definition runs — that would discard
+everything the reader retained on import (foreign extension elements, foreign attributes, unrecognized children, BPMN
+DI layout). Instead, it returns exactly the document `Import` stored at import time. This has a real consequence
+until BPMN-aware editing exists in Studio: **edits made through Elsa's own designer, after import, are not reflected
+in what `Export` returns.**
+
+`Export` also refuses outright, with `422 Unprocessable Entity`, rather than silently returning a stale or wrong
+document, in two situations:
+
+- The definition does not currently carry BPMN source — either it was never imported from BPMN, or a later save
+  replaced its custom properties wholesale (BPMN source travels on the same `CustomProperties` dictionary a workflow
+  edit can overwrite).
+- The definition has changed — by version — since the source was recorded, meaning the stored BPMN text no longer
+  corresponds to the current definition.
+
+A missing `definitionId` returns `404 Not Found`.
+
 ## Execution State Persistence
 
 The BPMN interpreter's execution state (`BpmnExecutionState`) and the scope's `BpmnWorkLedger` are both serialized as JSON strings in `ActivityExecutionContext.Properties` when the workflow suspends. The state is pruned before each persist: consumed tokens are removed so the serialized size stays bounded regardless of how many evaluations a long-running scope has processed.

--- a/src/modules/Elsa.Bpmn.Interchange/AssemblyInfo.cs
+++ b/src/modules/Elsa.Bpmn.Interchange/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Elsa.Bpmn.Interchange.UnitTests")]
+[assembly: InternalsVisibleTo("Elsa.Bpmn.Interchange.IntegrationTests")]

--- a/src/modules/Elsa.Bpmn.Interchange/Elsa.Bpmn.Interchange.csproj
+++ b/src/modules/Elsa.Bpmn.Interchange/Elsa.Bpmn.Interchange.csproj
@@ -11,10 +11,12 @@
 
 	<ItemGroup>
 		<PackageReference Include="Bpmn.Interchange" />
+		<PackageReference Include="Bpmn.Semantics" />
 	</ItemGroup>
 
 	<ItemGroup>
 		<ProjectReference Include="..\Elsa.Bpmn\Elsa.Bpmn.csproj" />
+		<ProjectReference Include="..\..\common\Elsa.Api.Common\Elsa.Api.Common.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/src/modules/Elsa.Bpmn.Interchange/Endpoints/Bpmn/Analyze/Endpoint.cs
+++ b/src/modules/Elsa.Bpmn.Interchange/Endpoints/Bpmn/Analyze/Endpoint.cs
@@ -1,0 +1,52 @@
+using Bpmn.Interchange;
+using Elsa.Abstractions;
+using Elsa.Bpmn.Interchange.Services;
+using JetBrains.Annotations;
+using Microsoft.AspNetCore.Http;
+
+namespace Elsa.Bpmn.Interchange.Endpoints.Bpmn.Analyze;
+
+/// <summary>
+/// Reads a <c>.bpmn</c> document and reports the element-scoped Info/Degraded/Dropped findings a read would produce,
+/// without persisting anything.
+/// </summary>
+/// <remarks>
+/// A thin wrapper over <see cref="BpmnInterchangeDocumentService.Analyze"/>, which runs the same code
+/// <see cref="Import.Import"/> reads with — see its remarks for why that is what makes this a genuine preview rather
+/// than a second opinion that can disagree with the import that follows it.
+/// </remarks>
+[UsedImplicitly]
+internal sealed class Analyze(BpmnInterchangeDocumentService documentService) : ElsaEndpointWithoutRequest<BpmnImportAnalysisModel>
+{
+    /// <inheritdoc />
+    public override void Configure()
+    {
+        Post("bpmn/analyze");
+        AllowFileUploads();
+        ConfigurePermissions("read:workflow-definitions");
+    }
+
+    /// <inheritdoc />
+    public override async Task HandleAsync(CancellationToken cancellationToken)
+    {
+        if (Files.Count != 1)
+        {
+            AddError("Upload exactly one .bpmn file.");
+            await Send.ErrorsAsync(StatusCodes.Status400BadRequest, cancellationToken);
+            return;
+        }
+
+        var xml = await BpmnUploadedFileReader.ReadTextAsync(Files[0], cancellationToken);
+
+        try
+        {
+            var analysis = documentService.Analyze(xml);
+            await Send.OkAsync(BpmnImportAnalysisModel.From(analysis), cancellationToken);
+        }
+        catch (BpmnInterchangeException exception)
+        {
+            AddError(exception.Message);
+            await Send.ErrorsAsync(StatusCodes.Status400BadRequest, cancellationToken);
+        }
+    }
+}

--- a/src/modules/Elsa.Bpmn.Interchange/Endpoints/Bpmn/BpmnImportAnalysisModel.cs
+++ b/src/modules/Elsa.Bpmn.Interchange/Endpoints/Bpmn/BpmnImportAnalysisModel.cs
@@ -1,0 +1,26 @@
+using Bpmn.Interchange;
+using JetBrains.Annotations;
+
+namespace Elsa.Bpmn.Interchange.Endpoints.Bpmn;
+
+/// <summary>What a document contains and how much of it survives a read, as reported over the API.</summary>
+[PublicAPI]
+public sealed class BpmnImportAnalysisModel
+{
+    /// <summary>The <c>id</c> of every <c>&lt;process&gt;</c> in the document, in document order.</summary>
+    public IReadOnlyCollection<string> ProcessIds { get; init; } = [];
+
+    /// <summary>How many of each BPMN local name were encountered, across all containers.</summary>
+    public IReadOnlyDictionary<string, int> ElementCounts { get; init; } = new Dictionary<string, int>();
+
+    /// <summary>Every finding, in the order the reader produced it.</summary>
+    public IReadOnlyCollection<BpmnImportIssueModel> Issues { get; init; } = [];
+
+    /// <summary>Maps a library analysis onto the API model.</summary>
+    public static BpmnImportAnalysisModel From(BpmnImportAnalysis analysis) => new()
+    {
+        ProcessIds = analysis.ProcessIds.ToList(),
+        ElementCounts = new Dictionary<string, int>(analysis.ElementCounts),
+        Issues = analysis.Issues.Select(BpmnImportIssueModel.From).ToList()
+    };
+}

--- a/src/modules/Elsa.Bpmn.Interchange/Endpoints/Bpmn/BpmnImportIssueModel.cs
+++ b/src/modules/Elsa.Bpmn.Interchange/Endpoints/Bpmn/BpmnImportIssueModel.cs
@@ -1,0 +1,30 @@
+using Bpmn.Interchange;
+using JetBrains.Annotations;
+
+namespace Elsa.Bpmn.Interchange.Endpoints.Bpmn;
+
+/// <summary>One element-scoped finding from a BPMN read, as reported over the API.</summary>
+[PublicAPI]
+public sealed class BpmnImportIssueModel
+{
+    /// <summary>How much of the element's authored meaning survived the read: <c>Info</c>, <c>Degraded</c> or <c>Dropped</c>.</summary>
+    public string Severity { get; init; } = string.Empty;
+
+    /// <summary>A sentence naming the element, what the document said, and what the reader did about it.</summary>
+    public string Message { get; init; } = string.Empty;
+
+    /// <summary>The BPMN id the finding is about, when it is about one element.</summary>
+    public string? ElementId { get; init; }
+
+    /// <summary>The process the finding occurred in, when it is scoped to one.</summary>
+    public string? ProcessId { get; init; }
+
+    /// <summary>Maps a library finding onto the API model.</summary>
+    public static BpmnImportIssueModel From(BpmnImportIssue issue) => new()
+    {
+        Severity = issue.Severity.ToString(),
+        Message = issue.Message,
+        ElementId = issue.ElementId,
+        ProcessId = issue.ProcessId
+    };
+}

--- a/src/modules/Elsa.Bpmn.Interchange/Endpoints/Bpmn/BpmnUploadedFileReader.cs
+++ b/src/modules/Elsa.Bpmn.Interchange/Endpoints/Bpmn/BpmnUploadedFileReader.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Http;
+
+namespace Elsa.Bpmn.Interchange.Endpoints.Bpmn;
+
+/// <summary>Reads an uploaded <c>.bpmn</c> file as text, shared by every endpoint that accepts one.</summary>
+internal static class BpmnUploadedFileReader
+{
+    public static async Task<string> ReadTextAsync(IFormFile file, CancellationToken cancellationToken)
+    {
+        await using var stream = file.OpenReadStream();
+        using var streamReader = new StreamReader(stream);
+        return await streamReader.ReadToEndAsync(cancellationToken);
+    }
+}

--- a/src/modules/Elsa.Bpmn.Interchange/Endpoints/Bpmn/Export/Endpoint.cs
+++ b/src/modules/Elsa.Bpmn.Interchange/Endpoints/Bpmn/Export/Endpoint.cs
@@ -1,0 +1,59 @@
+using Bpmn.Interchange;
+using Elsa.Abstractions;
+using Elsa.Bpmn.Interchange.Services;
+using Elsa.Common.Models;
+using Elsa.Extensions;
+using Elsa.Workflows.Management;
+using Elsa.Workflows.Models;
+using JetBrains.Annotations;
+using Microsoft.AspNetCore.Http;
+
+namespace Elsa.Bpmn.Interchange.Endpoints.Bpmn.Export;
+
+/// <summary>Writes a stored workflow definition back out as BPMN 2.0 XML.</summary>
+/// <remarks>
+/// A thin wrapper over <see cref="BpmnInterchangeDocumentService.Export"/>. See that type's remarks for why this
+/// re-reads the original document rather than reconstructing one from the Elsa activity graph the definition runs.
+/// </remarks>
+[UsedImplicitly]
+internal sealed class Export(IWorkflowDefinitionStore store, BpmnInterchangeDocumentService documentService) : ElsaEndpoint<Request>
+{
+    /// <inheritdoc />
+    public override void Configure()
+    {
+        Get("bpmn/definitions/{definitionId}/export");
+        ConfigurePermissions("read:workflow-definitions");
+    }
+
+    /// <inheritdoc />
+    public override async Task HandleAsync(Request request, CancellationToken cancellationToken)
+    {
+        var versionOptions = string.IsNullOrWhiteSpace(request.VersionOptions) ? VersionOptions.Latest : VersionOptions.FromString(request.VersionOptions);
+        var filter = WorkflowDefinitionHandle.ByDefinitionId(request.DefinitionId, versionOptions).ToFilter();
+        var definition = await store.FindAsync(filter, cancellationToken);
+
+        if (definition == null)
+        {
+            await Send.NotFoundAsync(cancellationToken);
+            return;
+        }
+
+        if (!definition.CustomProperties.TryGetValue<string>(BpmnInterchangeDocumentService.SourceXmlCustomPropertyKey, out var xml) || string.IsNullOrEmpty(xml))
+        {
+            AddError($"Workflow definition '{request.DefinitionId}' was not imported from a BPMN document, so it cannot be exported as BPMN 2.0 XML.");
+            await Send.ErrorsAsync(StatusCodes.Status422UnprocessableEntity, cancellationToken);
+            return;
+        }
+
+        try
+        {
+            var bytes = documentService.Export(xml);
+            await Send.BytesAsync(bytes, $"{request.DefinitionId}.bpmn", "application/xml", cancellation: cancellationToken);
+        }
+        catch (BpmnInterchangeException exception)
+        {
+            AddError(exception.Message);
+            await Send.ErrorsAsync(StatusCodes.Status400BadRequest, cancellationToken);
+        }
+    }
+}

--- a/src/modules/Elsa.Bpmn.Interchange/Endpoints/Bpmn/Export/Endpoint.cs
+++ b/src/modules/Elsa.Bpmn.Interchange/Endpoints/Bpmn/Export/Endpoint.cs
@@ -29,7 +29,31 @@ internal sealed class Export(IWorkflowDefinitionStore store, BpmnInterchangeDocu
     /// <inheritdoc />
     public override async Task HandleAsync(Request request, CancellationToken cancellationToken)
     {
-        var versionOptions = string.IsNullOrWhiteSpace(request.VersionOptions) ? VersionOptions.Latest : VersionOptions.FromString(request.VersionOptions);
+        VersionOptions versionOptions;
+
+        if (string.IsNullOrWhiteSpace(request.VersionOptions))
+        {
+            versionOptions = VersionOptions.Latest;
+        }
+        else
+        {
+            try
+            {
+                // VersionOptions.TryParse always returns true and still throws through FromString for a value it
+                // cannot make sense of, so it buys nothing over calling FromString directly — catch what it can
+                // actually throw instead: a non-numeric or out-of-range value that is not one of its named options.
+                versionOptions = VersionOptions.FromString(request.VersionOptions);
+            }
+            catch (Exception exception) when (exception is FormatException or OverflowException)
+            {
+                AddError(
+                    $"'{request.VersionOptions}' is not a valid version. Specify a whole number, or one of: AllVersions, Draft, Latest, Published, "
+                    + "LatestOrPublished, LatestAndPublished.");
+                await Send.ErrorsAsync(StatusCodes.Status400BadRequest, cancellationToken);
+                return;
+            }
+        }
+
         var filter = WorkflowDefinitionHandle.ByDefinitionId(request.DefinitionId, versionOptions).ToFilter();
         var definition = await store.FindAsync(filter, cancellationToken);
 

--- a/src/modules/Elsa.Bpmn.Interchange/Endpoints/Bpmn/Export/Endpoint.cs
+++ b/src/modules/Elsa.Bpmn.Interchange/Endpoints/Bpmn/Export/Endpoint.cs
@@ -1,8 +1,8 @@
 using Bpmn.Interchange;
 using Elsa.Abstractions;
+using Elsa.Bpmn.Interchange.Exceptions;
 using Elsa.Bpmn.Interchange.Services;
 using Elsa.Common.Models;
-using Elsa.Extensions;
 using Elsa.Workflows.Management;
 using Elsa.Workflows.Models;
 using JetBrains.Annotations;
@@ -12,8 +12,9 @@ namespace Elsa.Bpmn.Interchange.Endpoints.Bpmn.Export;
 
 /// <summary>Writes a stored workflow definition back out as BPMN 2.0 XML.</summary>
 /// <remarks>
-/// A thin wrapper over <see cref="BpmnInterchangeDocumentService.Export"/>. See that type's remarks for why this
-/// re-reads the original document rather than reconstructing one from the Elsa activity graph the definition runs.
+/// A thin wrapper over <see cref="BpmnInterchangeDocumentService.Export(Elsa.Workflows.Management.Entities.WorkflowDefinition)"/>.
+/// See that type's remarks for why this re-reads the original document rather than reconstructing one from the Elsa
+/// activity graph the definition runs, and for why a missing or stale source is refused rather than exported anyway.
 /// </remarks>
 [UsedImplicitly]
 internal sealed class Export(IWorkflowDefinitionStore store, BpmnInterchangeDocumentService documentService) : ElsaEndpoint<Request>
@@ -38,17 +39,15 @@ internal sealed class Export(IWorkflowDefinitionStore store, BpmnInterchangeDocu
             return;
         }
 
-        if (!definition.CustomProperties.TryGetValue<string>(BpmnInterchangeDocumentService.SourceXmlCustomPropertyKey, out var xml) || string.IsNullOrEmpty(xml))
-        {
-            AddError($"Workflow definition '{request.DefinitionId}' was not imported from a BPMN document, so it cannot be exported as BPMN 2.0 XML.");
-            await Send.ErrorsAsync(StatusCodes.Status422UnprocessableEntity, cancellationToken);
-            return;
-        }
-
         try
         {
-            var bytes = documentService.Export(xml);
+            var bytes = documentService.Export(definition);
             await Send.BytesAsync(bytes, $"{request.DefinitionId}.bpmn", "application/xml", cancellation: cancellationToken);
+        }
+        catch (BpmnExportUnavailableException exception)
+        {
+            AddError(exception.Message);
+            await Send.ErrorsAsync(StatusCodes.Status422UnprocessableEntity, cancellationToken);
         }
         catch (BpmnInterchangeException exception)
         {

--- a/src/modules/Elsa.Bpmn.Interchange/Endpoints/Bpmn/Export/Request.cs
+++ b/src/modules/Elsa.Bpmn.Interchange/Endpoints/Bpmn/Export/Request.cs
@@ -1,0 +1,14 @@
+using JetBrains.Annotations;
+
+namespace Elsa.Bpmn.Interchange.Endpoints.Bpmn.Export;
+
+/// <summary>Identifies the workflow definition to export as BPMN 2.0 XML.</summary>
+[PublicAPI]
+public sealed class Request
+{
+    /// <summary>The workflow definition id to export.</summary>
+    public string DefinitionId { get; set; } = string.Empty;
+
+    /// <summary>The version to export, e.g. <c>Latest</c> or <c>Published</c>. Defaults to <c>Latest</c>.</summary>
+    public string? VersionOptions { get; set; }
+}

--- a/src/modules/Elsa.Bpmn.Interchange/Endpoints/Bpmn/Import/Endpoint.cs
+++ b/src/modules/Elsa.Bpmn.Interchange/Endpoints/Bpmn/Import/Endpoint.cs
@@ -85,16 +85,21 @@ internal sealed class Import(BpmnInterchangeDocumentService documentService) : E
         }, cancellationToken);
     }
 
+    /// <remarks>
+    /// <see cref="BpmnCapabilityException"/> carries <see cref="BpmnCapabilityException.DrivingElementIds"/> as a
+    /// single flat list, already unioned across every missing capability — it does not say which element drove which
+    /// capability (unlike <c>BpmnCapabilityRequirements.DrivingElementIds</c>, which is per-capability, but that type
+    /// is gone by the time this catch clause sees the exception). Attributing the full, unioned list to each
+    /// capability individually would put elements next to a capability they may have nothing to do with, so this
+    /// reports the missing capabilities together with the combined element list once, rather than repeating it.
+    /// </remarks>
     private void AddCapabilityErrors(BpmnCapabilityException exception)
     {
+        var missingCapabilities = string.Join(", ", BpmnInterchangeDocumentService.IndividualCapabilities.Where(capability => exception.Missing.HasFlag(capability)));
         var elementIds = string.Join(", ", exception.DrivingElementIds);
 
-        foreach (var capability in BpmnInterchangeDocumentService.IndividualCapabilities)
-        {
-            if (!exception.Missing.HasFlag(capability))
-                continue;
-
-            AddError($"This deployment does not declare the '{capability}' BPMN host capability the document requires. Offending elements: {elementIds}.");
-        }
+        AddError(
+            $"This deployment does not declare the following BPMN host capabilities the document requires: {missingCapabilities}. "
+            + $"Offending elements (combined across all missing capabilities above, not attributable to any one of them): {elementIds}.");
     }
 }

--- a/src/modules/Elsa.Bpmn.Interchange/Endpoints/Bpmn/Import/Endpoint.cs
+++ b/src/modules/Elsa.Bpmn.Interchange/Endpoints/Bpmn/Import/Endpoint.cs
@@ -1,0 +1,100 @@
+using Bpmn.Interchange;
+using Bpmn.Semantics;
+using Elsa.Abstractions;
+using Elsa.Bpmn.Interchange.Exceptions;
+using Elsa.Bpmn.Interchange.Services;
+using JetBrains.Annotations;
+using Microsoft.AspNetCore.Http;
+
+namespace Elsa.Bpmn.Interchange.Endpoints.Bpmn.Import;
+
+/// <summary>
+/// Reads a <c>.bpmn</c> document and persists it as a workflow definition whose root is the <see cref="Elsa.Bpmn.Activities.BpmnProcess"/>
+/// scope <c>BpmnWorkBinder</c> builds for it.
+/// </summary>
+/// <remarks>
+/// A thin wrapper over <see cref="BpmnInterchangeDocumentService.ImportAsync"/>. Its remarks explain why capability
+/// refusal is surfaced here rather than left to first execution, and why nothing beyond the source XML is persisted
+/// alongside the bound activity graph.
+/// </remarks>
+[UsedImplicitly]
+internal sealed class Import(BpmnInterchangeDocumentService documentService) : ElsaEndpoint<Request>
+{
+    /// <inheritdoc />
+    public override void Configure()
+    {
+        Post("bpmn/import");
+        AllowFileUploads();
+        ConfigurePermissions("write:workflow-definitions");
+    }
+
+    /// <inheritdoc />
+    public override async Task HandleAsync(Request request, CancellationToken cancellationToken)
+    {
+        if (Files.Count != 1)
+        {
+            AddError("Upload exactly one .bpmn file.");
+            await Send.ErrorsAsync(StatusCodes.Status400BadRequest, cancellationToken);
+            return;
+        }
+
+        var xml = await BpmnUploadedFileReader.ReadTextAsync(Files[0], cancellationToken);
+
+        BpmnDocumentImportResult result;
+
+        try
+        {
+            result = await documentService.ImportAsync(xml, request.DefinitionId, request.Name, request.ProcessId, cancellationToken);
+        }
+        catch (BpmnInterchangeException exception)
+        {
+            AddError(exception.Message);
+            await Send.ErrorsAsync(StatusCodes.Status400BadRequest, cancellationToken);
+            return;
+        }
+        catch (BpmnBindingException exception)
+        {
+            AddError(exception.Message);
+            await Send.ErrorsAsync(StatusCodes.Status422UnprocessableEntity, cancellationToken);
+            return;
+        }
+        catch (BpmnCapabilityException exception)
+        {
+            AddCapabilityErrors(exception);
+            await Send.ErrorsAsync(StatusCodes.Status422UnprocessableEntity, cancellationToken);
+            return;
+        }
+
+        if (!result.ImportResult.Succeeded)
+        {
+            foreach (var validationError in result.ImportResult.ValidationErrors)
+                AddError(validationError.Message);
+
+            await Send.ErrorsAsync(StatusCodes.Status400BadRequest, cancellationToken);
+            return;
+        }
+
+        var definition = result.ImportResult.WorkflowDefinition;
+
+        await Send.OkAsync(new Response
+        {
+            Id = definition.Id,
+            DefinitionId = definition.DefinitionId,
+            Version = definition.Version,
+            Analysis = BpmnImportAnalysisModel.From(result.Analysis)
+        }, cancellationToken);
+    }
+
+    private void AddCapabilityErrors(BpmnCapabilityException exception)
+    {
+        var elementIds = string.Join(", ", exception.DrivingElementIds);
+
+        foreach (var capability in BpmnInterchangeDocumentService.IndividualCapabilities)
+        {
+            if (!exception.Missing.HasFlag(capability))
+                continue;
+
+            AddError($"This deployment does not declare the '{capability}' BPMN host capability the document requires. Offending elements: {elementIds}.");
+        }
+    }
+}

--- a/src/modules/Elsa.Bpmn.Interchange/Endpoints/Bpmn/Import/Request.cs
+++ b/src/modules/Elsa.Bpmn.Interchange/Endpoints/Bpmn/Import/Request.cs
@@ -1,0 +1,17 @@
+using JetBrains.Annotations;
+
+namespace Elsa.Bpmn.Interchange.Endpoints.Bpmn.Import;
+
+/// <summary>The form fields accompanying the uploaded <c>.bpmn</c> file.</summary>
+[PublicAPI]
+public sealed class Request
+{
+    /// <summary>The workflow definition to update, or empty to import as a new one.</summary>
+    public string? DefinitionId { get; set; }
+
+    /// <summary>The workflow definition's display name, defaulting to the process's own BPMN name or id.</summary>
+    public string? Name { get; set; }
+
+    /// <summary>The process to import when the document declares more than one.</summary>
+    public string? ProcessId { get; set; }
+}

--- a/src/modules/Elsa.Bpmn.Interchange/Endpoints/Bpmn/Import/Response.cs
+++ b/src/modules/Elsa.Bpmn.Interchange/Endpoints/Bpmn/Import/Response.cs
@@ -1,0 +1,20 @@
+using JetBrains.Annotations;
+
+namespace Elsa.Bpmn.Interchange.Endpoints.Bpmn.Import;
+
+/// <summary>The workflow definition a BPMN import produced, plus what the read cost.</summary>
+[PublicAPI]
+public sealed class Response
+{
+    /// <summary>The persisted version's own id.</summary>
+    public string Id { get; init; } = string.Empty;
+
+    /// <summary>The workflow definition id, stable across versions.</summary>
+    public string DefinitionId { get; init; } = string.Empty;
+
+    /// <summary>The persisted version number.</summary>
+    public int Version { get; init; }
+
+    /// <summary>The same analysis <see cref="Analyze.Analyze"/> would have produced for this document.</summary>
+    public BpmnImportAnalysisModel Analysis { get; init; } = new();
+}

--- a/src/modules/Elsa.Bpmn.Interchange/Exceptions/BpmnExportUnavailableException.cs
+++ b/src/modules/Elsa.Bpmn.Interchange/Exceptions/BpmnExportUnavailableException.cs
@@ -1,0 +1,12 @@
+namespace Elsa.Bpmn.Interchange.Exceptions;
+
+/// <summary>
+/// Thrown when a workflow definition cannot be exported as BPMN 2.0 XML because the source this deployment would
+/// need to write back out is missing or no longer trustworthy.
+/// </summary>
+/// <remarks>
+/// See <see cref="Services.BpmnInterchangeDocumentService"/>'s remarks for the two distinct situations this covers —
+/// a definition never imported from BPMN (or one whose source a later save dropped), and a definition that has
+/// changed since it was imported — and why each gets its own message rather than one generic refusal.
+/// </remarks>
+public class BpmnExportUnavailableException(string message) : Exception(message);

--- a/src/modules/Elsa.Bpmn.Interchange/Features/BpmnInterchangeFeature.cs
+++ b/src/modules/Elsa.Bpmn.Interchange/Features/BpmnInterchangeFeature.cs
@@ -1,5 +1,8 @@
+using Bpmn.Interchange;
 using Elsa.Bpmn.Features;
 using Elsa.Bpmn.Interchange.Binding;
+using Elsa.Bpmn.Interchange.Services;
+using Elsa.Extensions;
 using Elsa.Features.Abstractions;
 using Elsa.Features.Attributes;
 using Elsa.Features.Services;
@@ -25,9 +28,18 @@ public class BpmnInterchangeFeature : FeatureBase
     }
 
     /// <inheritdoc />
+    public override void Configure()
+    {
+        Module.AddFastEndpointsAssembly<BpmnInterchangeFeature>();
+    }
+
+    /// <inheritdoc />
     public override void Apply()
     {
         Services.AddSingleton<BpmnActivityBindingFormat>();
         Services.AddSingleton<BpmnWorkBinder>();
+        Services.AddSingleton<BpmnXmlReader>();
+        Services.AddSingleton<BpmnXmlWriter>();
+        Services.AddScoped<BpmnInterchangeDocumentService>();
     }
 }

--- a/src/modules/Elsa.Bpmn.Interchange/Services/BpmnInterchangeDocumentService.cs
+++ b/src/modules/Elsa.Bpmn.Interchange/Services/BpmnInterchangeDocumentService.cs
@@ -3,8 +3,12 @@ using Bpmn.Interchange;
 using Bpmn.Model;
 using Bpmn.Semantics;
 using Elsa.Bpmn.Activities;
+using Elsa.Bpmn.Hosting;
 using Elsa.Bpmn.Interchange.Binding;
+using Elsa.Bpmn.Interchange.Exceptions;
+using Elsa.Extensions;
 using Elsa.Workflows.Management;
+using Elsa.Workflows.Management.Entities;
 using Elsa.Workflows.Management.Models;
 
 namespace Elsa.Bpmn.Interchange.Services;
@@ -21,11 +25,33 @@ namespace Elsa.Bpmn.Interchange.Services;
 /// <para>
 /// <b>Export carries the whole library-owned document, not a reduced view of it.</b> The only thing <see cref="ImportAsync"/>
 /// persists beyond the bound Elsa activity graph is the original BPMN XML text, under <see cref="SourceXmlCustomPropertyKey"/>
-/// on the workflow definition's custom properties. <see cref="Export"/> re-reads that same text through the same reader
-/// and hands the resulting <see cref="BpmnImportResult"/> — retained extension elements, foreign attributes,
+/// on the workflow definition's custom properties. <see cref="Export(string)"/> re-reads that same text through the same
+/// reader and hands the resulting <see cref="BpmnImportResult"/> — retained extension elements, foreign attributes,
 /// unrecognized children and BPMN DI layout included — straight to <see cref="BpmnXmlWriter"/>. Nothing is
 /// reconstructed from the Elsa activity tree, which only carries a bindingRef-to-activityId map and would have to
 /// throw away everything the reader retained to get there.
+/// </para>
+/// <para>
+/// <b>Export is only ever the document as imported, and that is a real limitation, not a detail.</b> Until BPMN-aware
+/// editing exists (a Studio concern, out of scope for this program), nothing re-serializes edits made through Elsa's
+/// own designer back into BPMN — <see cref="Export(WorkflowDefinition)"/> always returns the source text
+/// <see cref="ImportAsync"/> stored, never a document reflecting what the definition currently is. That is why it
+/// refuses outright, rather than returning something, when it cannot prove that text still matches the definition:
+/// see <see cref="SourceVersionCustomPropertyKey"/>.
+/// </para>
+/// <para>
+/// <b>The stored source can go missing or stale after import, and each is refused with its own diagnosis.</b> BPMN
+/// source travels on <see cref="SourceXmlCustomPropertyKey"/>, one entry in the same <c>CustomProperties</c>
+/// dictionary a workflow edit can — and, through Elsa's own workflow-definition save endpoint, does — replace
+/// wholesale. A save that does not carry that key forward removes it as a side effect of editing something else
+/// entirely, which is indistinguishable, once it has happened, from a definition that was never imported from BPMN
+/// in the first place; <see cref="Export(WorkflowDefinition)"/> says so honestly rather than asserting the document
+/// was "never imported", which would be true in one case and false in the other. Separately, a save that DOES carry
+/// the key forward can still leave the definition materially changed — the graph, name, or anything else about it —
+/// while the stored BPMN text still describes the pre-edit document. <see cref="SourceVersionCustomPropertyKey"/>
+/// records the definition's own version at the moment of import for exactly this: if the current version no longer
+/// matches, the stored source is stale, and exporting it would silently hand back a document that is not what the
+/// caller has, which is worse than refusing.
 /// </para>
 /// <para>
 /// <b>Capability refusal happens here, at import, not at <c>BpmnGraph.Build</c>.</b> <see cref="BpmnCapabilityRequirements.Analyze"/>
@@ -38,25 +64,40 @@ namespace Elsa.Bpmn.Interchange.Services;
 /// it.
 /// </para>
 /// </remarks>
-public sealed class BpmnInterchangeDocumentService(BpmnXmlReader reader, BpmnXmlWriter writer, BpmnWorkBinder binder, IWorkflowDefinitionImporter importer)
+public sealed class BpmnInterchangeDocumentService(
+    BpmnXmlReader reader,
+    BpmnXmlWriter writer,
+    BpmnWorkBinder binder,
+    IWorkflowDefinitionImporter importer,
+    IWorkflowDefinitionStore store)
 {
-    /// <summary>The workflow definition custom property the original BPMN XML is carried under, for <see cref="Export"/>.</summary>
+    /// <summary>The workflow definition custom property the original BPMN XML is carried under, for <see cref="Export(WorkflowDefinition)"/>.</summary>
     public const string SourceXmlCustomPropertyKey = "Bpmn:SourceXml";
+
+    /// <summary>
+    /// The workflow definition custom property <see cref="ImportAsync"/> records the definition's own version number
+    /// under, at the moment it stores <see cref="SourceXmlCustomPropertyKey"/>.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Export(WorkflowDefinition)"/> compares this against the definition's current version to tell a
+    /// still-current source from a stale one. The version number is what <see cref="WorkflowDefinition"/> itself
+    /// already exposes for "has this definition changed", so this reuses it rather than inventing a second notion of
+    /// change (a content hash, a timestamp) that could disagree with the versioning the rest of the system already
+    /// uses.
+    /// </remarks>
+    public const string SourceVersionCustomPropertyKey = "Bpmn:SourceVersion";
 
     /// <summary>
     /// The host capabilities this deployment's BPMN runtime declares.
     /// </summary>
     /// <remarks>
-    /// This mirrors <c>Elsa.Bpmn.Hosting.BpmnScopeHost.Capabilities</c> exactly, and for the same reason that constant
-    /// gives for not simply writing <see cref="BpmnHostCapabilities.Full"/>: <c>Full</c> would silently grow to cover a
-    /// capability a later library version adds and the runtime host has never implemented, which would turn an
-    /// import-time approval into a runtime failure — the opposite of what capability refusal at import is for. That
-    /// constant is internal to <c>Elsa.Bpmn</c> (the runtime module, kept free of this package's dependency closure per
-    /// D12) and cannot be read from here directly, so it is restated. <b>If <c>BpmnScopeHost.Capabilities</c> ever
-    /// changes, this must change with it.</b>
+    /// Reads <see cref="BpmnRuntimeCapabilities.Declared"/> straight from <c>Elsa.Bpmn</c> — the runtime module,
+    /// which already publishes that constant for exactly this reason — rather than restating the flag set here.
+    /// A restatement could silently drift from what <c>Elsa.Bpmn.Hosting.BpmnScopeHost</c> actually honours at
+    /// execution time, which would mean import-time refusal and runtime behaviour disagreeing: the worse direction
+    /// for that drift to go is a document accepted here and only failing the first time it runs.
     /// </remarks>
-    public static readonly BpmnHostCapabilities DeclaredHostCapabilities =
-        BpmnHostCapabilities.SubtreeCancellation | BpmnHostCapabilities.ScopeSignalling | BpmnHostCapabilities.IterationScopes | BpmnHostCapabilities.ScopeVariables;
+    public static readonly BpmnHostCapabilities DeclaredHostCapabilities = BpmnRuntimeCapabilities.Declared;
 
     /// <summary>Every individually named capability, for turning a <see cref="BpmnHostCapabilities"/> flag set into readable names.</summary>
     public static readonly IReadOnlyList<BpmnHostCapabilities> IndividualCapabilities =
@@ -110,6 +151,17 @@ public sealed class BpmnInterchangeDocumentService(BpmnXmlReader reader, BpmnXml
 
         var importResult = await importer.ImportAsync(new SaveWorkflowDefinitionRequest { Model = model, Publish = false }, cancellationToken);
 
+        // The definition's final Version is only known once the importer/publisher has assigned and persisted it —
+        // see SourceVersionCustomPropertyKey's remarks for why that value, specifically, is what staleness is judged
+        // against. It cannot be included in the CustomProperties model built above because nothing before this point
+        // has decided it yet, so it is recorded with a second, explicit save rather than assumed or precomputed.
+        if (importResult.Succeeded)
+        {
+            var persisted = importResult.WorkflowDefinition;
+            persisted.CustomProperties[SourceVersionCustomPropertyKey] = persisted.Version;
+            await store.SaveAsync(persisted, cancellationToken);
+        }
+
         return new BpmnDocumentImportResult(importResult, result.Analysis);
     }
 
@@ -126,6 +178,46 @@ public sealed class BpmnInterchangeDocumentService(BpmnXmlReader reader, BpmnXml
         var document = writer.Write(result, new BpmnExportOptions());
 
         return Encoding.UTF8.GetBytes(document);
+    }
+
+    /// <summary>
+    /// Resolves the BPMN source a workflow definition was imported from and writes it back out, refusing rather than
+    /// guessing when that source is missing or no longer trustworthy. See this type's remarks for what "missing" and
+    /// "stale" mean and why each gets its own message.
+    /// </summary>
+    /// <param name="definition">The workflow definition to export, as read from the store.</param>
+    /// <exception cref="BpmnExportUnavailableException">
+    /// The definition does not currently carry BPMN source, or it does but the definition has changed since the
+    /// source was recorded.
+    /// </exception>
+    /// <exception cref="BpmnInterchangeException">The stored document cannot be read at all.</exception>
+    public byte[] Export(WorkflowDefinition definition)
+    {
+        if (!definition.CustomProperties.TryGetValue<string>(SourceXmlCustomPropertyKey, out var xml) || string.IsNullOrEmpty(xml))
+        {
+            throw new BpmnExportUnavailableException(
+                $"Workflow definition '{definition.DefinitionId}' does not currently carry BPMN source, so it cannot be exported as BPMN 2.0 XML. "
+                + "Either it was never imported from a BPMN document, or a later save replaced its custom properties wholesale and removed the "
+                + $"'{SourceXmlCustomPropertyKey}' entry as a side effect of editing something else.");
+        }
+
+        if (!definition.CustomProperties.TryGetValue<int>(SourceVersionCustomPropertyKey, out var sourceVersion))
+        {
+            throw new BpmnExportUnavailableException(
+                $"Workflow definition '{definition.DefinitionId}' carries BPMN source, but not the definition version it was recorded against, so "
+                + "whether that source still matches this definition cannot be verified. Exporting it would risk silently returning a document that "
+                + "is not what this definition currently is.");
+        }
+
+        if (sourceVersion != definition.Version)
+        {
+            throw new BpmnExportUnavailableException(
+                $"Workflow definition '{definition.DefinitionId}' has changed since it was imported from BPMN (imported at version {sourceVersion}, "
+                + $"currently at version {definition.Version}). The BPMN source stored on it no longer corresponds to this definition, so exporting it "
+                + "would silently return a document that is not what this definition currently is.");
+        }
+
+        return Export(xml);
     }
 
     private static BpmnProcessDefinition ResolveRootDefinition(BpmnDefinitions definitions, string? processId)

--- a/src/modules/Elsa.Bpmn.Interchange/Services/BpmnInterchangeDocumentService.cs
+++ b/src/modules/Elsa.Bpmn.Interchange/Services/BpmnInterchangeDocumentService.cs
@@ -145,19 +145,20 @@ public sealed class BpmnInterchangeDocumentService(
         {
             DefinitionId = definitionId ?? string.Empty,
             Name = string.IsNullOrWhiteSpace(name) ? rootDefinition.Name ?? rootDefinition.ProcessId : name,
-            Root = process,
-            CustomProperties = new Dictionary<string, object> { [SourceXmlCustomPropertyKey] = xml }
+            Root = process
         };
 
         var importResult = await importer.ImportAsync(new SaveWorkflowDefinitionRequest { Model = model, Publish = false }, cancellationToken);
 
         // The definition's final Version is only known once the importer/publisher has assigned and persisted it —
         // see SourceVersionCustomPropertyKey's remarks for why that value, specifically, is what staleness is judged
-        // against. It cannot be included in the CustomProperties model built above because nothing before this point
-        // has decided it yet, so it is recorded with a second, explicit save rather than assumed or precomputed.
+        // against. Neither custom property is written until it is known, so both land on this single, explicit save:
+        // if it fails or is cancelled, the definition carries neither key, which Export(WorkflowDefinition) reports
+        // honestly as "never imported" rather than as a partial import that cannot be diagnosed.
         if (importResult.Succeeded)
         {
             var persisted = importResult.WorkflowDefinition;
+            persisted.CustomProperties[SourceXmlCustomPropertyKey] = xml;
             persisted.CustomProperties[SourceVersionCustomPropertyKey] = persisted.Version;
             await store.SaveAsync(persisted, cancellationToken);
         }
@@ -204,18 +205,16 @@ public sealed class BpmnInterchangeDocumentService(
         if (!definition.CustomProperties.TryGetValue<int>(SourceVersionCustomPropertyKey, out var sourceVersion))
         {
             // Distinct from both other refusals: this is not "never imported" (the source text is right there) and
-            // not "stale" (there is no version to compare against yet). ImportAsync records SourceXmlCustomPropertyKey
-            // and SourceVersionCustomPropertyKey with two separate saves, because the definition's own version is
-            // only assigned once the first save persists it — see SourceVersionCustomPropertyKey's remarks. A
-            // definition in exactly this state is one whose import stored the source but did not finish recording
-            // the version it belongs to, most likely because the second save failed or was cancelled after the
-            // first one succeeded.
+            // not "stale" (there is no version to compare against yet). ImportAsync writes SourceXmlCustomPropertyKey
+            // and SourceVersionCustomPropertyKey together, in the single save described in its remarks, so this path
+            // is not reachable through import itself; it is kept as a defence against the same combination arising
+            // some other way — e.g. custom properties edited or migrated directly, outside ImportAsync — where
+            // "whether the source still matches" cannot be verified without a version to compare against.
             throw new BpmnExportUnavailableException(
-                $"Workflow definition '{definition.DefinitionId}' carries BPMN source, but not the definition version it was recorded against. This "
-                + "means the import that stored the source did not finish — the version marker that records what it was imported against was never "
-                + "written, most likely because that request failed or was cancelled partway through. It does not mean this definition was never "
-                + "imported from BPMN, and it does not mean the source is stale; whether it still matches this definition simply cannot be verified. "
-                + "Re-import the document to record a complete, exportable source.");
+                $"Workflow definition '{definition.DefinitionId}' carries BPMN source, but not the definition version it was recorded against, so "
+                + "whether that source still matches this definition cannot be verified. It does not mean this definition was never imported from "
+                + "BPMN, and it does not mean the source is stale — there is simply no version recorded to compare against. Re-import the document to "
+                + "record a complete, exportable source.");
         }
 
         if (sourceVersion != definition.Version)

--- a/src/modules/Elsa.Bpmn.Interchange/Services/BpmnInterchangeDocumentService.cs
+++ b/src/modules/Elsa.Bpmn.Interchange/Services/BpmnInterchangeDocumentService.cs
@@ -1,0 +1,184 @@
+using System.Text;
+using Bpmn.Interchange;
+using Bpmn.Model;
+using Bpmn.Semantics;
+using Elsa.Bpmn.Activities;
+using Elsa.Bpmn.Interchange.Binding;
+using Elsa.Workflows.Management;
+using Elsa.Workflows.Management.Models;
+
+namespace Elsa.Bpmn.Interchange.Services;
+
+/// <summary>
+/// The one code path the Analyze, Import and Export endpoints all sit on top of.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Analyze and Import never disagree.</b> Both call <see cref="BpmnXmlReader"/>, which — per its own contract —
+/// runs <see cref="BpmnXmlReader.Analyze"/> and <see cref="BpmnXmlReader.Read"/> through the same code, so a preview
+/// can never say something the import that follows contradicts.
+/// </para>
+/// <para>
+/// <b>Export carries the whole library-owned document, not a reduced view of it.</b> The only thing <see cref="ImportAsync"/>
+/// persists beyond the bound Elsa activity graph is the original BPMN XML text, under <see cref="SourceXmlCustomPropertyKey"/>
+/// on the workflow definition's custom properties. <see cref="Export"/> re-reads that same text through the same reader
+/// and hands the resulting <see cref="BpmnImportResult"/> — retained extension elements, foreign attributes,
+/// unrecognized children and BPMN DI layout included — straight to <see cref="BpmnXmlWriter"/>. Nothing is
+/// reconstructed from the Elsa activity tree, which only carries a bindingRef-to-activityId map and would have to
+/// throw away everything the reader retained to get there.
+/// </para>
+/// <para>
+/// <b>Capability refusal happens here, at import, not at <c>BpmnGraph.Build</c>.</b> <see cref="BpmnCapabilityRequirements.Analyze"/>
+/// is the static half of the same check <c>BpmnGraph.Build</c> performs at first execution: it needs only the
+/// definition, not bound work or a host snapshot. Running it at import means an unrunnable diagram is rejected before
+/// it is ever persisted, naming the missing capability and the elements that need it, rather than surfacing as an
+/// incident the first time the workflow runs. <c>BpmnGraph.Build</c> itself is deliberately not called here: building
+/// the graph also validates structural invariants that belong to the runtime module's own execution path
+/// (<c>Elsa.Bpmn.Hosting.BpmnScopeHost</c>), and re-running that here would duplicate it outside the module that owns
+/// it.
+/// </para>
+/// </remarks>
+public sealed class BpmnInterchangeDocumentService(BpmnXmlReader reader, BpmnXmlWriter writer, BpmnWorkBinder binder, IWorkflowDefinitionImporter importer)
+{
+    /// <summary>The workflow definition custom property the original BPMN XML is carried under, for <see cref="Export"/>.</summary>
+    public const string SourceXmlCustomPropertyKey = "Bpmn:SourceXml";
+
+    /// <summary>
+    /// The host capabilities this deployment's BPMN runtime declares.
+    /// </summary>
+    /// <remarks>
+    /// This mirrors <c>Elsa.Bpmn.Hosting.BpmnScopeHost.Capabilities</c> exactly, and for the same reason that constant
+    /// gives for not simply writing <see cref="BpmnHostCapabilities.Full"/>: <c>Full</c> would silently grow to cover a
+    /// capability a later library version adds and the runtime host has never implemented, which would turn an
+    /// import-time approval into a runtime failure — the opposite of what capability refusal at import is for. That
+    /// constant is internal to <c>Elsa.Bpmn</c> (the runtime module, kept free of this package's dependency closure per
+    /// D12) and cannot be read from here directly, so it is restated. <b>If <c>BpmnScopeHost.Capabilities</c> ever
+    /// changes, this must change with it.</b>
+    /// </remarks>
+    public static readonly BpmnHostCapabilities DeclaredHostCapabilities =
+        BpmnHostCapabilities.SubtreeCancellation | BpmnHostCapabilities.ScopeSignalling | BpmnHostCapabilities.IterationScopes | BpmnHostCapabilities.ScopeVariables;
+
+    /// <summary>Every individually named capability, for turning a <see cref="BpmnHostCapabilities"/> flag set into readable names.</summary>
+    public static readonly IReadOnlyList<BpmnHostCapabilities> IndividualCapabilities =
+    [
+        BpmnHostCapabilities.SubtreeCancellation,
+        BpmnHostCapabilities.ScopeSignalling,
+        BpmnHostCapabilities.IterationScopes,
+        BpmnHostCapabilities.ScopeVariables
+    ];
+
+    /// <summary>
+    /// Reports what a document contains and what a read would cost, without persisting anything.
+    /// </summary>
+    /// <exception cref="BpmnInterchangeException">The document cannot be read at all.</exception>
+    public BpmnImportAnalysis Analyze(string xml) => reader.Analyze(xml, new BpmnImportOptions());
+
+    /// <summary>
+    /// Reads a document, refuses it if the host cannot run what it declares, and binds it into the <see cref="BpmnProcess"/>
+    /// scope a workflow definition's root becomes.
+    /// </summary>
+    /// <param name="xml">The BPMN 2.0 XML to import.</param>
+    /// <param name="definitionId">The workflow definition to update, or <c>null</c>/empty to create a new one.</param>
+    /// <param name="name">The workflow definition's display name, defaulting to the process's own BPMN name or id.</param>
+    /// <param name="processId">
+    /// The process to bind when the document declares more than one; not needed when it declares exactly one.
+    /// </param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <exception cref="BpmnInterchangeException">The document cannot be read, or declares more than one process and <paramref name="processId"/> does not pick one.</exception>
+    /// <exception cref="BpmnCapabilityException">The document needs a host capability this deployment does not declare.</exception>
+    /// <exception cref="Exceptions.BpmnBindingException">A work binding cannot be turned into an Elsa activity.</exception>
+    public async Task<BpmnDocumentImportResult> ImportAsync(string xml, string? definitionId, string? name, string? processId, CancellationToken cancellationToken)
+    {
+        var result = reader.Read(xml, new BpmnImportOptions { ProcessId = processId });
+        var rootDefinition = ResolveRootDefinition(result.Definitions, processId);
+
+        EnsureCapabilitiesSatisfied(rootDefinition, result.Bindings);
+
+        var process = binder.Bind(rootDefinition, result.Bindings);
+
+        // Whoever composes a bound scope into a workflow says explicitly that it is an entry point; an import is
+        // exactly that, for the process the caller asked to import.
+        process.IsRootScope = true;
+
+        var model = new WorkflowDefinitionModel
+        {
+            DefinitionId = definitionId ?? string.Empty,
+            Name = string.IsNullOrWhiteSpace(name) ? rootDefinition.Name ?? rootDefinition.ProcessId : name,
+            Root = process,
+            CustomProperties = new Dictionary<string, object> { [SourceXmlCustomPropertyKey] = xml }
+        };
+
+        var importResult = await importer.ImportAsync(new SaveWorkflowDefinitionRequest { Model = model, Publish = false }, cancellationToken);
+
+        return new BpmnDocumentImportResult(importResult, result.Analysis);
+    }
+
+    /// <summary>
+    /// Writes the document a workflow definition was imported from back out as BPMN 2.0 XML, through the same
+    /// reader-then-writer path <see cref="ImportAsync"/> used, so retained extension elements, foreign attributes and
+    /// BPMN DI layout come back exactly as the reader retained them.
+    /// </summary>
+    /// <param name="xml">The BPMN 2.0 XML carried on the workflow definition's <see cref="SourceXmlCustomPropertyKey"/> custom property.</param>
+    /// <exception cref="BpmnInterchangeException">The document cannot be read at all.</exception>
+    public byte[] Export(string xml)
+    {
+        var result = reader.Read(xml, new BpmnImportOptions());
+        var document = writer.Write(result, new BpmnExportOptions());
+
+        return Encoding.UTF8.GetBytes(document);
+    }
+
+    private static BpmnProcessDefinition ResolveRootDefinition(BpmnDefinitions definitions, string? processId)
+    {
+        if (!string.IsNullOrWhiteSpace(processId))
+        {
+            // BpmnImportOptions.ProcessId already made the read fail fast if the document does not declare this
+            // process, so finding it here can only fail if that guarantee itself changes.
+            return definitions.Processes.First(process => string.Equals(process.ProcessId, processId, StringComparison.Ordinal));
+        }
+
+        if (definitions.Processes.Count == 1)
+            return definitions.Processes[0];
+
+        var declared = string.Join(", ", definitions.Processes.Select(process => process.ProcessId));
+
+        throw new BpmnInterchangeException(
+            $"The document declares {definitions.Processes.Count} processes ({declared}); specify which one to import.");
+    }
+
+    /// <summary>
+    /// Refuses the definition, naming the missing capability and the offending element ids, when it or any process
+    /// nested inside it needs a host capability <see cref="DeclaredHostCapabilities"/> does not cover.
+    /// </summary>
+    private static void EnsureCapabilitiesSatisfied(BpmnProcessDefinition definition, IReadOnlyList<BpmnWorkBinding> bindings) =>
+        EnsureCapabilitiesSatisfied(definition, bindings, DeclaredHostCapabilities);
+
+    /// <summary>
+    /// Refuses the definition, naming the missing capability and the offending element ids, when it or any process
+    /// nested inside it needs a host capability <paramref name="available"/> does not cover.
+    /// </summary>
+    /// <remarks>
+    /// Takes the available capability set as a parameter, rather than reading <see cref="DeclaredHostCapabilities"/>
+    /// directly, so a test can prove the refusal — and the walk into nested processes below — without a document that
+    /// needs a capability this deployment's runtime host has never declared, which the current library version
+    /// cannot produce because <see cref="DeclaredHostCapabilities"/> already covers every capability it defines.
+    /// <para>
+    /// A nested process is a separate scope with its own graph at execution time, so — mirroring that — it is
+    /// analyzed separately here too, walking every <see cref="BpmnWorkBinding.NestedProcess"/> binding whose owner is
+    /// the definition just checked.
+    /// </para>
+    /// </remarks>
+    internal static void EnsureCapabilitiesSatisfied(BpmnProcessDefinition definition, IReadOnlyList<BpmnWorkBinding> bindings, BpmnHostCapabilities available)
+    {
+        BpmnCapabilityRequirements.Analyze(definition).ThrowIfUnmet(available, definition.ProcessId);
+
+        foreach (var nested in bindings.OfType<BpmnWorkBinding.NestedProcess>())
+        {
+            if (string.Equals(nested.ProcessId, definition.ProcessId, StringComparison.Ordinal))
+                EnsureCapabilitiesSatisfied(nested.Definition, bindings, available);
+        }
+    }
+}
+
+/// <summary>The outcome of <see cref="BpmnInterchangeDocumentService.ImportAsync"/>: the persisted definition, plus what the read cost.</summary>
+public sealed record BpmnDocumentImportResult(ImportWorkflowResult ImportResult, BpmnImportAnalysis Analysis);

--- a/src/modules/Elsa.Bpmn.Interchange/Services/BpmnInterchangeDocumentService.cs
+++ b/src/modules/Elsa.Bpmn.Interchange/Services/BpmnInterchangeDocumentService.cs
@@ -203,10 +203,19 @@ public sealed class BpmnInterchangeDocumentService(
 
         if (!definition.CustomProperties.TryGetValue<int>(SourceVersionCustomPropertyKey, out var sourceVersion))
         {
+            // Distinct from both other refusals: this is not "never imported" (the source text is right there) and
+            // not "stale" (there is no version to compare against yet). ImportAsync records SourceXmlCustomPropertyKey
+            // and SourceVersionCustomPropertyKey with two separate saves, because the definition's own version is
+            // only assigned once the first save persists it — see SourceVersionCustomPropertyKey's remarks. A
+            // definition in exactly this state is one whose import stored the source but did not finish recording
+            // the version it belongs to, most likely because the second save failed or was cancelled after the
+            // first one succeeded.
             throw new BpmnExportUnavailableException(
-                $"Workflow definition '{definition.DefinitionId}' carries BPMN source, but not the definition version it was recorded against, so "
-                + "whether that source still matches this definition cannot be verified. Exporting it would risk silently returning a document that "
-                + "is not what this definition currently is.");
+                $"Workflow definition '{definition.DefinitionId}' carries BPMN source, but not the definition version it was recorded against. This "
+                + "means the import that stored the source did not finish — the version marker that records what it was imported against was never "
+                + "written, most likely because that request failed or was cancelled partway through. It does not mean this definition was never "
+                + "imported from BPMN, and it does not mean the source is stale; whether it still matches this definition simply cannot be verified. "
+                + "Re-import the document to record a complete, exportable source.");
         }
 
         if (sourceVersion != definition.Version)
@@ -264,11 +273,12 @@ public sealed class BpmnInterchangeDocumentService(
     {
         BpmnCapabilityRequirements.Analyze(definition).ThrowIfUnmet(available, definition.ProcessId);
 
-        foreach (var nested in bindings.OfType<BpmnWorkBinding.NestedProcess>())
-        {
-            if (string.Equals(nested.ProcessId, definition.ProcessId, StringComparison.Ordinal))
-                EnsureCapabilitiesSatisfied(nested.Definition, bindings, available);
-        }
+        var ownedNestedProcesses = bindings
+            .OfType<BpmnWorkBinding.NestedProcess>()
+            .Where(nested => string.Equals(nested.ProcessId, definition.ProcessId, StringComparison.Ordinal));
+
+        foreach (var nested in ownedNestedProcesses)
+            EnsureCapabilitiesSatisfied(nested.Definition, bindings, available);
     }
 }
 

--- a/src/modules/Elsa.Bpmn.Interchange/ShellFeatures/BpmnInterchangeFeature.cs
+++ b/src/modules/Elsa.Bpmn.Interchange/ShellFeatures/BpmnInterchangeFeature.cs
@@ -1,5 +1,8 @@
+using Bpmn.Interchange;
+using CShells.FastEndpoints.Features;
 using CShells.Features;
 using Elsa.Bpmn.Interchange.Binding;
+using Elsa.Bpmn.Interchange.Services;
 using Elsa.Bpmn.ShellFeatures;
 using Elsa.Common.ShellFeatures;
 using JetBrains.Annotations;
@@ -21,11 +24,14 @@ namespace Elsa.Bpmn.Interchange.ShellFeatures;
     Description = "Provides BPMN XML interchange (import/export) capabilities for workflows.",
     DependsOn = [typeof(BpmnFeature)])]
 [UsedImplicitly]
-public class BpmnInterchangeFeature : IShellFeature
+public class BpmnInterchangeFeature : IFastEndpointsShellFeature
 {
     public void ConfigureServices(IServiceCollection services)
     {
         services.AddSingleton<BpmnActivityBindingFormat>();
         services.AddSingleton<BpmnWorkBinder>();
+        services.AddSingleton<BpmnXmlReader>();
+        services.AddSingleton<BpmnXmlWriter>();
+        services.AddScoped<BpmnInterchangeDocumentService>();
     }
 }

--- a/src/modules/Elsa.Bpmn/Hosting/BpmnRuntimeCapabilities.cs
+++ b/src/modules/Elsa.Bpmn/Hosting/BpmnRuntimeCapabilities.cs
@@ -14,6 +14,14 @@ namespace Elsa.Bpmn.Hosting;
 /// would refuse it for at first execution, rather than restating the set as a second literal that can silently drift
 /// from this one. <see cref="BpmnScopeHost.Capabilities"/> is defined in terms of <see cref="Declared"/>, not the
 /// other way around, so there remains exactly one place this set is spelled out.
+/// <para>
+/// Capability refusal — <c>BpmnGraph.Build</c>'s <c>ThrowIfUnmet</c>, and the mirroring check in
+/// <c>BpmnInterchangeDocumentService.EnsureCapabilitiesSatisfied</c> — is currently unreachable: the pinned
+/// <c>Bpmn.Semantics</c> version defines no flag <see cref="Declared"/> does not already cover, so nothing can be
+/// refused for a missing capability today. <c>Elsa.Bpmn.UnitTests.BpmnRuntimeCapabilitiesTests</c> is what will say
+/// when that stops being true — it fails the moment the library adds a flag this constant doesn't declare, and its
+/// failure message names the decision that needs making.
+/// </para>
 /// </remarks>
 public static class BpmnRuntimeCapabilities
 {

--- a/src/modules/Elsa.Bpmn/Hosting/BpmnRuntimeCapabilities.cs
+++ b/src/modules/Elsa.Bpmn/Hosting/BpmnRuntimeCapabilities.cs
@@ -1,0 +1,26 @@
+using Bpmn.Semantics;
+
+namespace Elsa.Bpmn.Hosting;
+
+/// <summary>
+/// The single source of truth for the BPMN host capabilities this runtime module declares it can honour.
+/// </summary>
+/// <remarks>
+/// <see cref="BpmnScopeHost"/> is <c>internal</c> — <c>Elsa.Bpmn</c> is the runtime module, kept free of the
+/// interchange package's dependency closure per D12 — so its <see cref="BpmnScopeHost.Capabilities"/> constant
+/// cannot be read from outside this assembly. This type exists solely to make that same value reachable as public
+/// API, so <c>Elsa.Bpmn.Interchange</c> — which already references this module, so making the constant reachable
+/// does not touch the D12 split — can refuse a document at import time for exactly the capabilities the runtime
+/// would refuse it for at first execution, rather than restating the set as a second literal that can silently drift
+/// from this one. <see cref="BpmnScopeHost.Capabilities"/> is defined in terms of <see cref="Declared"/>, not the
+/// other way around, so there remains exactly one place this set is spelled out.
+/// </remarks>
+public static class BpmnRuntimeCapabilities
+{
+    /// <summary>
+    /// What <see cref="BpmnScopeHost"/> promises it can do. See its own remarks for what each flag is honoured by
+    /// and why this is spelled out rather than written as <see cref="BpmnHostCapabilities.Full"/>.
+    /// </summary>
+    public const BpmnHostCapabilities Declared =
+        BpmnHostCapabilities.SubtreeCancellation | BpmnHostCapabilities.ScopeSignalling | BpmnHostCapabilities.IterationScopes | BpmnHostCapabilities.ScopeVariables;
+}

--- a/src/modules/Elsa.Bpmn/Hosting/BpmnScopeHost.cs
+++ b/src/modules/Elsa.Bpmn/Hosting/BpmnScopeHost.cs
@@ -34,13 +34,12 @@ internal sealed class BpmnScopeHost
     /// Each capability is a claim, honoured elsewhere in this module: subtree cancellation by
     /// <see cref="BpmnWorkTeardown"/>, scope signalling by <see cref="BpmnScopeSignal"/>, iteration scopes by the
     /// applier's per-instance variables, and <see cref="BpmnHostCapabilities.ScopeVariables"/> by
-    /// <see cref="BpmnScopeVariables"/>. Spelled out rather than written as <c>BpmnHostCapabilities.Full</c> on
-    /// purpose: <c>Full</c> would silently grow to include a capability a later library version adds and this host
-    /// has never implemented, which is the one way a declaration can become a lie without anyone editing it.
-    /// The same set goes to <see cref="BpmnGraph.Build"/> and to every snapshot, which the port requires.
+    /// <see cref="BpmnScopeVariables"/>. Defined in terms of <see cref="BpmnRuntimeCapabilities.Declared"/> — see its
+    /// remarks for why the set is spelled out there rather than written as <c>BpmnHostCapabilities.Full</c>, and for
+    /// why that type exists at all. The same set goes to <see cref="BpmnGraph.Build"/> and to every snapshot, which
+    /// the port requires.
     /// </remarks>
-    public const BpmnHostCapabilities Capabilities =
-        BpmnHostCapabilities.SubtreeCancellation | BpmnHostCapabilities.ScopeSignalling | BpmnHostCapabilities.IterationScopes | BpmnHostCapabilities.ScopeVariables;
+    public const BpmnHostCapabilities Capabilities = BpmnRuntimeCapabilities.Declared;
 
     /// <summary>
     /// The property key under which a nested scope's invocation correlation is carried on its own context.

--- a/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Assets/camunda-order-process.bpmn
+++ b/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Assets/camunda-order-process.bpmn
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                   xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+                   xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC"
+                   xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI"
+                   xmlns:camunda="http://camunda.org/schema/1.0/bpmn"
+                   xmlns:elsa="https://elsaworkflows.io/schemas/bpmn/v1"
+                   id="Definitions_order-process"
+                   targetNamespace="http://bpmn.io/schema/bpmn"
+                   exporter="Camunda Modeler"
+                   exporterVersion="5.16.0">
+  <bpmn:process id="order-process" name="Order Process" isExecutable="true" camunda:versionTag="1.0">
+    <bpmn:extensionElements>
+      <camunda:properties>
+        <camunda:property name="owner" value="fulfillment-team" />
+      </camunda:properties>
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="StartEvent_1" name="Order Received">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="NotifyWarehouse" name="Notify Warehouse" camunda:asyncBefore="true">
+      <bpmn:documentation>Tells the warehouse an order needs picking.</bpmn:documentation>
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="orderId">${orderId}</camunda:inputParameter>
+        </camunda:inputOutput>
+        <elsa:activityBinding activityType="Elsa.WriteLine">
+          <elsa:input name="text">{"typeName":"String","expression":{"type":"Literal","value":"Notifying the warehouse"}}</elsa:input>
+        </elsa:activityBinding>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="EndEvent_1" name="Order Handled">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="NotifyWarehouse" />
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="NotifyWarehouse" targetRef="EndEvent_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="order-process">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <omgdc:Bounds x="152" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="NotifyWarehouse_di" bpmnElement="NotifyWarehouse">
+        <omgdc:Bounds x="240" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <omgdc:Bounds x="392" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1_di" bpmnElement="Flow_1">
+        <omgdi:waypoint x="188" y="120" />
+        <omgdi:waypoint x="240" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_2_di" bpmnElement="Flow_2">
+        <omgdi:waypoint x="340" y="120" />
+        <omgdi:waypoint x="392" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Assets/unbound-task-process.bpmn
+++ b/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Assets/unbound-task-process.bpmn
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                   id="Definitions_unbound-process"
+                   targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="unbound-process" name="Unbound Process" isExecutable="true">
+    <bpmn:startEvent id="Start_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="Unbound_1" name="Undeclared Task">
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="End_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="Start_1" targetRef="Unbound_1" />
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="Unbound_1" targetRef="End_1" />
+  </bpmn:process>
+</bpmn:definitions>

--- a/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Elsa.Bpmn.Interchange.IntegrationTests.csproj
+++ b/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Elsa.Bpmn.Interchange.IntegrationTests.csproj
@@ -10,4 +10,8 @@
         <ProjectReference Include="..\..\..\src\modules\Elsa.Bpmn.Interchange\Elsa.Bpmn.Interchange.csproj"/>
     </ItemGroup>
 
+    <ItemGroup>
+        <None Update="Assets\*.bpmn" CopyToOutputDirectory="PreserveNewest" />
+    </ItemGroup>
+
 </Project>

--- a/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Endpoints/BpmnInterchangeEndpointTests.cs
+++ b/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Endpoints/BpmnInterchangeEndpointTests.cs
@@ -5,6 +5,7 @@ using System.Text.Encodings.Web;
 using System.Text.Json;
 using Elsa;
 using Elsa.Bpmn.Interchange.Features;
+using Elsa.Bpmn.Interchange.IntegrationTests.Support;
 using Elsa.Bpmn.Interchange.Services;
 using Elsa.Common.Models;
 using Elsa.Extensions;
@@ -175,6 +176,16 @@ public class BpmnInterchangeEndpointTests(ITestOutputHelper testOutputHelper) : 
     }
 
     [Fact]
+    public async Task Export_WithAMalformedVersion_ReturnsBadRequest()
+    {
+        var response = await GetAuthenticatedAsync("bpmn/definitions/does-not-exist/export?VersionOptions=not-a-number", "read:workflow-definitions");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("not-a-number", body);
+    }
+
+    [Fact]
     public async Task Export_OfAFreshlyImportedDefinition_ReturnsOkWithBpmnXml()
     {
         using var importContent = new MultipartFormDataContent();
@@ -240,7 +251,7 @@ public class BpmnInterchangeEndpointTests(ITestOutputHelper testOutputHelper) : 
         content.Add(fileContent, formFieldName, $"{formFieldName}.bpmn");
     }
 
-    private static string ReadAsset(string fileName) => File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Assets", fileName));
+    private static string ReadAsset(string fileName) => BpmnAssetReader.Read(fileName);
 
     private async Task<HttpResponseMessage> PostAuthenticatedAsync(string requestUri, HttpContent content, params string[] permissions)
     {

--- a/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Endpoints/BpmnInterchangeEndpointTests.cs
+++ b/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Endpoints/BpmnInterchangeEndpointTests.cs
@@ -1,0 +1,289 @@
+using System.Net;
+using System.Security.Claims;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using Elsa;
+using Elsa.Bpmn.Interchange.Features;
+using Elsa.Bpmn.Interchange.Services;
+using Elsa.Common.Models;
+using Elsa.Extensions;
+using Elsa.Testing.Shared;
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Management;
+using Elsa.Workflows.Management.Entities;
+using Elsa.Workflows.Models;
+using FastEndpoints;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Xunit.Abstractions;
+
+namespace Elsa.Bpmn.Interchange.IntegrationTests.Endpoints;
+
+/// <summary>
+/// HTTP-level coverage for the Analyze/Import/Export endpoints: the wrapper-specific logic this whole program is
+/// named after — multipart file-count validation, exception-to-status-code mapping, and permission gating — none of
+/// which <see cref="Scenarios.Interchange.BpmnInterchangeDocumentServiceTests"/> or
+/// <see cref="Scenarios.Interchange.BpmnExportAvailabilityTests"/> exercise, since those call the service directly.
+/// Follows the precedent in <c>Elsa.Resilience.IntegrationTests.SimulateResponseEndpointTests</c>: a real
+/// <see cref="WebApplication"/> with FastEndpoints and a <see cref="TestServer"/>, so status codes and permission
+/// gating are asserted against real HTTP responses rather than an endpoint invoked in isolation.
+/// </summary>
+[Collection(nameof(BpmnInterchangeEndpointCollection))]
+public class BpmnInterchangeEndpointTests(ITestOutputHelper testOutputHelper) : IAsyncLifetime
+{
+    private WebApplication? _app;
+    private bool _wasSecurityEnabled;
+
+    private HttpClient HttpClient { get; set; } = null!;
+
+    public async Task InitializeAsync()
+    {
+        _wasSecurityEnabled = EndpointSecurityOptions.SecurityIsEnabled;
+        EndpointSecurityOptions.SecurityIsEnabled = true;
+
+        var builder = WebApplication.CreateSlimBuilder();
+        builder.WebHost.UseTestServer();
+
+        builder.Services.AddAuthentication(TestAuthenticationHandler.AuthenticationScheme)
+            .AddScheme<AuthenticationSchemeOptions, TestAuthenticationHandler>(TestAuthenticationHandler.AuthenticationScheme, _ => { });
+        builder.Services.AddAuthorization();
+        builder.Services.AddFastEndpoints(o =>
+        {
+            o.Assemblies = [typeof(BpmnInterchangeFeature).Assembly];
+            o.DisableAutoDiscovery = true;
+        });
+        builder.Services.AddLogging(logging => logging.AddProvider(new XunitLoggerProvider(testOutputHelper)));
+        builder.Services.AddElsa(elsa => elsa
+            .AddActivitiesFrom<WriteLine>()
+            .UseScheduling()
+            .UseCSharp(options => options.AllowHostCodeExecution = true)
+            .UseJavaScript()
+            .UseLiquid()
+            .UseWorkflowManagement()
+            .UseBpmnInterchange());
+
+        _app = builder.Build();
+        _app.UseAuthentication();
+        _app.UseAuthorization();
+        _app.UseFastEndpoints();
+
+        await _app.StartAsync();
+        await _app.Services.PopulateRegistriesAsync();
+        HttpClient = _app.GetTestClient();
+    }
+
+    public async Task DisposeAsync()
+    {
+        EndpointSecurityOptions.SecurityIsEnabled = _wasSecurityEnabled;
+        HttpClient.Dispose();
+
+        if (_app != null)
+        {
+            await _app.StopAsync();
+            await _app.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task Analyze_WithZeroFiles_ReturnsBadRequest()
+    {
+        using var content = new MultipartFormDataContent();
+        // A well-formed multipart body with no file part: an empty MultipartFormDataContent serializes a section
+        // whose Content-Disposition ASP.NET Core's form parser rejects outright, which would fail before the
+        // endpoint's own zero-files check ever runs.
+        content.Add(new StringContent("value"), "field");
+
+        var response = await PostAuthenticatedAsync("bpmn/analyze", content, "read:workflow-definitions");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Analyze_WithTwoFiles_ReturnsBadRequest()
+    {
+        using var content = new MultipartFormDataContent();
+        AddBpmnFile(content, ReadAsset("camunda-order-process.bpmn"), "first");
+        AddBpmnFile(content, ReadAsset("camunda-order-process.bpmn"), "second");
+
+        var response = await PostAuthenticatedAsync("bpmn/analyze", content, "read:workflow-definitions");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Analyze_WithOneValidFile_ReturnsOkWithAnalysis()
+    {
+        using var content = new MultipartFormDataContent();
+        AddBpmnFile(content, ReadAsset("camunda-order-process.bpmn"), "file");
+
+        var response = await PostAuthenticatedAsync("bpmn/analyze", content, "read:workflow-definitions");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        using var document = JsonDocument.Parse(body);
+        Assert.Contains("order-process", document.RootElement.GetProperty("processIds").EnumerateArray().Select(e => e.GetString()));
+    }
+
+    [Fact]
+    public async Task Import_OfADocumentWithAnUnboundTask_ReturnsUnprocessableEntity()
+    {
+        using var content = new MultipartFormDataContent();
+        AddBpmnFile(content, ReadAsset("unbound-task-process.bpmn"), "file");
+
+        var response = await PostAuthenticatedAsync("bpmn/import", content, "write:workflow-definitions");
+
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Import_OfAValidDocument_ReturnsOkAndPersistsADefinition()
+    {
+        using var content = new MultipartFormDataContent();
+        AddBpmnFile(content, ReadAsset("camunda-order-process.bpmn"), "file");
+
+        var response = await PostAuthenticatedAsync("bpmn/import", content, "write:workflow-definitions");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        using var document = JsonDocument.Parse(body);
+        Assert.False(string.IsNullOrWhiteSpace(document.RootElement.GetProperty("definitionId").GetString()));
+    }
+
+    [Fact]
+    public async Task Export_OfAMissingDefinition_ReturnsNotFound()
+    {
+        var response = await GetAuthenticatedAsync("bpmn/definitions/does-not-exist/export", "read:workflow-definitions");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Export_OfADefinitionNeverImportedFromBpmn_ReturnsUnprocessableEntity()
+    {
+        var definitionId = await CreateNonBpmnDefinitionAsync();
+
+        var response = await GetAuthenticatedAsync($"bpmn/definitions/{definitionId}/export", "read:workflow-definitions");
+
+        Assert.Equal(HttpStatusCode.UnprocessableEntity, response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("does not currently carry BPMN source", body);
+    }
+
+    [Fact]
+    public async Task Export_OfAFreshlyImportedDefinition_ReturnsOkWithBpmnXml()
+    {
+        using var importContent = new MultipartFormDataContent();
+        AddBpmnFile(importContent, ReadAsset("camunda-order-process.bpmn"), "file");
+        var importResponse = await PostAuthenticatedAsync("bpmn/import", importContent, "write:workflow-definitions");
+        Assert.Equal(HttpStatusCode.OK, importResponse.StatusCode);
+
+        using var importDocument = JsonDocument.Parse(await importResponse.Content.ReadAsStringAsync());
+        var definitionId = importDocument.RootElement.GetProperty("definitionId").GetString();
+
+        var exportResponse = await GetAuthenticatedAsync($"bpmn/definitions/{definitionId}/export", "read:workflow-definitions");
+
+        Assert.Equal(HttpStatusCode.OK, exportResponse.StatusCode);
+        var exportedXml = await exportResponse.Content.ReadAsStringAsync();
+        Assert.Contains("order-process", exportedXml);
+    }
+
+    [Fact]
+    public async Task Export_WhenUnauthenticated_ReturnsUnauthorized()
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, "bpmn/definitions/does-not-exist/export");
+        var response = await HttpClient.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Import_WhenAuthenticatedWithoutTheRequiredPermission_ReturnsForbidden()
+    {
+        using var content = new MultipartFormDataContent();
+        AddBpmnFile(content, ReadAsset("camunda-order-process.bpmn"), "file");
+
+        // Authenticated, but only holds the read permission Export needs, not the write permission Import needs.
+        var response = await PostAuthenticatedAsync("bpmn/import", content, "read:workflow-definitions");
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    private async Task<string> CreateNonBpmnDefinitionAsync()
+    {
+        using var scope = _app!.Services.CreateScope();
+        var store = scope.ServiceProvider.GetRequiredService<IWorkflowDefinitionStore>();
+        var definitionId = Guid.NewGuid().ToString();
+
+        await store.SaveAsync(new WorkflowDefinition
+        {
+            Id = Guid.NewGuid().ToString(),
+            DefinitionId = definitionId,
+            Name = "Not BPMN",
+            Version = 1,
+            IsLatest = true,
+            MaterializerName = "Json",
+            StringData = "{}"
+        });
+
+        return definitionId;
+    }
+
+    private static void AddBpmnFile(MultipartFormDataContent content, string xml, string formFieldName)
+    {
+        var fileContent = new ByteArrayContent(Encoding.UTF8.GetBytes(xml));
+        fileContent.Headers.ContentType = new("application/xml");
+        content.Add(fileContent, formFieldName, $"{formFieldName}.bpmn");
+    }
+
+    private static string ReadAsset(string fileName) => File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Assets", fileName));
+
+    private async Task<HttpResponseMessage> PostAuthenticatedAsync(string requestUri, HttpContent content, params string[] permissions)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, requestUri) { Content = content };
+        request.Headers.Add(TestAuthenticationHandler.PermissionHeader, string.Join(",", permissions));
+        return await HttpClient.SendAsync(request);
+    }
+
+    private async Task<HttpResponseMessage> GetAuthenticatedAsync(string requestUri, params string[] permissions)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+        request.Headers.Add(TestAuthenticationHandler.PermissionHeader, string.Join(",", permissions));
+        return await HttpClient.SendAsync(request);
+    }
+
+    private sealed class TestAuthenticationHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        UrlEncoder encoder) : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+    {
+        public const string AuthenticationScheme = "Test";
+        public const string PermissionHeader = "X-Test-Permissions";
+
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            if (!Request.Headers.TryGetValue(PermissionHeader, out var permissionHeader))
+                return Task.FromResult(AuthenticateResult.NoResult());
+
+            var claims = permissionHeader
+                .SelectMany(x => x?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries) ?? [])
+                .Select(x => new Claim(PermissionNames.ClaimType, x))
+                .ToList();
+
+            claims.Add(new Claim(ClaimTypes.NameIdentifier, "test-user"));
+
+            var identity = new ClaimsIdentity(claims, AuthenticationScheme);
+            var principal = new ClaimsPrincipal(identity);
+            var ticket = new AuthenticationTicket(principal, AuthenticationScheme);
+
+            return Task.FromResult(AuthenticateResult.Success(ticket));
+        }
+    }
+}
+
+[CollectionDefinition(nameof(BpmnInterchangeEndpointCollection), DisableParallelization = true)]
+public class BpmnInterchangeEndpointCollection;

--- a/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Scenarios/Interchange/BpmnExportAvailabilityTests.cs
+++ b/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Scenarios/Interchange/BpmnExportAvailabilityTests.cs
@@ -88,6 +88,31 @@ public class BpmnExportAvailabilityTests(ITestOutputHelper testOutputHelper) : B
         Assert.DoesNotContain("does not currently carry BPMN source", exception.Message);
     }
 
+    [Fact(DisplayName = "Exporting a definition whose import stored the source but never recorded its version marker is refused, distinctly from both other refusals")]
+    public async Task Export_OfAPartiallyImportedDefinition_IsRefused()
+    {
+        var xml = ReadAsset("camunda-order-process.bpmn");
+        var imported = await DocumentService.ImportAsync(xml, definitionId: null, name: null, processId: null, CancellationToken.None);
+        Assert.True(imported.ImportResult.Succeeded);
+
+        var stored = await FindLatestAsync(imported.ImportResult.WorkflowDefinition.DefinitionId);
+
+        // Mirrors what a cancelled or failed second save leaves behind: ImportAsync's first save records SourceXml,
+        // and only a second save records SourceVersion (see BpmnInterchangeDocumentService's remarks on why the
+        // version cannot be known until the first save assigns it). If that second save never happens, the source is
+        // there but the version marker it would have carried is not.
+        stored.CustomProperties.Remove(BpmnInterchangeDocumentService.SourceVersionCustomPropertyKey);
+        await DefinitionStore.SaveAsync(stored);
+
+        var refetched = await FindLatestAsync(stored.DefinitionId);
+
+        var exception = Assert.Throws<BpmnExportUnavailableException>(() => DocumentService.Export(refetched));
+
+        Assert.Contains("did not finish", exception.Message);
+        Assert.DoesNotContain("does not currently carry BPMN source", exception.Message);
+        Assert.DoesNotContain("has changed since it was imported", exception.Message);
+    }
+
     private async Task<WorkflowDefinition> FindLatestAsync(string definitionId)
     {
         var filter = WorkflowDefinitionHandle.ByDefinitionId(definitionId, VersionOptions.Latest).ToFilter();

--- a/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Scenarios/Interchange/BpmnExportAvailabilityTests.cs
+++ b/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Scenarios/Interchange/BpmnExportAvailabilityTests.cs
@@ -1,0 +1,98 @@
+using Elsa.Bpmn.Interchange.Exceptions;
+using Elsa.Bpmn.Interchange.Services;
+using Elsa.Common.Models;
+using Elsa.Extensions;
+using Elsa.Workflows.Management;
+using Elsa.Workflows.Management.Entities;
+using Elsa.Workflows.Models;
+using Xunit.Abstractions;
+
+namespace Elsa.Bpmn.Interchange.IntegrationTests.Scenarios.Interchange;
+
+/// <summary>
+/// <see cref="BpmnInterchangeDocumentService.Export(WorkflowDefinition)"/> refuses rather than mislead when the
+/// stored BPMN source is missing or stale, instead of silently exporting a document the caller does not actually
+/// have. See that type's remarks for why each situation gets its own message.
+/// </summary>
+public class BpmnExportAvailabilityTests(ITestOutputHelper testOutputHelper) : BpmnInterchangeTestBase(testOutputHelper)
+{
+    [Fact(DisplayName = "Exporting a freshly imported definition through the WorkflowDefinition overload succeeds")]
+    public async Task Export_OfAFreshlyImportedDefinition_Succeeds()
+    {
+        var xml = ReadAsset("camunda-order-process.bpmn");
+        var imported = await DocumentService.ImportAsync(xml, definitionId: null, name: null, processId: null, CancellationToken.None);
+        Assert.True(imported.ImportResult.Succeeded);
+
+        var stored = await FindLatestAsync(imported.ImportResult.WorkflowDefinition.DefinitionId);
+
+        var bytes = DocumentService.Export(stored);
+
+        Assert.NotEmpty(bytes);
+    }
+
+    [Fact(DisplayName = "Import records the definition's own version alongside the BPMN source")]
+    public async Task Import_RecordsTheSourceVersionAlongsideTheSourceXml()
+    {
+        var xml = ReadAsset("camunda-order-process.bpmn");
+        var imported = await DocumentService.ImportAsync(xml, definitionId: null, name: null, processId: null, CancellationToken.None);
+        Assert.True(imported.ImportResult.Succeeded);
+
+        var stored = await FindLatestAsync(imported.ImportResult.WorkflowDefinition.DefinitionId);
+
+        Assert.True(stored.CustomProperties.TryGetValue<int>(BpmnInterchangeDocumentService.SourceVersionCustomPropertyKey, out var sourceVersion));
+        Assert.Equal(stored.Version, sourceVersion);
+    }
+
+    [Fact(DisplayName = "Exporting a definition whose custom properties no longer carry the BPMN source is refused, naming that as the reason")]
+    public async Task Export_OfADefinitionWithoutStoredSource_IsRefused()
+    {
+        var xml = ReadAsset("camunda-order-process.bpmn");
+        var imported = await DocumentService.ImportAsync(xml, definitionId: null, name: null, processId: null, CancellationToken.None);
+        Assert.True(imported.ImportResult.Succeeded);
+
+        var stored = await FindLatestAsync(imported.ImportResult.WorkflowDefinition.DefinitionId);
+
+        // Mirrors what Elsa.Workflows.Api's workflow-definition save endpoint does to an edit that does not round-trip
+        // custom properties: it replaces CustomProperties wholesale, dropping the BPMN source as a side effect of
+        // saving something else entirely.
+        stored.CustomProperties = new Dictionary<string, object>();
+        await DefinitionStore.SaveAsync(stored);
+
+        var refetched = await FindLatestAsync(stored.DefinitionId);
+
+        var exception = Assert.Throws<BpmnExportUnavailableException>(() => DocumentService.Export(refetched));
+
+        Assert.Contains("does not currently carry BPMN source", exception.Message);
+        Assert.DoesNotContain("has changed since it was imported", exception.Message);
+    }
+
+    [Fact(DisplayName = "Exporting a definition that changed since it was imported is refused, naming that as the reason rather than returning the pre-edit document")]
+    public async Task Export_OfADefinitionThatHasChangedSinceImport_IsRefused()
+    {
+        var xml = ReadAsset("camunda-order-process.bpmn");
+        var imported = await DocumentService.ImportAsync(xml, definitionId: null, name: null, processId: null, CancellationToken.None);
+        Assert.True(imported.ImportResult.Succeeded);
+
+        var stored = await FindLatestAsync(imported.ImportResult.WorkflowDefinition.DefinitionId);
+
+        // Mirrors the case the source key survives a later save (unlike the test above), but the definition itself
+        // has moved on to a new version since the source was recorded — e.g. a publish followed by another edit.
+        stored.Version += 1;
+        await DefinitionStore.SaveAsync(stored);
+
+        var refetched = await FindLatestAsync(stored.DefinitionId);
+
+        var exception = Assert.Throws<BpmnExportUnavailableException>(() => DocumentService.Export(refetched));
+
+        Assert.Contains("has changed since it was imported", exception.Message);
+        Assert.DoesNotContain("does not currently carry BPMN source", exception.Message);
+    }
+
+    private async Task<WorkflowDefinition> FindLatestAsync(string definitionId)
+    {
+        var filter = WorkflowDefinitionHandle.ByDefinitionId(definitionId, VersionOptions.Latest).ToFilter();
+        var definition = await DefinitionStore.FindAsync(filter);
+        Assert.NotNull(definition);
+        return definition!;
+    }
+}

--- a/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Scenarios/Interchange/BpmnExportAvailabilityTests.cs
+++ b/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Scenarios/Interchange/BpmnExportAvailabilityTests.cs
@@ -1,10 +1,17 @@
+using Bpmn.Interchange;
+using Elsa.Bpmn.Interchange.Binding;
 using Elsa.Bpmn.Interchange.Exceptions;
+using Elsa.Bpmn.Interchange.IntegrationTests.Support;
 using Elsa.Bpmn.Interchange.Services;
 using Elsa.Common.Models;
 using Elsa.Extensions;
+using Elsa.Testing.Shared;
 using Elsa.Workflows.Management;
 using Elsa.Workflows.Management.Entities;
+using Elsa.Workflows.Management.Filters;
+using Elsa.Workflows.Management.Models;
 using Elsa.Workflows.Models;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit.Abstractions;
 
 namespace Elsa.Bpmn.Interchange.IntegrationTests.Scenarios.Interchange;
@@ -88,8 +95,8 @@ public class BpmnExportAvailabilityTests(ITestOutputHelper testOutputHelper) : B
         Assert.DoesNotContain("does not currently carry BPMN source", exception.Message);
     }
 
-    [Fact(DisplayName = "Exporting a definition whose import stored the source but never recorded its version marker is refused, distinctly from both other refusals")]
-    public async Task Export_OfAPartiallyImportedDefinition_IsRefused()
+    [Fact(DisplayName = "Exporting a definition that carries BPMN source without a recorded version is refused, distinctly from both other refusals")]
+    public async Task Export_OfADefinitionCarryingSourceWithoutAVersionMarker_IsRefused()
     {
         var xml = ReadAsset("camunda-order-process.bpmn");
         var imported = await DocumentService.ImportAsync(xml, definitionId: null, name: null, processId: null, CancellationToken.None);
@@ -97,10 +104,9 @@ public class BpmnExportAvailabilityTests(ITestOutputHelper testOutputHelper) : B
 
         var stored = await FindLatestAsync(imported.ImportResult.WorkflowDefinition.DefinitionId);
 
-        // Mirrors what a cancelled or failed second save leaves behind: ImportAsync's first save records SourceXml,
-        // and only a second save records SourceVersion (see BpmnInterchangeDocumentService's remarks on why the
-        // version cannot be known until the first save assigns it). If that second save never happens, the source is
-        // there but the version marker it would have carried is not.
+        // ImportAsync itself always writes both BPMN markers together (see this finding's fix), so this combination
+        // is not reachable through import; it is reproduced here directly to exercise the defence kept for the same
+        // combination arising some other way — e.g. custom properties edited or migrated outside ImportAsync.
         stored.CustomProperties.Remove(BpmnInterchangeDocumentService.SourceVersionCustomPropertyKey);
         await DefinitionStore.SaveAsync(stored);
 
@@ -108,8 +114,50 @@ public class BpmnExportAvailabilityTests(ITestOutputHelper testOutputHelper) : B
 
         var exception = Assert.Throws<BpmnExportUnavailableException>(() => DocumentService.Export(refetched));
 
-        Assert.Contains("did not finish", exception.Message);
+        Assert.Contains("carries BPMN source, but not the definition version", exception.Message);
         Assert.DoesNotContain("does not currently carry BPMN source", exception.Message);
+        Assert.DoesNotContain("has changed since it was imported", exception.Message);
+    }
+
+    [Fact(DisplayName = "A post-import save that fails leaves nothing durably carrying BPMN source, so the definition exports as never imported rather than as a partial import")]
+    public async Task ImportAsync_WhenThePostImportSaveFails_LeavesNothingDurablyCarryingEitherMarker()
+    {
+        var services = new TestApplicationBuilder(testOutputHelper)
+            .ConfigureElsa(elsa => elsa.UseBpmnInterchange())
+            .Build();
+        await services.PopulateRegistriesAsync();
+
+        // A stub importer stands in for the real IWorkflowDefinitionImporter/IWorkflowDefinitionStore pair so that
+        // "durably persisted" can be told apart from "the local object ImportAsync goes on to mutate in memory
+        // before the save that would have committed it fails" — a distinction a shared-reference in-memory test
+        // double cannot make, but any real store (which only reflects a committed write) does.
+        var draft = new WorkflowDefinition { Id = "draft-1", DefinitionId = "def-1", Version = 3, CustomProperties = new Dictionary<string, object>() };
+        var importer = new StubWorkflowDefinitionImporter(draft);
+        var store = new AlwaysFailingSaveWorkflowDefinitionStore();
+
+        var documentService = new BpmnInterchangeDocumentService(
+            services.GetRequiredService<BpmnXmlReader>(),
+            services.GetRequiredService<BpmnXmlWriter>(),
+            services.GetRequiredService<BpmnWorkBinder>(),
+            importer,
+            store);
+
+        var xml = BpmnAssetReader.Read("camunda-order-process.bpmn");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => documentService.ImportAsync(xml, draft.DefinitionId, name: null, processId: null, CancellationToken.None));
+
+        // What the importer's own (already-succeeded) save durably committed, captured independently of the `draft`
+        // reference ImportAsync went on to mutate for the save that then failed. Neither BPMN marker made it in —
+        // not just the version marker, which is all that would be missing under the old, two-save behaviour this
+        // finding replaced.
+        var persisted = new WorkflowDefinition { Id = draft.Id, DefinitionId = draft.DefinitionId, Version = draft.Version, CustomProperties = importer.CommittedCustomProperties };
+        Assert.False(persisted.CustomProperties.ContainsKey(BpmnInterchangeDocumentService.SourceXmlCustomPropertyKey));
+        Assert.False(persisted.CustomProperties.ContainsKey(BpmnInterchangeDocumentService.SourceVersionCustomPropertyKey));
+
+        var exception = Assert.Throws<BpmnExportUnavailableException>(() => documentService.Export(persisted));
+
+        Assert.Contains("does not currently carry BPMN source", exception.Message);
         Assert.DoesNotContain("has changed since it was imported", exception.Message);
     }
 
@@ -119,5 +167,54 @@ public class BpmnExportAvailabilityTests(ITestOutputHelper testOutputHelper) : B
         var definition = await DefinitionStore.FindAsync(filter);
         Assert.NotNull(definition);
         return definition!;
+    }
+
+    /// <summary>
+    /// Mirrors the one line of the real <see cref="Elsa.Workflows.Management.Services.WorkflowDefinitionImporter"/>
+    /// this test cares about — <c>draft.CustomProperties = model.CustomProperties ?? new Dictionary&lt;...&gt;()</c> —
+    /// so a regression that puts BPMN source back on the model passed into that call (the two-save behaviour this
+    /// finding replaced) is caught here too, not just a regression in the save that follows.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="CommittedCustomProperties"/> is a defensive copy, captured at the moment this "import" succeeds,
+    /// standing in for what a real store would have durably written — decoupled from <paramref name="definitionToReturn"/>,
+    /// which the caller goes on to mutate in memory for the save this test makes fail.
+    /// </remarks>
+    private sealed class StubWorkflowDefinitionImporter(WorkflowDefinition definitionToReturn) : IWorkflowDefinitionImporter
+    {
+        public IDictionary<string, object> CommittedCustomProperties { get; private set; } = new Dictionary<string, object>();
+
+        public Task<ImportWorkflowResult> ImportAsync(SaveWorkflowDefinitionRequest request, CancellationToken cancellationToken = default)
+        {
+            var modelCustomProperties = request.Model.CustomProperties ?? new Dictionary<string, object>();
+            CommittedCustomProperties = new Dictionary<string, object>(modelCustomProperties);
+            definitionToReturn.CustomProperties = new Dictionary<string, object>(modelCustomProperties);
+
+            return Task.FromResult(new ImportWorkflowResult(true, definitionToReturn, new List<WorkflowValidationError>()));
+        }
+    }
+
+    /// <summary>A store whose <see cref="SaveAsync"/> always fails; nothing else is exercised by the test that uses it.</summary>
+    private sealed class AlwaysFailingSaveWorkflowDefinitionStore : IWorkflowDefinitionStore
+    {
+        public Task SaveAsync(WorkflowDefinition definition, CancellationToken cancellationToken = default) =>
+            throw new InvalidOperationException("Simulated save failure for testing atomic BPMN import.");
+
+        public Task<WorkflowDefinition?> FindAsync(WorkflowDefinitionFilter filter, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<WorkflowDefinition?> FindAsync<TOrderBy>(WorkflowDefinitionFilter filter, WorkflowDefinitionOrder<TOrderBy> order, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<Page<WorkflowDefinition>> FindManyAsync(WorkflowDefinitionFilter filter, PageArgs pageArgs, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<Page<WorkflowDefinition>> FindManyAsync<TOrderBy>(WorkflowDefinitionFilter filter, WorkflowDefinitionOrder<TOrderBy> order, PageArgs pageArgs, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<IEnumerable<WorkflowDefinition>> FindManyAsync(WorkflowDefinitionFilter filter, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<IEnumerable<WorkflowDefinition>> FindManyAsync<TOrderBy>(WorkflowDefinitionFilter filter, WorkflowDefinitionOrder<TOrderBy> order, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<Page<WorkflowDefinitionSummary>> FindSummariesAsync(WorkflowDefinitionFilter filter, PageArgs pageArgs, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<Page<WorkflowDefinitionSummary>> FindSummariesAsync<TOrderBy>(WorkflowDefinitionFilter filter, WorkflowDefinitionOrder<TOrderBy> order, PageArgs pageArgs, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<IEnumerable<WorkflowDefinitionSummary>> FindSummariesAsync(WorkflowDefinitionFilter filter, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<IEnumerable<WorkflowDefinitionSummary>> FindSummariesAsync<TOrderBy>(WorkflowDefinitionFilter filter, WorkflowDefinitionOrder<TOrderBy> order, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<WorkflowDefinition?> FindLastVersionAsync(WorkflowDefinitionFilter filter, CancellationToken cancellationToken) => throw new NotSupportedException();
+        public Task SaveManyAsync(IEnumerable<WorkflowDefinition> definitions, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<long> DeleteAsync(WorkflowDefinitionFilter filter, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<bool> AnyAsync(WorkflowDefinitionFilter filter, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<long> CountDistinctAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<bool> GetIsNameUnique(string name, string? definitionId = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
     }
 }

--- a/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Scenarios/Interchange/BpmnInterchangeDocumentServiceTests.cs
+++ b/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Scenarios/Interchange/BpmnInterchangeDocumentServiceTests.cs
@@ -1,0 +1,132 @@
+using System.Xml.Linq;
+using Bpmn.Interchange;
+using Elsa.Bpmn.Interchange.Services;
+using Elsa.Common.Models;
+using Elsa.Extensions;
+using Elsa.Workflows.Management;
+using Elsa.Workflows.Models;
+using Xunit.Abstractions;
+
+namespace Elsa.Bpmn.Interchange.IntegrationTests.Scenarios.Interchange;
+
+/// <summary>
+/// The round trip the Analyze, Import and Export endpoints exist for: a Camunda-authored <c>.bpmn</c> file survives
+/// import and export with its foreign extension elements, foreign attributes and BPMN DI waypoints intact.
+/// </summary>
+public class BpmnInterchangeDocumentServiceTests(ITestOutputHelper testOutputHelper) : BpmnInterchangeTestBase(testOutputHelper)
+{
+    private static readonly XNamespace Camunda = "http://camunda.org/schema/1.0/bpmn";
+    private static readonly XNamespace Elsa = "https://elsaworkflows.io/schemas/bpmn/v1";
+    private static readonly XNamespace Dc = "http://www.omg.org/spec/DD/20100524/DC";
+    private static readonly XNamespace Di = "http://www.omg.org/spec/DD/20100524/DI";
+    private static readonly XNamespace Bpmn = "http://www.omg.org/spec/BPMN/20100524/MODEL";
+
+    [Fact(DisplayName = "Analyze and Import report the same findings for the same document")]
+    public async Task Analyze_AndImport_ReportTheSameFindings()
+    {
+        var xml = ReadAsset("camunda-order-process.bpmn");
+
+        var analysis = DocumentService.Analyze(xml);
+        var imported = await DocumentService.ImportAsync(xml, definitionId: null, name: null, processId: null, CancellationToken.None);
+
+        Assert.Equal(analysis.ProcessIds, imported.Analysis.ProcessIds);
+        Assert.Equal(analysis.Issues.Select(issue => issue.Message), imported.Analysis.Issues.Select(issue => issue.Message));
+    }
+
+    [Fact(DisplayName = "Importing a Camunda file binds the unbound task and persists a workflow definition")]
+    public async Task Import_BindsAndPersists()
+    {
+        var xml = ReadAsset("camunda-order-process.bpmn");
+
+        var result = await DocumentService.ImportAsync(xml, definitionId: null, name: null, processId: null, CancellationToken.None);
+
+        Assert.True(result.ImportResult.Succeeded, string.Join("; ", result.ImportResult.ValidationErrors.Select(error => error.Message)));
+        Assert.NotEmpty(result.ImportResult.WorkflowDefinition.DefinitionId);
+        Assert.Contains(result.Analysis.Issues, issue => issue.ElementId == "NotifyWarehouse" && issue.Severity == BpmnImportIssueSeverity.Info);
+    }
+
+    [Fact(DisplayName = "Exporting an imported definition retains foreign extension elements, foreign attributes and waypoints byte-identically")]
+    public async Task Export_RetainsForeignContentAndWaypoints()
+    {
+        var sourceXml = ReadAsset("camunda-order-process.bpmn");
+        var imported = await DocumentService.ImportAsync(sourceXml, definitionId: null, name: null, processId: null, CancellationToken.None);
+        Assert.True(imported.ImportResult.Succeeded);
+
+        var definitionId = imported.ImportResult.WorkflowDefinition.DefinitionId;
+        var filter = WorkflowDefinitionHandle.ByDefinitionId(definitionId, VersionOptions.Latest).ToFilter();
+        var stored = await DefinitionStore.FindAsync(filter);
+
+        Assert.NotNull(stored);
+        Assert.True(stored!.CustomProperties.TryGetValue<string>(BpmnInterchangeDocumentService.SourceXmlCustomPropertyKey, out var storedXml));
+        Assert.Equal(sourceXml, storedXml);
+
+        var exportedBytes = DocumentService.Export(storedXml!);
+        var exportedXml = System.Text.Encoding.UTF8.GetString(exportedBytes);
+
+        var sourceDocument = XDocument.Parse(sourceXml);
+        var exportedDocument = XDocument.Parse(exportedXml);
+
+        // Whole-file byte identity is explicitly not what the library guarantees: attribute order, whitespace and
+        // namespace prefixes are documented cuts. What survives is asserted piece by piece instead.
+        Assert.NotEqual(sourceXml, exportedXml);
+
+        AssertForeignAttributesRetained(sourceDocument, exportedDocument);
+        AssertForeignExtensionElementsRetained(sourceDocument, exportedDocument);
+        AssertWaypointsRetained(sourceDocument, exportedDocument);
+    }
+
+    private static void AssertForeignAttributesRetained(XDocument source, XDocument exported)
+    {
+        var sourceProcess = source.Descendants(Bpmn + "process").Single();
+        var exportedProcess = exported.Descendants(Bpmn + "process").Single();
+        Assert.Equal(sourceProcess.Attribute(Camunda + "versionTag")?.Value, exportedProcess.Attribute(Camunda + "versionTag")?.Value);
+
+        var sourceTask = source.Descendants(Bpmn + "serviceTask").Single();
+        var exportedTask = exported.Descendants(Bpmn + "serviceTask").Single();
+        Assert.Equal("true", sourceTask.Attribute(Camunda + "asyncBefore")?.Value);
+        Assert.Equal(sourceTask.Attribute(Camunda + "asyncBefore")?.Value, exportedTask.Attribute(Camunda + "asyncBefore")?.Value);
+    }
+
+    private static void AssertForeignExtensionElementsRetained(XDocument source, XDocument exported)
+    {
+        var sourceProperty = source.Descendants(Camunda + "property").Single();
+        var exportedProperty = exported.Descendants(Camunda + "property").Single();
+        Assert.Equal("owner", sourceProperty.Attribute("name")?.Value);
+        Assert.Equal(sourceProperty.Attribute("name")?.Value, exportedProperty.Attribute("name")?.Value);
+        Assert.Equal(sourceProperty.Attribute("value")?.Value, exportedProperty.Attribute("value")?.Value);
+
+        var sourceInputParameter = source.Descendants(Camunda + "inputParameter").Single();
+        var exportedInputParameter = exported.Descendants(Camunda + "inputParameter").Single();
+        Assert.Equal(sourceInputParameter.Value, exportedInputParameter.Value);
+
+        // The elsa: activity binding is foreign to Bpmn.Interchange itself (its own vendor namespace defaults to
+        // vw:), so it round-trips as opaque retained content exactly like the camunda: extensions above.
+        var sourceBinding = source.Descendants(Elsa + "activityBinding").Single();
+        var exportedBinding = exported.Descendants(Elsa + "activityBinding").Single();
+        Assert.Equal("Elsa.WriteLine", sourceBinding.Attribute("activityType")?.Value);
+        Assert.Equal(sourceBinding.Attribute("activityType")?.Value, exportedBinding.Attribute("activityType")?.Value);
+        Assert.Equal(sourceBinding.Descendants(Elsa + "input").Single().Value, exportedBinding.Descendants(Elsa + "input").Single().Value);
+
+        var sourceDocumentation = source.Descendants(Bpmn + "documentation").Single();
+        var exportedDocumentation = exported.Descendants(Bpmn + "documentation").Single();
+        Assert.Equal(sourceDocumentation.Value, exportedDocumentation.Value);
+    }
+
+    private static void AssertWaypointsRetained(XDocument source, XDocument exported)
+    {
+        var sourceWaypoints = source.Descendants(Di + "waypoint").Select(WaypointOf).ToList();
+        var exportedWaypoints = exported.Descendants(Di + "waypoint").Select(WaypointOf).ToList();
+
+        Assert.Equal(4, sourceWaypoints.Count);
+        Assert.Equal(sourceWaypoints, exportedWaypoints);
+
+        var sourceBounds = source.Descendants(Dc + "Bounds").Select(BoundsOf).ToList();
+        var exportedBounds = exported.Descendants(Dc + "Bounds").Select(BoundsOf).ToList();
+        Assert.Equal(sourceBounds, exportedBounds);
+    }
+
+    private static (string X, string Y) WaypointOf(XElement element) => (element.Attribute("x")!.Value, element.Attribute("y")!.Value);
+
+    private static (string X, string Y, string Width, string Height) BoundsOf(XElement element) =>
+        (element.Attribute("x")!.Value, element.Attribute("y")!.Value, element.Attribute("width")!.Value, element.Attribute("height")!.Value);
+}

--- a/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Scenarios/Interchange/BpmnInterchangeTestBase.cs
+++ b/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Scenarios/Interchange/BpmnInterchangeTestBase.cs
@@ -1,0 +1,37 @@
+using Elsa.Bpmn.Interchange.Services;
+using Elsa.Extensions;
+using Elsa.Testing.Shared;
+using Elsa.Workflows.Management;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit.Abstractions;
+
+namespace Elsa.Bpmn.Interchange.IntegrationTests.Scenarios.Interchange;
+
+/// <summary>
+/// The application the Analyze/Import/Export endpoints' shared service is exercised in.
+/// </summary>
+public abstract class BpmnInterchangeTestBase : IAsyncLifetime
+{
+    private readonly IServiceProvider _services;
+
+    protected BpmnInterchangeTestBase(ITestOutputHelper testOutputHelper)
+    {
+        _services = new TestApplicationBuilder(testOutputHelper)
+            .ConfigureElsa(elsa => elsa.UseBpmnInterchange())
+            .Build();
+
+        DocumentService = _services.GetRequiredService<BpmnInterchangeDocumentService>();
+        DefinitionStore = _services.GetRequiredService<IWorkflowDefinitionStore>();
+    }
+
+    protected BpmnInterchangeDocumentService DocumentService { get; }
+
+    protected IWorkflowDefinitionStore DefinitionStore { get; }
+
+    public Task InitializeAsync() => _services.PopulateRegistriesAsync();
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    /// <summary>Reads a fixture from the <c>Assets</c> directory shipped alongside this test project.</summary>
+    protected static string ReadAsset(string fileName) => File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Assets", fileName));
+}

--- a/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Scenarios/Interchange/BpmnInterchangeTestBase.cs
+++ b/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Scenarios/Interchange/BpmnInterchangeTestBase.cs
@@ -1,3 +1,4 @@
+using Elsa.Bpmn.Interchange.IntegrationTests.Support;
 using Elsa.Bpmn.Interchange.Services;
 using Elsa.Extensions;
 using Elsa.Testing.Shared;
@@ -33,5 +34,5 @@ public abstract class BpmnInterchangeTestBase : IAsyncLifetime
     public Task DisposeAsync() => Task.CompletedTask;
 
     /// <summary>Reads a fixture from the <c>Assets</c> directory shipped alongside this test project.</summary>
-    protected static string ReadAsset(string fileName) => File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Assets", fileName));
+    protected static string ReadAsset(string fileName) => BpmnAssetReader.Read(fileName);
 }

--- a/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Support/BpmnAssetReader.cs
+++ b/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Support/BpmnAssetReader.cs
@@ -10,14 +10,16 @@ internal static class BpmnAssetReader
     /// <param name="fileName">A plain file name (no directory segments) of a fixture under <c>Assets</c>.</param>
     /// <exception cref="ArgumentException">
     /// <paramref name="fileName"/> is rooted or contains a path segment, which could otherwise resolve outside the
-    /// <c>Assets</c> directory (a rooted second argument makes <see cref="Path.Combine(string,string,string)"/>
-    /// silently drop the arguments before it).
+    /// <c>Assets</c> directory. The guard below makes this defence-in-depth rather than the only thing standing
+    /// between the code and a wrong path: <see cref="Path.Join(string,string,string)"/> — used instead of
+    /// <see cref="Path.Combine(string,string,string)"/> below — does not discard earlier segments when a later one
+    /// looks rooted.
     /// </exception>
     public static string Read(string fileName)
     {
         if (Path.IsPathRooted(fileName) || fileName.Split('/', '\\').Length > 1)
             throw new ArgumentException($"'{fileName}' must be a plain file name, not a rooted or nested path.", nameof(fileName));
 
-        return File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Assets", fileName));
+        return File.ReadAllText(Path.Join(AppContext.BaseDirectory, "Assets", fileName));
     }
 }

--- a/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Support/BpmnAssetReader.cs
+++ b/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Support/BpmnAssetReader.cs
@@ -1,0 +1,23 @@
+namespace Elsa.Bpmn.Interchange.IntegrationTests.Support;
+
+/// <summary>
+/// Reads a fixture from the <c>Assets</c> directory shipped alongside this test project — the one place every test
+/// that needs a BPMN document body goes through, rather than each duplicating its own <see cref="Path.Combine"/> call.
+/// </summary>
+internal static class BpmnAssetReader
+{
+    /// <summary>Reads a fixture from the <c>Assets</c> directory shipped alongside this test project.</summary>
+    /// <param name="fileName">A plain file name (no directory segments) of a fixture under <c>Assets</c>.</param>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="fileName"/> is rooted or contains a path segment, which could otherwise resolve outside the
+    /// <c>Assets</c> directory (a rooted second argument makes <see cref="Path.Combine(string,string,string)"/>
+    /// silently drop the arguments before it).
+    /// </exception>
+    public static string Read(string fileName)
+    {
+        if (Path.IsPathRooted(fileName) || fileName.Split('/', '\\').Length > 1)
+            throw new ArgumentException($"'{fileName}' must be a plain file name, not a rooted or nested path.", nameof(fileName));
+
+        return File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Assets", fileName));
+    }
+}

--- a/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Support/BpmnAssetReaderTests.cs
+++ b/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Support/BpmnAssetReaderTests.cs
@@ -1,0 +1,26 @@
+namespace Elsa.Bpmn.Interchange.IntegrationTests.Support;
+
+/// <summary>
+/// <see cref="BpmnAssetReader.Read"/> is shared by every test that needs a BPMN fixture, so its guard against a
+/// rooted or nested file name — which would otherwise resolve outside the <c>Assets</c> directory — is covered once,
+/// here, rather than per call site.
+/// </summary>
+public class BpmnAssetReaderTests
+{
+    [Fact(DisplayName = "Reading a plain fixture name returns its contents")]
+    public void Read_OfAPlainFileName_ReturnsContents()
+    {
+        var content = BpmnAssetReader.Read("camunda-order-process.bpmn");
+
+        Assert.Contains("order-process", content);
+    }
+
+    [Theory(DisplayName = "Reading a rooted or nested file name is refused rather than resolved outside Assets")]
+    [InlineData("/etc/passwd")]
+    [InlineData("../secrets.txt")]
+    [InlineData("nested/file.bpmn")]
+    public void Read_OfARootedOrNestedFileName_Throws(string fileName)
+    {
+        Assert.Throws<ArgumentException>(() => BpmnAssetReader.Read(fileName));
+    }
+}

--- a/test/unit/Elsa.Bpmn.Interchange.UnitTests/BpmnInterchangeDocumentServiceCapabilityTests.cs
+++ b/test/unit/Elsa.Bpmn.Interchange.UnitTests/BpmnInterchangeDocumentServiceCapabilityTests.cs
@@ -1,0 +1,72 @@
+using Bpmn.Interchange;
+using Bpmn.Model;
+using Bpmn.Semantics;
+using Elsa.Bpmn.Interchange.Services;
+
+namespace Elsa.Bpmn.Interchange.UnitTests;
+
+/// <summary>
+/// Capability refusal at import: <see cref="BpmnInterchangeDocumentService.EnsureCapabilitiesSatisfied"/> is the
+/// internal seam the Import endpoint calls into, exercised here directly because the current library version defines
+/// no capability <see cref="BpmnInterchangeDocumentService.DeclaredHostCapabilities"/> does not already cover, so a
+/// document genuinely refused by import cannot be produced through the public API today.
+/// </summary>
+public class BpmnInterchangeDocumentServiceCapabilityTests
+{
+    [Fact(DisplayName = "A definition needing a capability the host does not declare is refused, naming the capability and the driving element")]
+    public void EnsureCapabilitiesSatisfied_RefusesADefinitionNeedingAnUndeclaredCapability()
+    {
+        var definition = MultiInstanceDefinition("main", "each");
+
+        var exception = Assert.Throws<BpmnCapabilityException>(() =>
+            BpmnInterchangeDocumentService.EnsureCapabilitiesSatisfied(definition, [], BpmnHostCapabilities.None));
+
+        Assert.Equal(BpmnHostCapabilities.IterationScopes, exception.Missing);
+        Assert.Contains("each", exception.DrivingElementIds);
+    }
+
+    [Fact(DisplayName = "The same definition is accepted once the host declares the capability it needs")]
+    public void EnsureCapabilitiesSatisfied_AcceptsADefinitionOnceTheCapabilityIsDeclared()
+    {
+        var definition = MultiInstanceDefinition("main", "each");
+
+        // No exception is the assertion: the capability the definition needs is now declared.
+        BpmnInterchangeDocumentService.EnsureCapabilitiesSatisfied(definition, [], BpmnHostCapabilities.IterationScopes);
+    }
+
+    [Fact(DisplayName = "A nested process needing an undeclared capability is refused even though the root process needs nothing")]
+    public void EnsureCapabilitiesSatisfied_WalksIntoNestedProcesses()
+    {
+        var nestedDefinition = MultiInstanceDefinition("sub", "each");
+        var rootDefinition = new BpmnProcessDefinition("main");
+
+        BpmnWorkBinding[] bindings = [new BpmnWorkBinding.NestedProcess("main", "sub", "node-sub", BpmnBindingSlot.Primary, nestedDefinition)];
+
+        var exception = Assert.Throws<BpmnCapabilityException>(() =>
+            BpmnInterchangeDocumentService.EnsureCapabilitiesSatisfied(rootDefinition, bindings, BpmnHostCapabilities.None));
+
+        Assert.Equal(BpmnHostCapabilities.IterationScopes, exception.Missing);
+        Assert.Contains("each", exception.DrivingElementIds);
+    }
+
+    [Fact(DisplayName = "Elsa.Bpmn's declared host capabilities cover every capability the current library defines")]
+    public void DeclaredHostCapabilities_CoversEveryCapabilityTheLibraryDefines()
+    {
+        // Pins the assumption BpmnInterchangeDocumentService's own remarks document: today Full and
+        // DeclaredHostCapabilities happen to be the same value. If the library ever adds a capability, Full grows and
+        // this goes red, which is the prompt to re-check Elsa.Bpmn.Hosting.BpmnScopeHost.Capabilities before touching
+        // DeclaredHostCapabilities to match.
+        Assert.Equal(BpmnHostCapabilities.Full, BpmnInterchangeDocumentService.DeclaredHostCapabilities);
+    }
+
+    private static BpmnProcessDefinition MultiInstanceDefinition(string processId, string elementId)
+    {
+        var element = new BpmnElement(
+            elementId,
+            BpmnElementTypes.ServiceTask,
+            bindingRef: $"node-{elementId}",
+            loopCharacteristics: new BpmnLoopCharacteristics(isSequential: false, cardinality: 3));
+
+        return new BpmnProcessDefinition(processId, Elements: [element]);
+    }
+}

--- a/test/unit/Elsa.Bpmn.Interchange.UnitTests/BpmnInterchangeDocumentServiceCapabilityTests.cs
+++ b/test/unit/Elsa.Bpmn.Interchange.UnitTests/BpmnInterchangeDocumentServiceCapabilityTests.cs
@@ -49,16 +49,6 @@ public class BpmnInterchangeDocumentServiceCapabilityTests
         Assert.Contains("each", exception.DrivingElementIds);
     }
 
-    [Fact(DisplayName = "Elsa.Bpmn's declared host capabilities cover every capability the current library defines")]
-    public void DeclaredHostCapabilities_CoversEveryCapabilityTheLibraryDefines()
-    {
-        // Pins the assumption BpmnInterchangeDocumentService's own remarks document: today Full and
-        // DeclaredHostCapabilities happen to be the same value. If the library ever adds a capability, Full grows and
-        // this goes red, which is the prompt to re-check Elsa.Bpmn.Hosting.BpmnScopeHost.Capabilities before touching
-        // DeclaredHostCapabilities to match.
-        Assert.Equal(BpmnHostCapabilities.Full, BpmnInterchangeDocumentService.DeclaredHostCapabilities);
-    }
-
     private static BpmnProcessDefinition MultiInstanceDefinition(string processId, string elementId)
     {
         var element = new BpmnElement(

--- a/test/unit/Elsa.Bpmn.UnitTests/BpmnRuntimeCapabilitiesTests.cs
+++ b/test/unit/Elsa.Bpmn.UnitTests/BpmnRuntimeCapabilitiesTests.cs
@@ -1,0 +1,31 @@
+using Bpmn.Semantics;
+using Elsa.Bpmn.Hosting;
+
+namespace Elsa.Bpmn.UnitTests;
+
+public class BpmnRuntimeCapabilitiesTests
+{
+    [Fact(DisplayName = "Declared covers every capability the library currently defines")]
+    public void Declared_CoversEveryCapabilityTheLibraryDefines()
+    {
+        Assert.True(
+            BpmnRuntimeCapabilities.Declared == BpmnHostCapabilities.Full,
+            $"""
+             Bpmn.Semantics now defines a capability flag Elsa's runtime host does not declare
+             (missing: {BpmnHostCapabilities.Full & ~BpmnRuntimeCapabilities.Declared}).
+
+             This is the one place capability refusal (BpmnGraph.Build's ThrowIfUnmet, and the
+             mirroring check in BpmnInterchangeDocumentService.EnsureCapabilitiesSatisfied) becomes
+             reachable, so it needs a deliberate answer, not a silent gap:
+
+               - If BpmnScopeHost can honour the new flag: implement it, then add the flag to
+                 BpmnRuntimeCapabilities.Declared so this test goes green again.
+               - If it cannot (yet): leave the flag out of BpmnRuntimeCapabilities.Declared on
+                 purpose, so BpmnGraph.Build correctly refuses documents that need it, and update
+                 this test's expectation to say so explicitly instead of silencing it.
+
+             Either answer is fine. Declaring a capability Elsa doesn't honour, or leaving this gap
+             undocumented, is not.
+             """);
+    }
+}


### PR DESCRIPTION
Adds the BPMN interchange endpoints — Analyze, Import, Export — to `Elsa.Bpmn.Interchange`, so a host that only executes BPMN never takes the XML reader or the API surface into its dependency closure (D12).

Closes #7930.

## What is here

Three FastEndpoints routes over one `BpmnInterchangeDocumentService`, following the pattern in `Elsa.Resilience`/`Elsa.Alterations`.

**Analyze and Import share the library's single code path.** That is the property that makes a preview unable to disagree with the import that follows, and it is why no analysis logic lives in either endpoint.

Import reuses the existing `BpmnWorkBinder`, so an imported definition is the same `BpmnProcess` scope the binder builds everywhere else.

## Three corrections to the issue, all verified against the pinned library

**`BpmnCapabilityAnalyzer` does not exist.** The issue names it; `Bpmn.Semantics 0.1.1-preview.19` has no such type. The real API is `BpmnCapabilityRequirements.Analyze(BpmnProcessDefinition).ThrowIfUnmet(BpmnHostCapabilities, string)`, which is what Import calls.

**Capability refusal is currently unreachable, and that is now written down.** The library defines exactly four capability flags — `SubtreeCancellation`, `ScopeSignalling`, `IterationScopes`, `ScopeVariables` — and Elsa's runtime host declares all four. So `ThrowIfUnmet` cannot fire today. The mechanism is correct and worth having; it goes live the moment the library defines a fifth flag. `BpmnRuntimeCapabilitiesTests` is the alert for that, and its failure message spells out both legitimate answers: implement the new capability and declare it, or deliberately leave it undeclared so `BpmnGraph.Build` refuses documents that need it.

**The capability set now has one home.** It was restated in `Elsa.Bpmn.Interchange` because `BpmnScopeHost.Capabilities` sits on an `internal` class. That is the drift D12 exists to prevent — import-time refusal silently disagreeing with what the runtime honours. It is now `BpmnRuntimeCapabilities.Declared`, public in `Elsa.Bpmn`, consumed by both.

## The export limitation, stated plainly

Import stores the source BPMN XML on the definition and Export re-reads it, so nothing is ever reconstructed from a reduced view. Review found the hole in that: `Elsa.Workflows.Api`'s save endpoint replaces `CustomProperties` **wholesale** from the client payload, so an ordinary edit-and-save either drops the stored source — leaving Export permanently unavailable — or leaves it **stale**, returning the pre-edit document while reporting success.

The second case is the dangerous one, and it is now impossible. Import records the definition version the source was captured at, and Export refuses with a distinct message when the definition has moved on since. Two failures, two diagnoses, neither of them silent:

- the source is absent — the definition was not imported from BPMN, or a later save replaced its custom properties;
- the source is stale — it no longer corresponds to the current definition, naming both versions.

**Until BPMN-aware editing exists (Studio, out of scope for this program), Export returns the document as imported; edits made through Elsa's own activity designer are not reflected in it.** That is documented on the service and in the wiki rather than left for someone to discover.

## Verification

| Suite | Result |
| --- | --- |
| `dotnet build Elsa.sln` | pass |
| `Elsa.Bpmn.UnitTests` | 17 (was 16) |
| `Elsa.Bpmn.IntegrationTests` | 23, unchanged |
| `Elsa.Bpmn.Interchange.UnitTests` | 8 |
| `Elsa.Bpmn.Interchange.IntegrationTests` | 42 (was 25) |

**HTTP-level tests now exist**, following `SimulateResponseEndpointTests`' precedent with a real `TestServer` and auth handler: multipart file-count validation, exception-to-status mapping, 404 on a missing definition, 422 on a definition never imported from BPMN, permission gating, and a happy path per endpoint. Both review axes called their absence a violation, and they were right — that wrapper logic is exactly what this issue is titled after.

The round-trip test imports a Camunda-shaped fixture with `camunda:properties`/`camunda:inputOutput` extension elements, foreign attributes, `bpmn:documentation` and DI waypoints, exports it, and asserts the retained content and every waypoint coordinate survive. It deliberately does **not** assert whole-file byte-identity — the library documents attribute order, whitespace and namespace prefixes as cuts — and it asserts the exported text differs from the source, so a no-op "export" cannot pass.

Mutations, each red then restored green: stripping the stored source document; disabling the capability refusal; removing the staleness check; and dropping a flag from the declared capability set.

## Also fixed in review

`AddCapabilityErrors` repeated the full union of driving element ids on every missing-capability line, so an operator would see elements that had nothing to do with that capability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
