### PR TITLE
feat(bpmn): adopt Bpmn.* 0.2.0, and start shipping the two BPMN modules

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -98,9 +98,9 @@
         <PackageVersion Include="Azure.ResourceManager.ServiceBus" Version="1.1.0"/>
         <PackageVersion Include="BenchmarkDotNet" Version="0.15.8"/>
         <PackageVersion Include="Bogus" Version="35.6.5"/>
-        <PackageVersion Include="Bpmn.Interchange" Version="0.1.1-preview.19"/>
-        <PackageVersion Include="Bpmn.Model" Version="0.1.1-preview.19"/>
-        <PackageVersion Include="Bpmn.Semantics" Version="0.1.1-preview.19"/>
+        <PackageVersion Include="Bpmn.Interchange" Version="0.2.0"/>
+        <PackageVersion Include="Bpmn.Model" Version="0.2.0"/>
+        <PackageVersion Include="Bpmn.Semantics" Version="0.2.0"/>
         <PackageVersion Include="ConfigureAwait.Fody" Version="3.3.2" PrivateAssets="All"/>
         <PackageVersion Include="ConsoleLogStreaming.Contracts" Version="1.1.0"/>
         <PackageVersion Include="ConsoleLogStreaming.Core" Version="1.1.0"/>

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -6,7 +6,6 @@
         <add key="NuGet official package source" value="https://api.nuget.org/v3/index.json" />
         <add key="cshells-feedz" value="https://f.feedz.io/sfmskywalker/cshells/nuget/index.json" />
         <add key="elsa-preview-feedz" value="https://f.feedz.io/elsa-workflows/elsa-3/nuget/index.json" />
-        <add key="bpmn-feedz" value="https://f.feedz.io/valence-works/bpmn/nuget/index.json" />
         <add key="valence-loom-feedz" value="https://f.feedz.io/valence-works/loom/nuget/index.json" />
     </packageSources>
     <packageSourceMapping>
@@ -22,9 +21,6 @@
         <packageSource key="elsa-preview-feedz">
             <package pattern="Elsa.Platform.PackageManifest.Generator" />
             <package pattern="Elsa.Platform.PackageManifest" />
-        </packageSource>
-        <packageSource key="bpmn-feedz">
-            <package pattern="Bpmn.*" />
         </packageSource>
         <packageSource key="valence-loom-feedz">
             <package pattern="Loom" />

--- a/src/modules/Elsa.Bpmn.Interchange/Elsa.Bpmn.Interchange.csproj
+++ b/src/modules/Elsa.Bpmn.Interchange/Elsa.Bpmn.Interchange.csproj
@@ -5,8 +5,6 @@
 			Provides BPMN XML interchange support by wiring the Bpmn.Interchange library into Elsa.
 		</Description>
 		<PackageTags>elsa extension module bpmn interchange</PackageTags>
-		<!-- Not packable until the Bpmn.* packages are published to nuget.org; they currently live only on the valence-works/bpmn feedz feed, so a published Elsa.Bpmn.Interchange would fail to restore for consumers. -->
-		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/modules/Elsa.Bpmn/Elsa.Bpmn.csproj
+++ b/src/modules/Elsa.Bpmn/Elsa.Bpmn.csproj
@@ -5,8 +5,6 @@
 			Provides BPMN execution support by wiring the Bpmn.Model and Bpmn.Semantics libraries into Elsa.
 		</Description>
 		<PackageTags>elsa extension module bpmn</PackageTags>
-		<!-- Not packable until the Bpmn.* packages are published to nuget.org; they currently live only on the valence-works/bpmn feedz feed, so a published Elsa.Bpmn would fail to restore for consumers. -->
-		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/test/integration/Elsa.Bpmn.IntegrationTests/Scenarios/HostPort/BpmnCompensationTests.cs
+++ b/test/integration/Elsa.Bpmn.IntegrationTests/Scenarios/HostPort/BpmnCompensationTests.cs
@@ -88,23 +88,34 @@ public class BpmnCompensationTests(ITestOutputHelper testOutputHelper)
         // Act: the other branch cancels the transaction, which stops the replay's coordinating token.
         await _host.FinishWorkAsync("fraudCheck");
 
-        // Assert: the released entries are registered again, so the cancellation's own replay claims them -- the head
-        // handler starting a second time is both the first half of the release being real *and* the symptom of
-        // valence-works/bpmn#13: BpmnInterpreter.CancelTransaction drops the live work it is abandoning without ever
-        // producing a PendingTeardown/CancelWorkSubtree command for it, so the host's original ledger record and
-        // bookmark for the releaseSeat slot survive untouched alongside the replay's freshly started one. The scope
-        // now holds two live records for the same (BindingRef, IterationId) slot -- pinned below so this fails the
-        // moment the library fix lands, at which point both counts become 1. Filed from here as #7959, closed as
-        // routed upstream; the applier is deliberately unpatched so this stays visible rather than worked around.
+        // Assert: the released entries are registered again, so the cancellation's own replay claims them, and the head
+        // handler starts a second time -- the first half of the release being real.
         //
-        // The flip may not be mechanical. Upstream is choosing between tearing down only the compensation handler it
-        // re-starts and tearing down every abandoned token; the second also cancels transaction branches still in
-        // flight, which can move other scenarios in this suite. Check which shipped when the Bpmn.Semantics pin moves.
+        // The second start is a *replacement*, not a duplicate, and that is what valence-works/bpmn#13 fixed in
+        // Bpmn.Semantics 0.2.0. CancelTransaction used to abandon the live work it was superseding without issuing a
+        // CancelWorkSubtree for it, so the host's original ledger record and bookmark for the releaseSeat slot
+        // survived alongside the replay's freshly started one -- two live records for one (BindingRef, IterationId)
+        // slot, which BpmnHostSnapshot documents as a host obligation never to allow, and which the interpreter's own
+        // BuildLiveWorkHandles then collapses last-wins. Upstream took the wide fix: every token a cancelled
+        // transaction abandons now gets a real teardown, not just the compensation handler being re-started.
+        //
+        // So all three of these are the fix, and each fails differently if it regresses: the handler runs twice
+        // (release), the first run is torn down (teardown), and the slot is left holding exactly one record
+        // (the invariant).
         Assert.Equal(2, _host.Log.Occurrences("executed:releaseSeat"));
+        Assert.Contains("cancelled:releaseSeat", _host.Log.Entries);
 
         var releaseSeatBindingRef = BpmnTestProcesses.BindingRef("releaseSeat");
         var releaseSeatLiveRecords = _host.LiveWorkOf("sub").Count(record => record.BindingRef == releaseSeatBindingRef);
-        Assert.Equal(2, releaseSeatLiveRecords);
+        Assert.Equal(1, releaseSeatLiveRecords);
+
+        // And the invariant holds at the moment that matters, not just once the dust settles. 0.2.0 states the
+        // at-most-one-live-unit-per-slot rule as holding after a command batch is applied in full and in order,
+        // because an interrupting path may emit the replacement StartWork ahead of the CancelWorkSubtree it
+        // supersedes. This snapshot is taken inside the replacement's own execution -- overwritten on each start, so
+        // it is the second one -- and a host that applied the batch out of order, or keyed its ledger by slot rather
+        // than by handle, would be holding two records here even though the count above settles at one.
+        Assert.Equal([releaseSeatBindingRef], _host.Log.Snapshot("liveWork@releaseSeat"));
 
         // And the entry that was claimed but never ran is reached once that head handler finishes: the other half.
         var result = await _host.FinishWorkAsync("releaseSeat");


### PR DESCRIPTION
Adopts `Bpmn.*` 0.2.0. The three changes here are one unit — the version bump is what makes the other two true — plus the one test that was built to go red on exactly this bump.

## 1. The pin

`Bpmn.Interchange`, `Bpmn.Model` and `Bpmn.Semantics` move `0.1.1-preview.19` → `0.2.0`.

This is a 0.x minor bump, so breaking changes were expected. **Nothing in the host needed to change to compile** — the whole bound surface (`BpmnHostCommand`, `BpmnContinuation`, `BpmnEvaluation`, `BpmnHostSnapshot`, `BpmnLiveWork`, `IBpmnVariableReader`, `BpmnValue`, `BpmnHostCapabilities`, `BpmnWorkBinding`, `BpmnExtensions`, `BpmnProcessBuilder`) still binds. `dotnet build Elsa.sln` is clean, no new warnings.

## 2. The private feed is retired

All three packages are on nuget.org at `0.2.0`, including `Bpmn.Semantics`, which had no stable release at all under 0.1.x and was the specific reason `IsPackable=false` went on. The `bpmn-feedz` source and its `Bpmn.*` `packageSourceMapping` entry are both removed, which drops a setup step for every consumer.

**This is not optional cleanup.** The feedz feed does not carry `0.2.0` stable, so leaving the mapping in place would route `Bpmn.*` there and the bump would not restore at all. With the mapping gone, `Bpmn.*` falls through the existing `*` → nuget.org rule.

Verified rather than assumed — after clearing the three packages from the local cache, restore reports:

```
bpmn.model      → https://api.nuget.org/v3/index.json
bpmn.semantics  → https://api.nuget.org/v3/index.json
bpmn.interchange → https://api.nuget.org/v3/index.json
```

## 3. `IsPackable=false` comes off, so both modules start shipping

The flag's own comment named its removal condition — *the `Bpmn.*` packages reaching nuget.org* — and that condition is now met. Confirmed on nuget.org specifically, not the feedz feed, because that was the distinction that mattered.

Sanity-checked that shipping is actually safe:

- Both pack cleanly, for `net8.0`/`net9.0`/`net10.0`.
- Every dependency is publicly restorable: `Elsa.*` siblings plus `Bpmn.* 0.2.0`.
- Both emit a package manifest with `runtimeKinds: ["elsa.server"]` — non-empty, so neither is silently excluded from the catalog by runtime-kind matching.
- They were the last two `IsPackable=false` projects under `src/`, so the exception is now fully retired.

## 4. The compensation test that was designed to go red

`BpmnCompensationTests.CompensationRunCancelledMidReplay` pinned a defect on purpose: `valence-works/bpmn#13`, filed from here as #7959 and routed upstream. **0.2.0 contains the fix**, so the test went red on the bump exactly as intended, and the assertions now describe the fixed behaviour. The applier is deliberately still unpatched.

Upstream took the **wide** fix — every token a cancelled transaction abandons now gets a real teardown, not just the compensation handler being re-started. The old comment predicted "both counts become 1"; that turned out to be half right, and the observed behaviour is more precise:

| | before | after |
|---|---|---|
| `executed:releaseSeat` | 2 | **2** (unchanged) |
| `cancelled:releaseSeat` | absent | **present** |
| live records for the slot | 2 | **1** |

The head handler still runs twice — that is the release being real, and it stays asserted. What changed is that the first run is now torn down, so the scope is left holding one live record per `(BindingRef, IterationId)` slot instead of two.

A third assertion is added for the ordering rule 0.2.0 introduces: the at-most-one-live-unit-per-slot invariant now holds *after a command batch is applied in full and in order*, because an interrupting path may emit the replacement `StartWork` ahead of the `CancelWorkSubtree` it supersedes. The snapshot taken inside the replacement's own execution proves Elsa applies the batch in order and keys its ledger by handle rather than by slot.

All three assertions were mutation-tested — with the applier's `CancelWorkSubtree` handling stubbed to a no-op, each one fails independently, and the snapshot assertion reports the doubled slot literally as `["node-releaseSeat", "node-releaseSeat"]`. The stub was reverted; the applier is byte-identical to `main`.

## Capabilities

`BpmnRuntimeCapabilitiesTests` **stays green** — 0.2.0 defines no capability flag Elsa does not already declare. 0.2.0 does make a cancel end event require the `SubtreeCancellation` capability, but `BpmnRuntimeCapabilities.Declared` already carries it. Elsa delegates to the library's own `BpmnCapabilityRequirements.Analyze().ThrowIfUnmet()` rather than restating requirements, so the new requirement is picked up without a change here and cannot drift.

## Persisted state — the one thing to be aware of

0.2.0 freezes the payload format at `1.0.0`, and **state persisted by 0.1.x no longer deserializes**. This is not abstract for Elsa: `BpmnScopeMemory` persists the library's `BpmnExecutionState` into workflow state under `Bpmn:ExecutionState`, and `bpmnExecutionState` is one of the two documented roots of the now-frozen schema. So a workflow suspended mid-BPMN-scope will not resume across this bump.

Neither `Elsa.Bpmn` nor `Elsa.Bpmn.Interchange` has ever been published (both 404 on nuget.org), so no released consumer can be holding such state — anyone affected is running a source build. That is precisely why this is the moment to take the break: it costs nothing now and would be unbounded once the packages ship.

## Verification

Baseline re-measured on `main` before anything changed, rather than trusting inherited counts — the unit suite had already moved from 17 to 18.

| suite | baseline | after |
|---|---|---|
| `Elsa.Bpmn.UnitTests` | 18 | 18 |
| `Elsa.Bpmn.Interchange.UnitTests` | 8 | 8 |
| `Elsa.Bpmn.IntegrationTests` | 53 | 53 |
| `Elsa.Bpmn.Interchange.IntegrationTests` | 57 | 57 |

No regression and no test lost.

Because this touches shared build configuration (`Directory.Packages.props`, `NuGet.Config`), the broader suite was run too, not just BPMN. CI's `Compile Test` job reports **49 projects, 3159 tests, zero failures**, and its BPMN counts match the local numbers above exactly (18 / 8 / 53 / 57) — checked against the job log rather than taken from the green tick, since a green check says nothing about what it actually covered.
