### PR TITLE
test: fix two intermittent test failures (#7957)

### DIFF
--- a/test/component/Elsa.Workflows.ComponentTests/Scenarios/Activities/Primitives/Event/PublishEventTests.cs
+++ b/test/component/Elsa.Workflows.ComponentTests/Scenarios/Activities/Primitives/Event/PublishEventTests.cs
@@ -20,6 +20,7 @@ public class PublishEventTests : AppComponentTest
     private readonly IWorkflowInstanceStore _workflowInstanceStore;
     private readonly IWorkflowRuntime _workflowRuntime;
     private readonly WorkflowEvents _workflowEvents;
+    private static readonly JsonSerializerOptions CaseInsensitive = new() { PropertyNameCaseInsensitive = true };
 
     public PublishEventTests(App app) : base(app)
     {
@@ -72,11 +73,16 @@ public class PublishEventTests : AppComponentTest
         Assert.True(consumerInstance.WorkflowState.Output.TryGetValue("ReceivedPayload", out var receivedPayload), "Consumer workflow should have ReceivedPayload output");
         Assert.NotNull(receivedPayload);
 
-        // Verify the payload structure and content
-        using var payloadDocument = JsonDocument.Parse(JsonSerializer.Serialize(receivedPayload));
-        Assert.True(payloadDocument.RootElement.TryGetProperty("Status", out var status), "Received payload should contain a Status property");
-        Assert.Equal("Shipped", status.GetString());
+        // Verify the payload content. The payload's runtime representation is not stable: while it is still the
+        // original CLR object its properties are PascalCase, but once it has been through the workflow state
+        // serializer it is an ExpandoObject whose keys have been camelCased by that serializer's naming policy.
+        // Which one this test observes depends on whether the instance was read back from the store, so match
+        // the property name case-insensitively rather than asserting one of the two representations.
+        var payload = JsonSerializer.Deserialize<ReceivedEventPayload>(JsonSerializer.Serialize(receivedPayload), CaseInsensitive);
+        Assert.Equal("Shipped", payload?.Status);
     }
+
+    private record ReceivedEventPayload(string? Status);
 
     private async Task<WorkflowInstance> GetSingleWorkflowInstanceAsync(string definitionId, string correlationId, int timeoutMs = 5000)
     {
@@ -87,9 +93,11 @@ public class PublishEventTests : AppComponentTest
         cts.Token.Register(() => tcs.TrySetException(new TimeoutException($"Workflow instance with DefinitionId '{definitionId}' and CorrelationId '{correlationId}' was not saved within {timeoutMs}ms")));
 
         // Subscribe to the WorkflowInstanceSaved event
+        // A workflow instance is saved several times over its lifetime, so only accept a terminal one: both callers
+        // assert on the finished state, and an intermediate save would hand them an instance that is still running.
         void OnWorkflowInstanceSaved(object? sender, WorkflowInstanceSavedEventArgs args)
         {
-            if (args.WorkflowInstance.DefinitionId == definitionId && args.WorkflowInstance.CorrelationId == correlationId)
+            if (args.WorkflowInstance.DefinitionId == definitionId && args.WorkflowInstance.CorrelationId == correlationId && args.WorkflowInstance.Status == WorkflowStatus.Finished)
             {
                 tcs.TrySetResult(args.WorkflowInstance);
             }
@@ -106,7 +114,7 @@ public class PublishEventTests : AppComponentTest
                 CorrelationId = correlationId
             }, cts.Token)).ToList();
 
-            if (existingInstances.Any())
+            if (existingInstances.Any(x => x.Status == WorkflowStatus.Finished))
                 return Assert.Single(existingInstances);
 
             // Wait for the event to be raised

--- a/test/unit/Elsa.Shells.Api.Tests/ShellsApiTestBase.cs
+++ b/test/unit/Elsa.Shells.Api.Tests/ShellsApiTestBase.cs
@@ -14,7 +14,6 @@ namespace Elsa.Shells.Api.Tests;
 public abstract class ShellsApiTestBase : IAsyncLifetime
 {
     private WebApplication? _app;
-    private bool _wasSecurityEnabled;
 
     protected IShellRegistry ShellRegistry { get; } = Substitute.For<IShellRegistry>();
     protected HttpClient HttpClient { get; private set; } = null!;
@@ -27,9 +26,6 @@ public abstract class ShellsApiTestBase : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        _wasSecurityEnabled = EndpointSecurityOptions.SecurityIsEnabled;
-        EndpointSecurityOptions.SecurityIsEnabled = false;
-
         var apiSerializer = Substitute.For<IApiSerializer>();
         apiSerializer.GetOptions().Returns(JsonOptions);
 
@@ -56,7 +52,6 @@ public abstract class ShellsApiTestBase : IAsyncLifetime
 
     public async Task DisposeAsync()
     {
-        EndpointSecurityOptions.SecurityIsEnabled = _wasSecurityEnabled;
         HttpClient.Dispose();
         if (_app != null)
         {

--- a/test/unit/Elsa.Shells.Api.Tests/TestSecurityDefaults.cs
+++ b/test/unit/Elsa.Shells.Api.Tests/TestSecurityDefaults.cs
@@ -1,0 +1,19 @@
+using System.Runtime.CompilerServices;
+
+namespace Elsa.Shells.Api.Tests;
+
+/// <summary>
+/// <see cref="EndpointSecurityOptions.SecurityIsEnabled"/> is process-global mutable state that FastEndpoints reads
+/// once per host, while <c>UseFastEndpoints()</c> configures the endpoints. xUnit runs the test classes in this
+/// assembly in parallel, so a per-test save/restore of that global races: one class restoring the flag to
+/// <c>true</c> between another class's write and its <c>UseFastEndpoints()</c> call produces endpoints carrying
+/// authorization metadata in a pipeline that has no <c>UseAuthorization</c>, which fails the request with
+/// "contains authorization metadata, but a middleware was not found that supports authorization".
+///
+/// Every test in this assembly wants security disabled, so set it once before any test runs and never touch it again.
+/// </summary>
+internal static class TestSecurityDefaults
+{
+    [ModuleInitializer]
+    internal static void DisableEndpointSecurity() => EndpointSecurityOptions.SecurityIsEnabled = false;
+}


### PR DESCRIPTION
Fixes both intermittent failures recorded in #7957. Full diagnosis, traces and reproductions are in [this comment](https://github.com/elsa-workflows/elsa-core/issues/7957#issuecomment-5361477661).

They are unrelated to each other. The shared factor is only that each test reads a value that is *usually* one thing and *occasionally* another, with a race deciding which.

## 1. `ReloadTests` — "a middleware was not found that supports authorization"

`EndpointSecurityOptions.SecurityIsEnabled` is a process-global mutable static. `ShellsApiTestBase` saved it, set it to `false`, built a host, and restored it — **per test method**, since xUnit constructs a fresh class instance per `[Fact]`. `ReloadTests` and `ReloadAllTests` carry no `[Collection]`, so xUnit runs them in **parallel**.

FastEndpoints reads that global once per host, inside `Configure()`, while `UseFastEndpoints()` runs. When one class's `DisposeAsync` restores `true` inside another class's set-false → `UseFastEndpoints()` window, that host's endpoints get `Permissions(...)` in a pipeline with no `UseAuthorization`, and every request to them throws. Reproduced verbatim by tracing and widening that window:

```
[22:20:43.822] ReloadAllTests: Dispose restore -> True
[22:20:43.895] ReloadTests:    Init.start sec=True      <-- host built with security on
  Failed ...ReloadTests.Post_WhenBlueprintUnavailable_Returns503WithFailedStatus [10 ms]
   System.InvalidOperationException : Endpoint HTTP: POST /shells/{shellId}/reload contains authorization
   metadata, but a middleware was not found that supports authorization.
```

That `Post_WhenBlueprintUnavailable_...` is the one that fails is not sampling: it is the last of `ReloadTests`' four tests, and `ReloadAllTests` has two, so `ReloadAllTests` is disposing right about then.

Every test in that assembly wants security off, so it is now set once in a `[ModuleInitializer]` and the per-test save/restore is gone. Nothing writes the flag after startup, so the window no longer exists.

## 2. `PublishEvent_WithPayload_TransmitsPayloadToConsumer`

Not a delivery race — the payload always arrives. The test asserted a JSON property name whose casing depends on which representation of the instance it happened to observe. `GetSingleWorkflowInstanceAsync` has two exits: the `WorkflowInstanceSaved` subscription hands back the **live in-memory** instance, the store shortcut hands back one **deserialized from the database**. Fetching the same consumer instance both ways:

```
PROBE in-memory Output: clrType=<>f__AnonymousType2`1[[System.String, ...]]  json={"Status":"Shipped"}
PROBE store     Output: clrType=System.Dynamic.ExpandoObject                  json={"status":"Shipped"}
```

`JsonWorkflowStateSerializer` camelCases keys (`PropertyNamingPolicy = JsonNamingPolicy.CamelCase`), and `JsonElement.TryGetProperty` is case-sensitive — hence the exact reported message. The test passes when it wins the race against the consumer workflow being persisted and fails when it loses it, which is why it is deterministic in one environment and green in another.

The assertion now checks the payload's *content* through a small DTO with `PropertyNameCaseInsensitive`. Both representations still have to carry `Status == "Shipped"`; only the accidental dependency on which one the harness observed is gone.

While there: `GetSingleWorkflowInstanceAsync` accepted **any** save, and an instance is saved several times over its lifetime. Both callers assert `Finished`, so an intermediate save could hand them a still-running instance — a second latent flake in the same helper. Both exits now require a terminal instance.

## Not fixed here

- `Elsa.ExternalAuthentication.IntegrationTests` has the same global-static race across **six** classes, one of which sets the flag to `true` while the other five set it to `false`. A module initializer will not work there since that assembly genuinely needs both values; it needs assembly-wide `DisableTestParallelization` or for the flag to stop being global. Worth its own issue.
- An `object` payload published through `PublishEvent` does not survive persistence with its original property casing — it returns as an `ExpandoObject` with camelCased keys, because `PolymorphicObjectConverter` falls back to `ExpandoObject` for a type it cannot resolve (an anonymous type here). That is a product question, not a test question.

## Verification

- `dotnet test test/unit/Elsa.Shells.Api.Tests` — 6/6.
- `PublishEventTests` — 3/3, plus the diagnostic probe above, against real SQL Server and RabbitMQ testcontainers.

Neither test was weakened and no retry was added: both still assert the payload carries `Status == "Shipped"` and that the consumer finished.

🤖 Generated with [Claude Code](https://claude.com/claude-code)