### PR TITLE
docs(bpmn): repoint the cancelled-transaction pin at the upstream issue

### DIFF
--- a/test/integration/Elsa.Bpmn.IntegrationTests/Scenarios/HostPort/BpmnCompensationTests.cs
+++ b/test/integration/Elsa.Bpmn.IntegrationTests/Scenarios/HostPort/BpmnCompensationTests.cs
@@ -90,11 +90,16 @@ public class BpmnCompensationTests(ITestOutputHelper testOutputHelper)
 
         // Assert: the released entries are registered again, so the cancellation's own replay claims them -- the head
         // handler starting a second time is both the first half of the release being real *and* the symptom of
-        // #7959: BpmnInterpreter.CancelTransaction drops the live work it is abandoning without ever producing a
-        // PendingTeardown/CancelWorkSubtree command for it, so the host's original ledger record and bookmark for
-        // the releaseSeat slot survive untouched alongside the replay's freshly started one. The scope now holds two
-        // live records for the same (BindingRef, IterationId) slot -- pinned below so this fails the moment #7959
-        // lands, at which point it should be changed to assert a single record.
+        // valence-works/bpmn#13: BpmnInterpreter.CancelTransaction drops the live work it is abandoning without ever
+        // producing a PendingTeardown/CancelWorkSubtree command for it, so the host's original ledger record and
+        // bookmark for the releaseSeat slot survive untouched alongside the replay's freshly started one. The scope
+        // now holds two live records for the same (BindingRef, IterationId) slot -- pinned below so this fails the
+        // moment the library fix lands, at which point both counts become 1. Filed from here as #7959, closed as
+        // routed upstream; the applier is deliberately unpatched so this stays visible rather than worked around.
+        //
+        // The flip may not be mechanical. Upstream is choosing between tearing down only the compensation handler it
+        // re-starts and tearing down every abandoned token; the second also cancels transaction branches still in
+        // flight, which can move other scenarios in this suite. Check which shipped when the Bpmn.Semantics pin moves.
         Assert.Equal(2, _host.Log.Occurrences("executed:releaseSeat"));
 
         var releaseSeatBindingRef = BpmnTestProcesses.BindingRef("releaseSeat");


### PR DESCRIPTION
Comment-only follow-up to the routing decision on elsa-workflows/elsa-core#7959.

## Why

`BpmnCompensationTests.CompensationRunCancelledMidReplay` pins a two-live-records-per-slot state with an assertion written to fail once the bug is fixed. That bug's root cause is inside `BpmnInterpreter.CancelTransaction` in `Bpmn.Semantics` — a different repo and release train — and the wrong-handle resolution it leads to happens inside the library's own `BuildLiveWorkHandles`. Neither is reachable from this host, so it was raised upstream as valence-works/bpmn#13 rather than worked around here.

#7959 is now closed as routed upstream, which made the test comment point at a closed issue as its live tracker. This repoints it at bpmn#13 and keeps #7959 named as provenance, since that is where the decompiled evidence and the host-vs-library rationale live.

## What else the comment now records

Two things a future reader would otherwise have to reconstruct:

- Both counts become `1` when the fix lands, not just the record count.
- **The flip may not be mechanical.** Upstream is choosing between a narrow fix (tear down only the compensation handler `CancelTransaction` re-starts) and a wide one (tear down every abandoned token). Both turn these assertions into single-record ones, but the wide shape also cancels transaction branches still genuinely in flight across a cancellation, which can move other scenarios in this suite. The reproducer cannot distinguish the two — when the cancel end event fires, `fraudCheck` has already completed, so `releaseSeat` is the only live work.

## Scope

Comment text only. No assertions changed, and `BpmnCommandApplier` remains deliberately unpatched — that is what keeps #7932's measured "compensation needs no applier changes" claim honest rather than quietly falsified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)