### PR TITLE
fix(external-auth): make the upstream logout continuation reachable

### DIFF
--- a/src/modules/Elsa.ExternalAuthentication/Endpoints/Broker/Logout.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Endpoints/Broker/Logout.cs
@@ -12,6 +12,8 @@ internal sealed class Logout(IExternalAuthenticationBroker broker) : ElsaEndpoin
 {
     public override void Configure()
     {
+        // Deliberately authenticated without a permission: the session id is read from the caller's
+        // principal below, so an identity is required, but logging out is never permission-gated.
         Post("/external-authentication/logout");
     }
 
@@ -46,16 +48,35 @@ internal sealed record LogoutResponse(bool Completed, string? NavigationUrl, str
 
 internal sealed class ContinueLogout(IExternalAuthenticationBroker broker) : ElsaEndpointWithoutRequest
 {
-    public override void Configure() => Get("/external-authentication/logout/continue/{handle}");
+    public override void Configure()
+    {
+        Get("/external-authentication/logout/continue/{handle}");
+
+        // Anonymous, like every other broker endpoint the browser is navigated to. The single-use
+        // route handle carries the authority; the caller's Elsa session has already been revoked by
+        // the time this runs, and a top-level browser navigation sends no Authorization header, so
+        // this endpoint can never present authenticated credentials.
+        AllowAnonymous();
+    }
 
     public override async Task HandleAsync(CancellationToken cancellationToken)
     {
         var result = await broker.ContinueLogoutAsync(Route<string>("handle")!, cancellationToken);
-        if (result.Error is not null || result.NavigationUri is null)
+        if (result.Error is { } error)
         {
-            HttpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
+            await BrokerEndpointSupport.SendErrorAsync(Send, error, cancellationToken);
             return;
         }
-        HttpContext.Response.Redirect(result.NavigationUri.ToString());
+
+        if (result.NavigationUri is null)
+        {
+            await BrokerEndpointSupport.SendErrorAsync(Send, BrokerErrorFactory.Create(BrokerErrorCategory.InvalidRequest), cancellationToken);
+            return;
+        }
+
+        // Responses must go through the Send API: writing to HttpContext.Response without starting it
+        // lets the FastEndpoints auto-response overwrite the status with 204, which silently discarded
+        // both the redirect and the error this endpoint used to produce.
+        await Send.RedirectAsync(result.NavigationUri.ToString(), false, true);
     }
 }

--- a/test/integration/Elsa.ExternalAuthentication.IntegrationTests/Broker/LogoutAuthorizationTests.cs
+++ b/test/integration/Elsa.ExternalAuthentication.IntegrationTests/Broker/LogoutAuthorizationTests.cs
@@ -1,0 +1,129 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Encodings.Web;
+using Elsa.Common.Multitenancy;
+using Elsa.ExternalAuthentication.Contracts;
+using Elsa.ExternalAuthentication.Features;
+using Elsa.ExternalAuthentication.IntegrationTests.Fixtures;
+using Elsa.ExternalAuthentication.Models;
+using Elsa.ExternalAuthentication.Services;
+using FastEndpoints;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Elsa.ExternalAuthentication.IntegrationTests.Broker;
+
+/// <summary>
+/// The upstream-logout continuation is reached by a top-level browser navigation, after the caller's
+/// Elsa session has already been revoked. These tests pin that it answers without credentials, and that
+/// its sibling <c>Logout</c> still does not.
+/// </summary>
+[Collection(nameof(EndpointSecurityCollection))]
+public class LogoutAuthorizationTests : IAsyncLifetime
+{
+    private WebApplication? _app;
+    private HttpClient? _client;
+    private IExternalAuthenticationBroker _broker = null!;
+    private bool _wasSecurityEnabled;
+
+    public async Task InitializeAsync()
+    {
+        _wasSecurityEnabled = EndpointSecurityOptions.SecurityIsEnabled;
+        EndpointSecurityOptions.SecurityIsEnabled = true;
+
+        var builder = WebApplication.CreateSlimBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Services.AddFastEndpoints(options =>
+        {
+            options.Assemblies = [typeof(ExternalAuthenticationFeature).Assembly];
+            options.Filter = endpoint => endpoint.Namespace == "Elsa.ExternalAuthentication.Endpoints.Broker";
+        });
+
+        _broker = Substitute.For<IExternalAuthenticationBroker>();
+        _broker.ContinueLogoutAsync("handle-a", Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(BrokerLogoutResult.Navigate(new Uri("https://idp.example/end-session"))));
+
+        var tenant = Substitute.For<ITenantAccessor>();
+        tenant.TenantId.Returns("tenant-a");
+        builder.Services.AddSingleton(_broker);
+        builder.Services.AddSingleton(tenant);
+        builder.Services.AddRateLimiter(_ => { });
+
+        // A scheme that never authenticates, standing in for a browser navigation that carries no
+        // Authorization header. No principal is injected: that is the condition under test.
+        builder.Services
+            .AddAuthentication(NoCredentialsHandler.SchemeName)
+            .AddScheme<AuthenticationSchemeOptions, NoCredentialsHandler>(NoCredentialsHandler.SchemeName, _ => { });
+        builder.Services.AddAuthorization();
+
+        _app = builder.Build();
+        _app.UseAuthentication();
+        _app.UseAuthorization();
+        _app.UseFastEndpoints();
+        await _app.StartAsync();
+        _client = _app.GetTestClient();
+    }
+
+    public async Task DisposeAsync()
+    {
+        EndpointSecurityOptions.SecurityIsEnabled = _wasSecurityEnabled;
+        _client?.Dispose();
+        if (_app is not null)
+        {
+            await _app.StopAsync();
+            await _app.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task ContinueLogoutRedirectsUpstreamWithoutCredentials()
+    {
+        var response = await _client!.GetAsync("/external-authentication/logout/continue/handle-a");
+
+        Assert.NotEqual(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.Equal(HttpStatusCode.Found, response.StatusCode);
+        Assert.Equal("https://idp.example/end-session", response.Headers.Location?.AbsoluteUri);
+        await _broker.Received(1).ContinueLogoutAsync("handle-a", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ContinueLogoutRejectsAnUnknownHandleWithoutCredentials()
+    {
+        _broker.ContinueLogoutAsync("unknown", Arg.Any<CancellationToken>())
+            .Returns(ValueTask.FromResult(BrokerLogoutResult.Fail(BrokerErrorFactory.Create(BrokerErrorCategory.InvalidRequest))));
+
+        var response = await _client!.GetAsync("/external-authentication/logout/continue/unknown");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task LogoutStillRequiresAnAuthenticatedCaller()
+    {
+        var response = await _client!.PostAsJsonAsync("/external-authentication/logout", new
+        {
+            clientId = "studio",
+            postLogoutRedirectUri = "https://studio.example/logout-callback",
+            mode = "local"
+        });
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        await _broker.DidNotReceive().LogoutAsync(Arg.Any<BrokerLogoutRequest>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    private sealed class NoCredentialsHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        UrlEncoder encoder)
+        : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+    {
+        public const string SchemeName = "NoCredentials";
+
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync() => Task.FromResult(AuthenticateResult.NoResult());
+    }
+}


### PR DESCRIPTION
Fixes #7976.

`ContinueLogout` was unreachable and, once reached, produced no response. Two independent defects — both had to be fixed for the endpoint to work at all. The second was found while writing the regression test for the first.

## 1. It could never authenticate

The endpoint declared neither a permission nor `AllowAnonymous`, so it inherited the FastEndpoints default and required an authenticated caller. It cannot ever satisfy that:

- The broker **revokes the session** (`ExternalAuthenticationBroker.cs:440`) *before* issuing the continuation handle (`:500`), so the caller's credentials are gone by the time the browser navigates.
- The endpoint is reached by a **top-level browser navigation**, which sends no `Authorization` header — and that header is the only transport Elsa authentication uses (`DefaultAuthenticationFeature` selects JWT or API key by inspecting it).

Every other broker endpoint the browser is navigated to — `CompleteCallback`, `CompleteLogout`, `InitiateExternal` — is already `AllowAnonymous` for exactly this reason. The single-use, hashed route handle carries the authority: `ContinueLogoutAsync` does a `TryTakeAsync` against `Hash(handle)` and never touches `HttpContext.User`.

## 2. It never sent a response

The handler wrote to `HttpContext.Response` directly rather than through the `Send` API, so the response never started and the FastEndpoints auto-response overwrote the status with **204 No Content**. Both branches were affected — the redirect to the provider's end-session endpoint *and* the 400 for an unknown handle were each discarded.

Now mirrors its sibling `CompleteLogout`: `Send.RedirectAsync` for the redirect, `BrokerEndpointSupport.SendErrorAsync` for the error, which writes a body and so starts the response.

## The sibling endpoint

`Logout` in the same file also relies on an inherited default, but there the default is **correct** — it reads the external session id from the principal, so it needs an identity and no permission. Left behaviourally unchanged, with a comment saying why. An explicit authenticated-only declaration arrives with the authorization model work (#7974), which adds that third declaration state.

## Testing

Adds `LogoutAuthorizationTests`, which builds a host with authorization actually enforced and **no principal injected** — the existing broker fixture injects one and disables endpoint security, so it could not have caught either defect.

Verified by reverting the fix: `401 Unauthorized` on the auth defect, then `204 NoContent` on the response defect once auth was fixed. Green after.

- `Elsa.ExternalAuthentication.IntegrationTests`: 136 passed
- `Elsa.ExternalAuthentication.UnitTests`: 154 passed

## Note

This is a behaviour change on a previously non-functional path, so nothing can regress from it — but it is worth confirming against a real upstream-logout flow that the provider's end-session redirect now completes end to end. I could not exercise a live identity provider here.