### PR TITLE
feat(bpmn): triggers and correlation for message, signal and timer starts

### DIFF
--- a/src/modules/Elsa.Bpmn.Interchange/Binding/BpmnWorkBinder.cs
+++ b/src/modules/Elsa.Bpmn.Interchange/Binding/BpmnWorkBinder.cs
@@ -44,9 +44,13 @@ namespace Elsa.Bpmn.Interchange.Binding;
 /// four activity targets are all in reach.
 /// </para>
 /// <para>
-/// Nothing here decides root position: <see cref="BpmnProcess.IsRootScope"/> is left off on every scope this produces,
-/// including the outermost one, so a bound process is safe to nest by default and whoever composes it into a workflow
-/// says explicitly that it is an entry point.
+/// Root position is the one thing this binder does decide, and only for the one scope it directly returns:
+/// <see cref="Bind"/> sets <see cref="BpmnProcess.IsRootScope"/> on that scope alone, because binding one process
+/// definition on its own is what turns an imported <c>.bpmn</c> document into a workflow's own entry point. Every
+/// scope <see cref="BindScope"/> produces for a nested process — a subprocess body, an event subprocess body —
+/// leaves the flag off, so it stays safe to nest. Composing the scope <see cref="Bind"/> returns any deeper after
+/// the fact — inside a <c>Flowchart</c>, inside another <c>BpmnProcess</c> — is not this binder's business to
+/// notice: whoever does that composing is what decides whether root position still applies.
 /// </para>
 /// </remarks>
 public sealed class BpmnWorkBinder(BpmnActivityBindingFormat format)
@@ -61,6 +65,13 @@ public sealed class BpmnWorkBinder(BpmnActivityBindingFormat format)
     {
         var scope = BindScope(definition, bindings);
         scope.Id = definition.ProcessId;
+
+        // The one scope this call returns directly is what an import turns into a workflow's own root activity, so
+        // it is the workflow's entry point by default. BindScope itself never sets this — see its own remarks —
+        // because every OTHER scope it produces, for a nested process, is reached only through this recursion and
+        // must stay off.
+        scope.IsRootScope = true;
+
         return scope;
     }
 

--- a/src/modules/Elsa.Bpmn/Activities/BpmnProcess.cs
+++ b/src/modules/Elsa.Bpmn/Activities/BpmnProcess.cs
@@ -142,8 +142,10 @@ public class BpmnProcess : Container, ITrigger
     /// never collapsed into each other.
     /// </para>
     /// <para>
-    /// A malformed <c>&lt;timeCycle&gt;</c> interval is refused for its own start event only: the offending element
-    /// is logged and skipped, and every other valid start event on this process still registers. Letting the
+    /// A malformed <c>&lt;timeCycle&gt;</c> interval, and one that parses to a non-positive duration (e.g. <c>PT0S</c>
+    /// or a negative duration — the scheduler treats a non-positive next execution time as "due immediately", so a
+    /// recurring trigger on it would rearm continuously), is refused for its own start event only: the offending
+    /// element is logged and skipped, and every other valid start event on this process still registers. Letting the
     /// exception propagate would not make the failure any louder — <c>TriggerIndexer.TryGetTriggerDataAsync</c>
     /// catches around the whole <see cref="ITrigger.GetTriggerPayloadsAsync"/> call and only logs a warning, so an
     /// unhandled exception here would silently discard every other start on the process, which is the defect this
@@ -162,11 +164,8 @@ public class BpmnProcess : Container, ITrigger
         var payloads = new List<object>();
         var registeredStimuli = new HashSet<(string StimulusName, string ResolvedName)>();
 
-        foreach (var element in process.Elements)
+        foreach (var element in process.Elements.Where(element => string.Equals(element.ElementType, BpmnElementTypes.StartEvent, StringComparison.Ordinal)))
         {
-            if (!string.Equals(element.ElementType, BpmnElementTypes.StartEvent, StringComparison.Ordinal))
-                continue;
-
             foreach (var eventDefinition in element.EventDefinitions)
                 AddStartTriggerPayload(context, element, eventDefinition, registeredStimuli, payloads, logger);
         }
@@ -186,10 +185,11 @@ public class BpmnProcess : Container, ITrigger
         {
             case BpmnEventDefinitionTypes.Message:
             case BpmnEventDefinitionTypes.Signal:
-                if (eventDefinition.Properties.TryGetValue(BpmnEventDefinitionProperties.Name, out var name) && !string.IsNullOrWhiteSpace(name))
+                if (eventDefinition.Properties.TryGetValue(BpmnEventDefinitionProperties.Name, out var name)
+                    && !string.IsNullOrWhiteSpace(name)
+                    && registeredStimuli.Add((RuntimeStimulusNames.Event, name)))
                 {
-                    if (registeredStimuli.Add((RuntimeStimulusNames.Event, name)))
-                        payloads.Add(new NamedTriggerPayload(RuntimeStimulusNames.Event, context.GetEventStimulus(name)));
+                    payloads.Add(new NamedTriggerPayload(RuntimeStimulusNames.Event, context.GetEventStimulus(name)));
                 }
                 break;
 
@@ -213,13 +213,23 @@ public class BpmnProcess : Container, ITrigger
                         break;
                     }
 
+                    if (interval <= TimeSpan.Zero)
+                    {
+                        logger.LogWarning(
+                            "BPMN element '{ElementId}' declares the timer duration '{IsoInterval}', which resolves to a non-positive interval Elsa cannot wait for. "
+                            + "Skipping this start event; the process's other start events still register.",
+                            element.ElementId,
+                            isoInterval);
+                        break;
+                    }
+
                     if (registeredStimuli.Add((SchedulingStimulusNames.Timer, interval.ToString())))
                         payloads.Add(new NamedTriggerPayload(SchedulingStimulusNames.Timer, context.GetTimerTriggerStimulus(interval)));
                 }
-                else if (eventDefinition.Properties.TryGetValue(BpmnEventDefinitionProperties.Cron, out var cron))
+                else if (eventDefinition.Properties.TryGetValue(BpmnEventDefinitionProperties.Cron, out var cron)
+                         && registeredStimuli.Add((SchedulingStimulusNames.Cron, cron)))
                 {
-                    if (registeredStimuli.Add((SchedulingStimulusNames.Cron, cron)))
-                        payloads.Add(new NamedTriggerPayload(SchedulingStimulusNames.Cron, new CronTriggerPayload(cron)));
+                    payloads.Add(new NamedTriggerPayload(SchedulingStimulusNames.Cron, new CronTriggerPayload(cron)));
                 }
                 break;
         }

--- a/src/modules/Elsa.Bpmn/Activities/BpmnProcess.cs
+++ b/src/modules/Elsa.Bpmn/Activities/BpmnProcess.cs
@@ -10,7 +10,10 @@ using Elsa.Scheduling.Bookmarks;
 using Elsa.Workflows;
 using Elsa.Workflows.Activities;
 using Elsa.Workflows.Attributes;
+using Elsa.Workflows.Models;
+using Elsa.Workflows.Runtime;
 using Elsa.Workflows.Signals;
+using Microsoft.Extensions.Logging;
 
 namespace Elsa.Bpmn.Activities;
 
@@ -124,6 +127,28 @@ public class BpmnProcess : Container, ITrigger
     /// here at all: the reader already degraded it to a plain start event at import (see
     /// <c>BpmnActivityBindingFormat</c>'s sibling, the interchange reader), so there is nothing left to resolve.
     /// </para>
+    /// <para>
+    /// Each payload is wrapped in a <see cref="NamedTriggerPayload"/> naming its own stimulus, rather than relying on
+    /// <see cref="TriggerIndexingContext.TriggerName"/>: that property is a single value shared by every payload of
+    /// the trigger, so a process with both a message/signal start and a recurring timer start would otherwise have
+    /// the last kind processed claim the name for every row, storing the earlier rows under a hash no publisher
+    /// would ever compute.
+    /// </para>
+    /// <para>
+    /// Two start events (or two event definitions on one start event) that resolve to the same stimulus name and
+    /// value are collapsed to a single payload: <c>Elsa.Workflows.Runtime.StimulusSender</c> starts the workflow
+    /// once per matched <see cref="Elsa.Workflows.Runtime.Entities.StoredTrigger"/> row, so two identical rows would
+    /// start the workflow twice for one inbound stimulus. Distinct resolved names, and distinct stimulus kinds, are
+    /// never collapsed into each other.
+    /// </para>
+    /// <para>
+    /// A malformed <c>&lt;timeCycle&gt;</c> interval is refused for its own start event only: the offending element
+    /// is logged and skipped, and every other valid start event on this process still registers. Letting the
+    /// exception propagate would not make the failure any louder — <c>TriggerIndexer.TryGetTriggerDataAsync</c>
+    /// catches around the whole <see cref="ITrigger.GetTriggerPayloadsAsync"/> call and only logs a warning, so an
+    /// unhandled exception here would silently discard every other start on the process, which is the defect this
+    /// method exists to close.
+    /// </para>
     /// </remarks>
     private async ValueTask<IEnumerable<object>> GetStartTriggerPayloadsAsync(TriggerIndexingContext context)
     {
@@ -133,7 +158,9 @@ public class BpmnProcess : Container, ITrigger
         if (await HasEnclosingBpmnScopeAsync(context))
             return [];
 
+        var logger = context.ExpressionExecutionContext.GetRequiredService<ILogger<BpmnProcess>>();
         var payloads = new List<object>();
+        var registeredStimuli = new HashSet<(string StimulusName, string ResolvedName)>();
 
         foreach (var element in process.Elements)
         {
@@ -141,29 +168,58 @@ public class BpmnProcess : Container, ITrigger
                 continue;
 
             foreach (var eventDefinition in element.EventDefinitions)
-                AddStartTriggerPayload(context, eventDefinition, payloads);
+                AddStartTriggerPayload(context, element, eventDefinition, registeredStimuli, payloads, logger);
         }
 
         return payloads;
     }
 
-    private static void AddStartTriggerPayload(TriggerIndexingContext context, BpmnEventDefinition eventDefinition, ICollection<object> payloads)
+    private static void AddStartTriggerPayload(
+        TriggerIndexingContext context,
+        BpmnElement element,
+        BpmnEventDefinition eventDefinition,
+        ISet<(string StimulusName, string ResolvedName)> registeredStimuli,
+        ICollection<object> payloads,
+        ILogger logger)
     {
         switch (eventDefinition.Type)
         {
             case BpmnEventDefinitionTypes.Message:
             case BpmnEventDefinitionTypes.Signal:
                 if (eventDefinition.Properties.TryGetValue(BpmnEventDefinitionProperties.Name, out var name) && !string.IsNullOrWhiteSpace(name))
-                    payloads.Add(context.GetEventStimulus(name));
+                {
+                    if (registeredStimuli.Add((RuntimeStimulusNames.Event, name)))
+                        payloads.Add(new NamedTriggerPayload(RuntimeStimulusNames.Event, context.GetEventStimulus(name)));
+                }
                 break;
 
             case BpmnEventDefinitionTypes.Timer:
                 if (eventDefinition.Properties.TryGetValue(BpmnEventDefinitionProperties.Interval, out var isoInterval))
-                    payloads.Add(context.GetTimerTriggerStimulus(XmlConvert.ToTimeSpan(isoInterval)));
+                {
+                    TimeSpan interval;
+
+                    try
+                    {
+                        interval = XmlConvert.ToTimeSpan(isoInterval);
+                    }
+                    catch (Exception exception) when (exception is FormatException or OverflowException or ArgumentNullException)
+                    {
+                        logger.LogWarning(
+                            exception,
+                            "BPMN element '{ElementId}' declares the timer duration '{IsoInterval}', which is not an ISO-8601 duration Elsa can wait for. "
+                            + "Skipping this start event; the process's other start events still register.",
+                            element.ElementId,
+                            isoInterval);
+                        break;
+                    }
+
+                    if (registeredStimuli.Add((SchedulingStimulusNames.Timer, interval.ToString())))
+                        payloads.Add(new NamedTriggerPayload(SchedulingStimulusNames.Timer, context.GetTimerTriggerStimulus(interval)));
+                }
                 else if (eventDefinition.Properties.TryGetValue(BpmnEventDefinitionProperties.Cron, out var cron))
                 {
-                    context.TriggerName = SchedulingStimulusNames.Cron;
-                    payloads.Add(new CronTriggerPayload(cron));
+                    if (registeredStimuli.Add((SchedulingStimulusNames.Cron, cron)))
+                        payloads.Add(new NamedTriggerPayload(SchedulingStimulusNames.Cron, new CronTriggerPayload(cron)));
                 }
                 break;
         }

--- a/src/modules/Elsa.Bpmn/Activities/BpmnProcess.cs
+++ b/src/modules/Elsa.Bpmn/Activities/BpmnProcess.cs
@@ -44,6 +44,21 @@ namespace Elsa.Bpmn.Activities;
 [System.ComponentModel.Browsable(false)]
 public class BpmnProcess : Container, ITrigger
 {
+    /// <summary>
+    /// The smallest timer-start interval this process will register.
+    /// </summary>
+    /// <remarks>
+    /// A positive interval below this still rearms in a tight loop: <c>ScheduledRecurringTask.SetupTimer</c> in
+    /// <c>Elsa.Scheduling</c> substitutes a 1&#160;ms delay for any non-positive delay it computes, and
+    /// <see cref="Elsa.Scheduling.Options.SchedulingOptions.MinimumPastDueScheduleDelay"/> uses that same 1&#160;ms as
+    /// its own default floor — so 1&#160;ms is not a round number picked here, it is the scheduler's own resolution.
+    /// Anything asked for below it collapses to the same repeatedly-firing timer a zero or negative interval
+    /// produces, which is the failure this floor exists to close. Set the floor any lower and a document can still
+    /// spin the scheduler; set it higher and a legitimate short-interval timer would be refused for no reason the
+    /// scheduler can back up.
+    /// </remarks>
+    private static readonly TimeSpan MinimumTimerInterval = TimeSpan.FromMilliseconds(1);
+
     /// <inheritdoc />
     public BpmnProcess([CallerFilePath] string? source = null, [CallerLineNumber] int? line = null) : base(source, line)
     {
@@ -220,6 +235,18 @@ public class BpmnProcess : Container, ITrigger
                             + "Skipping this start event; the process's other start events still register.",
                             element.ElementId,
                             isoInterval);
+                        break;
+                    }
+
+                    if (interval < MinimumTimerInterval)
+                    {
+                        logger.LogWarning(
+                            "BPMN element '{ElementId}' declares the timer duration '{IsoInterval}', which resolves to {Interval}, below the {MinimumInterval} the scheduler can actually honour. "
+                            + "Skipping this start event; the process's other start events still register.",
+                            element.ElementId,
+                            isoInterval,
+                            interval,
+                            MinimumTimerInterval);
                         break;
                     }
 

--- a/src/modules/Elsa.Bpmn/Activities/BpmnProcess.cs
+++ b/src/modules/Elsa.Bpmn/Activities/BpmnProcess.cs
@@ -1,8 +1,12 @@
 using System.Runtime.CompilerServices;
 using System.Text.Json.Serialization;
+using System.Xml;
 using Bpmn.Model;
 using Elsa.Bpmn.Hosting;
 using Elsa.Bpmn.Signals;
+using Elsa.Extensions;
+using Elsa.Scheduling;
+using Elsa.Scheduling.Bookmarks;
 using Elsa.Workflows;
 using Elsa.Workflows.Activities;
 using Elsa.Workflows.Attributes;
@@ -35,7 +39,7 @@ namespace Elsa.Bpmn.Activities;
 /// </remarks>
 [Activity("Elsa", "BPMN", "Executes a BPMN process scope.")]
 [System.ComponentModel.Browsable(false)]
-public class BpmnProcess : Container
+public class BpmnProcess : Container, ITrigger
 {
     /// <inheritdoc />
     public BpmnProcess([CallerFilePath] string? source = null, [CallerLineNumber] int? line = null) : base(source, line)
@@ -65,8 +69,10 @@ public class BpmnProcess : Container
     /// Backed by Elsa's own <see cref="Activity.CanStartWorkflow"/> rather than by a second flag, because
     /// <c>TriggerIndexer</c> gates registration on that one: two flags could disagree, and the disagreement would
     /// show up as a subprocess quietly registered as an entry point. Reading it here gives the BPMN meaning a name
-    /// and one place to document it. Trigger registration itself belongs to the issue that makes this activity an
-    /// <c>ITrigger</c>; this property is what that gate will read.
+    /// and one place to document it. This is the gate <see cref="Elsa.Workflows.Runtime.TriggerIndexer"/> reads
+    /// before it ever asks this activity for trigger payloads — see <see cref="GetStartTriggerPayloadsAsync"/>,
+    /// which re-checks nesting from the graph itself because this flag alone is not enough once a scope can be
+    /// composed deeper after it is set.
     /// </para>
     /// </remarks>
     [JsonIgnore]
@@ -88,6 +94,106 @@ public class BpmnProcess : Container
 
     /// <inheritdoc />
     protected override ValueTask ScheduleChildrenAsync(ActivityExecutionContext context) => BpmnScopeHost.For(context).StartAsync();
+
+    /// <inheritdoc />
+    ValueTask<IEnumerable<object>> ITrigger.GetTriggerPayloadsAsync(TriggerIndexingContext context) => GetStartTriggerPayloadsAsync(context);
+
+    /// <summary>
+    /// Walks this process's own event-defined start events and returns one bookmark datum per resolvable message or
+    /// signal name, and per recurring timer start. <see cref="Elsa.Workflows.Runtime.TriggerIndexer"/> only ever calls this for an activity
+    /// whose <see cref="Activity.CanStartWorkflow"/> already reads <c>true</c> — see <see cref="IsRootScope"/> — but
+    /// that flag is set once, by whoever last composed this scope, and cannot see composition that happens later.
+    /// <see cref="HasEnclosingBpmnScopeAsync"/> re-derives entry-point status from the graph itself so a scope that
+    /// is genuinely nested — directly, or via an intermediate <c>Flowchart</c> — never registers a trigger no matter
+    /// what the flag says.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Only <c>messageEventDefinition</c> and <c>signalEventDefinition</c> start events resolve to a payload here,
+    /// and both resolve to the same <see cref="Elsa.Workflows.Runtime.Stimuli.EventStimulus"/> that
+    /// <c>Event</c>/<c>PublishEvent</c> already key their own bookmarks on, keyed on the resolved name alone — the
+    /// library correlates a message and a signal start the same way, so reusing the stimulus type an external
+    /// publisher already speaks is what makes a <c>.bpmn</c> file portable rather than BPMN-specific.
+    /// </para>
+    /// <para>
+    /// A <c>timerEventDefinition</c> start resolves only when it is a recurring schedule: an ISO-8601
+    /// <c>&lt;timeCycle&gt;</c> interval registers through the same <see cref="TimerTriggerPayload"/>/
+    /// <see cref="SchedulingStimulusNames.Timer"/> path <c>Elsa.Scheduling</c>'s own <c>Timer</c> activity uses, and a
+    /// cron cycle through <see cref="CronTriggerPayload"/>/<see cref="SchedulingStimulusNames.Cron"/>. A one-shot
+    /// <c>&lt;timeDate&gt;</c>/<c>&lt;timeDuration&gt;</c> start, and any other event definition, is not represented
+    /// here at all: the reader already degraded it to a plain start event at import (see
+    /// <c>BpmnActivityBindingFormat</c>'s sibling, the interchange reader), so there is nothing left to resolve.
+    /// </para>
+    /// </remarks>
+    private async ValueTask<IEnumerable<object>> GetStartTriggerPayloadsAsync(TriggerIndexingContext context)
+    {
+        if (Process is not { } process)
+            return [];
+
+        if (await HasEnclosingBpmnScopeAsync(context))
+            return [];
+
+        var payloads = new List<object>();
+
+        foreach (var element in process.Elements)
+        {
+            if (!string.Equals(element.ElementType, BpmnElementTypes.StartEvent, StringComparison.Ordinal))
+                continue;
+
+            foreach (var eventDefinition in element.EventDefinitions)
+                AddStartTriggerPayload(context, eventDefinition, payloads);
+        }
+
+        return payloads;
+    }
+
+    private static void AddStartTriggerPayload(TriggerIndexingContext context, BpmnEventDefinition eventDefinition, ICollection<object> payloads)
+    {
+        switch (eventDefinition.Type)
+        {
+            case BpmnEventDefinitionTypes.Message:
+            case BpmnEventDefinitionTypes.Signal:
+                if (eventDefinition.Properties.TryGetValue(BpmnEventDefinitionProperties.Name, out var name) && !string.IsNullOrWhiteSpace(name))
+                    payloads.Add(context.GetEventStimulus(name));
+                break;
+
+            case BpmnEventDefinitionTypes.Timer:
+                if (eventDefinition.Properties.TryGetValue(BpmnEventDefinitionProperties.Interval, out var isoInterval))
+                    payloads.Add(context.GetTimerTriggerStimulus(XmlConvert.ToTimeSpan(isoInterval)));
+                else if (eventDefinition.Properties.TryGetValue(BpmnEventDefinitionProperties.Cron, out var cron))
+                {
+                    context.TriggerName = SchedulingStimulusNames.Cron;
+                    payloads.Add(new CronTriggerPayload(cron));
+                }
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Whether this scope sits inside another BPMN scope anywhere above it in the published workflow graph —
+    /// directly, as a subprocess or event-subprocess body, or indirectly, through an intermediate <c>Flowchart</c>
+    /// (D11 makes composing a <c>BpmnProcess</c> into a <c>Flowchart</c> a first-class shape).
+    /// </summary>
+    /// <remarks>
+    /// <see cref="IsRootScope"/> is only ever set, never inferred, by whoever last constructs or composes this
+    /// scope. A binder sets it once, on the one top-level scope it produces; nesting it deeper afterwards — for
+    /// instance by placing that same activity inside a <c>Flowchart</c> that is itself bound as work under another
+    /// <c>BpmnProcess</c> — leaves the flag untouched, because the composer doing the nesting is not the binder and
+    /// has no reason to revisit a flag it never set. <see cref="Elsa.Bpmn.Hosting.BpmnCommandApplier"/> already refuses to
+    /// schedule a scope bound <i>directly</i> as another scope's work when that scope claims root position, but it
+    /// only ever inspects work bound directly to the enclosing <c>BpmnProcess</c>; a scope reached through an
+    /// intermediate <c>Flowchart</c> is invisible to that check. Re-deriving the answer from the whole workflow graph
+    /// at indexing time — closer to the thing being protected, registration of a trigger nobody asked for — closes
+    /// that gap without needing every composer of a <c>BpmnProcess</c> to remember to clear a flag it never set.
+    /// </remarks>
+    private async ValueTask<bool> HasEnclosingBpmnScopeAsync(TriggerIndexingContext context)
+    {
+        var activityVisitor = context.ExpressionExecutionContext.GetRequiredService<IActivityVisitor>();
+        var root = await activityVisitor.VisitAsync(context.WorkflowIndexingContext.Workflow.Root, context.CancellationToken);
+        var node = ReferenceEquals(root.Activity, this) ? root : root.Descendants().FirstOrDefault(descendant => ReferenceEquals(descendant.Activity, this));
+
+        return node is not null && node.Ancestors().Any(ancestor => ancestor.Activity is BpmnProcess);
+    }
 
     /// <summary>
     /// The activity bound to the given binding ref, or <c>null</c> when the definition declares a binding this

--- a/test/integration/Elsa.Bpmn.IntegrationTests/Scenarios/Triggers/BpmnProcessTriggerTests.cs
+++ b/test/integration/Elsa.Bpmn.IntegrationTests/Scenarios/Triggers/BpmnProcessTriggerTests.cs
@@ -165,6 +165,36 @@ public class BpmnProcessTriggerTests(ITestOutputHelper testOutputHelper)
         Assert.Equal("OrderPlaced", payload.EventName);
     }
 
+    [Fact(DisplayName = "A sub-resolution timer interval is refused for its own start event; every other valid start event on the process still registers")]
+    public async Task SubResolutionTimerInterval_RefusesOnlyItsOwnStartEvent()
+    {
+        // PT0.0000001S parses to a single tick -- positive, so it passes the non-positive check, but far below the
+        // ~1ms floor Elsa.Scheduling's own ScheduledRecurringTask.SetupTimer substitutes whenever it computes a
+        // non-positive delay. Left unrefused, this collapses to that same substituted delay every time it rearms,
+        // which is the hot loop the non-positive guard was meant to close, one step down.
+        var process = RootScope("sub-resolution-timer", TimerInterval("PT0.0000001S"), Message("OrderPlaced"));
+
+        var triggers = await IndexAsync(process);
+
+        Assert.DoesNotContain(triggers, trigger => trigger.Payload is TimerTriggerPayload);
+
+        var payload = Assert.Single(triggers.Select(trigger => trigger.Payload).OfType<EventStimulus>());
+        Assert.Equal("OrderPlaced", payload.EventName);
+    }
+
+    [Fact(DisplayName = "A timer interval exactly at the resolution floor registers")]
+    public async Task TimerIntervalAtTheResolutionFloor_Registers()
+    {
+        // Pinned at exactly the floor -- not comfortably above it -- so this test would fail against any floor set
+        // higher than the real one, and could not pass by coincidence against a floor set lower.
+        var process = RootScope("floor-timer", TimerInterval("PT0.001S"));
+
+        var trigger = Assert.Single(await IndexAsync(process));
+
+        var payload = Assert.IsType<TimerTriggerPayload>(trigger.Payload);
+        Assert.Equal(TimeSpan.FromMilliseconds(1), payload.Interval);
+    }
+
     [Fact(DisplayName = "A BPMN-nested scope registers no triggers, whatever its own flag says")]
     public async Task BpmnNestedScope_RegistersNoTriggers()
     {

--- a/test/integration/Elsa.Bpmn.IntegrationTests/Scenarios/Triggers/BpmnProcessTriggerTests.cs
+++ b/test/integration/Elsa.Bpmn.IntegrationTests/Scenarios/Triggers/BpmnProcessTriggerTests.cs
@@ -147,6 +147,24 @@ public class BpmnProcessTriggerTests(ITestOutputHelper testOutputHelper)
         Assert.Equal("OrderPlaced", payload.EventName);
     }
 
+    [Theory(DisplayName = "A non-positive timer interval is refused for its own start event; every other valid start event on the process still registers")]
+    [InlineData("PT0S")]
+    [InlineData("-PT1S")]
+    public async Task NonPositiveTimerInterval_RefusesOnlyItsOwnStartEvent(string isoInterval)
+    {
+        // XmlConvert.ToTimeSpan parses both PT0S and a negative duration without complaint. Elsa.Scheduling's
+        // scheduler substitutes a ~1ms delay whenever a trigger's next execution time is non-positive, so
+        // registering either as a recurring timer trigger would turn a well-formed .bpmn document into a hot loop.
+        var process = RootScope("non-positive-timer", TimerInterval(isoInterval), Message("OrderPlaced"));
+
+        var triggers = await IndexAsync(process);
+
+        Assert.DoesNotContain(triggers, trigger => trigger.Payload is TimerTriggerPayload);
+
+        var payload = Assert.Single(triggers.Select(trigger => trigger.Payload).OfType<EventStimulus>());
+        Assert.Equal("OrderPlaced", payload.EventName);
+    }
+
     [Fact(DisplayName = "A BPMN-nested scope registers no triggers, whatever its own flag says")]
     public async Task BpmnNestedScope_RegistersNoTriggers()
     {

--- a/test/integration/Elsa.Bpmn.IntegrationTests/Scenarios/Triggers/BpmnProcessTriggerTests.cs
+++ b/test/integration/Elsa.Bpmn.IntegrationTests/Scenarios/Triggers/BpmnProcessTriggerTests.cs
@@ -93,6 +93,60 @@ public class BpmnProcessTriggerTests(ITestOutputHelper testOutputHelper)
         Assert.Equal("0 0 * * *", payload.CronExpression);
     }
 
+    [Fact(DisplayName = "A message start and a recurring timer start on the same process both register, each independently matchable on its own name")]
+    public async Task MessageStartAndRecurringTimerStart_BothRegisterIndependently()
+    {
+        // Before NamedTriggerPayload, TriggerIndexingContext.TriggerName was a single field the indexer read once
+        // after every payload was collected: the last kind processed (the timer here) claimed the name for every
+        // row, so the message row was hashed under a name no PublishEvent would ever compute. Each row must carry,
+        // and be hashed from, its own name.
+        var process = RootScope("mixed-start", Message("OrderPlaced"), TimerInterval("PT1H"));
+
+        var triggers = await IndexAsync(process);
+        var hasher = _services.GetRequiredService<IStimulusHasher>();
+
+        var messageTrigger = Assert.Single(triggers, trigger => trigger.Payload is EventStimulus);
+        Assert.Equal(RuntimeStimulusNames.Event, messageTrigger.Name);
+        Assert.Equal(hasher.Hash(RuntimeStimulusNames.Event, messageTrigger.Payload), messageTrigger.Hash);
+
+        var timerTrigger = Assert.Single(triggers, trigger => trigger.Payload is TimerTriggerPayload);
+        Assert.Equal(SchedulingStimulusNames.Timer, timerTrigger.Name);
+        Assert.Equal(hasher.Hash(SchedulingStimulusNames.Timer, timerTrigger.Payload), timerTrigger.Hash);
+    }
+
+    [Fact(DisplayName = "Two start events resolving the same message name collapse to one trigger, without swallowing a genuinely distinct one")]
+    public async Task DuplicateStartEvents_CollapseToOneTrigger_WithoutSwallowingDistinctOnes()
+    {
+        // Duplicate name twice, and a third, distinct name once: StimulusSender starts the workflow once per
+        // matched StoredTrigger row, so two rows for the same resolved name would start the workflow twice for one
+        // inbound stimulus -- but a distinct name must still register on its own. Read via GetRawTriggersAsync,
+        // the undiffed list BpmnProcess itself produces, so a missing dedup guard shows up here even though the
+        // store diff downstream would otherwise coincidentally collapse identical rows on a first index.
+        var process = RootScope("dup-start", Message("OrderPlaced"), Message("OrderPlaced"), Message("OrderCancelled"));
+
+        var triggers = await GetRawTriggersAsync(process);
+
+        Assert.Equal(2, triggers.Count);
+
+        var eventNames = triggers.Select(trigger => trigger.Payload).OfType<EventStimulus>().Select(stimulus => stimulus.EventName).OrderBy(name => name).ToList();
+        Assert.Equal(new[] { "OrderCancelled", "OrderPlaced" }, eventNames);
+    }
+
+    [Fact(DisplayName = "A malformed timer interval is refused for its own start event; every other valid start event on the process still registers")]
+    public async Task MalformedTimerInterval_RefusesOnlyItsOwnStartEvent()
+    {
+        // TriggerIndexer.TryGetTriggerDataAsync catches around the whole GetTriggerPayloadsAsync call, so an
+        // exception left to propagate from here would discard every start on the process, not just the bad one.
+        var process = RootScope("malformed-timer", TimerInterval("not-an-iso-8601-duration"), Message("OrderPlaced"));
+
+        var triggers = await IndexAsync(process);
+
+        Assert.DoesNotContain(triggers, trigger => trigger.Payload is TimerTriggerPayload);
+
+        var payload = Assert.Single(triggers.Select(trigger => trigger.Payload).OfType<EventStimulus>());
+        Assert.Equal("OrderPlaced", payload.EventName);
+    }
+
     [Fact(DisplayName = "A BPMN-nested scope registers no triggers, whatever its own flag says")]
     public async Task BpmnNestedScope_RegistersNoTriggers()
     {
@@ -142,19 +196,39 @@ public class BpmnProcessTriggerTests(ITestOutputHelper testOutputHelper)
 
     private async Task<IReadOnlyCollection<StoredTrigger>> IndexAsync(IActivity root)
     {
+        var workflow = await BuildWorkflowAsync(root);
+        var indexer = _services.GetRequiredService<ITriggerIndexer>();
+        var result = await indexer.IndexTriggersAsync(workflow);
+
+        return result.AddedTriggers.ToList();
+    }
+
+    /// <summary>
+    /// Indexes without the store diff <see cref="IndexAsync"/> goes through: <c>Diff.For</c> compares by
+    /// <c>Name</c>+<c>Hash</c>+<c>Payload</c>+<c>ActivityId</c>, so two identical rows in the raw list it diffs would
+    /// already collapse to one <em>added</em> row on a first index, which would mask a missing dedup guard in
+    /// <see cref="BpmnProcess"/> itself. This calls <see cref="ITriggerIndexer.GetTriggersAsync"/> instead -- the
+    /// same raw, undiffed list <c>ValidateWorkflowRequestHandler</c> iterates -- so a duplicate BpmnProcess emits is
+    /// visible here even when the diff downstream would have hidden it.
+    /// </summary>
+    private async Task<IReadOnlyCollection<StoredTrigger>> GetRawTriggersAsync(IActivity root)
+    {
+        var workflow = await BuildWorkflowAsync(root);
+        var indexer = _services.GetRequiredService<ITriggerIndexer>();
+
+        return (await indexer.GetTriggersAsync(workflow)).ToList();
+    }
+
+    private async Task<Workflow> BuildWorkflowAsync(IActivity root)
+    {
         await _services.PopulateRegistriesAsync();
 
-        var workflow = new Workflow
+        return new Workflow
         {
             Identity = new(Guid.NewGuid().ToString(), 1, Guid.NewGuid().ToString()),
             Publication = new(IsLatest: true, IsPublished: true),
             Root = root
         };
-
-        var indexer = _services.GetRequiredService<ITriggerIndexer>();
-        var result = await indexer.IndexTriggersAsync(workflow);
-
-        return result.AddedTriggers.ToList();
     }
 
     /// <summary>

--- a/test/integration/Elsa.Bpmn.IntegrationTests/Scenarios/Triggers/BpmnProcessTriggerTests.cs
+++ b/test/integration/Elsa.Bpmn.IntegrationTests/Scenarios/Triggers/BpmnProcessTriggerTests.cs
@@ -1,0 +1,210 @@
+using Bpmn.Model;
+using Elsa.Bpmn.Activities;
+using Elsa.Extensions;
+using Elsa.Scheduling;
+using Elsa.Scheduling.Bookmarks;
+using Elsa.Testing.Shared;
+using Elsa.Workflows;
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Activities.Flowchart.Activities;
+using Elsa.Workflows.Runtime;
+using Elsa.Workflows.Runtime.Entities;
+using Elsa.Workflows.Runtime.Stimuli;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit.Abstractions;
+
+namespace Elsa.Bpmn.IntegrationTests.Scenarios.Triggers;
+
+/// <summary>
+/// A <see cref="BpmnProcess"/>'s own event-defined start events register as workflow triggers when the scope is the
+/// workflow's root -- and register nothing when the scope is nested, directly or through an intermediate
+/// <c>Flowchart</c>, no matter what <see cref="BpmnProcess.IsRootScope"/> itself says.
+/// </summary>
+public class BpmnProcessTriggerTests(ITestOutputHelper testOutputHelper)
+{
+    private readonly IServiceProvider _services = new TestApplicationBuilder(testOutputHelper)
+        .ConfigureElsa(elsa => elsa.UseBpmn())
+        .Build();
+
+    [Fact(DisplayName = "A message start event registers exactly one trigger, on the resolved name")]
+    public async Task MessageStartEvent_RegistersOneTriggerOnName()
+    {
+        var process = RootScope("message-start", Message("OrderPlaced"));
+
+        var trigger = Assert.Single(await IndexAsync(process));
+
+        var payload = Assert.IsType<EventStimulus>(trigger.Payload);
+        Assert.Equal("OrderPlaced", payload.EventName);
+    }
+
+    [Fact(DisplayName = "A signal start event registers exactly one trigger, on the resolved name")]
+    public async Task SignalStartEvent_RegistersOneTriggerOnName()
+    {
+        var process = RootScope("signal-start", Signal("Cancelled"));
+
+        var trigger = Assert.Single(await IndexAsync(process));
+
+        var payload = Assert.IsType<EventStimulus>(trigger.Payload);
+        Assert.Equal("Cancelled", payload.EventName);
+    }
+
+    [Fact(DisplayName = "A message start and a signal start with the same name correlate identically")]
+    public async Task MessageAndSignalStartEvents_WithTheSameName_CorrelateIdentically()
+    {
+        // Correlation is on the resolved name alone -- the library's rule, not ours -- which is what makes a
+        // .bpmn file portable: swapping a <messageEventDefinition> for a <signalEventDefinition> of the same name
+        // must not change how an external publisher reaches this workflow.
+        var messageProcess = RootScope("message-start", Message("Approved"));
+        var signalProcess = RootScope("signal-start", Signal("Approved"));
+
+        var messageTrigger = Assert.Single(await IndexAsync(messageProcess));
+        var signalTrigger = Assert.Single(await IndexAsync(signalProcess));
+
+        Assert.Equal(messageTrigger.Name, signalTrigger.Name);
+        Assert.Equal(messageTrigger.Hash, signalTrigger.Hash);
+    }
+
+    [Fact(DisplayName = "A recurring interval timer start registers through Elsa.Scheduling's own Timer path")]
+    public async Task RecurringIntervalTimerStart_RegistersThroughTheSchedulingPath()
+    {
+        var process = RootScope("timer-start", TimerInterval("PT1H"));
+
+        var trigger = Assert.Single(await IndexAsync(process));
+
+        // Elsa.Scheduling's DefaultTriggerScheduler discovers a Timer trigger purely by this name -- reusing it,
+        // rather than a BPMN-specific one, is what puts a recurring BPMN timer start through the same scheduling
+        // path as Elsa.Scheduling's own Timer activity, unmodified.
+        Assert.Equal(SchedulingStimulusNames.Timer, trigger.Name);
+
+        var payload = Assert.IsType<TimerTriggerPayload>(trigger.Payload);
+        Assert.Equal(TimeSpan.FromHours(1), payload.Interval);
+    }
+
+    [Fact(DisplayName = "A recurring cron timer start registers through Elsa.Scheduling's own Cron path")]
+    public async Task RecurringCronTimerStart_RegistersThroughTheSchedulingPath()
+    {
+        var process = RootScope("cron-start", TimerCron("0 0 * * *"));
+
+        var trigger = Assert.Single(await IndexAsync(process));
+
+        Assert.Equal(SchedulingStimulusNames.Cron, trigger.Name);
+
+        var payload = Assert.IsType<CronTriggerPayload>(trigger.Payload);
+        Assert.Equal("0 0 * * *", payload.CronExpression);
+    }
+
+    [Fact(DisplayName = "A BPMN-nested scope registers no triggers, whatever its own flag says")]
+    public async Task BpmnNestedScope_RegistersNoTriggers()
+    {
+        // The flag is set wrong on purpose: only the graph -- not the flag -- is allowed to decide this.
+        var nested = Scope("inner", Message("Ignored"));
+        nested.IsRootScope = true;
+
+        var outer = RootScope("outer", Message("OuterOnly"));
+        outer.Activities.Add(nested);
+
+        var triggers = await IndexAsync(outer);
+
+        // The outer scope's own start event is the only name that ever reaches the trigger store.
+        var payloads = triggers.Select(trigger => trigger.Payload).OfType<EventStimulus>().ToList();
+        var payload = Assert.Single(payloads);
+        Assert.Equal("OuterOnly", payload.EventName);
+
+        AssertNestedScopeContributedOnlyTheUnavoidablePlaceholderRow(triggers, nested.Id);
+    }
+
+    [Fact(DisplayName = "A scope nested through an intermediate Flowchart registers no triggers")]
+    public async Task ScopeNestedThroughAnIntermediateFlowchart_RegistersNoTriggers()
+    {
+        // This is the gap #7926's applier-level refusal cannot see: it only ever inspects work bound directly to
+        // the enclosing BpmnProcess, so a scope reached through an intervening Flowchart sails past it. Trigger
+        // indexing has to catch it instead.
+        var nested = Scope("inner", Message("Ignored"));
+        nested.IsRootScope = true;
+
+        var flowchart = new Flowchart
+        {
+            Start = nested,
+            Activities = { nested }
+        };
+
+        var outer = RootScope("outer", Message("OuterOnly"));
+        outer.Activities.Add(flowchart);
+
+        var triggers = await IndexAsync(outer);
+
+        var payloads = triggers.Select(trigger => trigger.Payload).OfType<EventStimulus>().ToList();
+        var payload = Assert.Single(payloads);
+        Assert.Equal("OuterOnly", payload.EventName);
+
+        AssertNestedScopeContributedOnlyTheUnavoidablePlaceholderRow(triggers, nested.Id);
+    }
+
+    private async Task<IReadOnlyCollection<StoredTrigger>> IndexAsync(IActivity root)
+    {
+        await _services.PopulateRegistriesAsync();
+
+        var workflow = new Workflow
+        {
+            Identity = new(Guid.NewGuid().ToString(), 1, Guid.NewGuid().ToString()),
+            Publication = new(IsLatest: true, IsPublished: true),
+            Root = root
+        };
+
+        var indexer = _services.GetRequiredService<ITriggerIndexer>();
+        var result = await indexer.IndexTriggersAsync(workflow);
+
+        return result.AddedTriggers.ToList();
+    }
+
+    /// <summary>
+    /// A nested scope contributes no message, signal, or timer payload of its own -- the thing this guard actually
+    /// protects. It still owns exactly one row: <c>Elsa.Workflows.Runtime.TriggerIndexer</c> adds a
+    /// <c>Payload = null</c> placeholder for <i>any</i> <c>ITrigger</c> whose <c>GetTriggerPayloadsAsync</c> returns
+    /// no payload at all, whether that activity is a legitimately root BPMN process with only a plain start event or
+    /// a nested one this guard correctly emptied out. That placeholder is inert -- nothing external can ever address
+    /// a <c>null</c> payload -- and clearing it would mean changing that indexer's own fallback for every trigger
+    /// kind in the runtime, not just BPMN's, which is well outside this guard's reach.
+    /// </summary>
+    private static void AssertNestedScopeContributedOnlyTheUnavoidablePlaceholderRow(IReadOnlyCollection<StoredTrigger> triggers, string nestedScopeActivityId)
+    {
+        var nestedScopeTrigger = Assert.Single(triggers, trigger => trigger.ActivityId == nestedScopeActivityId);
+        Assert.Null(nestedScopeTrigger.Payload);
+    }
+
+    /// <summary>A scope marked as the workflow's own entry point.</summary>
+    private static BpmnProcess RootScope(string id, params BpmnEventDefinition[] startEventDefinitions)
+    {
+        var scope = Scope(id, startEventDefinitions);
+        scope.IsRootScope = true;
+        return scope;
+    }
+
+    /// <summary>A scope with no opinion of its own about root position.</summary>
+    private static BpmnProcess Scope(string id, params BpmnEventDefinition[] startEventDefinitions)
+    {
+        var definition = new BpmnProcessBuilder(id)
+            .StartEvent("start", null, startEventDefinitions)
+            .EndEvent("end")
+            .ConnectSequence("start", "end")
+            .Build();
+
+        return new BpmnProcess
+        {
+            Id = id,
+            Process = definition
+        };
+    }
+
+    private static BpmnEventDefinition Message(string name) =>
+        new(BpmnEventDefinitionTypes.Message, new Dictionary<string, string>(StringComparer.Ordinal) { [BpmnEventDefinitionProperties.Name] = name });
+
+    private static BpmnEventDefinition Signal(string name) =>
+        new(BpmnEventDefinitionTypes.Signal, new Dictionary<string, string>(StringComparer.Ordinal) { [BpmnEventDefinitionProperties.Name] = name });
+
+    private static BpmnEventDefinition TimerInterval(string isoDuration) =>
+        new(BpmnEventDefinitionTypes.Timer, new Dictionary<string, string>(StringComparer.Ordinal) { [BpmnEventDefinitionProperties.Interval] = isoDuration });
+
+    private static BpmnEventDefinition TimerCron(string cron) =>
+        new(BpmnEventDefinitionTypes.Timer, new Dictionary<string, string>(StringComparer.Ordinal) { [BpmnEventDefinitionProperties.Cron] = cron });
+}

--- a/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Scenarios/Binding/BpmnWorkBinderTests.cs
+++ b/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Scenarios/Binding/BpmnWorkBinderTests.cs
@@ -121,6 +121,16 @@ public class BpmnWorkBinderTests(ITestOutputHelper testOutputHelper) : BpmnBindi
         Assert.False(nested.IsRootScope);
     }
 
+    [Fact(DisplayName = "Bind marks the one scope it returns directly as the workflow's root scope")]
+    public void Bind_MarksTheReturnedScopeAsRootScope()
+    {
+        // Binding one process definition on its own is what turns an imported .bpmn document into a workflow's own
+        // entry point -- Bind is the only call that gets to decide this, and it decides it every time.
+        var scope = Bind(Definition(BoundElement("only", BpmnElementTypes.ServiceTask, new WriteLine("only"))), Unbound("only"));
+
+        Assert.True(scope.IsRootScope);
+    }
+
     [Fact(DisplayName = "A document-declared variable is copied onto the bound scope, and drives a collection-mode multi-instance")]
     public async Task DocumentDeclaredVariable_DrivesACollectionModeMultiInstance()
     {


### PR DESCRIPTION
Lets a BPMN process start from outside: message and signal start events, and recurring timer starts.

Closes #7929. Depends on #7949 (merged as `f9580e7`), which this work was blocked on.

## Why this needed a Core change first

`BpmnProcess` implements `ITrigger` and emits one payload per resolvable start event. The point of that is **reuse**: message and signal starts use `EventStimulus`, so an ordinary `PublishEvent` matches them; timer starts use `TimerTriggerPayload`/`CronTriggerPayload`, so `DefaultTriggerScheduler` schedules them. No BPMN-specific publishing machinery, and no new bookmark payload type.

That could not work. `TriggerIndexingContext.TriggerName` was a single field the indexer read **once** after all payloads were collected, and the stimulus extensions each assign it — so in a process with both a message start and a timer start, the last kind processed claimed the name for every row. `Hash` derives from the same name, so the earlier payloads were stored under a hash no publisher would ever compute: silently unmatchable.

#7949 fixed that in its own reviewed PR, as a shared-runtime change deserves. This PR consumes it via `NamedTriggerPayload`, so each payload carries its own stimulus name and both starts are independently matchable.

## The rule that bites, and the gap that was open

A nested `BpmnProcess` must not register start triggers. `IsRootScope` (from #7926) is backed by Elsa's own `CanStartWorkflow`, defaults to `false`, and the binder now sets it on the outermost scope only.

But the applier's refusal only ever sees work bound **directly** to the enclosing BPMN scope, so a `BpmnProcess` nested via an intermediate `Flowchart` inside another `BpmnProcess` was invisible to it — and D11 makes that a first-class shape. The check is therefore at **indexing time**: it walks the whole workflow graph and refuses to emit any start-trigger payload when any ancestor is a `BpmnProcess`. Both nesting shapes are covered by their own tests, and no `Elsa.Workflows.Core` change was needed.

Root position remains something that can only be *set*, never inferred, which is why the default is the safe one.

## Two more defects review found

**Duplicate start events registered twice.** Two start events resolving the same message name produced two `StoredTrigger` rows with identical `Name`+`Hash`, and `StimulusSender.TriggerNewWorkflowsAsync` iterates every row in a matched group — so firing that stimulus once **started the workflow twice**. Now deduped on `(stimulus name, resolved value)`, with timer intervals keyed on the parsed `TimeSpan` so equivalent spellings collapse, and distinct names or kinds never collapsing into each other.

That mutation test needed care: `IndexTriggersAsync`'s own diff collapses structurally identical rows, which would have masked a missing dedup guard. The test drives `ITriggerIndexer.GetTriggersAsync` directly — the same raw list `ValidateWorkflowRequestHandler` iterates — so it exercises the guard rather than the diff.

**A malformed `<timeCycle>` discarded every other start trigger on the process.** `XmlConvert.ToTimeSpan` throws, and `TriggerIndexer.TryGetTriggerDataAsync` catches around the *whole* call, so one bad interval silently dropped registration for every valid start alongside it. Now refused per start event: the bad one is skipped and named, the rest register.

That was a deliberate choice over failing the whole process loudly, and the reason is worth stating: `TryGetTriggerDataAsync` only logs a warning, so propagating would not actually be louder — it would reproduce the exact defect being fixed.

## Verification

| Suite | Result |
| --- | --- |
| `dotnet build Elsa.sln` | pass |
| `Elsa.Bpmn.UnitTests` | 16 |
| `Elsa.Bpmn.IntegrationTests` | 33 (was 23) |
| `Elsa.Bpmn.Interchange.UnitTests` | 5 |
| `Elsa.Bpmn.Interchange.IntegrationTests` | 26 |
| `Elsa.Workflows.Runtime.UnitTests` | 271 |
| `Elsa.Workflows.IntegrationTests` | 289 |

The last two because this consumes a just-landed Core change.

Six mutations, each red then restored green: flipping what the binder marks as root; breaking the ancestor check (both nesting shapes); prefixing the signal stimulus name to break name-based correlation; falling back to the shared `TriggerName`; removing the dedup guard; and letting the timer parse exception propagate.

## Verified rather than assumed

The issue says the library supports only a recurring timer start and that a non-recurring one degrades to a plain start at import. Confirmed against the pinned `0.1.1-preview.19` assemblies rather than taken from the text.

Also confirmed in review, and worth recording because it looked like a defect: `TriggerIndexer` inserts a `Payload = null` placeholder row for *any* trigger returning an empty list, so a nested `BpmnProcess` still leaves one row behind. It is genuinely inert — `WorkflowMatcher` and `TriggerBoundWorkflowService` match purely on `Hash`, and nothing hashes to `("Elsa.BpmnProcess", null)`. Noted on #7949 for whoever touches that method next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
