### PR TITLE
feat(bpmn): publish-time validation gate for unbound tasks

### DIFF
--- a/src/modules/Elsa.Bpmn.Interchange/Features/BpmnInterchangeFeature.cs
+++ b/src/modules/Elsa.Bpmn.Interchange/Features/BpmnInterchangeFeature.cs
@@ -1,6 +1,7 @@
 using Bpmn.Interchange;
 using Elsa.Bpmn.Features;
 using Elsa.Bpmn.Interchange.Binding;
+using Elsa.Bpmn.Interchange.Handlers.Notifications;
 using Elsa.Bpmn.Interchange.Services;
 using Elsa.Extensions;
 using Elsa.Features.Abstractions;
@@ -41,5 +42,6 @@ public class BpmnInterchangeFeature : FeatureBase
         Services.AddSingleton<BpmnXmlReader>();
         Services.AddSingleton<BpmnXmlWriter>();
         Services.AddScoped<BpmnInterchangeDocumentService>();
+        Services.AddNotificationHandler<ValidateBpmnProcessBindings>();
     }
 }

--- a/src/modules/Elsa.Bpmn.Interchange/Handlers/Notifications/ValidateBpmnProcessBindings.cs
+++ b/src/modules/Elsa.Bpmn.Interchange/Handlers/Notifications/ValidateBpmnProcessBindings.cs
@@ -12,9 +12,14 @@ namespace Elsa.Bpmn.Interchange.Handlers.Notifications;
 /// <summary>
 /// The second net for <see cref="BpmnWorkBinding.UnboundTask"/>. <see cref="Binding.BpmnWorkBinder"/> already
 /// refuses an unbound task at <em>import</em>, but a definition can be edited after import — through Elsa's own
-/// workflow designer, not through the BPMN document — and an edit can remove the activity a task was bound to.
-/// That edit never touches the BPMN document this scope still carries, so it is invisible to the bind-time
-/// refusal; this handler is what catches it before the definition publishes.
+/// workflow designer, not through the BPMN document — and an edit can remove the activity a task was bound to,
+/// or leave the binding pointing at an activity type that has since been uninstalled. Neither edit touches the
+/// BPMN document this scope still carries, so neither is visible to the bind-time refusal; this handler is what
+/// catches both before the definition publishes. The two are reported with different messages: an id with no
+/// bound activity at all is "not bound", while an id resolved through <see cref="IActivitySerializer"/> to a
+/// <see cref="NotFoundActivity"/> - the same placeholder <c>BpmnActivityBindingFormat</c> already refuses at bind
+/// time for the identical reason - is "bound to an activity type that is no longer installed"; an operator needs
+/// to know which.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -74,13 +79,27 @@ public class ValidateBpmnProcessBindings(IWorkflowGraphBuilder workflowGraphBuil
 
             foreach (var element in scope.Process!.Elements)
             {
-                if (!IsUnboundTaskCandidate(element) || IsBound(scope, element.BindingRef!))
+                if (!IsUnboundTaskCandidate(element))
                     continue;
 
-                notification.ValidationErrors.Add(new(
-                    $"BPMN element '{element.ElementId}' ({element.ElementType}) of process '{scope.Process.ProcessId}' is not bound to an Elsa activity. "
-                    + "BPMN does not say what this task does; declare an activity binding for it, or remove the element.",
-                    element.ElementId));
+                var boundActivity = FindBoundActivity(scope, element.BindingRef!);
+
+                if (boundActivity is null)
+                {
+                    notification.ValidationErrors.Add(new(
+                        $"BPMN element '{element.ElementId}' ({element.ElementType}) of process '{scope.Process.ProcessId}' is not bound to an Elsa activity. "
+                        + "BPMN does not say what this task does; declare an activity binding for it, or remove the element.",
+                        scope.Id));
+                    continue;
+                }
+
+                if (boundActivity is NotFoundActivity notFound)
+                {
+                    notification.ValidationErrors.Add(new(
+                        $"BPMN element '{element.ElementId}' ({element.ElementType}) of process '{scope.Process.ProcessId}' is bound to an activity "
+                        + $"type that is no longer installed ('{notFound.MissingTypeName}'). Rebind the element to an installed activity type, or remove it.",
+                        scope.Id));
+                }
             }
         }
     }
@@ -90,7 +109,8 @@ public class ValidateBpmnProcessBindings(IWorkflowGraphBuilder workflowGraphBuil
         && UnboundTaskElementTypes.Contains(element.ElementType)
         && !element.Properties.ContainsKey(BpmnXmlReader.MessageNamePropertyKey);
 
-    private static bool IsBound(BpmnProcess scope, string bindingRef) =>
+    private static IActivity? FindBoundActivity(BpmnProcess scope, string bindingRef) =>
         scope.WorkBindings.TryGetValue(bindingRef, out var activityId)
-        && scope.Activities.Any(activity => string.Equals(activity.Id, activityId, StringComparison.Ordinal));
+            ? scope.Activities.FirstOrDefault(activity => string.Equals(activity.Id, activityId, StringComparison.Ordinal))
+            : null;
 }

--- a/src/modules/Elsa.Bpmn.Interchange/Handlers/Notifications/ValidateBpmnProcessBindings.cs
+++ b/src/modules/Elsa.Bpmn.Interchange/Handlers/Notifications/ValidateBpmnProcessBindings.cs
@@ -72,16 +72,13 @@ public class ValidateBpmnProcessBindings(IWorkflowGraphBuilder workflowGraphBuil
     {
         var graph = await workflowGraphBuilder.BuildAsync(notification.Workflow, cancellationToken);
 
-        foreach (var node in graph.Nodes)
+        foreach (var scope in graph.Nodes
+                     .Select(node => node.Activity)
+                     .OfType<BpmnProcess>()
+                     .Where(process => process.Process is not null))
         {
-            if (node.Activity is not BpmnProcess { Process: not null } scope)
-                continue;
-
-            foreach (var element in scope.Process!.Elements)
+            foreach (var element in scope.Process!.Elements.Where(IsUnboundTaskCandidate))
             {
-                if (!IsUnboundTaskCandidate(element))
-                    continue;
-
                 var boundActivity = FindBoundActivity(scope, element.BindingRef!);
 
                 if (boundActivity is null)

--- a/src/modules/Elsa.Bpmn.Interchange/Handlers/Notifications/ValidateBpmnProcessBindings.cs
+++ b/src/modules/Elsa.Bpmn.Interchange/Handlers/Notifications/ValidateBpmnProcessBindings.cs
@@ -1,0 +1,96 @@
+using Bpmn.Interchange;
+using Bpmn.Model;
+using Elsa.Bpmn.Activities;
+using Elsa.Mediator.Contracts;
+using Elsa.Workflows;
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Management.Models;
+using Elsa.Workflows.Management.Notifications;
+
+namespace Elsa.Bpmn.Interchange.Handlers.Notifications;
+
+/// <summary>
+/// The second net for <see cref="BpmnWorkBinding.UnboundTask"/>. <see cref="Binding.BpmnWorkBinder"/> already
+/// refuses an unbound task at <em>import</em>, but a definition can be edited after import — through Elsa's own
+/// workflow designer, not through the BPMN document — and an edit can remove the activity a task was bound to.
+/// That edit never touches the BPMN document this scope still carries, so it is invisible to the bind-time
+/// refusal; this handler is what catches it before the definition publishes.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Where the truth lives.</b> This inspects the materialized activity graph — each <see cref="BpmnProcess"/>'s
+/// own <see cref="BpmnProcess.WorkBindings"/> and <see cref="Container.Activities"/> — not the BPMN source text a
+/// document was imported from. The two can disagree, and only one of them is what a published workflow would
+/// actually run: <see cref="BpmnProcess.Process"/> is an inert snapshot of the document as it read at import time,
+/// so removing a bound activity from the graph after import leaves that snapshot, and any <c>elsa:activityBinding</c>
+/// extension on it, exactly as it was. Checking the snapshot instead of the graph would make this gate pass on a
+/// definition it exists to catch. Re-reading the document's stored source XML (kept only for BPMN export, and
+/// already documented there as one a post-import edit can leave stale or remove outright) has the identical defect
+/// for the identical reason: neither the snapshot nor the source text moves when a graph edit removes a binding, so
+/// only the graph itself can answer whether the definition being published still has one. The graph is reached
+/// through <see cref="IWorkflowGraphBuilder"/>, the same service <c>ValidateOutputConverters</c> in
+/// <c>Elsa.Workflows.Management</c> uses for the same reason: it, not a hand-rolled walk of <c>Container.Activities</c>,
+/// is what correctly reaches an activity nested through any composition shape a workflow can use, including a
+/// <c>BpmnProcess</c> composed into a <c>Flowchart</c> (D11).
+/// </para>
+/// <para>
+/// <b>Which elements this looks at.</b> Of every BPMN element kind that carries a <see cref="BpmnElement.BindingRef"/>,
+/// only the task family — <see cref="BpmnElementTypes.Task"/>, <see cref="BpmnElementTypes.UserTask"/>,
+/// <see cref="BpmnElementTypes.ServiceTask"/>, <see cref="BpmnElementTypes.ScriptTask"/>,
+/// <see cref="BpmnElementTypes.ManualTask"/>, <see cref="BpmnElementTypes.BusinessRuleTask"/>,
+/// <see cref="BpmnElementTypes.SendTask"/> and <see cref="BpmnElementTypes.ReceiveTask"/> — can be an
+/// <see cref="BpmnWorkBinding.UnboundTask"/>; every other bindable kind (a call activity, a nested subprocess, a
+/// message/signal/timer catch or throw, a message/signal/timer boundary) binds to an Elsa activity automatically and
+/// takes no <c>elsa:activityBinding</c> declaration, so <see cref="Binding.BpmnWorkBinder"/> never refuses those for
+/// want of one. A send or receive task that resolved a BPMN <c>message</c> is excluded the same way
+/// <c>Bpmn.Interchange</c>'s own reader tells the two apart: it carries
+/// <see cref="BpmnXmlReader.MessageNamePropertyKey"/> in its <see cref="BpmnElement.Properties"/>, which only that
+/// resolution ever sets.
+/// </para>
+/// </remarks>
+public class ValidateBpmnProcessBindings(IWorkflowGraphBuilder workflowGraphBuilder) : INotificationHandler<WorkflowDefinitionValidating>
+{
+    private static readonly IReadOnlySet<string> UnboundTaskElementTypes = new HashSet<string>(StringComparer.Ordinal)
+    {
+        BpmnElementTypes.Task,
+        BpmnElementTypes.UserTask,
+        BpmnElementTypes.ServiceTask,
+        BpmnElementTypes.ScriptTask,
+        BpmnElementTypes.ManualTask,
+        BpmnElementTypes.BusinessRuleTask,
+        BpmnElementTypes.SendTask,
+        BpmnElementTypes.ReceiveTask
+    };
+
+    /// <inheritdoc />
+    public async Task HandleAsync(WorkflowDefinitionValidating notification, CancellationToken cancellationToken)
+    {
+        var graph = await workflowGraphBuilder.BuildAsync(notification.Workflow, cancellationToken);
+
+        foreach (var node in graph.Nodes)
+        {
+            if (node.Activity is not BpmnProcess { Process: not null } scope)
+                continue;
+
+            foreach (var element in scope.Process!.Elements)
+            {
+                if (!IsUnboundTaskCandidate(element) || IsBound(scope, element.BindingRef!))
+                    continue;
+
+                notification.ValidationErrors.Add(new(
+                    $"BPMN element '{element.ElementId}' ({element.ElementType}) of process '{scope.Process.ProcessId}' is not bound to an Elsa activity. "
+                    + "BPMN does not say what this task does; declare an activity binding for it, or remove the element.",
+                    element.ElementId));
+            }
+        }
+    }
+
+    private static bool IsUnboundTaskCandidate(BpmnElement element) =>
+        element.BindingRef is not null
+        && UnboundTaskElementTypes.Contains(element.ElementType)
+        && !element.Properties.ContainsKey(BpmnXmlReader.MessageNamePropertyKey);
+
+    private static bool IsBound(BpmnProcess scope, string bindingRef) =>
+        scope.WorkBindings.TryGetValue(bindingRef, out var activityId)
+        && scope.Activities.Any(activity => string.Equals(activity.Id, activityId, StringComparison.Ordinal));
+}

--- a/src/modules/Elsa.Bpmn.Interchange/ShellFeatures/BpmnInterchangeFeature.cs
+++ b/src/modules/Elsa.Bpmn.Interchange/ShellFeatures/BpmnInterchangeFeature.cs
@@ -2,6 +2,7 @@ using Bpmn.Interchange;
 using CShells.FastEndpoints.Features;
 using CShells.Features;
 using Elsa.Bpmn.Interchange.Binding;
+using Elsa.Bpmn.Interchange.Handlers.Notifications;
 using Elsa.Bpmn.Interchange.Services;
 using Elsa.Bpmn.ShellFeatures;
 using Elsa.Common.ShellFeatures;
@@ -33,5 +34,6 @@ public class BpmnInterchangeFeature : IFastEndpointsShellFeature
         services.AddSingleton<BpmnXmlReader>();
         services.AddSingleton<BpmnXmlWriter>();
         services.AddScoped<BpmnInterchangeDocumentService>();
+        services.AddNotificationHandler<ValidateBpmnProcessBindings>();
     }
 }

--- a/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Assets/publish-gate-process.bpmn
+++ b/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Assets/publish-gate-process.bpmn
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                   xmlns:elsa="https://elsaworkflows.io/schemas/bpmn/v1"
+                   id="Definitions_publish-gate-process"
+                   targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="publish-gate-process" name="Publish Gate Process" isExecutable="true">
+    <bpmn:startEvent id="Start_1">
+      <bpmn:timerEventDefinition>
+        <bpmn:timeCycle>R/PT1H</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="NotifyWarehouse" name="Notify Warehouse">
+      <bpmn:extensionElements>
+        <elsa:activityBinding activityType="Elsa.WriteLine">
+          <elsa:input name="text">{"typeName":"String","expression":{"type":"Literal","value":"Notifying the warehouse"}}</elsa:input>
+        </elsa:activityBinding>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="End_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="Start_1" targetRef="NotifyWarehouse" />
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="NotifyWarehouse" targetRef="End_1" />
+  </bpmn:process>
+</bpmn:definitions>

--- a/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Scenarios/Publishing/BpmnPublishGateTestBase.cs
+++ b/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Scenarios/Publishing/BpmnPublishGateTestBase.cs
@@ -1,0 +1,75 @@
+using Elsa.Bpmn.Interchange.Binding;
+using Elsa.Bpmn.Interchange.IntegrationTests.Support;
+using Elsa.Bpmn.Interchange.Services;
+using Elsa.Extensions;
+using Elsa.Testing.Shared;
+using Elsa.Workflows;
+using Elsa.Workflows.Management;
+using Elsa.Workflows.Management.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit.Abstractions;
+
+namespace Elsa.Bpmn.Interchange.IntegrationTests.Scenarios.Publishing;
+
+/// <summary>
+/// The application <c>ValidateBpmnProcessBindings</c> — the publish-time second net for an unbound task, alongside
+/// <see cref="BpmnWorkBinder"/>'s own bind-time refusal — is exercised in.
+/// </summary>
+public abstract class BpmnPublishGateTestBase : IAsyncLifetime
+{
+    private readonly IServiceProvider _services;
+
+    protected BpmnPublishGateTestBase(ITestOutputHelper testOutputHelper)
+    {
+        _services = new TestApplicationBuilder(testOutputHelper)
+            .ConfigureElsa(elsa => elsa.UseBpmnInterchange())
+            .Build();
+
+        Binder = _services.GetRequiredService<BpmnWorkBinder>();
+        Format = _services.GetRequiredService<BpmnActivityBindingFormat>();
+        DocumentService = _services.GetRequiredService<BpmnInterchangeDocumentService>();
+        Importer = _services.GetRequiredService<IWorkflowDefinitionImporter>();
+        Publisher = _services.GetRequiredService<IWorkflowDefinitionPublisher>();
+        DefinitionService = _services.GetRequiredService<IWorkflowDefinitionService>();
+    }
+
+    protected BpmnWorkBinder Binder { get; }
+
+    protected BpmnActivityBindingFormat Format { get; }
+
+    protected BpmnInterchangeDocumentService DocumentService { get; }
+
+    protected IWorkflowDefinitionImporter Importer { get; }
+
+    protected IWorkflowDefinitionPublisher Publisher { get; }
+
+    protected IWorkflowDefinitionService DefinitionService { get; }
+
+    public Task InitializeAsync() => _services.PopulateRegistriesAsync();
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    /// <summary>Reads a fixture from the <c>Assets</c> directory shipped alongside this test project.</summary>
+    protected static string ReadAsset(string fileName) => BpmnAssetReader.Read(fileName);
+
+    /// <summary>
+    /// Saves <paramref name="root"/> as an unpublished draft, exactly as an author's save does. Draft saves never
+    /// validate — see <c>WorkflowDefinitionImporter</c> — so a draft that fails to publish must fail at the explicit
+    /// <see cref="PublishAsync"/> call below, not here.
+    /// </summary>
+    protected async Task<string> SaveDraftAsync(IActivity root, string? definitionId = null)
+    {
+        var result = await Importer.ImportAsync(new()
+        {
+            Model = new WorkflowDefinitionModel { DefinitionId = definitionId ?? string.Empty, Name = "Publish gate fixture", Root = root },
+            Publish = false
+        });
+
+        Assert.True(result.Succeeded, string.Join("; ", result.ValidationErrors.Select(error => error.Message)));
+
+        return result.WorkflowDefinition.DefinitionId;
+    }
+
+    /// <summary>Publishes the latest draft of <paramref name="definitionId"/>, the same call the Publish endpoint makes.</summary>
+    protected Task<PublishWorkflowDefinitionResult> PublishAsync(string definitionId) => Publisher.PublishAsync(definitionId);
+}

--- a/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Scenarios/Publishing/BpmnPublishGateTestBase.cs
+++ b/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Scenarios/Publishing/BpmnPublishGateTestBase.cs
@@ -1,8 +1,7 @@
 using Elsa.Bpmn.Interchange.Binding;
+using Elsa.Bpmn.Interchange.IntegrationTests.Scenarios.Binding;
 using Elsa.Bpmn.Interchange.IntegrationTests.Support;
 using Elsa.Bpmn.Interchange.Services;
-using Elsa.Extensions;
-using Elsa.Testing.Shared;
 using Elsa.Workflows;
 using Elsa.Workflows.Management;
 using Elsa.Workflows.Management.Models;
@@ -15,27 +14,20 @@ namespace Elsa.Bpmn.Interchange.IntegrationTests.Scenarios.Publishing;
 /// The application <c>ValidateBpmnProcessBindings</c> — the publish-time second net for an unbound task, alongside
 /// <see cref="BpmnWorkBinder"/>'s own bind-time refusal — is exercised in.
 /// </summary>
-public abstract class BpmnPublishGateTestBase : IAsyncLifetime
+/// <remarks>
+/// Derives from <see cref="BpmnBindingTestBase"/> rather than duplicating its container setup and its <c>Ref</c>/
+/// <c>BoundElement</c> helpers: both suites exercise the same binder and format over the same kind of application,
+/// and a definition that publishes here was, in the "edited after import" cases, produced by that same binder.
+/// </remarks>
+public abstract class BpmnPublishGateTestBase : BpmnBindingTestBase
 {
-    private readonly IServiceProvider _services;
-
-    protected BpmnPublishGateTestBase(ITestOutputHelper testOutputHelper)
+    protected BpmnPublishGateTestBase(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
     {
-        _services = new TestApplicationBuilder(testOutputHelper)
-            .ConfigureElsa(elsa => elsa.UseBpmnInterchange())
-            .Build();
-
-        Binder = _services.GetRequiredService<BpmnWorkBinder>();
-        Format = _services.GetRequiredService<BpmnActivityBindingFormat>();
-        DocumentService = _services.GetRequiredService<BpmnInterchangeDocumentService>();
-        Importer = _services.GetRequiredService<IWorkflowDefinitionImporter>();
-        Publisher = _services.GetRequiredService<IWorkflowDefinitionPublisher>();
-        DefinitionService = _services.GetRequiredService<IWorkflowDefinitionService>();
+        DocumentService = Services.GetRequiredService<BpmnInterchangeDocumentService>();
+        Importer = Services.GetRequiredService<IWorkflowDefinitionImporter>();
+        Publisher = Services.GetRequiredService<IWorkflowDefinitionPublisher>();
+        DefinitionService = Services.GetRequiredService<IWorkflowDefinitionService>();
     }
-
-    protected BpmnWorkBinder Binder { get; }
-
-    protected BpmnActivityBindingFormat Format { get; }
 
     protected BpmnInterchangeDocumentService DocumentService { get; }
 
@@ -44,10 +36,6 @@ public abstract class BpmnPublishGateTestBase : IAsyncLifetime
     protected IWorkflowDefinitionPublisher Publisher { get; }
 
     protected IWorkflowDefinitionService DefinitionService { get; }
-
-    public Task InitializeAsync() => _services.PopulateRegistriesAsync();
-
-    public Task DisposeAsync() => Task.CompletedTask;
 
     /// <summary>Reads a fixture from the <c>Assets</c> directory shipped alongside this test project.</summary>
     protected static string ReadAsset(string fileName) => BpmnAssetReader.Read(fileName);

--- a/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Scenarios/Publishing/BpmnPublishGateTests.cs
+++ b/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Scenarios/Publishing/BpmnPublishGateTests.cs
@@ -1,0 +1,99 @@
+using Bpmn.Interchange;
+using Bpmn.Model;
+using Elsa.Bpmn.Activities;
+using Elsa.Bpmn.Interchange.Binding;
+using Elsa.Common.Models;
+using Elsa.Workflows;
+using Elsa.Workflows.Activities;
+using Xunit.Abstractions;
+
+namespace Elsa.Bpmn.Interchange.IntegrationTests.Scenarios.Publishing;
+
+/// <summary>
+/// The publish-time second net for <see cref="BpmnWorkBinding.UnboundTask"/> (#7931/W8): <see cref="Binding.BpmnWorkBinder"/>
+/// already refuses one at import, naming the element; these tests are for the definition that got past that first
+/// net and now needs the second one — one that imported clean and was edited afterward.
+/// </summary>
+public class BpmnPublishGateTests(ITestOutputHelper testOutputHelper) : BpmnPublishGateTestBase(testOutputHelper)
+{
+    private const string ProcessId = "main";
+
+    [Fact(DisplayName = "A process whose unbound task has no bound activity fails publication, naming the element")]
+    public async Task UnboundTaskWithNoBoundActivity_FailsPublication()
+    {
+        // Built by hand rather than through BpmnWorkBinder: the binder itself already refuses this shape at bind
+        // time (that is the first net, unchanged by this issue), so the only way to reach a materialized workflow
+        // this second net has to catch is to construct the graph directly - exactly what a post-import edit that
+        // deletes a bound activity, or a hand-authored workflow, would leave behind.
+        // IsRootScope is left at its default (false): root position only affects trigger registration, which this
+        // fixture declares no start event for and which the binding gate under test does not consult.
+        var process = new BpmnProcess
+        {
+            Id = ProcessId,
+            Process = new BpmnProcessDefinition(ProcessId, Elements: [new BpmnElement("ServiceTask1", BpmnElementTypes.ServiceTask, bindingRef: "ref-ServiceTask1")])
+        };
+
+        var definitionId = await SaveDraftAsync(process);
+        var result = await PublishAsync(definitionId);
+
+        Assert.False(result.Succeeded);
+        Assert.Contains(result.ValidationErrors, error => error.ActivityId == "ServiceTask1");
+    }
+
+    [Fact(DisplayName = "A process whose tasks are all bound publishes successfully")]
+    public async Task AllTasksBound_PublishesSuccessfully()
+    {
+        // Proves the gate is not satisfied by refusing everything: a fully bound scope, produced by the same
+        // binder the first net uses, must not trip it.
+        var scope = Binder.Bind(
+            new BpmnProcessDefinition(ProcessId, Elements: [BoundElement("approve", BpmnElementTypes.UserTask, new WriteLine("approved"))]),
+            [new BpmnWorkBinding.UnboundTask(ProcessId, "approve", Ref("approve"), BpmnBindingSlot.Primary, BpmnElementTypes.UserTask)]);
+
+        // Bind always marks the scope it returns as root position (see its own remarks); this fixture declares no
+        // start event; clearing it keeps the unrelated "a startable trigger needs a payload" runtime validation out
+        // of what is being asserted here.
+        scope.IsRootScope = false;
+
+        var definitionId = await SaveDraftAsync(scope);
+        var result = await PublishAsync(definitionId);
+
+        Assert.True(result.Succeeded, string.Join("; ", result.ValidationErrors.Select(error => error.Message)));
+    }
+
+    [Fact(DisplayName = "A definition that imported cleanly and then had its binding removed fails publication on re-publish")]
+    public async Task DefinitionEditedAfterImport_LosesItsBinding_FailsRepublication()
+    {
+        var xml = ReadAsset("publish-gate-process.bpmn");
+        var imported = await DocumentService.ImportAsync(xml, definitionId: null, name: null, processId: null, CancellationToken.None);
+        Assert.True(imported.ImportResult.Succeeded, string.Join("; ", imported.ImportResult.ValidationErrors.Select(error => error.Message)));
+
+        var definitionId = imported.ImportResult.WorkflowDefinition.DefinitionId;
+
+        // Publishing the document as imported succeeds - the binding is intact, so this is not a gate that refuses
+        // everything either.
+        var publishedAsImported = await PublishAsync(definitionId);
+        Assert.True(publishedAsImported.Succeeded, string.Join("; ", publishedAsImported.ValidationErrors.Select(error => error.Message)));
+
+        // Simulate the edit the issue exists for: through Elsa's own designer, not the BPMN document, the activity
+        // NotifyWarehouse was bound to gets deleted from the graph. The BPMN source this scope still carries -
+        // Process.Elements, and its elsa:activityBinding - is untouched by this; only WorkBindings/Activities move.
+        var definition = await DefinitionService.FindWorkflowDefinitionAsync(definitionId, VersionOptions.Latest);
+        var graph = await DefinitionService.MaterializeWorkflowAsync(definition!);
+        var scope = Assert.IsType<BpmnProcess>(graph.Workflow.Root);
+        var boundActivityId = Assert.Single(scope.WorkBindings.Values);
+        var boundActivity = Assert.Single(scope.Activities, activity => activity.Id == boundActivityId);
+
+        Assert.True(scope.Activities.Remove(boundActivity));
+
+        await SaveDraftAsync(scope, definitionId);
+        var publishedAfterEdit = await PublishAsync(definitionId);
+
+        Assert.False(publishedAfterEdit.Succeeded);
+        Assert.Contains(publishedAfterEdit.ValidationErrors, error => error.ActivityId == "NotifyWarehouse");
+    }
+
+    private static string Ref(string elementId) => $"ref-{elementId}";
+
+    private BpmnElement BoundElement(string elementId, string elementType, IActivity activity) =>
+        new(elementId, elementType, bindingRef: Ref(elementId), extensions: BpmnActivityBindingFormat.Attach(null, Format.Write(activity)));
+}

--- a/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Scenarios/Publishing/BpmnPublishGateTests.cs
+++ b/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Scenarios/Publishing/BpmnPublishGateTests.cs
@@ -37,7 +37,67 @@ public class BpmnPublishGateTests(ITestOutputHelper testOutputHelper) : BpmnPubl
         var result = await PublishAsync(definitionId);
 
         Assert.False(result.Succeeded);
-        Assert.Contains(result.ValidationErrors, error => error.ActivityId == "ServiceTask1");
+        // ActivityId names the containing BpmnProcess node - the real node in the materialized graph - not the BPMN
+        // element id, which resolves to no node there; the element id still appears in the message text.
+        Assert.Contains(result.ValidationErrors, error => error.ActivityId == process.Id && error.Message.Contains("ServiceTask1"));
+    }
+
+    [Fact(DisplayName = "A process whose task is bound to a no-longer-installed activity type fails publication, naming the element and the missing type")]
+    public async Task UnboundTaskWithNotFoundActivity_FailsPublication()
+    {
+        // Simulates the module-removed scenario the finding describes without needing to actually uninstall a
+        // module: a NotFoundActivity is exactly what IActivitySerializer hands back when a binding's activity type
+        // can no longer be resolved (see BpmnActivityBindingFormat, which refuses this at bind time for the same
+        // reason), so constructing one directly reproduces the shape a stale WorkBindings entry leaves behind.
+        const string activityId = "notfound-1";
+        const string missingTypeName = "Acme.RemovedActivity";
+        var process = new BpmnProcess
+        {
+            Id = ProcessId,
+            Process = new BpmnProcessDefinition(ProcessId, Elements: [new BpmnElement("ServiceTask1", BpmnElementTypes.ServiceTask, bindingRef: "ref-ServiceTask1")]),
+            WorkBindings = new Dictionary<string, string>(StringComparer.Ordinal) { ["ref-ServiceTask1"] = activityId },
+            Activities =
+            [
+                new NotFoundActivity(missingTypeName: missingTypeName)
+                {
+                    Id = activityId,
+                    // Round-tripped through the JSON activity serializer on save and on publish: ActivityJsonConverter
+                    // re-derives a NotFoundActivity's missing-type identity from this, not from the in-memory
+                    // properties set above, so it needs to look like what that converter itself would have written.
+                    OriginalActivityJson = $$"""{"id":"{{activityId}}","type":"{{missingTypeName}}","version":1}"""
+                }
+            ]
+        };
+
+        var definitionId = await SaveDraftAsync(process);
+        var result = await PublishAsync(definitionId);
+
+        Assert.False(result.Succeeded);
+        Assert.Contains(result.ValidationErrors, error =>
+            error.ActivityId == process.Id
+            && error.Message.Contains("ServiceTask1")
+            && error.Message.Contains("no longer installed")
+            && error.Message.Contains(missingTypeName));
+    }
+
+    [Fact(DisplayName = "A BPMN process composed inside a Flowchart with an unbound task fails publication, naming the element")]
+    public async Task UnboundTaskInsideFlowchartComposedProcess_FailsPublication()
+    {
+        // Proves the justification for reaching the graph through IWorkflowGraphBuilder rather than a hand-rolled
+        // walk of Container.Activities (see this handler's own remarks): a BpmnProcess nested a level deeper, inside
+        // a Flowchart, must still be found and checked.
+        var process = new BpmnProcess
+        {
+            Id = ProcessId,
+            Process = new BpmnProcessDefinition(ProcessId, Elements: [new BpmnElement("ServiceTask1", BpmnElementTypes.ServiceTask, bindingRef: "ref-ServiceTask1")])
+        };
+        var flowchart = new Elsa.Workflows.Activities.Flowchart.Activities.Flowchart { Activities = [process] };
+
+        var definitionId = await SaveDraftAsync(flowchart);
+        var result = await PublishAsync(definitionId);
+
+        Assert.False(result.Succeeded);
+        Assert.Contains(result.ValidationErrors, error => error.ActivityId == process.Id && error.Message.Contains("ServiceTask1"));
     }
 
     [Fact(DisplayName = "A process whose tasks are all bound publishes successfully")]
@@ -89,11 +149,7 @@ public class BpmnPublishGateTests(ITestOutputHelper testOutputHelper) : BpmnPubl
         var publishedAfterEdit = await PublishAsync(definitionId);
 
         Assert.False(publishedAfterEdit.Succeeded);
-        Assert.Contains(publishedAfterEdit.ValidationErrors, error => error.ActivityId == "NotifyWarehouse");
+        // Same distinction as above: ActivityId is the containing BpmnProcess's node id, not the removed element's.
+        Assert.Contains(publishedAfterEdit.ValidationErrors, error => error.ActivityId == scope.Id && error.Message.Contains("NotifyWarehouse"));
     }
-
-    private static string Ref(string elementId) => $"ref-{elementId}";
-
-    private BpmnElement BoundElement(string elementId, string elementType, IActivity activity) =>
-        new(elementId, elementType, bindingRef: Ref(elementId), extensions: BpmnActivityBindingFormat.Attach(null, Format.Write(activity)));
 }


### PR DESCRIPTION
The publish-time gate: a definition containing a BPMN task that will not run fails publication, naming the offending element ids.

Closes #7931.

## Why a second net

`BpmnWorkBinder` already refuses an unbound `UnboundTask` at **bind** time. That is the import net, and it stays exactly as it is. This is the second one, and it exists because a definition can be edited after import — and an edit can remove a binding.

## The design question the issue poses, and the answer

The issue leaves open where the truth lives. It matters more than it looks.

`BpmnProcess` carries three things that could answer "is this task bound": the `BpmnProcessDefinition` snapshot, the stored BPMN source XML, and the materialized activity graph. **Only the last one reflects an edit.** The first two are inert copies of the document as it read at import; a graph-only edit — deleting the bound activity in Elsa's own designer — never touches either. A gate reading them would pass on precisely the case it exists to catch.

So the gate cross-references each `BpmnProcess`'s `WorkBindings` against its `Activities`, which is exactly what `BpmnProcess.FindWorkActivity` does at execution time. The gate checks the same thing the runtime resolves against.

It walks the graph through `IWorkflowGraphBuilder` rather than `Container.Activities` by hand, so it also reaches a `BpmnProcess` composed inside a `Flowchart` (D11) or nested in another `BpmnProcess`. **That justification is now tested**, and mutation-tested in the way that proves it: swapping the graph walk for a shallow root-only check turns the Flowchart-nested test red while the top-level test stays green.

## Two things review added

**A binding pointing at a missing activity type was passing.** The original check only asked whether an activity with the matching id existed in `Activities`, not whether it was a real resolvable type. A binding whose activity deserialized to a `NotFoundActivity` — say the module providing it was removed — sailed through and failed at run time with `ActivityNotFoundException`. That is the issue's own title. It is now refused, with a message that distinguishes *"bound to an activity type that is no longer installed"* (naming the missing type) from *"not bound at all"* — different diagnoses needing different fixes.

**`WorkflowValidationError.ActivityId` was carrying a BPMN element id.** That field is documented as the id of the activity that caused the error, and consumers use it to locate the node; `ValidateOutputConverters` passes a real graph-node id. A BPMN element id resolves to nothing in the materialized graph. It now carries the containing `BpmnProcess`'s id — a real node — with the element id in the message, which is what the issue actually asks for.

## The two "consider" items, and why neither is implemented

The issue asks to consider refusing `Dropped` findings that change executable meaning, and to surface `Degraded` findings as warnings. **Neither is achievable through the current extension points**, verified by decompiling the pinned `0.1.1-preview.19` package rather than inferred:

- `BpmnImportIssue` is `(Severity, Message, ElementId, ProcessId)`. There is no field marking a finding as changing executable meaning, and no discoverable pattern across the sites that report `Dropped`. Building that classification would mean guessing at message text.
- `BpmnImportAnalysis` is **never persisted**. It is the transient return of analyze/import; only the source XML and a version marker reach the definition. A publish-time handler sees a materialized `Workflow` and has no findings to gate on at all.
- `WorkflowValidationError` is `(Message, ActivityId?)`. There is no severity, so a warning cannot be expressed here — it would be silently promoted to a blocker or silently dropped.

Reporting that the issue asks for a distinction the library does not expose seemed better than a classifier that looks authoritative and is a guess. Both reviewers verified all three claims independently.

## Verification

| Suite | Result |
| --- | --- |
| `dotnet build Elsa.sln` | pass |
| `Elsa.Bpmn.UnitTests` | 17 |
| `Elsa.Bpmn.IntegrationTests` | 37 |
| `Elsa.Bpmn.Interchange.UnitTests` | 8 |
| `Elsa.Bpmn.Interchange.IntegrationTests` | 55 (was 49) |

Mutations, each red then restored green: gutting the gate body; forcing every binding unbound; checking `WorkBindings` alone while ignoring `Activities`; removing the `NotFoundActivity` refusal; and the shallow-walk test above.

The "all tasks bound publishes successfully" case goes through the real `BpmnWorkBinder`, not a hand-rolled shortcut, so the gate cannot be satisfied by refusing everything.

## Known and not closed

`IsBound`'s sibling problem in the wider system: there is no generic publish-time check anywhere for an activity that deserialized to `NotFoundActivity`. This PR closes it for BPMN bindings only. A definition can still be published with a `NotFoundActivity` reached by any other route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
