### PR TITLE
fix(external-auth)!: wildcard-aware permission grant boundary, and startup smoke tests for both hosts

### DIFF
--- a/Elsa.sln
+++ b/Elsa.sln
@@ -514,6 +514,7 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.UserTasks.Persistence.EFCore.UnitTests", "test\unit\Elsa.UserTasks.Persistence.EFCore.UnitTests\Elsa.UserTasks.Persistence.EFCore.UnitTests.csproj", "{A4F3CB08-759D-4FE6-B715-E8D91E3E3F3E}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.UserTasks.Persistence.ConformanceTests", "test\unit\Elsa.UserTasks.Persistence.ConformanceTests\Elsa.UserTasks.Persistence.ConformanceTests.csproj", "{0C16ED4D-2483-488D-9CA1-D269ED5BEB9F}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elsa.Hosts.SmokeTests", "test\integration\Elsa.Hosts.SmokeTests\Elsa.Hosts.SmokeTests.csproj", "{0BE4BC01-D02D-4185-A433-E33780584261}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -2455,6 +2456,18 @@ Global
 		{0C16ED4D-2483-488D-9CA1-D269ED5BEB9F}.Release|x64.Build.0 = Release|Any CPU
 		{0C16ED4D-2483-488D-9CA1-D269ED5BEB9F}.Release|x86.ActiveCfg = Release|Any CPU
 		{0C16ED4D-2483-488D-9CA1-D269ED5BEB9F}.Release|x86.Build.0 = Release|Any CPU
+		{0BE4BC01-D02D-4185-A433-E33780584261}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0BE4BC01-D02D-4185-A433-E33780584261}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0BE4BC01-D02D-4185-A433-E33780584261}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{0BE4BC01-D02D-4185-A433-E33780584261}.Debug|x64.Build.0 = Debug|Any CPU
+		{0BE4BC01-D02D-4185-A433-E33780584261}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0BE4BC01-D02D-4185-A433-E33780584261}.Debug|x86.Build.0 = Debug|Any CPU
+		{0BE4BC01-D02D-4185-A433-E33780584261}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0BE4BC01-D02D-4185-A433-E33780584261}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0BE4BC01-D02D-4185-A433-E33780584261}.Release|x64.ActiveCfg = Release|Any CPU
+		{0BE4BC01-D02D-4185-A433-E33780584261}.Release|x64.Build.0 = Release|Any CPU
+		{0BE4BC01-D02D-4185-A433-E33780584261}.Release|x86.ActiveCfg = Release|Any CPU
+		{0BE4BC01-D02D-4185-A433-E33780584261}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -2659,6 +2672,7 @@ Global
 		{FB045674-6D63-4B49-A060-73D580E0FAC0} = {AB07AAEB-2C7A-1088-880A-08DB82DA218D}
 		{A4F3CB08-759D-4FE6-B715-E8D91E3E3F3E} = {AB07AAEB-2C7A-1088-880A-08DB82DA218D}
 		{0C16ED4D-2483-488D-9CA1-D269ED5BEB9F} = {18453B51-25EB-4317-A4B3-B10518252E92}
+		{0BE4BC01-D02D-4185-A433-E33780584261} = {90031D64-CA0F-46D0-9AF4-8DC023A5FFCD}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D4B5CEAA-7D70-4FCB-A68E-B03FBE5E0E5E}

--- a/doc/migrations/authorization-model.md
+++ b/doc/migrations/authorization-model.md
@@ -47,6 +47,29 @@ The default access-token lifetime drops from 1 hour to **15 minutes**. This is t
 
 For a tighter bound, enable the optional permission stamp (`Identity:PermissionStamp:IsEnabled`). It is derived from the user's roles rather than stored, so it needs no schema change and no cross-node cache invalidation. `CacheLifetime`, default 30 seconds, is the effective bound when enabled.
 
+## External authentication grant boundaries
+
+`ExternalAuthentication:PermissionGrants:AllowedPermissions` and `DeniedPermissions` bound which permissions an
+external identity provider connection may confer. Both lists are now matched as **permission patterns** rather than
+by exact string, so they read the way a role does.
+
+- **Denied** is matched in both directions. `workflows/*:delete` denies `workflows/definitions:delete`, and a
+  connection granting `workflows/*:delete` is denied by a deny list naming only `workflows/definitions:delete`.
+  Before this release both comparisons were exact, so either spelling slipped past the other and a deployment's
+  deny list did not hold. If you carried a deny list across the upgrade, re-read it: it may now deny more than it
+  used to, which is the intent.
+- **Allowed** is matched one way: an allow entry must cover the whole grant. `workflows/*:delete` admits
+  `workflows/definitions:delete`, but an allow list naming only `workflows/definitions:delete` refuses a
+  `workflows/*:delete` grant rather than admitting the part that overlaps.
+
+Rewrite both lists into the new `{resource}:{verb}` vocabulary using the [full mapping](#full-mapping). A value that
+is not a well-formed permission matches nothing, and a grant that is not well-formed is dropped at sign-in with a
+`malformed_permission` warning instead of being carried into a token.
+
+The same matching now governs the delegation check: an actor may configure a mapping only for permissions their own
+grants cover, so holding `workflows/*:delete` lets them delegate `workflows/definitions:delete`, while holding just
+that leaf does not let them delegate the subtree.
+
 ## Third-party modules
 
 Modules outside this repository keep compiling. `ConfigurePermissions(params string[])` remains available but obsolete, and a permission that resolves to no registered descriptor registers an implicit one marked unverified, logs a warning, and appears as such in the catalog. The module keeps working and the gap stays visible.

--- a/doc/migrations/authorization-model.md
+++ b/doc/migrations/authorization-model.md
@@ -62,6 +62,18 @@ by exact string, so they read the way a role does.
   `workflows/definitions:delete`, but an allow list naming only `workflows/definitions:delete` refuses a
   `workflows/*:delete` grant rather than admitting the part that overlaps.
 
+The boundary now also applies to permissions the user's **own Elsa roles** carry, not only to those an external
+claim mapping confers. Previously token issuance concatenated role permissions raw, so a permission the boundary
+excluded during sign-in reappeared in the issued token from the same roles — which made the deny list
+unenforceable for anything a role happened to carry. If you configured a boundary expecting it to bound the whole
+token, it now does. If you configured one expecting it to bound only claim-mapped permissions, an external login
+may now carry fewer permissions than before; widen the list, or move the restriction into the roles themselves.
+Deployments with no boundary configured, which is the default, are unaffected.
+
+A boundary that does not parse is now a **startup failure** rather than a silently ignored setting. An allow list
+whose entries are all malformed used to reduce to an empty list, which means unrestricted, so a typo turned the
+boundary off. Fix the entries the startup error names; the mapping table below gives the new spelling.
+
 Rewrite both lists into the new `{resource}:{verb}` vocabulary using the [full mapping](#full-mapping). A value that
 is not a well-formed permission matches nothing, and a grant that is not well-formed is dropped at sign-in with a
 `malformed_permission` warning instead of being carried into a token.

--- a/src/apps/Elsa.ModularServer.Web/ModularServerHost.cs
+++ b/src/apps/Elsa.ModularServer.Web/ModularServerHost.cs
@@ -1,0 +1,16 @@
+using JetBrains.Annotations;
+
+namespace Elsa.ModularServer.Web;
+
+/// <summary>
+/// Entry-point marker so a test can boot this host with <c>WebApplicationFactory</c>.
+/// </summary>
+/// <remarks>
+/// The host is built from top-level statements, whose generated entry point is internal, so a test project
+/// needs some public type from this assembly to name as the factory's entry point. A dedicated marker is
+/// used rather than an incidental public type so that deleting an unrelated class cannot quietly break the
+/// smoke test, and rather than a <c>public partial class Program</c> because Elsa.Server.Web already
+/// declares one in the global namespace and a test referencing both hosts could not tell them apart.
+/// </remarks>
+[UsedImplicitly]
+public sealed class ModularServerHost;

--- a/src/apps/Elsa.Server.Web/ClassicServerHost.cs
+++ b/src/apps/Elsa.Server.Web/ClassicServerHost.cs
@@ -1,0 +1,15 @@
+using JetBrains.Annotations;
+
+namespace Elsa.Server.Web;
+
+/// <summary>
+/// Entry-point marker so a test can boot this host with <c>WebApplicationFactory</c>.
+/// </summary>
+/// <remarks>
+/// This assembly already declares a <c>public partial class Program</c> in the global namespace, and so
+/// does Elsa.ModularServer.Web, so a test project referencing both hosts cannot name either unambiguously.
+/// Each host therefore carries a namespaced marker for that purpose. This does not replace <c>Program</c>,
+/// which existing component tests still use.
+/// </remarks>
+[UsedImplicitly]
+public sealed class ClassicServerHost;

--- a/src/modules/Elsa.Diagnostics.ConsoleLogs/AssemblyInfo.cs
+++ b/src/modules/Elsa.Diagnostics.ConsoleLogs/AssemblyInfo.cs
@@ -1,3 +1,1 @@
-using System.Runtime.CompilerServices;
-
 [assembly: InternalsVisibleTo("Elsa.Diagnostics.ConsoleLogs.UnitTests")]

--- a/src/modules/Elsa.Diagnostics.ConsoleLogs/Contracts/ConsoleStreamJsonConverter.cs
+++ b/src/modules/Elsa.Diagnostics.ConsoleLogs/Contracts/ConsoleStreamJsonConverter.cs
@@ -1,6 +1,5 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using ConsoleLogStreaming.Core.Models;
 
 namespace Elsa.Diagnostics.ConsoleLogs.Contracts;
 

--- a/src/modules/Elsa.Diagnostics.ConsoleLogs/Endpoints/ConsoleLogs/Recent/Endpoint.cs
+++ b/src/modules/Elsa.Diagnostics.ConsoleLogs/Endpoints/ConsoleLogs/Recent/Endpoint.cs
@@ -2,7 +2,6 @@ using Elsa.Authorization;
 using System.Text.Json;
 using ConsoleLogStreaming.Core;
 using Elsa.Abstractions;
-using Elsa.Diagnostics.ConsoleLogs.Permissions;
 using Elsa.Diagnostics.ConsoleLogs.Services;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Http;

--- a/src/modules/Elsa.Diagnostics.ConsoleLogs/Endpoints/ConsoleLogs/Sources/Endpoint.cs
+++ b/src/modules/Elsa.Diagnostics.ConsoleLogs/Endpoints/ConsoleLogs/Sources/Endpoint.cs
@@ -1,7 +1,6 @@
 using Elsa.Authorization;
 using ConsoleLogStreaming.Core;
 using Elsa.Abstractions;
-using Elsa.Diagnostics.ConsoleLogs.Permissions;
 using JetBrains.Annotations;
 using ConsoleLogSource = ConsoleLogStreaming.Core.Models.ConsoleLogSource;
 

--- a/src/modules/Elsa.Diagnostics.ConsoleLogs/Services/ConsoleLogCaptureShellLease.cs
+++ b/src/modules/Elsa.Diagnostics.ConsoleLogs/Services/ConsoleLogCaptureShellLease.cs
@@ -1,5 +1,4 @@
 using ConsoleLogStreaming.Core;
-using ConsoleLogStreaming.Core.Capture;
 using CShells.Lifecycle;
 using Microsoft.Extensions.DependencyInjection;
 

--- a/src/modules/Elsa.Diagnostics.ConsoleLogs/Services/ElsaConsoleLogStreamHubAuthorizer.cs
+++ b/src/modules/Elsa.Diagnostics.ConsoleLogs/Services/ElsaConsoleLogStreamHubAuthorizer.cs
@@ -1,6 +1,5 @@
 using Elsa.Authorization;
 using Elsa.Diagnostics.ConsoleLogs.Permissions;
-using FastEndpoints.Security;
 using Microsoft.AspNetCore.SignalR;
 
 namespace Elsa.Diagnostics.ConsoleLogs.Services;

--- a/src/modules/Elsa.Diagnostics.StructuredLogs.Dashboard/Dashboard/StructuredLogsDashboardContributor.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs.Dashboard/Dashboard/StructuredLogsDashboardContributor.cs
@@ -2,9 +2,13 @@ using Elsa.Dashboard.Abstractions.Contracts;
 using Elsa.Dashboard.Abstractions.Models;
 using Elsa.Diagnostics.StructuredLogs.Contracts;
 using Elsa.Diagnostics.StructuredLogs.Models;
+using JetBrains.Annotations;
 
+// ReSharper disable once CheckNamespace
 namespace Elsa.Diagnostics.StructuredLogs.Dashboard;
 
+/// <inheritdoc />
+[UsedImplicitly]
 public class StructuredLogsDashboardContributor(
     IStructuredLogProvider provider,
     IEnumerable<IStructuredLogStorageDiagnostics> storageDiagnostics) : IDashboardContributor

--- a/src/modules/Elsa.Diagnostics.StructuredLogs/Endpoints/StructuredLogs/Recent/Endpoint.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs/Endpoints/StructuredLogs/Recent/Endpoint.cs
@@ -14,7 +14,7 @@ internal class Endpoint(IStructuredLogProvider logProvider) : ElsaEndpoint<Struc
     {
         Verbs(FastEndpoints.Http.GET, FastEndpoints.Http.POST);
         Routes("/diagnostics/structured-logs/recent");
-        RequirePermission(Elsa.Diagnostics.StructuredLogs.Permissions.StructuredLogsResourcePermissions.StructuredLogs, CoreVerbs.View);
+        RequirePermission(StructuredLogsResourcePermissions.StructuredLogs, CoreVerbs.View);
     }
     
     public override async Task<RecentStructuredLogsResult> ExecuteAsync(StructuredLogFilter request, CancellationToken cancellationToken)

--- a/src/modules/Elsa.Diagnostics.StructuredLogs/Endpoints/StructuredLogs/Sources/Endpoint.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs/Endpoints/StructuredLogs/Sources/Endpoint.cs
@@ -13,7 +13,7 @@ internal class Endpoint(IStructuredLogProvider logProvider) : ElsaEndpointWithou
     public override void Configure()
     {
         Get("/diagnostics/structured-logs/sources");
-        RequirePermission(Elsa.Diagnostics.StructuredLogs.Permissions.StructuredLogsResourcePermissions.StructuredLogs, CoreVerbs.View);
+        RequirePermission(StructuredLogsResourcePermissions.StructuredLogs, CoreVerbs.View);
     }
     
     public override async Task<IReadOnlyCollection<StructuredLogSource>> ExecuteAsync(CancellationToken cancellationToken)

--- a/src/modules/Elsa.Diagnostics.StructuredLogs/Endpoints/StructuredLogs/Storage/Endpoint.cs
+++ b/src/modules/Elsa.Diagnostics.StructuredLogs/Endpoints/StructuredLogs/Storage/Endpoint.cs
@@ -13,7 +13,7 @@ internal class Endpoint(IEnumerable<IStructuredLogStorageDiagnostics> storageDia
     public override void Configure()
     {
         Get("/diagnostics/structured-logs/storage");
-        RequirePermission(Elsa.Diagnostics.StructuredLogs.Permissions.StructuredLogsResourcePermissions.StructuredLogs, CoreVerbs.View);
+        RequirePermission(StructuredLogsResourcePermissions.StructuredLogs, CoreVerbs.View);
     }
     
     public override Task<StructuredLogStorageDiagnostics> ExecuteAsync(CancellationToken cancellationToken)

--- a/src/modules/Elsa.Expressions.JavaScript/Endpoints/TypeDefinitions/Endpoint.cs
+++ b/src/modules/Elsa.Expressions.JavaScript/Endpoints/TypeDefinitions/Endpoint.cs
@@ -2,6 +2,7 @@ using Elsa.Authorization;
 using System.Text;
 using Elsa.Abstractions;
 using Elsa.Common.Models;
+using Elsa.Expressions.JavaScript.Permissions;
 using Elsa.Expressions.JavaScript.TypeDefinitions.Contracts;
 using Elsa.Expressions.JavaScript.TypeDefinitions.Models;
 using Elsa.Workflows.Management;
@@ -30,7 +31,7 @@ internal class Get : ElsaEndpoint<Request>
     public override void Configure()
     {
         Post("scripting/javascript/type-definitions/{workflowDefinitionId}");
-        RequirePermission(Elsa.Expressions.JavaScript.Permissions.JavaScriptPermissions.Scripting, CoreVerbs.View);
+        RequirePermission(JavaScriptPermissions.Scripting, CoreVerbs.View);
     }
 
     /// <inheritdoc />
@@ -61,7 +62,7 @@ internal class Get : ElsaEndpoint<Request>
 
 internal record Request(string WorkflowDefinitionId, string? ActivityTypeName, string? PropertyName)
 {
-    public Request() : this(default!, default!, default)
+    public Request() : this(null!, null!, null)
     {
     }
 }

--- a/src/modules/Elsa.ExternalAuthentication/Endpoints/Broker/CompleteCallback.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Endpoints/Broker/CompleteCallback.cs
@@ -1,10 +1,7 @@
 using Elsa.Abstractions;
 using Elsa.ExternalAuthentication.Constants;
-using Elsa.ExternalAuthentication.Models;
 using Elsa.ExternalAuthentication.Services;
-using FastEndpoints;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.RateLimiting;
 
 namespace Elsa.ExternalAuthentication.Endpoints.Broker;
 

--- a/src/modules/Elsa.ExternalAuthentication/Endpoints/Broker/CompleteLogout.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Endpoints/Broker/CompleteLogout.cs
@@ -1,9 +1,7 @@
 using Elsa.Abstractions;
 using Elsa.ExternalAuthentication.Constants;
 using Elsa.ExternalAuthentication.Services;
-using FastEndpoints;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.RateLimiting;
 
 namespace Elsa.ExternalAuthentication.Endpoints.Broker;
 

--- a/src/modules/Elsa.ExternalAuthentication/Endpoints/Broker/DiscoverLoginMethods.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Endpoints/Broker/DiscoverLoginMethods.cs
@@ -3,9 +3,7 @@ using Elsa.Common.Multitenancy;
 using Elsa.ExternalAuthentication.Constants;
 using Elsa.ExternalAuthentication.Models;
 using Elsa.ExternalAuthentication.Services;
-using FastEndpoints;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.RateLimiting;
 
 namespace Elsa.ExternalAuthentication.Endpoints.Broker;
 
@@ -25,12 +23,12 @@ internal sealed class DiscoverLoginMethods(IExternalAuthenticationBroker broker,
         {
             var methods = await broker.DiscoverAsync(tenantAccessor.TenantId, clientId, cancellationToken);
             HttpContext.Response.Headers.CacheControl = "no-store";
-            return new DiscoverLoginMethodsResponse(methods, methods.SingleOrDefault(x => x.IsPreferred)?.Key);
+            return new(methods, methods.SingleOrDefault(x => x.IsPreferred)?.Key);
         }
         catch (InvalidOperationException)
         {
             HttpContext.Response.StatusCode = 400;
-            return new DiscoverLoginMethodsResponse([], null);
+            return new([], null);
         }
     }
 }

--- a/src/modules/Elsa.ExternalAuthentication/Endpoints/Broker/ExchangeToken.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Endpoints/Broker/ExchangeToken.cs
@@ -2,9 +2,7 @@ using Elsa.Abstractions;
 using Elsa.ExternalAuthentication.Constants;
 using Elsa.ExternalAuthentication.Models;
 using Elsa.ExternalAuthentication.Services;
-using FastEndpoints;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.RateLimiting;
 
 namespace Elsa.ExternalAuthentication.Endpoints.Broker;
 
@@ -28,7 +26,7 @@ internal sealed class ExchangeToken(IExternalAuthenticationBroker broker) : Elsa
         }
 
         var basicCredentials = TryGetBasicCredentials(HttpContext.Request.Headers.Authorization);
-        var result = await broker.ExchangeAsync(new BrokerTokenRequest(request.GrantType ?? string.Empty, request.ClientId ?? string.Empty, redirectUri, request.Code, request.CodeVerifier, request.RefreshToken, HttpContext.Request.Headers.Origin, basicCredentials?.ClientId, basicCredentials?.Secret), cancellationToken);
+        var result = await broker.ExchangeAsync(new(request.GrantType ?? string.Empty, request.ClientId ?? string.Empty, redirectUri, request.Code, request.CodeVerifier, request.RefreshToken, HttpContext.Request.Headers.Origin, basicCredentials?.ClientId, basicCredentials?.Secret), cancellationToken);
         if (result.Error is { } error)
         {
             await BrokerEndpointSupport.SendErrorAsync(Send, error, cancellationToken);

--- a/src/modules/Elsa.ExternalAuthentication/Endpoints/Broker/InitiateExternal.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Endpoints/Broker/InitiateExternal.cs
@@ -3,9 +3,7 @@ using Elsa.Common.Multitenancy;
 using Elsa.ExternalAuthentication.Constants;
 using Elsa.ExternalAuthentication.Models;
 using Elsa.ExternalAuthentication.Services;
-using FastEndpoints;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.RateLimiting;
 
 namespace Elsa.ExternalAuthentication.Endpoints.Broker;
 
@@ -32,7 +30,7 @@ internal sealed class InitiateExternal(IExternalAuthenticationBroker broker, ITe
             return;
         }
 
-        var result = await broker.InitiateExternalAsync(new BrokerAuthorizationRequest(
+        var result = await broker.InitiateExternalAsync(new(
             clientId ?? string.Empty, redirectUri, responseType ?? string.Empty, codeChallenge ?? string.Empty,
             codeChallengeMethod ?? string.Empty, returnPath ?? string.Empty, request.ConnectionKey ?? string.Empty, request.State), tenantAccessor.TenantId, cancellationToken);
         if (result.Error is { } error)

--- a/src/modules/Elsa.ExternalAuthentication/Endpoints/Broker/InitiateLocal.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Endpoints/Broker/InitiateLocal.cs
@@ -3,9 +3,7 @@ using Elsa.Common.Multitenancy;
 using Elsa.ExternalAuthentication.Constants;
 using Elsa.ExternalAuthentication.Models;
 using Elsa.ExternalAuthentication.Services;
-using FastEndpoints;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.RateLimiting;
 
 namespace Elsa.ExternalAuthentication.Endpoints.Broker;
 
@@ -26,7 +24,7 @@ internal sealed class InitiateLocal(IExternalAuthenticationBroker broker, ITenan
             return;
         }
 
-        var result = await broker.InitiateLocalAsync(new LocalBrokerAuthorizationRequest(
+        var result = await broker.InitiateLocalAsync(new(
             request.ClientId ?? string.Empty, redirectUri, request.ResponseType ?? string.Empty, request.CodeChallenge ?? string.Empty,
             request.CodeChallengeMethod ?? string.Empty, request.ReturnPath ?? string.Empty, request.Username ?? string.Empty,
             request.Password ?? string.Empty, request.State), tenantAccessor.TenantId, cancellationToken);

--- a/src/modules/Elsa.ExternalAuthentication/Endpoints/Broker/Logout.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Endpoints/Broker/Logout.cs
@@ -1,10 +1,7 @@
 using Elsa.Abstractions;
-using Elsa.ExternalAuthentication.Constants;
 using Elsa.ExternalAuthentication.Models;
 using Elsa.ExternalAuthentication.Services;
 using Elsa.Identity.Constants;
-using FastEndpoints;
-using Microsoft.AspNetCore.Http;
 
 namespace Elsa.ExternalAuthentication.Endpoints.Broker;
 
@@ -30,7 +27,7 @@ internal sealed class Logout(IExternalAuthenticationBroker broker) : ElsaEndpoin
             return;
         }
 
-        var result = await broker.LogoutAsync(new BrokerLogoutRequest(request.ClientId ?? string.Empty, redirectUri, request.Mode ?? "local"), sessionId, cancellationToken);
+        var result = await broker.LogoutAsync(new(request.ClientId ?? string.Empty, redirectUri, request.Mode ?? "local"), sessionId, cancellationToken);
         if (result.Error is { } error)
         {
             await BrokerEndpointSupport.SendErrorAsync(Send, error, cancellationToken);

--- a/src/modules/Elsa.ExternalAuthentication/Endpoints/Connections/ConnectionEndpointSupport.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Endpoints/Connections/ConnectionEndpointSupport.cs
@@ -1,8 +1,9 @@
-using System.Security.Claims;
+using Elsa.Authorization;
 using Elsa.ExternalAuthentication.Contracts;
 using Elsa.ExternalAuthentication.Models;
 using Elsa.ExternalAuthentication.Services;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Elsa.ExternalAuthentication.Endpoints.Connections;
 
@@ -37,7 +38,18 @@ internal static class ConnectionEndpointSupport
 
     public static Task SendErrorAsync(HttpContext context, int statusCode, string error, string message, CancellationToken cancellationToken) => SendErrorAsync(context, statusCode, error, message, null, cancellationToken);
 
-    public static bool HasPermission(ClaimsPrincipal user, string permission) => user.FindAll(PermissionNames.ClaimType).Any(x => x.Value == PermissionNames.All || x.Value == permission);
+    /// <summary>
+    /// Whether the acting user holds <paramref name="resource"/> and <paramref name="verb"/>.
+    /// </summary>
+    /// <remarks>
+    /// These are the checks an endpoint makes after its own <c>RequirePermission</c> gate has passed, for the
+    /// extra operations a single request can opt into: managing a policy, revoking sessions, or confirming an
+    /// unsafe setting. Routing them through <see cref="IPermissionEvaluator"/> is what makes a wildcard grant
+    /// mean the same thing here as it does on the gate itself. Comparing claim values directly, as this used
+    /// to, also silently stopped matching anything once the legacy permission names were retired.
+    /// </remarks>
+    public static bool HasPermission(HttpContext context, string resource, string verb) =>
+        (context.RequestServices.GetService<IPermissionEvaluator>() ?? PermissionEvaluator.Shared).HasPermission(context.User, resource, verb);
     public static bool RequiresPolicyManagement(ConnectionRequest request) => request.UnlinkedPolicy is not null || request.PermissionGrantSources is { Count: > 0 };
     public static bool IsDatabaseOwned(EffectiveIdentityProviderConnection connection) => connection.Ownership == ConnectionSourceOwnership.Database;
 }

--- a/src/modules/Elsa.ExternalAuthentication/Endpoints/Connections/ConnectionEndpointSupport.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Endpoints/Connections/ConnectionEndpointSupport.cs
@@ -1,8 +1,6 @@
 using System.Security.Claims;
-using Elsa.Abstractions;
 using Elsa.ExternalAuthentication.Contracts;
 using Elsa.ExternalAuthentication.Models;
-using Elsa.ExternalAuthentication.Permissions;
 using Elsa.ExternalAuthentication.Services;
 using Microsoft.AspNetCore.Http;
 
@@ -12,9 +10,9 @@ internal static class ConnectionEndpointSupport
 {
     public static bool TryGetExpectedRevision(HttpContext context, out long revision)
     {
-        revision = default;
+        revision = 0;
         var value = context.Request.Headers.IfMatch.FirstOrDefault();
-        return !string.IsNullOrWhiteSpace(value) && value.Length >= 2 && value[0] == '"' && value[^1] == '"' && long.TryParse(value[1..^1], out revision) && revision > 0;
+        return !string.IsNullOrWhiteSpace(value) && value is ['"', _, ..] && value[^1] == '"' && long.TryParse(value[1..^1], out revision) && revision > 0;
     }
 
     public static void SetEtag(HttpContext context, long revision) => context.Response.Headers.ETag = $"\"{revision}\"";

--- a/src/modules/Elsa.ExternalAuthentication/Endpoints/Connections/ConnectionManagementEndpoints.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Endpoints/Connections/ConnectionManagementEndpoints.cs
@@ -142,7 +142,7 @@ internal sealed class CreateConnection(IdentityProviderConnectionManagementServi
             await ConnectionEndpointSupport.SendErrorAsync(HttpContext, StatusCodes.Status400BadRequest, "secret_bindings_mutation_not_allowed", "Secret bindings must be managed through the dedicated write-only secret endpoint.", cancellationToken);
             return;
         }
-        if (ConnectionEndpointSupport.RequiresPolicyManagement(request) && !ConnectionEndpointSupport.HasPermission(User, ExternalAuthenticationPermissions.PoliciesManage))
+        if (ConnectionEndpointSupport.RequiresPolicyManagement(request) && !ConnectionEndpointSupport.HasPermission(HttpContext, ExternalAuthenticationResourcePermissions.Policies, CoreVerbs.Update))
         {
             await ConnectionEndpointSupport.SendErrorAsync(HttpContext, StatusCodes.Status403Forbidden, "forbidden", "The caller may not configure policies or permission grants.", cancellationToken);
             return;
@@ -202,7 +202,7 @@ internal sealed class UpdateConnection(IdentityProviderConnectionManagementServi
             await ConnectionEndpointSupport.SendErrorAsync(HttpContext, StatusCodes.Status400BadRequest, "secret_bindings_mutation_not_allowed", "Secret bindings must be managed through the dedicated write-only secret endpoint.", cancellationToken);
             return;
         }
-        if (ConnectionEndpointSupport.RequiresPolicyManagement(request) && !ConnectionEndpointSupport.HasPermission(User, ExternalAuthenticationPermissions.PoliciesManage))
+        if (ConnectionEndpointSupport.RequiresPolicyManagement(request) && !ConnectionEndpointSupport.HasPermission(HttpContext, ExternalAuthenticationResourcePermissions.Policies, CoreVerbs.Update))
         {
             await ConnectionEndpointSupport.SendErrorAsync(HttpContext, StatusCodes.Status403Forbidden, "forbidden", "The caller may not configure policies or permission grants.", cancellationToken);
             return;
@@ -258,7 +258,7 @@ internal abstract class ConnectionLifecycleEndpoint(IdentityProviderConnectionMa
 
         var confirmOverride = string.Equals(HttpContext.Request.Query["confirmFinalLoginPathOverride"], "true", StringComparison.OrdinalIgnoreCase);
         var revokeActiveSessions = string.Equals(HttpContext.Request.Query["revokeActiveSessions"], "true", StringComparison.OrdinalIgnoreCase);
-        if (revokeActiveSessions && !ConnectionEndpointSupport.HasPermission(User, ExternalAuthenticationPermissions.SessionsRevoke))
+        if (revokeActiveSessions && !ConnectionEndpointSupport.HasPermission(HttpContext, ExternalAuthenticationResourcePermissions.Sessions, ExternalAuthenticationVerbs.Revoke))
         {
             await ConnectionEndpointSupport.SendErrorAsync(HttpContext, StatusCodes.Status403Forbidden, "forbidden", "Revoking active sessions requires the external-authentication sessions-revoke permission.", cancellationToken);
             return;
@@ -321,7 +321,7 @@ internal sealed class ValidateConnection(IdentityProviderConnectionManagementSer
             return;
         }
 
-        var validation = await management.ValidateAsync(connection.Connection, User, tenantAccessor.TenantId, requireCompleteConfiguration: true, confirmUnsafeSettings: ConnectionEndpointSupport.HasPermission(User, ExternalAuthenticationPermissions.ProviderTrustUnsafe), cancellationToken: cancellationToken);
+        var validation = await management.ValidateAsync(connection.Connection, User, tenantAccessor.TenantId, requireCompleteConfiguration: true, confirmUnsafeSettings: ConnectionEndpointSupport.HasPermission(HttpContext, ExternalAuthenticationResourcePermissions.ProviderTrust, ExternalAuthenticationVerbs.Override), cancellationToken: cancellationToken);
         await HttpContext.Response.WriteAsJsonAsync(new ConnectionValidationResponse(validation.IsValid, validation.Errors, validation.Warnings), cancellationToken);
     }
 }

--- a/src/modules/Elsa.ExternalAuthentication/Endpoints/Connections/ConnectionManagementEndpoints.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Endpoints/Connections/ConnectionManagementEndpoints.cs
@@ -17,7 +17,7 @@ internal sealed class ListConnections(IdentityProviderConnectionManagementServic
     public override void Configure()
     {
         Get("/external-authentication/connections");
-        RequirePermission(Elsa.ExternalAuthentication.Permissions.ExternalAuthenticationResourcePermissions.Connections, CoreVerbs.View);
+        RequirePermission(ExternalAuthenticationResourcePermissions.Connections, CoreVerbs.View);
     }
 
     public override async Task<ConnectionListResponse> ExecuteAsync(ConnectionListRequest request, CancellationToken cancellationToken)
@@ -31,7 +31,7 @@ internal sealed class ListConnections(IdentityProviderConnectionManagementServic
             !TryDecodeCursor(request.Cursor, out var cursor))
         {
             HttpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
-            return new ConnectionListResponse([], null);
+            return new([], null);
         }
 
         var filter = new ConnectionFilter
@@ -58,7 +58,7 @@ internal sealed class ListConnections(IdentityProviderConnectionManagementServic
         var page = hasNextPage ? connections[..^1] : connections;
         var observationResults = await Task.WhenAll(page.Select(x => observations.FindLatestAsync(x.Connection.Id, cancellationToken).AsTask()));
         var items = await Task.WhenAll(page.Select((x, index) => ConnectionResponse.FromAsync(x, management, adapters, observationResults[index], cancellationToken).AsTask()));
-        return new ConnectionListResponse(items, hasNextPage ? EncodeCursor(CursorFor(page[^1])) : null);
+        return new(items, hasNextPage ? EncodeCursor(CursorFor(page[^1])) : null);
     }
 
     private static bool IsKnownSource(string? source) => string.IsNullOrWhiteSpace(source) ||
@@ -105,7 +105,7 @@ internal sealed class GetConnection(IdentityProviderConnectionManagementService 
     public override void Configure()
     {
         Get("/external-authentication/connections/{connectionId}");
-        RequirePermission(Elsa.ExternalAuthentication.Permissions.ExternalAuthenticationResourcePermissions.Connections, CoreVerbs.View);
+        RequirePermission(ExternalAuthenticationResourcePermissions.Connections, CoreVerbs.View);
     }
 
     public override async Task HandleAsync(CancellationToken cancellationToken)
@@ -127,7 +127,7 @@ internal sealed class CreateConnection(IdentityProviderConnectionManagementServi
     public override void Configure()
     {
         Post("/external-authentication/connections");
-        RequirePermission(Elsa.ExternalAuthentication.Permissions.ExternalAuthenticationResourcePermissions.Connections, CoreVerbs.Create);
+        RequirePermission(ExternalAuthenticationResourcePermissions.Connections, CoreVerbs.Create);
     }
 
     public override async Task HandleAsync(ConnectionRequest request, CancellationToken cancellationToken)
@@ -162,7 +162,7 @@ internal sealed class CreateConnection(IdentityProviderConnectionManagementServi
         await HttpContext.Response.WriteAsJsonAsync(await ConnectionResponse.FromAsync(effective, management, adapters, null, cancellationToken), cancellationToken);
     }
 
-    private static ConnectionScope ToScope(string tenantId) => tenantId == ConnectionScope.HostTenantId ? ConnectionScope.Host : tenantId.Length == 0 ? ConnectionScope.DefaultTenant : new ConnectionScope(ConnectionScopeKind.Tenant, tenantId);
+    private static ConnectionScope ToScope(string tenantId) => tenantId == ConnectionScope.HostTenantId ? ConnectionScope.Host : tenantId.Length == 0 ? ConnectionScope.DefaultTenant : new(ConnectionScopeKind.Tenant, tenantId);
 }
 
 internal sealed class UpdateConnection(IdentityProviderConnectionManagementService management, IExternalAuthenticationAdapterRegistry adapters, ITenantAccessor tenantAccessor) : ElsaEndpoint<ConnectionRequest>
@@ -170,7 +170,7 @@ internal sealed class UpdateConnection(IdentityProviderConnectionManagementServi
     public override void Configure()
     {
         Put("/external-authentication/connections/{connectionId}");
-        RequirePermission(Elsa.ExternalAuthentication.Permissions.ExternalAuthenticationResourcePermissions.Connections, CoreVerbs.Update);
+        RequirePermission(ExternalAuthenticationResourcePermissions.Connections, CoreVerbs.Update);
     }
 
     public override async Task HandleAsync(ConnectionRequest request, CancellationToken cancellationToken)
@@ -272,7 +272,7 @@ internal abstract class ConnectionLifecycleEndpoint(IdentityProviderConnectionMa
 
         ConnectionEndpointSupport.SetEtag(HttpContext, connection.Revision);
         HttpContext.Response.StatusCode = StatusCodes.Status200OK;
-        await HttpContext.Response.WriteAsJsonAsync(await ConnectionResponse.FromAsync(new EffectiveIdentityProviderConnection(connection, ConnectionSourceOwnership.Database, effective.Scope, ConnectionValidity.Unknown, false, "database"), management, adapters, null, cancellationToken), cancellationToken);
+        await HttpContext.Response.WriteAsJsonAsync(await ConnectionResponse.FromAsync(new(connection, ConnectionSourceOwnership.Database, effective.Scope, ConnectionValidity.Unknown, false, "database"), management, adapters, null, cancellationToken), cancellationToken);
     }
 }
 
@@ -293,14 +293,14 @@ internal sealed class DisableConnection(IdentityProviderConnectionManagementServ
 internal sealed class ArchiveConnection(IdentityProviderConnectionManagementService management, IExternalAuthenticationAdapterRegistry adapters, ITenantAccessor tenantAccessor) : ConnectionLifecycleEndpoint(management, adapters, tenantAccessor)
 {
     protected override ConnectionLifecycle Action => ConnectionLifecycle.Archived;
-    protected override string Verb => "archive";
+    protected override string Verb => ExternalAuthenticationVerbs.Archive;
     protected override void ConfigureRoute() => Delete("/external-authentication/connections/{connectionId}");
 }
 
 internal sealed class RestoreConnection(IdentityProviderConnectionManagementService management, IExternalAuthenticationAdapterRegistry adapters, ITenantAccessor tenantAccessor) : ConnectionLifecycleEndpoint(management, adapters, tenantAccessor)
 {
     protected override ConnectionLifecycle Action => ConnectionLifecycle.Draft;
-    protected override string Verb => "archive";
+    protected override string Verb => ExternalAuthenticationVerbs.Archive;
     protected override void ConfigureRoute() => Post("/external-authentication/connections/{connectionId}/restore");
 }
 
@@ -309,7 +309,7 @@ internal sealed class ValidateConnection(IdentityProviderConnectionManagementSer
     public override void Configure()
     {
         Post("/external-authentication/connections/{connectionId}/validate");
-        RequirePermission(Elsa.ExternalAuthentication.Permissions.ExternalAuthenticationResourcePermissions.Connections, CoreVerbs.View);
+        RequirePermission(ExternalAuthenticationResourcePermissions.Connections, CoreVerbs.View);
     }
 
     public override async Task HandleAsync(CancellationToken cancellationToken)
@@ -340,7 +340,7 @@ internal sealed class ReplaceManagedSecretBinding(
     public override void Configure()
     {
         Put("/external-authentication/connections/{connectionId}/secret-bindings/{fieldName}/managed");
-        RequirePermission(Elsa.ExternalAuthentication.Permissions.ExternalAuthenticationResourcePermissions.Connections, CoreVerbs.Update);
+        RequirePermission(ExternalAuthenticationResourcePermissions.Connections, CoreVerbs.Update);
     }
 
     public override async Task HandleAsync(ManagedSecretBindingRequest request, CancellationToken cancellationToken)
@@ -381,7 +381,7 @@ internal sealed class ReplaceManagedSecretBinding(
         }
 
         using var value = new SensitiveString(request.Value);
-        var stagedBinding = await writer.StageAsync(new ManagedSecretBindingWriteRequest(effective.Connection.Id, fieldName, value), cancellationToken);
+        var stagedBinding = await writer.StageAsync(new(effective.Connection.Id, fieldName, value), cancellationToken);
         if (effective.Connection.SecretBindings.TryGetValue(fieldName, out var liveBinding) &&
             string.Equals(liveBinding.ResolverType, stagedBinding.ResolverType, StringComparison.Ordinal) &&
             string.Equals(liveBinding.Reference, stagedBinding.Reference, StringComparison.Ordinal))
@@ -411,7 +411,7 @@ internal sealed class ReplaceManagedSecretBinding(
             await ManagedSecretBindingCleanup.TryRemoveAsync(previousWriter, previousBinding, effective.Connection.Id, logger);
 
         ConnectionEndpointSupport.SetEtag(HttpContext, connection.Revision);
-        await HttpContext.Response.WriteAsJsonAsync(await ConnectionResponse.FromAsync(new EffectiveIdentityProviderConnection(connection, ConnectionSourceOwnership.Database, effective.Scope, ConnectionValidity.Unknown, false, "database"), management, adapters, null, cancellationToken), cancellationToken);
+        await HttpContext.Response.WriteAsJsonAsync(await ConnectionResponse.FromAsync(new(connection, ConnectionSourceOwnership.Database, effective.Scope, ConnectionValidity.Unknown, false, "database"), management, adapters, null, cancellationToken), cancellationToken);
 
         return;
 
@@ -449,7 +449,7 @@ internal sealed class RemoveSecretBinding(
     public override void Configure()
     {
         Delete("/external-authentication/connections/{connectionId}/secret-bindings/{fieldName}");
-        RequirePermission(Elsa.ExternalAuthentication.Permissions.ExternalAuthenticationResourcePermissions.Connections, CoreVerbs.Update);
+        RequirePermission(ExternalAuthenticationResourcePermissions.Connections, CoreVerbs.Update);
     }
 
     public override async Task HandleAsync(CancellationToken cancellationToken)
@@ -481,7 +481,7 @@ internal sealed class RemoveSecretBinding(
             await ConnectionEndpointSupport.SendErrorAsync(HttpContext, StatusCodes.Status403Forbidden, "external_secret_binding_read_only", "Deployment-owned external secret bindings cannot be removed through this API.", cancellationToken);
             return;
         }
-        var candidate = Elsa.ExternalAuthentication.Services.IdentityProviderConnectionCloner.Clone(effective.Connection);
+        var candidate = IdentityProviderConnectionCloner.Clone(effective.Connection);
         candidate.SecretBindings.Remove(fieldName);
         var result = await management.UpdateAsync(candidate.Id, candidate, revision, User, tenantAccessor.TenantId, false, cancellationToken: cancellationToken);
         if (result is not ManagementConnectionMutationResult.Success(var connection))
@@ -492,7 +492,7 @@ internal sealed class RemoveSecretBinding(
         if (_writers.TryGetValue(existingBinding.ResolverType, out var writer))
             await ManagedSecretBindingCleanup.TryRemoveAsync(writer, existingBinding, effective.Connection.Id, logger);
         ConnectionEndpointSupport.SetEtag(HttpContext, connection.Revision);
-        await HttpContext.Response.WriteAsJsonAsync(await ConnectionResponse.FromAsync(new EffectiveIdentityProviderConnection(connection, ConnectionSourceOwnership.Database, effective.Scope, ConnectionValidity.Unknown, false, "database"), management, adapters, null, cancellationToken), cancellationToken);
+        await HttpContext.Response.WriteAsJsonAsync(await ConnectionResponse.FromAsync(new(connection, ConnectionSourceOwnership.Database, effective.Scope, ConnectionValidity.Unknown, false, "database"), management, adapters, null, cancellationToken), cancellationToken);
     }
 }
 

--- a/src/modules/Elsa.ExternalAuthentication/Endpoints/Connections/ConnectionManagementModels.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Endpoints/Connections/ConnectionManagementModels.cs
@@ -119,7 +119,7 @@ internal sealed class ConnectionResponse
     public string MaterialRevision { get; init; } = null!;
     public ConnectionObservationResponse? LatestObservation { get; init; }
 
-    public static async ValueTask<ConnectionResponse> FromAsync(EffectiveIdentityProviderConnection effective, Services.IdentityProviderConnectionManagementService management, IExternalAuthenticationAdapterRegistry adapters, ConnectionObservation? observation, CancellationToken cancellationToken)
+    public static async ValueTask<ConnectionResponse> FromAsync(EffectiveIdentityProviderConnection effective, IdentityProviderConnectionManagementService management, IExternalAuthenticationAdapterRegistry adapters, ConnectionObservation? observation, CancellationToken cancellationToken)
     {
         var states = await management.GetSecretBindingStatesAsync(effective.Connection, cancellationToken);
         var adapterSettings = effective.Connection.AdapterSettings.ValueKind == JsonValueKind.Undefined
@@ -127,12 +127,12 @@ internal sealed class ConnectionResponse
             : adapters.TryGet(effective.Connection.AdapterType, out var adapter)
                 ? AdapterSettingsSecretFieldGuard.RedactDeclaredSecrets(effective.Connection.AdapterSettings, adapter.Describe())
                 : JsonSerializer.SerializeToElement(new Dictionary<string, object?>());
-        return new ConnectionResponse
+        return new()
         {
             Id = effective.Connection.Id,
             Key = effective.Connection.Key,
             Source = effective.Ownership == ConnectionSourceOwnership.Configuration ? "configuration" : "database",
-            Scope = new ConnectionScopeResponse(effective.Scope.Kind switch { ConnectionScopeKind.Host => "host", ConnectionScopeKind.DefaultTenant => "defaultTenant", _ => "tenant" }, effective.Scope.TenantId),
+            Scope = new(effective.Scope.Kind switch { ConnectionScopeKind.Host => "host", ConnectionScopeKind.DefaultTenant => "defaultTenant", _ => "tenant" }, effective.Scope.TenantId),
             AdapterType = effective.Connection.AdapterType,
             CallbackUri = management.GetProviderCallbackUri(effective.Connection),
             PreviewCallbackUri = management.GetProviderPreviewCallbackUri(effective.Connection),
@@ -157,7 +157,7 @@ internal sealed class ConnectionResponse
             CanCreateOverride = effective.Ownership == ConnectionSourceOwnership.Configuration && management.CanCreateConfigurationOverride(),
             CanPromoteToConfigurationOverride = management.CanPromoteToConfigurationOverride(effective),
             EnabledIntent = effective.Connection.IsEnabled,
-            EffectivelyEnabled = effective.Connection.IsEnabled && !effective.Connection.ArchivedAt.HasValue && !effective.IsShadowed && effective.Validity != ConnectionValidity.Invalid,
+            EffectivelyEnabled = effective is { Connection: { IsEnabled: true, ArchivedAt: null }, IsShadowed: false } && effective.Validity != ConnectionValidity.Invalid,
             Validity = effective.Validity.ToString().ToLowerInvariant(),
             Shadowed = effective.IsShadowed,
             ShadowedBy = effective.ShadowedBy is null ? null : ConnectionReferenceResponse.From(effective.ShadowedBy),

--- a/src/modules/Elsa.ExternalAuthentication/Endpoints/Connections/TestConnection.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Endpoints/Connections/TestConnection.cs
@@ -1,4 +1,3 @@
-using Elsa.Authorization;
 using Elsa.Abstractions;
 using Elsa.Common.Multitenancy;
 using Elsa.ExternalAuthentication.Permissions;
@@ -13,7 +12,7 @@ internal sealed class TestConnection(IServiceProvider services, ITenantAccessor 
     public override void Configure()
     {
         Post("/external-authentication/connections/{connectionId}/test");
-        RequirePermission(Elsa.ExternalAuthentication.Permissions.ExternalAuthenticationResourcePermissions.Connections, "test");
+        RequirePermission(ExternalAuthenticationResourcePermissions.Connections, ExternalAuthenticationVerbs.Test);
     }
 
     public override async Task HandleAsync(CancellationToken cancellationToken)

--- a/src/modules/Elsa.ExternalAuthentication/Endpoints/Descriptors/DescriptorCatalogEndpoints.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Endpoints/Descriptors/DescriptorCatalogEndpoints.cs
@@ -3,7 +3,6 @@ using Elsa.Abstractions;
 using Elsa.ExternalAuthentication.Contracts;
 using Elsa.ExternalAuthentication.Models;
 using Elsa.ExternalAuthentication.Options;
-using Elsa.ExternalAuthentication.Permissions;
 using Microsoft.Extensions.Options;
 
 namespace Elsa.ExternalAuthentication.Endpoints.Descriptors;
@@ -14,7 +13,7 @@ internal sealed class ListAdapterDescriptors(IExternalAuthenticationAdapterRegis
     public override void Configure()
     {
         Get("/external-authentication/descriptors/adapters");
-        RequirePermission(Elsa.ExternalAuthentication.Permissions.ExternalAuthenticationResourcePermissions.Connections, CoreVerbs.View);
+        RequirePermission(ExternalAuthentication.Permissions.ExternalAuthenticationResourcePermissions.Connections, CoreVerbs.View);
     }
 
     public override Task<IReadOnlyCollection<ExternalAuthenticationAdapterDescriptor>> ExecuteAsync(CancellationToken cancellationToken)
@@ -33,7 +32,7 @@ internal sealed class ListPolicyDescriptors(IUnlinkedIdentityPolicyRegistry regi
     public override void Configure()
     {
         Get("/external-authentication/descriptors/policies");
-        RequirePermission(Elsa.ExternalAuthentication.Permissions.ExternalAuthenticationResourcePermissions.Connections, CoreVerbs.View);
+        RequirePermission(ExternalAuthentication.Permissions.ExternalAuthenticationResourcePermissions.Connections, CoreVerbs.View);
     }
 
     public override Task<IReadOnlyCollection<UnlinkedIdentityPolicyDescriptor>> ExecuteAsync(CancellationToken cancellationToken)
@@ -47,7 +46,7 @@ internal sealed class ListPermissionSourceDescriptors(IPermissionGrantSourceRegi
     public override void Configure()
     {
         Get("/external-authentication/descriptors/permission-sources");
-        RequirePermission(Elsa.ExternalAuthentication.Permissions.ExternalAuthenticationResourcePermissions.Connections, CoreVerbs.View);
+        RequirePermission(ExternalAuthentication.Permissions.ExternalAuthenticationResourcePermissions.Connections, CoreVerbs.View);
     }
 
     public override Task<IReadOnlyCollection<PermissionGrantSourceDescriptor>> ExecuteAsync(CancellationToken cancellationToken)
@@ -61,7 +60,7 @@ internal sealed class ListExternalUserMatcherDescriptors(IExternalUserMatcherReg
     public override void Configure()
     {
         Get("/external-authentication/descriptors/user-matchers");
-        RequirePermission(Elsa.ExternalAuthentication.Permissions.ExternalAuthenticationResourcePermissions.Connections, CoreVerbs.View);
+        RequirePermission(ExternalAuthentication.Permissions.ExternalAuthenticationResourcePermissions.Connections, CoreVerbs.View);
     }
 
     public override Task<IReadOnlyCollection<ExternalUserMatcherDescriptor>> ExecuteAsync(CancellationToken cancellationToken) => Task.FromResult(registry.ListDescriptors());
@@ -76,7 +75,7 @@ internal sealed class ListManagedSecretResolverDescriptors(IEnumerable<IManagedS
     public override void Configure()
     {
         Get("/external-authentication/descriptors/managed-secret-resolvers");
-        RequirePermission(Elsa.ExternalAuthentication.Permissions.ExternalAuthenticationResourcePermissions.Connections, CoreVerbs.View);
+        RequirePermission(ExternalAuthentication.Permissions.ExternalAuthenticationResourcePermissions.Connections, CoreVerbs.View);
     }
 
     public override Task<ManagedSecretResolverDescriptorResponse> ExecuteAsync(CancellationToken cancellationToken) => Task.FromResult(new ManagedSecretResolverDescriptorResponse(
@@ -88,7 +87,7 @@ internal sealed class ListPermissionDescriptors(IPermissionDescriptorRegistry re
     public override void Configure()
     {
         Get("/external-authentication/descriptors/permissions");
-        RequirePermission(Elsa.ExternalAuthentication.Permissions.ExternalAuthenticationResourcePermissions.Connections, CoreVerbs.View);
+        RequirePermission(ExternalAuthentication.Permissions.ExternalAuthenticationResourcePermissions.Connections, CoreVerbs.View);
     }
 
     public override Task<IReadOnlyCollection<PermissionDescriptor>> ExecuteAsync(CancellationToken cancellationToken) => Task.FromResult(registry.List());

--- a/src/modules/Elsa.ExternalAuthentication/Endpoints/IdentityLinks/IdentityLinkEndpoints.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Endpoints/IdentityLinks/IdentityLinkEndpoints.cs
@@ -1,11 +1,9 @@
 using Elsa.Authorization;
-using System.Security.Claims;
 using System.Text;
 using System.Text.Json;
 using Elsa.Abstractions;
 using Elsa.Common.Multitenancy;
 using Elsa.ExternalAuthentication.Models;
-using Elsa.ExternalAuthentication.Permissions;
 using Elsa.ExternalAuthentication.Services;
 using Microsoft.AspNetCore.Http;
 
@@ -16,7 +14,7 @@ internal sealed class GetIdentityLinks(ExternalIdentityLinkManagementService man
     public override void Configure()
     {
         Get("/external-authentication/identity-links");
-        RequirePermission(Elsa.ExternalAuthentication.Permissions.ExternalAuthenticationResourcePermissions.IdentityLinks, CoreVerbs.Write);
+        RequirePermission(ExternalAuthentication.Permissions.ExternalAuthenticationResourcePermissions.IdentityLinks, CoreVerbs.Write);
     }
 
     public override async Task<IdentityLinkListResponse> ExecuteAsync(IdentityLinkListRequest request, CancellationToken cancellationToken)
@@ -24,19 +22,20 @@ internal sealed class GetIdentityLinks(ExternalIdentityLinkManagementService man
         if (request.PageSize is < 1 or > 100 || !IdentityLinkPagination.TryDecodeCursor(request.Cursor, out var cursor))
         {
             HttpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
-            return new IdentityLinkListResponse([], null);
+            return new([], null);
         }
 
         var pageSize = request.PageSize ?? 100;
-        var links = (await management.ListAsync(tenantAccessor.TenantId, new ExternalIdentityLinkFilter { UserId = request.UserId, ConnectionKey = request.ConnectionKey }, cancellationToken)).Items
+        var links = (await management.ListAsync(tenantAccessor.TenantId, new()
+                { UserId = request.UserId, ConnectionKey = request.ConnectionKey }, cancellationToken)).Items
             .OrderBy(x => x.CreatedAt)
             .ThenBy(x => x.Id, StringComparer.Ordinal)
-            .Where(x => cursor is null || IdentityLinkPagination.Compare(new IdentityLinkCursor(x.CreatedAt, x.Id), cursor) > 0)
+            .Where(x => cursor is null || IdentityLinkPagination.Compare(new(x.CreatedAt, x.Id), cursor) > 0)
             .Take(pageSize + 1)
             .ToArray();
         var hasMore = links.Length > pageSize;
         var items = hasMore ? links[..^1] : links;
-        return new IdentityLinkListResponse(items.Select(IdentityLinkDocument.From).ToArray(), hasMore ? IdentityLinkPagination.EncodeCursor(new IdentityLinkCursor(items[^1].CreatedAt, items[^1].Id)) : null);
+        return new(items.Select(IdentityLinkDocument.From).ToArray(), hasMore ? IdentityLinkPagination.EncodeCursor(new(items[^1].CreatedAt, items[^1].Id)) : null);
     }
 }
 
@@ -45,7 +44,7 @@ internal sealed class FindUsers(ExternalIdentityLinkManagementService management
     public override void Configure()
     {
         Get("/external-authentication/user-options");
-        RequirePermission(Elsa.ExternalAuthentication.Permissions.ExternalAuthenticationResourcePermissions.IdentityLinks, CoreVerbs.Write);
+        RequirePermission(ExternalAuthentication.Permissions.ExternalAuthenticationResourcePermissions.IdentityLinks, CoreVerbs.Write);
     }
 
     public override async Task<FindIdentityLinkUsersResponse> ExecuteAsync(FindIdentityLinkUsersRequest request, CancellationToken cancellationToken)
@@ -53,17 +52,17 @@ internal sealed class FindUsers(ExternalIdentityLinkManagementService management
         if (request.PageSize is < 1 or > 50 || !IdentityLinkPagination.TryDecodeUserCursor(request.Cursor, out var cursor))
         {
             HttpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
-            return new FindIdentityLinkUsersResponse([], null);
+            return new([], null);
         }
 
         var pageSize = request.PageSize ?? 50;
         var users = (await management.FindUsersAsync(tenantAccessor.TenantId, request.Search, cancellationToken)).Items
-            .Where(x => cursor is null || IdentityLinkPagination.Compare(new UserCursor(x.DisplayName, x.Id), cursor) > 0)
+            .Where(x => cursor is null || IdentityLinkPagination.Compare(new(x.DisplayName, x.Id), cursor) > 0)
             .Take(pageSize + 1)
             .ToArray();
         var hasMore = users.Length > pageSize;
         var items = hasMore ? users[..^1] : users;
-        return new FindIdentityLinkUsersResponse(items.Select(x => new IdentityLinkUserDocument(x.Id, x.DisplayName)).ToArray(), hasMore ? IdentityLinkPagination.EncodeUserCursor(new UserCursor(items[^1].DisplayName, items[^1].Id)) : null);
+        return new(items.Select(x => new IdentityLinkUserDocument(x.Id, x.DisplayName)).ToArray(), hasMore ? IdentityLinkPagination.EncodeUserCursor(new(items[^1].DisplayName, items[^1].Id)) : null);
     }
 }
 
@@ -72,7 +71,7 @@ internal sealed class PrelinkIdentityLink(ExternalIdentityLinkManagementService 
     public override void Configure()
     {
         Post("/external-authentication/identity-links");
-        RequirePermission(Elsa.ExternalAuthentication.Permissions.ExternalAuthenticationResourcePermissions.IdentityLinks, CoreVerbs.Write);
+        RequirePermission(ExternalAuthentication.Permissions.ExternalAuthenticationResourcePermissions.IdentityLinks, CoreVerbs.Write);
     }
 
     public override async Task HandleAsync(PrelinkIdentityLinkRequest request, CancellationToken cancellationToken)
@@ -110,7 +109,7 @@ internal sealed class ReplaceIdentityLink(ExternalIdentityLinkManagementService 
     public override void Configure()
     {
         Post("/external-authentication/identity-links/{linkId}/replace");
-        RequirePermission(Elsa.ExternalAuthentication.Permissions.ExternalAuthenticationResourcePermissions.IdentityLinks, CoreVerbs.Write);
+        RequirePermission(ExternalAuthentication.Permissions.ExternalAuthenticationResourcePermissions.IdentityLinks, CoreVerbs.Write);
     }
 
     public override async Task HandleAsync(ReplaceIdentityLinkRequest request, CancellationToken cancellationToken)
@@ -155,7 +154,7 @@ internal sealed class DeleteIdentityLink(ExternalIdentityLinkManagementService m
     public override void Configure()
     {
         Delete("/external-authentication/identity-links/{linkId}");
-        RequirePermission(Elsa.ExternalAuthentication.Permissions.ExternalAuthenticationResourcePermissions.IdentityLinks, CoreVerbs.Write);
+        RequirePermission(ExternalAuthentication.Permissions.ExternalAuthenticationResourcePermissions.IdentityLinks, CoreVerbs.Write);
     }
 
     public override async Task HandleAsync(CancellationToken cancellationToken)

--- a/src/modules/Elsa.ExternalAuthentication/Endpoints/Previews/PreviewSignInEndpoints.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Endpoints/Previews/PreviewSignInEndpoints.cs
@@ -1,4 +1,3 @@
-using Elsa.Authorization;
 using Elsa.Abstractions;
 using Elsa.Common.Multitenancy;
 using Elsa.ExternalAuthentication.Constants;
@@ -7,7 +6,6 @@ using Elsa.ExternalAuthentication.Permissions;
 using Elsa.ExternalAuthentication.Services;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.RateLimiting;
 
 namespace Elsa.ExternalAuthentication.Endpoints.Previews;
 
@@ -16,12 +14,12 @@ internal sealed class InitiatePreview(PreviewSignInService previews, ITenantAcce
     public override void Configure()
     {
         Post("/external-authentication/connections/{connectionId}/preview");
-        RequirePermission(Elsa.ExternalAuthentication.Permissions.ExternalAuthenticationResourcePermissions.Connections, "preview");
+        RequirePermission(ExternalAuthenticationResourcePermissions.Connections, ExternalAuthenticationVerbs.Preview);
     }
 
     public override async Task HandleAsync(CancellationToken cancellationToken)
     {
-        if (!Endpoints.Connections.ConnectionEndpointSupport.TryGetExpectedRevision(HttpContext, out var revision))
+        if (!Connections.ConnectionEndpointSupport.TryGetExpectedRevision(HttpContext, out var revision))
         {
             HttpContext.Response.StatusCode = StatusCodes.Status428PreconditionRequired;
             return;
@@ -100,7 +98,7 @@ internal sealed class GetPreviewResult(PreviewSignInService previews, ITenantAcc
     public override void Configure()
     {
         Get("/external-authentication/previews/{previewHandle}");
-        RequirePermission(Elsa.ExternalAuthentication.Permissions.ExternalAuthenticationResourcePermissions.Connections, "preview");
+        RequirePermission(ExternalAuthenticationResourcePermissions.Connections, ExternalAuthenticationVerbs.Preview);
     }
 
     public override async Task HandleAsync(CancellationToken cancellationToken)

--- a/src/modules/Elsa.ExternalAuthentication/Endpoints/Sessions/ExternalAuthenticationSessionEndpoints.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Endpoints/Sessions/ExternalAuthenticationSessionEndpoints.cs
@@ -1,5 +1,5 @@
-using Elsa.Authorization;
 using System.Security.Claims;
+using Elsa.Authorization;
 using System.Text;
 using System.Text.Json;
 using Elsa.Abstractions;
@@ -22,7 +22,7 @@ internal sealed class ListExternalAuthenticationSessions(
     public override void Configure()
     {
         Get("/external-authentication/sessions");
-        RequirePermission(Elsa.ExternalAuthentication.Permissions.ExternalAuthenticationResourcePermissions.Sessions, CoreVerbs.View);
+        RequirePermission(ExternalAuthenticationResourcePermissions.Sessions, CoreVerbs.View);
     }
 
     public override async Task<ExternalAuthenticationSessionListResponse> ExecuteAsync(ExternalAuthenticationSessionListRequest request, CancellationToken cancellationToken)
@@ -30,21 +30,22 @@ internal sealed class ListExternalAuthenticationSessions(
         if (!options.Value.Operations.EnableSessionAdministration)
         {
             HttpContext.Response.StatusCode = StatusCodes.Status404NotFound;
-            return new ExternalAuthenticationSessionListResponse([], null);
+            return new([], null);
         }
         if (request.PageSize is < 1 or > 100 || !IsKnownStatus(request.Status) || !TryDecode(request.Cursor, out var cursor))
         {
             HttpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
-            return new ExternalAuthenticationSessionListResponse([], null);
+            return new([], null);
         }
         var pageSize = request.PageSize ?? 100;
-        var rows = (await sessions.FindAsync(new Models.ExternalAuthenticationSessionFilter { TenantId = tenantAccessor.TenantId, UserId = request.UserId, ConnectionKey = request.ConnectionKey, Status = request.Status }, cancellationToken))
+        var rows = (await sessions.FindAsync(new()
+                { TenantId = tenantAccessor.TenantId, UserId = request.UserId, ConnectionKey = request.ConnectionKey, Status = request.Status }, cancellationToken))
             .OrderBy(x => x.StartedAt).ThenBy(x => x.Id, StringComparer.Ordinal)
-            .Where(x => cursor is null || Compare(new SessionCursor(x.StartedAt, x.Id), cursor) > 0)
+            .Where(x => cursor is null || Compare(new(x.StartedAt, x.Id), cursor) > 0)
             .Take(pageSize + 1).ToArray();
         var hasMore = rows.Length > pageSize;
         var page = hasMore ? rows[..^1] : rows;
-        return new ExternalAuthenticationSessionListResponse(page.Select(ExternalAuthenticationSessionDocument.From).ToArray(), hasMore ? Encode(new SessionCursor(page[^1].StartedAt, page[^1].Id)) : null);
+        return new(page.Select(ExternalAuthenticationSessionDocument.From).ToArray(), hasMore ? Encode(new(page[^1].StartedAt, page[^1].Id)) : null);
     }
 
     private static bool IsKnownStatus(string? status) => string.IsNullOrWhiteSpace(status) || status.Equals("active", StringComparison.OrdinalIgnoreCase) || status.Equals("revoked", StringComparison.OrdinalIgnoreCase);
@@ -74,7 +75,7 @@ internal sealed class RevokeExternalAuthenticationSession(
     public override void Configure()
     {
         Delete("/external-authentication/sessions/{sessionId}");
-        RequirePermission(Elsa.ExternalAuthentication.Permissions.ExternalAuthenticationResourcePermissions.Sessions, "revoke");
+        RequirePermission(ExternalAuthenticationResourcePermissions.Sessions, ExternalAuthenticationVerbs.Revoke);
     }
 
     public override async Task HandleAsync(RevokeExternalAuthenticationSessionRequest request, CancellationToken cancellationToken)

--- a/src/modules/Elsa.ExternalAuthentication/Extensions/ServiceCollectionExtensions.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Extensions/ServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using Elsa.Extensions;
 using Elsa.ExternalAuthentication.Contracts;
 using Elsa.ExternalAuthentication.Options;
 using Elsa.ExternalAuthentication.Permissions;
@@ -8,7 +9,6 @@ using Elsa.ExternalAuthentication.Stores.InMemory;
 using Elsa.ExternalAuthentication.Validation;
 using Elsa.Identity.Contracts;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -31,6 +31,11 @@ public static class ServiceCollectionExtensions
         var options = services.AddOptions<ExternalAuthenticationOptions>().ValidateOnStart();
         if (configureOptions != null)
             options.Configure(configureOptions);
+
+        // The module evaluates permissions outside endpoint authorization -- delegation, the grant boundary,
+        // and the recovery override -- so it depends on the evaluator whether or not a host wired one up.
+        // The call is TryAdd-based and idempotent, so a host that already registered one keeps it.
+        services.AddElsaAuthorization();
 
         services.AddExternalAuthenticationExtension(ExternalAuthenticationExtensionKind.UnlinkedIdentityPolicy, RejectUnlinkedIdentityPolicy.PolicyType);
         services.AddExternalAuthenticationExtension(ExternalAuthenticationExtensionKind.UnlinkedIdentityPolicy, CreateUserUnlinkedIdentityPolicy.PolicyType);
@@ -112,7 +117,7 @@ public static class ServiceCollectionExtensions
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(type);
         services.Configure<ExternalAuthenticationExtensionOptions>(options =>
-            options.Registrations.Add(new ExternalAuthenticationExtensionRegistration(kind, type)));
+            options.Registrations.Add(new(kind, type)));
         return services;
     }
 }

--- a/src/modules/Elsa.ExternalAuthentication/Options/ConfigureExternalAuthenticationRateLimiterOptions.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Options/ConfigureExternalAuthenticationRateLimiterOptions.cs
@@ -33,7 +33,7 @@ public sealed class ConfigureExternalAuthenticationRateLimiterOptions(IOptions<E
     {
         options.AddPolicy(name, context => RateLimitPartition.GetFixedWindowLimiter(
             GetPartitionKey(context, partitionStrategy),
-            _ => new FixedWindowRateLimiterOptions
+            _ => new()
             {
                 PermitLimit = rule.PermitLimit,
                 Window = rule.Window,

--- a/src/modules/Elsa.ExternalAuthentication/Options/ExternalAuthenticationOptions.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Options/ExternalAuthenticationOptions.cs
@@ -1,4 +1,5 @@
 using Elsa.ExternalAuthentication.Models;
+using Elsa.Authorization;
 using Elsa.ExternalAuthentication.Permissions;
 using Microsoft.Extensions.Configuration;
 
@@ -225,7 +226,7 @@ public class FinalLoginPathGuardOptions
     /// <summary>Require another normal method, local login, break glass, or privileged confirmation.</summary>
     public bool RequireRecoveryMethod { get; set; } = true;
     /// <summary>Permission required for a confirmed final-login-path override.</summary>
-    public string PrivilegedOverridePermission { get; set; } = ExternalAuthenticationPermissions.ProviderTrustUnsafe;
+    public string PrivilegedOverridePermission { get; set; } = $"{ExternalAuthenticationResourcePermissions.ProviderTrust}{Permission.Separator}{ExternalAuthenticationVerbs.Override}";
     /// <summary>Set by deployment configuration when a separately hosted break-glass method remains available.</summary>
     public bool HasBreakGlassAuthentication { get; set; }
 }

--- a/src/modules/Elsa.ExternalAuthentication/Permissions/BuiltInPermissionGrantSourceDescriptors.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Permissions/BuiltInPermissionGrantSourceDescriptors.cs
@@ -51,7 +51,7 @@ internal static class BuiltInPermissionGrantSourceDescriptors
             uiHint,
             defaultValue,
             [],
-            new SettingFieldValidation(MaximumLength: 16_384),
+            new(MaximumLength: 16_384),
             false,
             false,
             null,

--- a/src/modules/Elsa.ExternalAuthentication/Permissions/ClaimMappingPermissionGrantSource.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Permissions/ClaimMappingPermissionGrantSource.cs
@@ -19,6 +19,6 @@ public sealed class ClaimMappingPermissionGrantSource : IPermissionGrantSource
                 ? mapping.Permissions.Select(permission => new PermissionGrant(permission, sourceType, $"{mapping.ClaimType}:{mapping.Value}"))
                 : [])
             .ToArray();
-        return new PermissionGrantResult(grants, []);
+        return new(grants, []);
     }
 }

--- a/src/modules/Elsa.ExternalAuthentication/Permissions/ElsaRolePermissionGrantSource.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Permissions/ElsaRolePermissionGrantSource.cs
@@ -14,16 +14,18 @@ public sealed class ElsaRolePermissionGrantSource(IUserProvider userProvider, IR
 
     public async ValueTask<PermissionGrantResult> GetGrantsAsync(PermissionGrantContext context, CancellationToken cancellationToken = default)
     {
-        var user = await userProvider.FindAsync(new UserFilter { Id = context.UserId }, cancellationToken);
+        var user = await userProvider.FindAsync(new()
+            { Id = context.UserId }, cancellationToken);
         if (user is null || !string.Equals(user.TenantId, context.TargetTenantId, StringComparison.Ordinal))
-            return new PermissionGrantResult([], [new PermissionGrantWarning("user_not_available", "The Elsa user is not available in the target tenant.")]);
+            return new([], [new("user_not_available", "The Elsa user is not available in the target tenant.")]);
 
-        var roles = await roleProvider.FindManyAsync(new RoleFilter { Ids = user.Roles.ToArray() }, cancellationToken);
+        var roles = await roleProvider.FindManyAsync(new()
+            { Ids = user.Roles.ToArray() }, cancellationToken);
         var grants = roles
             .Where(x => string.Equals(x.TenantId, context.TargetTenantId, StringComparison.Ordinal))
             .OrderBy(x => x.Id, StringComparer.Ordinal)
             .SelectMany(role => role.Permissions.Where(permission => !string.IsNullOrWhiteSpace(permission)).OrderBy(permission => permission, StringComparer.Ordinal).Select(permission => new PermissionGrant(permission, Type, role.Id)))
             .ToArray();
-        return new PermissionGrantResult(grants, []);
+        return new(grants, []);
     }
 }

--- a/src/modules/Elsa.ExternalAuthentication/Permissions/ExternalAuthenticationResourcePermissions.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Permissions/ExternalAuthenticationResourcePermissions.cs
@@ -28,6 +28,35 @@ public static class ExternalAuthenticationResourcePermissions
     public const string PermissionGrants = "external-authentication/permission-grants";
 }
 
+/// <summary>
+/// The non-core verbs External Authentication declares. They live beside the resources they apply to so a
+/// call site and the catalog cannot drift apart, and so a delegation check cannot spell one differently
+/// from the endpoint it guards.
+/// </summary>
+public static class ExternalAuthenticationVerbs
+{
+    /// <summary>Archive or restore a connection. Reversible, and preserves identity links.</summary>
+    public const string Archive = "archive";
+
+    /// <summary>Run an on-demand connection test against the provider.</summary>
+    public const string Test = "test";
+
+    /// <summary>Run a redacted, non-mutating sign-in preview.</summary>
+    public const string Preview = "preview";
+
+    /// <summary>Revoke a session and the refresh credentials issued against it.</summary>
+    public const string Revoke = "revoke";
+
+    /// <summary>Confirm an unsafe provider trust setting or a final-login-path recovery override.</summary>
+    public const string Override = "override";
+
+    /// <summary>Configure mappings that confer permissions the actor already holds.</summary>
+    public const string Delegate = "delegate";
+
+    /// <summary>Configure permission mappings without possessing every delegated permission.</summary>
+    public const string DelegateUnrestricted = "delegate-unrestricted";
+}
+
 /// <summary>Contributes the External Authentication resources to the permission catalog.</summary>
 [UsedImplicitly]
 public sealed class ExternalAuthenticationResourcePermissionsDescriptorProvider : IPermissionDescriptorProvider
@@ -35,13 +64,13 @@ public sealed class ExternalAuthenticationResourcePermissionsDescriptorProvider 
     /// <inheritdoc />
     public IEnumerable<PermissionDescriptor> GetDescriptors() =>
     [
-        new(ExternalAuthenticationResourcePermissions.Connections, [CoreVerbs.View, CoreVerbs.Create, CoreVerbs.Update, "archive", "test", "preview"], "Identity provider connections", "Manage connections to external identity providers. Archive is reversible and preserves links; there is no hard delete.", "External Authentication"),
+        new(ExternalAuthenticationResourcePermissions.Connections, [CoreVerbs.View, CoreVerbs.Create, CoreVerbs.Update, ExternalAuthenticationVerbs.Archive, ExternalAuthenticationVerbs.Test, ExternalAuthenticationVerbs.Preview], "Identity provider connections", "Manage connections to external identity providers. Archive is reversible and preserves links; there is no hard delete.", "External Authentication"),
         new(ExternalAuthenticationResourcePermissions.Descriptors, [CoreVerbs.View], "External authentication descriptors", "Browse installed adapters, policies, permission sources, user matchers, and secret resolvers.", "External Authentication"),
         new(ExternalAuthenticationResourcePermissions.IdentityLinks, [CoreVerbs.View, CoreVerbs.Write, CoreVerbs.Delete], "External identity links", "Search users and link, relink, or unlink external identities.", "External Authentication"),
-        new(ExternalAuthenticationResourcePermissions.Sessions, [CoreVerbs.View, "revoke"], "External authentication sessions", "Inspect and revoke external authentication sessions.", "External Authentication"),
+        new(ExternalAuthenticationResourcePermissions.Sessions, [CoreVerbs.View, ExternalAuthenticationVerbs.Revoke], "External authentication sessions", "Inspect and revoke external authentication sessions.", "External Authentication"),
         new(ExternalAuthenticationResourcePermissions.Policies, [CoreVerbs.View, CoreVerbs.Update], "Unlinked identity policies", "Configure how unknown external identities are admitted.", "External Authentication"),
         new(ExternalAuthenticationResourcePermissions.PolicyDefaultRoles, [CoreVerbs.Update], "Policy default roles", "Choose the roles granted to a user created for an unknown external identity.", "External Authentication"),
-        new(ExternalAuthenticationResourcePermissions.ProviderTrust, ["override"], "Provider trust overrides", "Confirm an unsafe provider trust setting or a final-login-path recovery override.", "External Authentication"),
-        new(ExternalAuthenticationResourcePermissions.PermissionGrants, ["delegate", "delegate-unrestricted"], "External permission grants", "Configure which Elsa permissions an external claim mapping may confer. The unrestricted verb lifts the requirement that the actor already holds them.", "External Authentication"),
+        new(ExternalAuthenticationResourcePermissions.ProviderTrust, [ExternalAuthenticationVerbs.Override], "Provider trust overrides", "Confirm an unsafe provider trust setting or a final-login-path recovery override.", "External Authentication"),
+        new(ExternalAuthenticationResourcePermissions.PermissionGrants, [ExternalAuthenticationVerbs.Delegate, ExternalAuthenticationVerbs.DelegateUnrestricted], "External permission grants", "Configure which Elsa permissions an external claim mapping may confer. The unrestricted verb lifts the requirement that the actor already holds them.", "External Authentication"),
     ];
 }

--- a/src/modules/Elsa.ExternalAuthentication/Permissions/PermissionEvaluatorExtensions.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Permissions/PermissionEvaluatorExtensions.cs
@@ -1,0 +1,23 @@
+using System.Security.Claims;
+using Elsa.Authorization;
+
+namespace Elsa.ExternalAuthentication.Permissions;
+
+/// <summary>
+/// Evaluates permissions the module carries as configured or delegated <em>strings</em> rather than as a
+/// resource and verb pair.
+/// </summary>
+/// <remarks>
+/// These are the call sites that used to compare claim values with ordinal equality, which made a wildcard
+/// grant mean one thing on an endpoint and another here. Routing them through <see cref="IPermissionEvaluator"/>
+/// leaves one matching rule for the whole module.
+/// </remarks>
+internal static class PermissionEvaluatorExtensions
+{
+    /// <summary>
+    /// Whether <paramref name="actor"/> holds a permission satisfying <paramref name="permission"/>. A value
+    /// that is not a well-formed permission is held by nobody, so a malformed setting fails closed.
+    /// </summary>
+    public static bool HasPermission(this IPermissionEvaluator evaluator, ClaimsPrincipal? actor, string permission) =>
+        Permission.TryParse(permission, out var required) && evaluator.HasPermission(actor, required);
+}

--- a/src/modules/Elsa.ExternalAuthentication/Permissions/PermissionGrantMappingSettings.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Permissions/PermissionGrantMappingSettings.cs
@@ -17,7 +17,7 @@ internal static class PermissionGrantMappingSettings
         if (mappings.ValueKind == JsonValueKind.Object)
         {
             foreach (var property in mappings.EnumerateObject().OrderBy(x => x.Name, StringComparer.Ordinal))
-                result.Add(new PermissionGrantMapping(claimType, property.Name, ReadPermissions(property.Value)));
+                result.Add(new(claimType, property.Name, ReadPermissions(property.Value)));
         }
         else if (mappings.ValueKind == JsonValueKind.Array)
         {
@@ -30,7 +30,7 @@ internal static class PermissionGrantMappingSettings
                 if (string.IsNullOrWhiteSpace(value))
                     continue;
 
-                result.Add(new PermissionGrantMapping(claimType, value, ReadPermissions(permissionsProperty)));
+                result.Add(new(claimType, value, ReadPermissions(permissionsProperty)));
             }
         }
 

--- a/src/modules/Elsa.ExternalAuthentication/Policies/CreateUserUnlinkedIdentityPolicy.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Policies/CreateUserUnlinkedIdentityPolicy.cs
@@ -25,7 +25,7 @@ public sealed class CreateUserUnlinkedIdentityPolicy : IUnlinkedIdentityPolicy
     public ValueTask<UnlinkedIdentityDecision> EvaluateAsync(UnlinkedIdentityContext context, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        return ValueTask.FromResult<UnlinkedIdentityDecision>(new UnlinkedIdentityDecision.CreateUser(new UserCreationProposal(DefaultUserNamePrefix, DefaultRoleIds: ReadRoleIds(context.Settings))));
+        return ValueTask.FromResult<UnlinkedIdentityDecision>(new UnlinkedIdentityDecision.CreateUser(new(DefaultUserNamePrefix, DefaultRoleIds: ReadRoleIds(context.Settings))));
     }
 
     internal static IReadOnlyCollection<string> ReadRoleIds(JsonElement settings) =>

--- a/src/modules/Elsa.ExternalAuthentication/Policies/MatchExternalUserUnlinkedIdentityPolicy.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Policies/MatchExternalUserUnlinkedIdentityPolicy.cs
@@ -32,7 +32,7 @@ public sealed class MatchExternalUserUnlinkedIdentityPolicy(IExternalUserMatcher
 
         var requiredClaims = (descriptor.RequiredClaimTypes ?? []).ToHashSet(StringComparer.Ordinal);
         var claims = context.ProjectedClaims.Where(x => requiredClaims.Contains(x.Key)).ToDictionary(x => x.Key, x => x.Value, StringComparer.Ordinal);
-        var match = await matcher.MatchAsync(new ExternalUserMatcherContext(context.TargetTenantId, context.Connection, context.Identity, claims, selection.Settings), cancellationToken);
+        var match = await matcher.MatchAsync(new(context.TargetTenantId, context.Connection, context.Identity, claims, selection.Settings), cancellationToken);
         if (match is ExternalUserMatchResult.Match { UserId: { Length: > 0 } userId, AuthorizationBasis: { Length: > 0 } basis })
             return new UnlinkedIdentityDecision.LinkExistingUser(userId, basis);
 
@@ -40,13 +40,13 @@ public sealed class MatchExternalUserUnlinkedIdentityPolicy(IExternalUserMatcher
             return new UnlinkedIdentityDecision.Reject("identity_unlinked");
 
         return string.Equals(ReadString(context.Settings, "noMatchAction"), "create-user", StringComparison.OrdinalIgnoreCase)
-            ? new UnlinkedIdentityDecision.CreateUser(new UserCreationProposal("external", DefaultRoleIds: CreateUserUnlinkedIdentityPolicy.ReadRoleIds(context.Settings)))
+            ? new UnlinkedIdentityDecision.CreateUser(new("external", DefaultRoleIds: CreateUserUnlinkedIdentityPolicy.ReadRoleIds(context.Settings)))
             : new UnlinkedIdentityDecision.Reject("identity_unlinked");
     }
 
     private static bool TryReadMatcher(JsonElement settings, out MatcherSelection selection)
     {
-        selection = default!;
+        selection = null!;
         if (settings.ValueKind != JsonValueKind.Object || !settings.TryGetProperty("matcher", out var value) || value.ValueKind != JsonValueKind.Object)
             return false;
         var type = ReadString(value, "type");
@@ -54,7 +54,7 @@ public sealed class MatchExternalUserUnlinkedIdentityPolicy(IExternalUserMatcher
         var matcherSettings = value.TryGetProperty("settings", out var matcherSettingsValue) ? matcherSettingsValue.Clone() : default;
         if (string.IsNullOrWhiteSpace(type) || version <= 0)
             return false;
-        selection = new MatcherSelection(type, version, matcherSettings);
+        selection = new(type, version, matcherSettings);
         return true;
     }
 

--- a/src/modules/Elsa.ExternalAuthentication/Providers/ConfigurationIdentityProviderConnectionSource.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Providers/ConfigurationIdentityProviderConnectionSource.cs
@@ -78,7 +78,7 @@ public sealed class ConfigurationIdentityProviderConnectionSource(
     private static ClaimProjection CloneClaimProjection(ClaimProjection? projection)
     {
         projection ??= ClaimProjection.Empty;
-        return new ClaimProjection(
+        return new(
             new HashSet<string>(projection.AllowedClaimTypes ?? new HashSet<string>(), StringComparer.Ordinal),
             new HashSet<string>(projection.RedactedClaimTypes ?? new HashSet<string>(), StringComparer.Ordinal),
             projection.MaximumClaimCount,

--- a/src/modules/Elsa.ExternalAuthentication/Providers/DatabaseIdentityProviderConnectionSource.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Providers/DatabaseIdentityProviderConnectionSource.cs
@@ -21,10 +21,11 @@ public sealed class DatabaseIdentityProviderConnectionSource(
     public async ValueTask<ConnectionSourceSnapshot> GetSnapshotAsync(ConnectionScope scope, CancellationToken cancellationToken = default)
     {
         if (!options.CurrentValue.EnableDatabaseConnections)
-            return new ConnectionSourceSnapshot(scope, "disabled", []);
+            return new(scope, "disabled", []);
 
-        var page = await store.FindAsync(new ConnectionFilter { Scope = scope }, cancellationToken);
+        var page = await store.FindAsync(new()
+            { Scope = scope }, cancellationToken);
         var version = await versions.GetVersionAsync(cancellationToken);
-        return new ConnectionSourceSnapshot(scope, version.ToString(System.Globalization.CultureInfo.InvariantCulture), page.Items.ToArray());
+        return new(scope, version.ToString(System.Globalization.CultureInfo.InvariantCulture), page.Items.ToArray());
     }
 }

--- a/src/modules/Elsa.ExternalAuthentication/Services/AdapterSettingsMigrationService.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Services/AdapterSettingsMigrationService.cs
@@ -29,7 +29,7 @@ public sealed class AdapterSettingsMigrationService(
         if (settingsVersion <= 0 || settingsVersion > currentVersion)
             throw new InvalidOperationException($"Settings version {settingsVersion} is not compatible with adapter '{adapterType}' version {currentVersion}.");
         if (settingsVersion == currentVersion)
-            return new AdapterSettingsMigrationResult(currentVersion, settings.Clone(), false);
+            return new(currentVersion, settings.Clone(), false);
 
         var migrated = settings.Clone();
         var version = settingsVersion;
@@ -47,7 +47,7 @@ public sealed class AdapterSettingsMigrationService(
             version = migration.ToVersion;
         }
 
-        return new AdapterSettingsMigrationResult(version, migrated, true);
+        return new(version, migrated, true);
     }
 
     private static IReadOnlyDictionary<(string AdapterType, int FromVersion), IAdapterSettingsMigration> BuildMigrationIndex(

--- a/src/modules/Elsa.ExternalAuthentication/Services/BrokerErrorFactory.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Services/BrokerErrorFactory.cs
@@ -25,7 +25,7 @@ public static class BrokerErrorFactory
             _ => throw new ArgumentOutOfRangeException(nameof(category), category, null)
         };
 
-        return new PublicBrokerError(error, message, IsSafeCorrelationId(correlationId) ? correlationId! : CreateCorrelationId());
+        return new(error, message, IsSafeCorrelationId(correlationId) ? correlationId! : CreateCorrelationId());
     }
 
     public static string CreateCorrelationId()

--- a/src/modules/Elsa.ExternalAuthentication/Services/ConfigurationSecretBindingResolver.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Services/ConfigurationSecretBindingResolver.cs
@@ -27,7 +27,7 @@ public sealed class ConfigurationSecretBindingResolver(
         var value = configuration[binding.Reference];
         if (string.IsNullOrWhiteSpace(value))
             throw new InvalidOperationException("The configured secret binding could not be resolved.");
-        return ValueTask.FromResult(new ResolvedSecretBinding(new SensitiveString(value), hasher.Hash($"{ResolverType}:{binding.Reference}:{value}")));
+        return ValueTask.FromResult(new ResolvedSecretBinding(new(value), hasher.Hash($"{ResolverType}:{binding.Reference}:{value}")));
     }
 
     private static void EnsureType(SecretBinding binding)

--- a/src/modules/Elsa.ExternalAuthentication/Services/ConnectionTestService.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Services/ConnectionTestService.cs
@@ -34,7 +34,7 @@ public sealed class ConnectionTestService(
         try
         {
             secrets = await ResolveSecretsAsync(connection.Connection.SecretBindings, cancellationToken);
-            test = await adapter.TestAsync(new ConnectionTestContext(connection, secrets, clock), cancellationToken);
+            test = await adapter.TestAsync(new(connection, secrets, clock), cancellationToken);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -42,7 +42,7 @@ public sealed class ConnectionTestService(
         }
         catch
         {
-            test = new ConnectionTestResult(ConnectionObservationStatus.Failed, "unavailable", "The provider test could not be completed.", []);
+            test = new(ConnectionObservationStatus.Failed, "unavailable", "The provider test could not be completed.", []);
         }
         finally
         {

--- a/src/modules/Elsa.ExternalAuthentication/Services/DefaultExternalAuthenticationTokenIssuer.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Services/DefaultExternalAuthenticationTokenIssuer.cs
@@ -6,7 +6,9 @@ using Elsa.Extensions;
 using Elsa.ExternalAuthentication.Contracts;
 using Elsa.ExternalAuthentication.Models;
 using Elsa.Identity.Contracts;
+using Elsa.ExternalAuthentication.Options;
 using Elsa.Identity.Models;
+using Microsoft.Extensions.Options;
 
 namespace Elsa.ExternalAuthentication.Services;
 
@@ -18,7 +20,8 @@ public sealed class DefaultExternalAuthenticationTokenIssuer(
     IRoleProvider roleProvider,
     IElsaTokenService tokenService,
     ITenantAccessor tenantAccessor,
-    ISystemClock clock) : IExternalAuthenticationTokenIssuer
+    ISystemClock clock,
+    IOptions<ExternalAuthenticationOptions> options) : IExternalAuthenticationTokenIssuer
 {
     public async ValueTask<ExternalTokenResponse> IssueAsync(ExternalAuthenticationSession session, CancellationToken cancellationToken = default)
     {
@@ -61,7 +64,19 @@ public sealed class DefaultExternalAuthenticationTokenIssuer(
                        { Id = session.UserId }, cancellationToken)
             ?? throw new InvalidOperationException("The external authentication session user no longer exists.");
         var roles = (await roleProvider.FindByIdsAsync(user.Roles, cancellationToken)).ToArray();
-        var permissions = roles.SelectMany(x => x.Permissions).Concat(session.ExternalGrants.Select(x => x.Permission)).Distinct(StringComparer.Ordinal).ToArray();
+        // Role permissions go through the same deployment boundary as the external grants beside them. They
+        // used to be concatenated raw, which let a permission the boundary had just excluded during grant
+        // resolution reappear here from the same roles -- making the deny list unenforceable for anything a
+        // role happened to carry, and ElsaRolePermissionGrantSource's own filtering pointless. Re-applying it
+        // at issuance also picks up a boundary that changed since sign-in, because refreshing reissues.
+        // With no boundary configured, which is the default, every well-formed permission passes and nothing
+        // about this changes.
+        var boundary = new PermissionGrantBoundary(options.Value.PermissionGrants);
+        var permissions = roles.SelectMany(x => x.Permissions)
+            .Concat(session.ExternalGrants.Select(x => x.Permission))
+            .Where(boundary.Allows)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
         var accessToken = await tokenService.IssueAccessTokenAsync(new(user, roles.Select(x => x.Name).ToArray(), permissions, [], session.Id), cancellationToken);
         var now = clock.UtcNow;
         return new(

--- a/src/modules/Elsa.ExternalAuthentication/Services/DefaultExternalAuthenticationTokenIssuer.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Services/DefaultExternalAuthenticationTokenIssuer.cs
@@ -55,14 +55,16 @@ public sealed class DefaultExternalAuthenticationTokenIssuer(
 
     private async ValueTask<ExternalTokenResponse> IssueResponseAsync(ExternalAuthenticationSession session, string refreshToken, CancellationToken cancellationToken)
     {
-        using var tenantContext = tenantAccessor.PushContext(new Tenant { Id = session.TenantId, Name = session.TenantId });
-        var user = await userProvider.FindAsync(new UserFilter { Id = session.UserId }, cancellationToken)
+        using var tenantContext = tenantAccessor.PushContext(new()
+            { Id = session.TenantId, Name = session.TenantId });
+        var user = await userProvider.FindAsync(new()
+                       { Id = session.UserId }, cancellationToken)
             ?? throw new InvalidOperationException("The external authentication session user no longer exists.");
         var roles = (await roleProvider.FindByIdsAsync(user.Roles, cancellationToken)).ToArray();
         var permissions = roles.SelectMany(x => x.Permissions).Concat(session.ExternalGrants.Select(x => x.Permission)).Distinct(StringComparer.Ordinal).ToArray();
-        var accessToken = await tokenService.IssueAccessTokenAsync(new TokenIssuanceContext(user, roles.Select(x => x.Name).ToArray(), permissions, [], session.Id), cancellationToken);
+        var accessToken = await tokenService.IssueAccessTokenAsync(new(user, roles.Select(x => x.Name).ToArray(), permissions, [], session.Id), cancellationToken);
         var now = clock.UtcNow;
-        return new ExternalTokenResponse(
+        return new(
             accessToken.Token,
             "Bearer",
             Math.Max(0, (long)(accessToken.ExpiresAt - now).TotalSeconds),

--- a/src/modules/Elsa.ExternalAuthentication/Services/DefaultExternalIdentityResolver.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Services/DefaultExternalIdentityResolver.cs
@@ -24,13 +24,13 @@ public sealed class DefaultExternalIdentityResolver(
         if (existingLink is not null)
         {
             ValidateLink(existingLink, context);
-            return new ExternalIdentityResolution(existingLink.UserId, false);
+            return new(existingLink.UserId, false);
         }
 
         var selection = GetPolicySelection(context.Connection);
         var policy = _policies.GetValueOrDefault(selection.Type)
             ?? throw new InvalidOperationException($"The unlinked identity policy '{selection.Type}' is not available.");
-        var decision = await policy.EvaluateAsync(new UnlinkedIdentityContext(
+        var decision = await policy.EvaluateAsync(new(
             context.TargetTenantId,
             context.Connection,
             context.Identity,
@@ -41,14 +41,14 @@ public sealed class DefaultExternalIdentityResolver(
         {
             UnlinkedIdentityDecision.Reject reject => throw new ExternalIdentityUnlinkedException(reject.SafeReason),
             UnlinkedIdentityDecision.CreateUser createUser => await provisioner.CreateLinkOrGetExistingAsync(
-                new ProvisioningRequest(context.TargetTenantId, connectionKey, context.Identity, createUser.Proposal), cancellationToken),
+                new(context.TargetTenantId, connectionKey, context.Identity, createUser.Proposal), cancellationToken),
             UnlinkedIdentityDecision.LinkExistingUser linkExistingUser => await provisioner.CreateLinkOrGetExistingAsync(
-                new ProvisioningRequest(context.TargetTenantId, connectionKey, context.Identity, null, linkExistingUser.UserId), cancellationToken),
+                new(context.TargetTenantId, connectionKey, context.Identity, null, linkExistingUser.UserId), cancellationToken),
             _ => throw new InvalidOperationException("The unlinked identity policy returned an unsupported decision.")
         };
 
         ValidateLink(result.Link, context);
-        return new ExternalIdentityResolution(result.UserId, result.WasCreated);
+        return new(result.UserId, result.WasCreated);
     }
 
     public ValueTask<bool> RecordSuccessfulSignInAsync(
@@ -69,7 +69,7 @@ public sealed class DefaultExternalIdentityResolver(
         if (configuredPolicy is not null && mayOverride)
             return configuredPolicy;
 
-        return new PolicySelection(options.Value.UnlinkedIdentityPolicy.DefaultType, 1, default);
+        return new(options.Value.UnlinkedIdentityPolicy.DefaultType, 1, default);
     }
 
     private static void ValidateLink(ExternalIdentityLink link, ExternalIdentityResolutionContext context)

--- a/src/modules/Elsa.ExternalAuthentication/Services/DefaultIdentityProviderConnectionRegistry.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Services/DefaultIdentityProviderConnectionRegistry.cs
@@ -45,7 +45,7 @@ public sealed class DefaultIdentityProviderConnectionRegistry(
             var candidatesForKey = group.ToArray();
             var hasInheritedScopeCollision = candidatesForKey.Select(x => x.Scope).Distinct().Skip(1).Any();
 
-            var explicitOverride = candidatesForKey.FirstOrDefault(x => x.Source.Ownership == ConnectionSourceOwnership.Database && x.Connection.OverridesConfigurationConnection && !x.Connection.ArchivedAt.HasValue);
+            var explicitOverride = candidatesForKey.FirstOrDefault(x => x.Source.Ownership == ConnectionSourceOwnership.Database && x.Connection is { OverridesConfigurationConnection: true, ArchivedAt: null });
             var preferred = explicitOverride ?? candidatesForKey.FirstOrDefault(x => x.Source.Ownership == ConnectionSourceOwnership.Configuration) ?? candidatesForKey.First();
             var preferredReference = ToReference(preferred);
             var shadowedReferences = hasInheritedScopeCollision
@@ -60,7 +60,7 @@ public sealed class DefaultIdentityProviderConnectionRegistry(
                 var candidate = candidatesForKey[index];
                 var isArchived = candidate.Connection.ArchivedAt.HasValue;
                 var isShadowed = !isArchived && !hasInheritedScopeCollision && !ReferenceEquals(candidate, preferred);
-                connections.Add(new EffectiveIdentityProviderConnection(
+                connections.Add(new(
                     candidate.Connection,
                     candidate.Source.Ownership,
                     candidate.Scope,
@@ -82,7 +82,7 @@ public sealed class DefaultIdentityProviderConnectionRegistry(
 
         var version = revisionCalculator.CalculateRegistryVersion(snapshots.Select(x => (x.Source.Name, x.Source.Ownership, x.Snapshot)));
         var loginMethods = CreateLoginMethods(orderedConnections);
-        return new EffectiveConnectionRegistry(orderedConnections, loginMethods, version);
+        return new(orderedConnections, loginMethods, version);
     }
 
     public async ValueTask<EffectiveIdentityProviderConnection?> FindByKeyAsync(string targetTenantId, string key, CancellationToken cancellationToken = default)
@@ -106,7 +106,7 @@ public sealed class DefaultIdentityProviderConnectionRegistry(
             .Where(IsAvailableForAuthentication)
             .ToArray();
         var configuredPreferred = available
-            .Where(x => x.Ownership == ConnectionSourceOwnership.Configuration && x.Connection.IsPreferred)
+            .Where(x => x is { Ownership: ConnectionSourceOwnership.Configuration, Connection.IsPreferred: true })
             .OrderBy(x => x.Connection.DisplayOrder)
             .ThenBy(x => ConnectionRevisionCalculator.NormalizeKey(x.Connection.Key), StringComparer.Ordinal)
             .ThenBy(x => x.Connection.Id, StringComparer.Ordinal)
@@ -137,7 +137,7 @@ public sealed class DefaultIdentityProviderConnectionRegistry(
                 x.Connection.IconId,
                 x.Connection.DisplayOrder,
                 string.Equals(x.Connection.Id, preferredConnectionId, StringComparison.Ordinal),
-                new Uri($"/external-authentication/authorize/{Uri.EscapeDataString(x.Connection.Key)}", UriKind.Relative)))
+                new($"/external-authentication/authorize/{Uri.EscapeDataString(x.Connection.Key)}", UriKind.Relative)))
             .ToArray();
 
     private static IReadOnlyList<ConnectionScope> GetApplicableScopes() => [ConnectionScope.Host];
@@ -146,8 +146,7 @@ public sealed class DefaultIdentityProviderConnectionRegistry(
     private static bool IsAvailableForAuthentication(EffectiveIdentityProviderConnection connection) =>
         !connection.IsShadowed &&
         connection.Validity != ConnectionValidity.Invalid &&
-        connection.Connection.IsEnabled &&
-        !connection.Connection.ArchivedAt.HasValue;
+        connection.Connection is { IsEnabled: true, ArchivedAt: null };
     private static int GetOwnershipPriority(ConnectionSourceOwnership ownership) => ownership == ConnectionSourceOwnership.Configuration ? 0 : 1;
     private static IdentityProviderConnectionReference ToReference(Candidate candidate) =>
         new(candidate.Connection.Id, candidate.Connection.DisplayName, candidate.Source.Ownership);

--- a/src/modules/Elsa.ExternalAuthentication/Services/DefaultPermissionGrantResolver.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Services/DefaultPermissionGrantResolver.cs
@@ -1,3 +1,5 @@
+using System.Security.Claims;
+using Elsa.Authorization;
 using Elsa.ExternalAuthentication.Contracts;
 using Elsa.ExternalAuthentication.Models;
 using Elsa.ExternalAuthentication.Options;
@@ -25,30 +27,38 @@ public sealed class DefaultPermissionGrantResolver(
         {
             if (!IsAllowedSource(selection.Type) || !_sources.TryGetValue(selection.Type, out var source))
             {
-                AddWarning(warnings, warningKeys, new PermissionGrantWarning("permission_grant_source_unavailable", $"The permission grant source '{selection.Type}' is not available."));
+                AddWarning(warnings, warningKeys, new("permission_grant_source_unavailable", $"The permission grant source '{selection.Type}' is not available."));
                 continue;
             }
 
-            var result = await source.GetGrantsAsync(new PermissionGrantContext(context.TargetTenantId, context.UserId, context.Connection, context.Identity, context.ProjectedClaims, selection), cancellationToken);
+            var result = await source.GetGrantsAsync(new(context.TargetTenantId, context.UserId, context.Connection, context.Identity, context.ProjectedClaims, selection), cancellationToken);
             foreach (var warning in result.Warnings)
                 AddWarning(warnings, warningKeys, warning);
             foreach (var grant in result.Grants)
             {
+                // A value the evaluator cannot parse authorizes nothing, so carrying it into a token only
+                // hides the mistake. Say so rather than passing it through as an opaque string.
+                if (!Permission.TryParse(grant.Permission, out _))
+                {
+                    AddWarning(warnings, warningKeys, new("malformed_permission", $"The permission '{grant.Permission}' is not well-formed and was dropped."));
+                    continue;
+                }
+
                 if (!boundary.Allows(grant.Permission))
                 {
-                    AddWarning(warnings, warningKeys, new PermissionGrantWarning("permission_denied_by_deployment", $"The permission '{grant.Permission}' is outside the deployment grant boundary."));
+                    AddWarning(warnings, warningKeys, new("permission_denied_by_deployment", $"The permission '{grant.Permission}' is outside the deployment grant boundary."));
                     continue;
                 }
 
                 if (!knownPermissions.Contains(grant.Permission))
-                    AddWarning(warnings, warningKeys, new PermissionGrantWarning("unknown_permission_descriptor", $"No module advertises a descriptor for permission '{grant.Permission}'."));
+                    AddWarning(warnings, warningKeys, new("unknown_permission_descriptor", $"No module advertises a descriptor for permission '{grant.Permission}'."));
 
                 if (grants.All(x => !string.Equals(x.Permission, grant.Permission, StringComparison.Ordinal)))
                     grants.Add(grant);
             }
         }
 
-        return new PermissionGrantResult(grants, warnings);
+        return new(grants, warnings);
     }
 
     private bool IsAllowedSource(string type) => options.Value.AllowedPermissionGrantSourceTypes.Count == 0 || options.Value.AllowedPermissionGrantSourceTypes.Contains(type, StringComparer.Ordinal);
@@ -59,26 +69,48 @@ public sealed class DefaultPermissionGrantResolver(
     }
 }
 
-public sealed class DefaultPermissionDelegationAuthorizer(IOptions<ExternalAuthenticationOptions> options) : IPermissionDelegationAuthorizer
+public sealed class DefaultPermissionDelegationAuthorizer(IOptions<ExternalAuthenticationOptions> options, IPermissionEvaluator permissionEvaluator) : IPermissionDelegationAuthorizer
 {
-    public ValueTask<PermissionDelegationResult> AuthorizeAsync(System.Security.Claims.ClaimsPrincipal actor, IReadOnlyCollection<GrantSourceSelection> selections, CancellationToken cancellationToken = default)
+    public ValueTask<PermissionDelegationResult> AuthorizeAsync(ClaimsPrincipal actor, IReadOnlyCollection<GrantSourceSelection> selections, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        var actorPermissions = actor.FindAll(PermissionNames.ClaimType).Select(x => x.Value).ToHashSet(StringComparer.Ordinal);
         var boundary = new PermissionGrantBoundary(options.Value.PermissionGrants);
         var configuredPermissions = selections.SelectMany(x => PermissionGrantMappingSettings.Read(x.Settings)).SelectMany(x => x.Permissions)
             .Concat(selections.Where(x => string.Equals(x.Type, ClaimPassThroughPermissionGrantSource.SourceType, StringComparison.Ordinal)).SelectMany(x => PermissionGrantMappingSettings.ReadPassThroughPermissions(x.Settings)))
             .Distinct(StringComparer.Ordinal).OrderBy(x => x, StringComparer.Ordinal).ToArray();
-        var unrestricted = actorPermissions.Contains(PermissionNames.All) || actorPermissions.Contains(Permissions.ExternalAuthenticationPermissions.PermissionsDelegateUnrestricted);
-        var mayDelegate = unrestricted || actorPermissions.Contains(Permissions.ExternalAuthenticationPermissions.PermissionsDelegate);
-        var unauthorized = configuredPermissions.Where(permission => !boundary.Allows(permission) || !mayDelegate || (!unrestricted && !actorPermissions.Contains(permission))).ToArray();
+        var unrestricted = permissionEvaluator.HasPermission(actor, ExternalAuthenticationResourcePermissions.PermissionGrants, ExternalAuthenticationVerbs.DelegateUnrestricted);
+        var mayDelegate = unrestricted || permissionEvaluator.HasPermission(actor, ExternalAuthenticationResourcePermissions.PermissionGrants, ExternalAuthenticationVerbs.Delegate);
+        var unauthorized = configuredPermissions.Where(permission => !boundary.Allows(permission) || !mayDelegate || (!unrestricted && !permissionEvaluator.HasPermission(actor, permission))).ToArray();
         return ValueTask.FromResult(new PermissionDelegationResult(unauthorized.Length == 0, unauthorized));
     }
 }
 
+/// <summary>
+/// The deployment's allow and deny boundary on delegated permissions. Both lists are permission patterns,
+/// so they read the same way a role does: <c>workflows/*:delete</c> denies every delete beneath
+/// <c>workflows</c>, not just a permission spelled exactly that way.
+/// </summary>
 internal sealed class PermissionGrantBoundary(PermissionGrantOptions options)
 {
-    private readonly IReadOnlySet<string> _allowed = options.AllowedPermissions.ToHashSet(StringComparer.Ordinal);
-    private readonly IReadOnlySet<string> _denied = options.DeniedPermissions.ToHashSet(StringComparer.Ordinal);
-    public bool Allows(string permission) => !string.IsNullOrWhiteSpace(permission) && !_denied.Contains(permission) && (_allowed.Count == 0 || _allowed.Contains(permission));
+    private readonly IReadOnlyCollection<Permission> _allowed = Parse(options.AllowedPermissions);
+    private readonly IReadOnlyCollection<Permission> _denied = Parse(options.DeniedPermissions);
+
+    public bool Allows(string permission)
+    {
+        if (!Permission.TryParse(permission, out var candidate))
+            return false;
+
+        // Deny wins, and it is tested in both directions: a grant beneath a denied subtree is denied, and a
+        // wildcard grant that would reach a denied permission is denied too. Testing only one direction
+        // would let 'workflows/*:delete' hand out a delete the deployment denied by name.
+        if (_denied.Any(x => PermissionMatcher.Satisfies(x, candidate) || PermissionMatcher.Satisfies(candidate, x)))
+            return false;
+
+        // Allow is one-directional on purpose. An allow entry must cover the whole grant, so a grant broader
+        // than anything allowed is refused rather than admitted for the part that overlaps.
+        return _allowed.Count == 0 || _allowed.Any(x => PermissionMatcher.Satisfies(x, candidate));
+    }
+
+    private static IReadOnlyCollection<Permission> Parse(IEnumerable<string> values) =>
+        values.Select(x => Permission.TryParse(x, out var permission) ? permission : (Permission?)null).OfType<Permission>().ToArray();
 }

--- a/src/modules/Elsa.ExternalAuthentication/Services/DefaultPermissionGrantResolver.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Services/DefaultPermissionGrantResolver.cs
@@ -90,14 +90,29 @@ public sealed class DefaultPermissionDelegationAuthorizer(IOptions<ExternalAuthe
 /// so they read the same way a role does: <c>workflows/*:delete</c> denies every delete beneath
 /// <c>workflows</c>, not just a permission spelled exactly that way.
 /// </summary>
-internal sealed class PermissionGrantBoundary(PermissionGrantOptions options)
+internal sealed class PermissionGrantBoundary
 {
-    private readonly IReadOnlyCollection<Permission> _allowed = Parse(options.AllowedPermissions);
-    private readonly IReadOnlyCollection<Permission> _denied = Parse(options.DeniedPermissions);
+    private readonly IReadOnlyCollection<Permission> _allowed;
+    private readonly IReadOnlyCollection<Permission> _denied;
+    private readonly bool _isUnusable;
+
+    public PermissionGrantBoundary(PermissionGrantOptions options)
+    {
+        _allowed = Parse(options.AllowedPermissions);
+        _denied = Parse(options.DeniedPermissions);
+
+        // A boundary the deployment configured but that does not parse is a configuration error, and the only
+        // safe reading of one is "allow nothing". Dropping the unparseable entries and carrying on would turn
+        // a typo in the allow list into no allow list at all -- an empty allow list means unrestricted -- and
+        // a typo in the deny list into a silent un-denying of whatever it named. ExternalAuthenticationOptionsValidator
+        // rejects this at startup, so reaching it here means that validation was bypassed rather than that an
+        // operator is mid-edit.
+        _isUnusable = _allowed.Count != options.AllowedPermissions.Count || _denied.Count != options.DeniedPermissions.Count;
+    }
 
     public bool Allows(string permission)
     {
-        if (!Permission.TryParse(permission, out var candidate))
+        if (_isUnusable || !Permission.TryParse(permission, out var candidate))
             return false;
 
         // Deny wins, and it is tested in both directions: a grant beneath a denied subtree is denied, and a

--- a/src/modules/Elsa.ExternalAuthentication/Services/ExternalAuthenticationBroker.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Services/ExternalAuthenticationBroker.cs
@@ -82,7 +82,7 @@ public sealed class ExternalAuthenticationBroker(
         if (!localOptions.IsEnabled)
             return externalMethods;
 
-        var local = new LoginMethod("local", "local", LoginMethodKind.Local, localOptions.DisplayName, localOptions.IconId, localOptions.DisplayOrder, localOptions.IsPreferred && !externalMethods.Any(x => x.IsPreferred), new Uri("/external-authentication/local/authorize", UriKind.Relative));
+        var local = new LoginMethod("local", "local", LoginMethodKind.Local, localOptions.DisplayName, localOptions.IconId, localOptions.DisplayOrder, localOptions.IsPreferred && !externalMethods.Any(x => x.IsPreferred), new("/external-authentication/local/authorize", UriKind.Relative));
         return [local, .. externalMethods];
     }
 
@@ -140,7 +140,7 @@ public sealed class ExternalAuthenticationBroker(
         {
             secrets = await ResolveSecretsAsync(connection.Connection.SecretBindings, cancellationToken);
             transaction.SecretGenerationFingerprint = GetSecretFingerprint(secrets);
-            adapterRequest = await adapter.CreateAuthorizationRequestAsync(new ExternalAuthorizationContext(connection, secrets, transaction, state, clock), cancellationToken);
+            adapterRequest = await adapter.CreateAuthorizationRequestAsync(new(connection, secrets, transaction, state, clock), cancellationToken);
             transaction.ProtectedPayload = dataProtectionProvider.CreateProtector("Elsa.ExternalAuthentication.AdapterPayload.v1").Protect(adapterRequest.ProtectedAdapterState);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -193,7 +193,7 @@ public sealed class ExternalAuthenticationBroker(
                 ExternalAuthenticationResult authentication;
                 try
                 {
-                    authentication = await adapter.AuthenticateCallbackAsync(new ExternalCallbackContext(connection, secrets, transaction, state, parameters, clock), cancellationToken);
+                    authentication = await adapter.AuthenticateCallbackAsync(new(connection, secrets, transaction, state, parameters, clock), cancellationToken);
                 }
                 finally
                 {
@@ -201,8 +201,8 @@ public sealed class ExternalAuthenticationBroker(
                 }
 
                 using var upstreamLogoutHint = authentication.UpstreamLogoutHint;
-                var resolution = await identityResolver.ResolveAsync(new ExternalIdentityResolutionContext(transaction.TenantId, connection, authentication.Identity, authentication.ProjectedClaims), cancellationToken);
-                var grantResult = await permissionGrantResolver.ResolveAsync(new PermissionGrantResolutionContext(
+                var resolution = await identityResolver.ResolveAsync(new(transaction.TenantId, connection, authentication.Identity, authentication.ProjectedClaims), cancellationToken);
+                var grantResult = await permissionGrantResolver.ResolveAsync(new(
                     transaction.TenantId,
                     resolution.UserId,
                     connection,
@@ -230,7 +230,8 @@ public sealed class ExternalAuthenticationBroker(
                 };
                 await sessionStore.SaveAsync(session, cancellationToken);
                 var code = CreateOpaqueValue();
-                await grantStore.SaveAsync(new AuthorizationGrant { CodeHash = Hash(code), ClientId = transaction.ClientId, CallbackUri = transaction.CallbackUri, TenantId = transaction.TenantId, UserId = resolution.UserId, ExternalSessionId = session.Id, PkceChallenge = transaction.PkceChallenge, ExpiresAt = clock.UtcNow.Add(options.Value.Lifetimes.CompletionCodeLifetime) }, cancellationToken);
+                await grantStore.SaveAsync(new()
+                    { CodeHash = Hash(code), ClientId = transaction.ClientId, CallbackUri = transaction.CallbackUri, TenantId = transaction.TenantId, UserId = resolution.UserId, ExternalSessionId = session.Id, PkceChallenge = transaction.PkceChallenge, ExpiresAt = clock.UtcNow.Add(options.Value.Lifetimes.CompletionCodeLifetime) }, cancellationToken);
                 if (notifier is not null)
                     await notifier.PublishAsync(new ExternalSignInCompleted(
                     ExternalAuthenticationSecurityNotifier.Context(null, transaction.TenantId, connection.Connection.Id, resolution.UserId, SecurityEventOutcome.Succeeded, "External sign-in completed."),
@@ -280,7 +281,7 @@ public sealed class ExternalAuthenticationBroker(
         }
         if (!options.Value.LocalLogin.IsEnabled)
             return await CallbackOutcomeAsync(BrokerCallbackResult.Fail(BrokerErrorFactory.Create(BrokerErrorCategory.MethodUnavailable)), "local", "initiate", targetTenantId, null, cancellationToken);
-        Elsa.Identity.Entities.User? user;
+        Identity.Entities.User? user;
         try
         {
             user = await credentialsValidator.ValidateAsync(request.Username.Trim(), request.Password, cancellationToken);
@@ -297,7 +298,8 @@ public sealed class ExternalAuthenticationBroker(
             return await CallbackOutcomeAsync(BrokerCallbackResult.Fail(BrokerErrorFactory.Create(BrokerErrorCategory.AuthenticationFailed)), "local", "initiate", targetTenantId, null, cancellationToken);
 
         var code = CreateOpaqueValue();
-        await grantStore.SaveAsync(new AuthorizationGrant { CodeHash = Hash(code), ClientId = request.ClientId, CallbackUri = request.RedirectUri, TenantId = targetTenantId, UserId = user.Id, PkceChallenge = request.CodeChallenge, ExpiresAt = clock.UtcNow.Add(options.Value.Lifetimes.CompletionCodeLifetime) }, cancellationToken);
+        await grantStore.SaveAsync(new()
+            { CodeHash = Hash(code), ClientId = request.ClientId, CallbackUri = request.RedirectUri, TenantId = targetTenantId, UserId = user.Id, PkceChallenge = request.CodeChallenge, ExpiresAt = clock.UtcNow.Add(options.Value.Lifetimes.CompletionCodeLifetime) }, cancellationToken);
         return await CallbackOutcomeAsync(BrokerCallbackResult.Redirect(AppendCallbackParameters(request.RedirectUri, code, request.ClientState)), "local", "initiate", targetTenantId, null, cancellationToken);
     }
 
@@ -365,8 +367,10 @@ public sealed class ExternalAuthenticationBroker(
             }
         }
 
-        using var tenantContext = tenantAccessor.PushContext(new Tenant { Id = grant.TenantId, Name = grant.TenantId });
-        var user = await userProvider.FindAsync(new UserFilter { Id = grant.UserId }, cancellationToken);
+        using var tenantContext = tenantAccessor.PushContext(new()
+            { Id = grant.TenantId, Name = grant.TenantId });
+        var user = await userProvider.FindAsync(new()
+            { Id = grant.UserId }, cancellationToken);
         if (user is null)
             return await TokenOutcomeAsync(BrokerTokenResult.Fail(BrokerErrorFactory.Create(BrokerErrorCategory.AccessDenied)), "token_exchange", "resolve_user", cancellationToken);
         try
@@ -375,7 +379,7 @@ public sealed class ExternalAuthenticationBroker(
             var context = new TokenIssuanceContext(user, roles.Select(x => x.Name).ToArray(), roles.SelectMany(x => x.Permissions).Distinct().ToArray(), []);
             var access = await elsaTokenService.IssueAccessTokenAsync(context, cancellationToken);
             var refresh = await elsaTokenService.IssueRefreshTokenAsync(context, cancellationToken);
-            return await TokenOutcomeAsync(BrokerTokenResult.Success(new ExternalTokenResponse(
+            return await TokenOutcomeAsync(BrokerTokenResult.Success(new(
                 access.Token,
                 "Bearer",
                 SecondsUntil(access.ExpiresAt),
@@ -400,7 +404,7 @@ public sealed class ExternalAuthenticationBroker(
         if (tokens is null)
             return null;
 
-        return new ExternalTokenResponse(
+        return new(
             tokens.AccessToken,
             "Bearer",
             SecondsUntil(GetExpiresAt(tokens.AccessToken)),
@@ -478,7 +482,7 @@ public sealed class ExternalAuthenticationBroker(
             using var upstreamLogoutHint = session.ProtectedUpstreamLogoutHint is { Length: > 0 }
                 ? new SensitiveString(Encoding.UTF8.GetString(dataProtectionProvider.CreateProtector("Elsa.ExternalAuthentication.UpstreamLogoutHint.v1").Unprotect(session.ProtectedUpstreamLogoutHint)))
                 : null;
-            upstream = await adapter.CreateLogoutRequestAsync(new ExternalLogoutContext(connection, logoutSecrets, transaction, state, clock, upstreamLogoutHint), cancellationToken);
+            upstream = await adapter.CreateLogoutRequestAsync(new(connection, logoutSecrets, transaction, state, clock, upstreamLogoutHint), cancellationToken);
             transaction.ProtectedPayload = dataProtectionProvider.CreateProtector("Elsa.ExternalAuthentication.AdapterPayload.v1").Protect(upstream?.ProtectedAdapterState ?? []);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -504,7 +508,7 @@ public sealed class ExternalAuthenticationBroker(
             CallbackUri = request.PostLogoutRedirectUri, ReturnPath = upstream.NavigationUri.AbsoluteUri, TenantId = session.TenantId,
             ExpiresAt = transaction.ExpiresAt
         }, transaction.ExpiresAt, cancellationToken);
-        return await LogoutOutcomeAsync(BrokerLogoutResult.Navigate(new Uri($"/external-authentication/logout/continue/{Uri.EscapeDataString(continuationHandle)}", UriKind.Relative)), "initiate", cancellationToken);
+        return await LogoutOutcomeAsync(BrokerLogoutResult.Navigate(new($"/external-authentication/logout/continue/{Uri.EscapeDataString(continuationHandle)}", UriKind.Relative)), "initiate", cancellationToken);
     }
 
     public async ValueTask<BrokerCallbackResult> CompleteLogoutAsync(string connectionKey, string state, CancellationToken cancellationToken = default)
@@ -544,7 +548,7 @@ public sealed class ExternalAuthenticationBroker(
         var result = AppendQuery(uri, "code", code);
         return string.IsNullOrWhiteSpace(clientState) ? result : AppendQuery(result, "state", clientState);
     }
-    private static Uri AppendQuery(Uri uri, string key, string value) { var separator = string.IsNullOrEmpty(uri.Query) ? "?" : "&"; return new Uri(uri + separator + Uri.EscapeDataString(key) + "=" + Uri.EscapeDataString(value), uri.IsAbsoluteUri ? UriKind.Absolute : UriKind.Relative); }
+    private static Uri AppendQuery(Uri uri, string key, string value) { var separator = string.IsNullOrEmpty(uri.Query) ? "?" : "&"; return new(uri + separator + Uri.EscapeDataString(key) + "=" + Uri.EscapeDataString(value), uri.IsAbsoluteUri ? UriKind.Absolute : UriKind.Relative); }
     private async ValueTask<BrokerCallbackResult> FailTrustedCallbackAsync(BrokerTransaction transaction, BrokerErrorCategory category, CancellationToken cancellationToken)
     {
         var error = BrokerErrorFactory.Create(category);

--- a/src/modules/Elsa.ExternalAuthentication/Services/ExternalAuthenticationHealthCheck.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Services/ExternalAuthenticationHealthCheck.cs
@@ -11,7 +11,7 @@ public sealed class ExternalAuthenticationHealthCheck(
     public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
     {
         var registrySnapshot = await registry.GetAsync(string.Empty, cancellationToken);
-        var enabled = registrySnapshot.Connections.Where(x => x.Connection.IsEnabled && x.Connection.ArchivedAt is null && !x.IsShadowed).ToArray();
+        var enabled = registrySnapshot.Connections.Where(x => x is { Connection: { IsEnabled: true, ArchivedAt: null }, IsShadowed: false }).ToArray();
         if (enabled.Length == 0)
             return HealthCheckResult.Healthy("No enabled external identity provider connections.");
 

--- a/src/modules/Elsa.ExternalAuthentication/Services/ExternalAuthenticationRoleDeletionDependencyContributor.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Services/ExternalAuthenticationRoleDeletionDependencyContributor.cs
@@ -3,6 +3,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using Elsa.Authorization;
 using Elsa.ExternalAuthentication.Contracts;
 using Elsa.ExternalAuthentication.Models;
 using Elsa.ExternalAuthentication.Notifications;
@@ -19,10 +20,11 @@ namespace Elsa.ExternalAuthentication.Services;
 public sealed class ExternalAuthenticationRoleDeletionDependencyContributor(
     IIdentityProviderConnectionStore store,
     IOptionsMonitor<ExternalAuthenticationOptions> options,
-    Elsa.Identity.Contracts.IRoleAuthorizationService roleAuthorizationService,
+    IRoleAuthorizationService roleAuthorizationService,
     IConnectionRegistryVersionStore registryVersions,
     ConnectionRevisionCalculator revisionCalculator,
-    ExternalAuthenticationSecurityNotifier notifier) : IRoleDeletionDependencyContributor
+    ExternalAuthenticationSecurityNotifier notifier,
+    IPermissionEvaluator permissionEvaluator) : IRoleDeletionDependencyContributor
 {
     public const string SourceName = "external-authentication";
     public string Source => SourceName;
@@ -38,12 +40,12 @@ public sealed class ExternalAuthenticationRoleDeletionDependencyContributor(
             configurationIndex++;
         }
 
-        var databaseConnections = await store.FindAsync(new ConnectionFilter(), cancellationToken);
+        var databaseConnections = await store.FindAsync(new(), cancellationToken);
         foreach (var connection in databaseConnections.Items)
         {
             if (!TryGetRoleReference(connection.UnlinkedPolicy, roleId, out var policyBranch, out _, out var removesLastDefaultRole))
                 continue;
-            dependencies.Add(new RoleDeletionDependency(
+            dependencies.Add(new(
                 Source,
                 connection.Id,
                 connection.Key,
@@ -59,14 +61,14 @@ public sealed class ExternalAuthenticationRoleDeletionDependencyContributor(
             .ThenBy(x => x.OwnerId, StringComparer.Ordinal)
             .ThenBy(x => x.ConfigurationPath, StringComparer.Ordinal)
             .ToArray();
-        return new RoleDeletionDependencySnapshot(Source, CalculateVersion(ordered), false, ordered);
+        return new(Source, CalculateVersion(ordered), false, ordered);
     }
 
     public async ValueTask<RoleReferenceRemovalValidationResult> ValidateRemovalAsync(RoleReferenceRemovalRequest request, CancellationToken cancellationToken = default)
     {
-        if (!HasPermission(request.Actor, ExternalAuthenticationPermissions.ConnectionsUpdate) ||
-            !HasPermission(request.Actor, ExternalAuthenticationPermissions.PoliciesManage) ||
-            !HasPermission(request.Actor, ExternalAuthenticationPermissions.RolesAssign))
+        if (!permissionEvaluator.HasPermission(request.Actor, ExternalAuthenticationResourcePermissions.Connections, CoreVerbs.Update) ||
+            !permissionEvaluator.HasPermission(request.Actor, ExternalAuthenticationResourcePermissions.Policies, CoreVerbs.Update) ||
+            !permissionEvaluator.HasPermission(request.Actor, ExternalAuthenticationResourcePermissions.PolicyDefaultRoles, CoreVerbs.Update))
             return new RoleReferenceRemovalValidationResult.Forbidden("missing_policy_permissions");
         if (request.Dependencies.Count == 0 ||
             request.Dependencies.Any(x => x.Ownership != RoleDeletionDependencyOwnership.Database || !string.Equals(x.Source, Source, StringComparison.Ordinal)))
@@ -167,7 +169,7 @@ public sealed class ExternalAuthenticationRoleDeletionDependencyContributor(
         {
             if (string.Equals(configuredRoleId, roleId, StringComparison.Ordinal))
             {
-                yield return new RoleDeletionDependency(
+                yield return new(
                     Source,
                     string.IsNullOrWhiteSpace(connection.Id) ? $"configuration:{connectionIndex}" : connection.Id,
                     connection.Key,
@@ -209,8 +211,8 @@ public sealed class ExternalAuthenticationRoleDeletionDependencyContributor(
     {
         var root = settings.ValueKind == JsonValueKind.Object
             ? JsonNode.Parse(settings.GetRawText()) as JsonObject
-            : new JsonObject();
-        root ??= new JsonObject();
+            : new();
+        root ??= new();
         var remainingRoleIds = ReadRoleIdsWithDuplicates(settings)
             .Where(x => !string.Equals(x, roleId, StringComparison.Ordinal))
             .Distinct(StringComparer.Ordinal)
@@ -240,9 +242,6 @@ public sealed class ExternalAuthenticationRoleDeletionDependencyContributor(
         value.ValueKind == JsonValueKind.String
             ? value.GetString()
             : null;
-
-    private static bool HasPermission(ClaimsPrincipal actor, string permission) =>
-        actor.FindAll(PermissionNames.ClaimType).Any(x => x.Value == PermissionNames.All || string.Equals(x.Value, permission, StringComparison.Ordinal));
 
     private static string CalculateVersion(IEnumerable<RoleDeletionDependency> dependencies)
     {

--- a/src/modules/Elsa.ExternalAuthentication/Services/ExternalAuthenticationSecurityNotifier.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Services/ExternalAuthenticationSecurityNotifier.cs
@@ -10,7 +10,7 @@ public sealed class ExternalAuthenticationSecurityNotifier(IServiceProvider serv
     public ValueTask PublishAsync(INotification notification, CancellationToken cancellationToken = default)
     {
         var sender = services.GetService<INotificationSender>();
-        return sender is null ? ValueTask.CompletedTask : new ValueTask(sender.SendAsync(notification, cancellationToken));
+        return sender is null ? ValueTask.CompletedTask : new(sender.SendAsync(notification, cancellationToken));
     }
 
     public static SecurityEventContext Context(

--- a/src/modules/Elsa.ExternalAuthentication/Services/ExternalAuthenticationUserDeletionDependencyContributor.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Services/ExternalAuthenticationUserDeletionDependencyContributor.cs
@@ -16,7 +16,7 @@ public sealed class ExternalAuthenticationUserDeletionDependencyContributor(
     /// <inheritdoc />
     public async ValueTask<UserDeletionDependency?> InspectAsync(User user, CancellationToken cancellationToken = default)
     {
-        var linksForUser = await links.FindAsync(new ExternalIdentityLinkFilter
+        var linksForUser = await links.FindAsync(new()
         {
             TenantId = user.TenantId ?? string.Empty,
             UserId = user.Id

--- a/src/modules/Elsa.ExternalAuthentication/Services/ExternalIdentityLinkManagementService.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Services/ExternalIdentityLinkManagementService.cs
@@ -34,7 +34,8 @@ public sealed class ExternalIdentityLinkManagementService(
     {
         ValidateTargetTenant(tenantId);
         var normalizedSearch = search?.Trim();
-        var usersInTenant = (await users.FindManyAsync(new UserFilter { TenantId = tenantId }, cancellationToken))
+        var usersInTenant = (await users.FindManyAsync(new()
+                { TenantId = tenantId }, cancellationToken))
             .Where(x => string.IsNullOrEmpty(normalizedSearch) || x.Name.Contains(normalizedSearch, StringComparison.OrdinalIgnoreCase))
             .OrderBy(x => x.Name, StringComparer.Ordinal)
             .ThenBy(x => x.Id, StringComparer.Ordinal)
@@ -51,7 +52,8 @@ public sealed class ExternalIdentityLinkManagementService(
         var normalizedIssuer = NormalizeIssuer(issuer);
         var normalizedSubject = NormalizeSubject(subject);
 
-        var user = await users.FindAsync(new UserFilter { Id = userId }, cancellationToken);
+        var user = await users.FindAsync(new()
+            { Id = userId }, cancellationToken);
         if (user is null || !string.Equals(user.TenantId, tenantId, StringComparison.Ordinal))
             return new ExternalIdentityLinkPrelinkResult.UserNotFound();
 
@@ -62,10 +64,10 @@ public sealed class ExternalIdentityLinkManagementService(
 
         try
         {
-            var result = await provisioner.CreateLinkOrGetExistingAsync(new ProvisioningRequest(
+            var result = await provisioner.CreateLinkOrGetExistingAsync(new(
                 tenantId,
                 ConnectionRevisionCalculator.NormalizeKey(connection.Connection.Key),
-                new ExternalIdentity(normalizedIssuer, normalizedSubject, new Dictionary<string, IReadOnlyCollection<string>>()),
+                new(normalizedIssuer, normalizedSubject, new Dictionary<string, IReadOnlyCollection<string>>()),
                 null,
                 user.Id), cancellationToken);
 
@@ -87,7 +89,8 @@ public sealed class ExternalIdentityLinkManagementService(
     {
         ValidateTargetTenant(tenantId);
         ArgumentException.ThrowIfNullOrWhiteSpace(linkId);
-        var existing = await links.FindAsync(new ExternalIdentityLinkFilter { TenantId = tenantId }, cancellationToken);
+        var existing = await links.FindAsync(new()
+            { TenantId = tenantId }, cancellationToken);
         var link = existing.Items.FirstOrDefault(x => string.Equals(x.Id, linkId, StringComparison.Ordinal));
         if (link is null || !await links.DeleteAsync(tenantId, linkId, cancellationToken))
             return false;
@@ -113,7 +116,8 @@ public sealed class ExternalIdentityLinkManagementService(
         var normalizedIssuer = NormalizeIssuer(issuer);
         var normalizedSubject = NormalizeSubject(subject);
 
-        var user = await users.FindAsync(new UserFilter { Id = userId }, cancellationToken);
+        var user = await users.FindAsync(new()
+            { Id = userId }, cancellationToken);
         if (user is null || !string.Equals(user.TenantId, tenantId, StringComparison.Ordinal))
             return new ExternalIdentityLinkReplaceResult.NotFound();
 
@@ -125,12 +129,12 @@ public sealed class ExternalIdentityLinkManagementService(
         try
         {
             result = await provisioner.ReplaceAsync(
-                new ExternalIdentityLinkReplaceRequest(
+                new(
                     tenantId,
                     linkId,
                     user.Id,
                     ConnectionRevisionCalculator.NormalizeKey(connection.Connection.Key),
-                    new ExternalIdentity(normalizedIssuer, normalizedSubject, new Dictionary<string, IReadOnlyCollection<string>>())),
+                    new(normalizedIssuer, normalizedSubject, new Dictionary<string, IReadOnlyCollection<string>>())),
                 cancellationToken);
         }
         catch (InvalidOperationException)
@@ -164,8 +168,7 @@ public sealed class ExternalIdentityLinkManagementService(
         var normalizedKey = ConnectionRevisionCalculator.NormalizeKey(connectionKey);
         var registry = await connections.GetAsync(tenantId, cancellationToken);
         return registry.Connections.FirstOrDefault(x =>
-            !x.IsShadowed &&
-            !x.Connection.ArchivedAt.HasValue &&
+            x is { IsShadowed: false, Connection.ArchivedAt: null } &&
             string.Equals(ConnectionRevisionCalculator.NormalizeKey(x.Connection.Key), normalizedKey, StringComparison.Ordinal));
     }
 

--- a/src/modules/Elsa.ExternalAuthentication/Services/ExternalIdentityUserProvisioningService.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Services/ExternalIdentityUserProvisioningService.cs
@@ -28,7 +28,8 @@ public sealed class ExternalIdentityUserProvisioningService(
     {
         if (!string.IsNullOrWhiteSpace(request.ExistingUserId))
         {
-            var existingUser = await userProvider.FindAsync(new UserFilter { Id = request.ExistingUserId }, cancellationToken)
+            var existingUser = await userProvider.FindAsync(new()
+                                   { Id = request.ExistingUserId }, cancellationToken)
                 ?? throw new InvalidOperationException("The requested Elsa user does not exist.");
             if (!string.Equals(existingUser.TenantId, request.TenantId, StringComparison.Ordinal))
                 throw new InvalidOperationException("The requested Elsa user is outside the target tenant.");
@@ -44,7 +45,8 @@ public sealed class ExternalIdentityUserProvisioningService(
             var name = $"{prefix}-{identityGenerator.GenerateId()}";
             if (tryReserveUserName is not null && !tryReserveUserName(name))
                 continue;
-            if (await userProvider.FindAsync(new UserFilter { Name = name }, cancellationToken) is not null)
+            if (await userProvider.FindAsync(new()
+                    { Name = name }, cancellationToken) is not null)
                 continue;
 
             var user = new User
@@ -64,17 +66,21 @@ public sealed class ExternalIdentityUserProvisioningService(
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
-                var persistedUser = await userStore.FindAsync(new UserFilter { Id = user.Id }, CancellationToken.None);
+                var persistedUser = await userStore.FindAsync(new()
+                    { Id = user.Id }, CancellationToken.None);
                 if (persistedUser is not null)
-                    await userStore.DeleteAsync(new UserFilter { Id = user.Id }, CancellationToken.None);
+                    await userStore.DeleteAsync(new()
+                        { Id = user.Id }, CancellationToken.None);
                 throw;
             }
             catch
             {
-                var persistedUser = await userProvider.FindAsync(new UserFilter { Id = user.Id }, cancellationToken);
+                var persistedUser = await userProvider.FindAsync(new()
+                    { Id = user.Id }, cancellationToken);
                 if (persistedUser is not null)
                     return (persistedUser, true);
-                if (await userProvider.FindAsync(new UserFilter { Name = name }, cancellationToken) is null)
+                if (await userProvider.FindAsync(new()
+                        { Name = name }, cancellationToken) is null)
                     throw;
             }
         }
@@ -86,15 +92,18 @@ public sealed class ExternalIdentityUserProvisioningService(
     /// Removes a user created by an operation that could not publish its external identity link.
     /// </summary>
     public Task RemoveAsync(User user, CancellationToken cancellationToken = default) =>
-        userStore.DeleteAsync(new UserFilter { Id = user.Id }, cancellationToken);
+        userStore.DeleteAsync(new()
+            { Id = user.Id }, cancellationToken);
 
     /// <summary>
     /// Checks that the resolved user still exists in the source that supplied it.
     /// </summary>
     public async ValueTask<bool> ExistsAsync(User user, bool wasCreated, CancellationToken cancellationToken = default) =>
         wasCreated
-            ? await userStore.FindAsync(new UserFilter { Id = user.Id }, cancellationToken) is not null
-            : await userProvider.FindAsync(new UserFilter { Id = user.Id }, cancellationToken) is not null;
+            ? await userStore.FindAsync(new()
+                { Id = user.Id }, cancellationToken) is not null
+            : await userProvider.FindAsync(new()
+                { Id = user.Id }, cancellationToken) is not null;
 
     private static string NormalizeUserNamePrefix(string prefix)
     {

--- a/src/modules/Elsa.ExternalAuthentication/Services/FinalLoginPathGuard.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Services/FinalLoginPathGuard.cs
@@ -1,4 +1,5 @@
 using System.Security.Claims;
+using Elsa.Authorization;
 using Elsa.ExternalAuthentication.Contracts;
 using Elsa.ExternalAuthentication.Models;
 using Elsa.ExternalAuthentication.Options;
@@ -8,7 +9,7 @@ using Microsoft.Extensions.Options;
 namespace Elsa.ExternalAuthentication.Services;
 
 /// <summary>Prevents a management edit from removing the final ordinary sign-in path by accident.</summary>
-public sealed class FinalLoginPathGuard(IIdentityProviderConnectionRegistry registry, IOptions<ExternalAuthenticationOptions> options)
+public sealed class FinalLoginPathGuard(IIdentityProviderConnectionRegistry registry, IOptions<ExternalAuthenticationOptions> options, IPermissionEvaluator permissionEvaluator)
 {
     public async ValueTask<FinalLoginPathGuardResult> AuthorizeAsync(IdentityProviderConnection existing, IdentityProviderConnection candidate, string targetTenantId, ClaimsPrincipal actor, bool confirmedOverride, CancellationToken cancellationToken = default)
     {
@@ -18,11 +19,11 @@ public sealed class FinalLoginPathGuard(IIdentityProviderConnectionRegistry regi
         var effective = await registry.GetAsync(targetTenantId, cancellationToken);
         if (effective.Connections.Any(x => !string.Equals(x.Connection.Id, existing.Id, StringComparison.Ordinal) && IsNormal(x.Connection) && !x.IsShadowed && x.Validity != ConnectionValidity.Invalid))
             return FinalLoginPathGuardResult.Allowed;
-        var canOverride = confirmedOverride && actor.FindAll(PermissionNames.ClaimType).Any(x => x.Value == PermissionNames.All || x.Value == guard.PrivilegedOverridePermission);
+        var canOverride = confirmedOverride && permissionEvaluator.HasPermission(actor, guard.PrivilegedOverridePermission);
         return canOverride ? FinalLoginPathGuardResult.Allowed : FinalLoginPathGuardResult.Denied;
     }
 
-    private static bool IsNormal(IdentityProviderConnection connection) => connection.IsEnabled && connection.ArchivedAt is null;
+    private static bool IsNormal(IdentityProviderConnection connection) => connection is { IsEnabled: true, ArchivedAt: null };
 }
 
 public enum FinalLoginPathGuardResult { Allowed, Denied }

--- a/src/modules/Elsa.ExternalAuthentication/Services/IdentityProviderConnectionCloner.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Services/IdentityProviderConnectionCloner.cs
@@ -41,7 +41,7 @@ internal static class IdentityProviderConnectionCloner
     private static ClaimProjection CloneProjection(ClaimProjection? source)
     {
         source ??= ClaimProjection.Empty;
-        return new ClaimProjection(
+        return new(
             new HashSet<string>(source.AllowedClaimTypes ?? new HashSet<string>(), StringComparer.Ordinal),
             new HashSet<string>(source.RedactedClaimTypes ?? new HashSet<string>(), StringComparer.Ordinal),
             source.MaximumClaimCount,

--- a/src/modules/Elsa.ExternalAuthentication/Services/IdentityProviderConnectionManagementService.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Services/IdentityProviderConnectionManagementService.cs
@@ -1,7 +1,7 @@
 using System.Security.Claims;
 using System.Text.Json;
-using Elsa.Abstractions;
 using Elsa.Common;
+using Elsa.Authorization;
 using Elsa.ExternalAuthentication.Contracts;
 using Elsa.ExternalAuthentication.Models;
 using Elsa.ExternalAuthentication.Notifications;
@@ -32,6 +32,7 @@ public sealed partial class IdentityProviderConnectionManagementService(
     IEnumerable<ISecretBindingResolver> secretBindingResolvers,
     IEnumerable<IManagedSecretBindingWriter> managedSecretBindingWriters,
     IPermissionDelegationAuthorizer delegationAuthorizer,
+    IPermissionEvaluator permissionEvaluator,
     ConnectionRevisionCalculator revisionCalculator,
     ISystemClock clock,
     IOptions<ExternalAuthenticationOptions> options,
@@ -150,15 +151,11 @@ public sealed partial class IdentityProviderConnectionManagementService(
                 {
                     var current = await registry.GetAsync(targetTenantId, cancellationToken);
                     if (current.Connections.Any(x =>
-                            x.Ownership == ConnectionSourceOwnership.Configuration &&
-                            !x.IsShadowed &&
-                            x.Connection.IsEnabled &&
-                            !x.Connection.ArchivedAt.HasValue &&
-                            x.Connection.IsPreferred &&
+                            x is { Ownership: ConnectionSourceOwnership.Configuration, IsShadowed: false, Connection: { IsEnabled: true, ArchivedAt: null, IsPreferred: true } } &&
                             x.Validity != ConnectionValidity.Invalid &&
                             (!candidate.OverridesConfigurationConnection || !string.Equals(x.Connection.Key, candidate.Key, StringComparison.Ordinal))))
                         return new ManagementConnectionMutationResult.Conflict("configuration_preferred_connection");
-                    if (current.Connections.Any(x => x.Ownership == ConnectionSourceOwnership.Database && x.Connection.IsPreferred && !x.Connection.ArchivedAt.HasValue && x.Scope == ToScope(candidate.TenantId) && !string.Equals(x.Connection.Id, candidate.Id, StringComparison.Ordinal)))
+                    if (current.Connections.Any(x => x is { Ownership: ConnectionSourceOwnership.Database, Connection: { IsPreferred: true, ArchivedAt: null } } && x.Scope == ToScope(candidate.TenantId) && !string.Equals(x.Connection.Id, candidate.Id, StringComparison.Ordinal)))
                         return new ManagementConnectionMutationResult.Conflict("default_connection_conflict");
                 }
                 candidate.IsEnabled = true;
@@ -206,7 +203,7 @@ public sealed partial class IdentityProviderConnectionManagementService(
         ValidateEnvelope(connection, configuredOptions, errors);
 
         if (!adapters.TryGet(connection.AdapterType, out var adapter) || !IsAllowed(configuredOptions.AllowedAdapterTypes, connection.AdapterType))
-            errors.Add(new ConnectionValidationError("adapterType", "unavailable", "The selected adapter is not installed or is not allowed by this deployment."));
+            errors.Add(new("adapterType", "unavailable", "The selected adapter is not installed or is not allowed by this deployment."));
 
         await ValidatePolicyAsync(connection, actor, configuredOptions, errors, cancellationToken);
         ValidateGrantSources(connection, configuredOptions, errors);
@@ -214,21 +211,21 @@ public sealed partial class IdentityProviderConnectionManagementService(
         {
             var delegation = await delegationAuthorizer.AuthorizeAsync(actor, connection.PermissionGrantSources.ToArray(), cancellationToken);
             if (!delegation.IsAuthorized)
-                errors.Add(new ConnectionValidationError("permissionGrantSources", "delegation_denied", "The caller may not delegate one or more configured permissions."));
+                errors.Add(new("permissionGrantSources", "delegation_denied", "The caller may not delegate one or more configured permissions."));
         }
 
         if (adapter is null)
-            return new ConnectionValidationResult(false, errors, warnings);
+            return new(false, errors, warnings);
 
         await ApplySettingsMigrationAsync(connection, errors, cancellationToken);
         if (errors.Count != 0)
-            return new ConnectionValidationResult(false, errors, warnings);
+            return new(false, errors, warnings);
 
         var descriptor = adapter.Describe();
         ValidateSecretBindingFields(connection, descriptor, requireCompleteConfiguration, errors);
         ValidateSecretBindingsAreNotAdapterSettings(connection.AdapterSettings, descriptor, errors);
-        if (requireUnsafeConfirmation && UsesUnsafeSettings(connection.AdapterSettings, descriptor) && (!confirmUnsafeSettings || !HasPermission(actor, ExternalAuthenticationPermissions.ProviderTrustUnsafe)))
-            errors.Add(new ConnectionValidationError("adapterSettings", "unsafe_confirmation_required", "Unsafe provider trust settings require permission and explicit confirmation."));
+        if (requireUnsafeConfirmation && UsesUnsafeSettings(connection.AdapterSettings, descriptor) && (!confirmUnsafeSettings || !permissionEvaluator.HasPermission(actor, ExternalAuthenticationResourcePermissions.ProviderTrust, ExternalAuthenticationVerbs.Override)))
+            errors.Add(new("adapterSettings", "unsafe_confirmation_required", "Unsafe provider trust settings require permission and explicit confirmation."));
 
         if (requireCompleteConfiguration)
         {
@@ -236,20 +233,20 @@ public sealed partial class IdentityProviderConnectionManagementService(
             foreach (var (name, state) in secretStates)
             {
                 if (!state.IsConfigured)
-                    errors.Add(new ConnectionValidationError($"secretBindings.{name}", "required", "A required secret binding is not configured."));
+                    errors.Add(new($"secretBindings.{name}", "required", "A required secret binding is not configured."));
                 else if (!state.IsResolvable)
-                    errors.Add(new ConnectionValidationError($"secretBindings.{name}", "unresolvable", "The secret binding cannot be resolved."));
+                    errors.Add(new($"secretBindings.{name}", "unresolvable", "The secret binding cannot be resolved."));
             }
         }
 
         if (errors.Count != 0 || allowIncompleteDraft)
-            return new ConnectionValidationResult(errors.Count == 0, errors, warnings);
+            return new(errors.Count == 0, errors, warnings);
 
         var effective = ToEffective(connection);
-        var adapterValidation = await adapter.ValidateAsync(new ConnectionValidationContext(effective, new Dictionary<string, ResolvedSecretBinding>(), clock), cancellationToken);
+        var adapterValidation = await adapter.ValidateAsync(new(effective, new Dictionary<string, ResolvedSecretBinding>(), clock), cancellationToken);
         errors.AddRange(adapterValidation.Errors);
         warnings.AddRange(adapterValidation.Warnings);
-        return new ConnectionValidationResult(errors.Count == 0 && adapterValidation.IsValid, errors, warnings);
+        return new(errors.Count == 0 && adapterValidation.IsValid, errors, warnings);
     }
 
     public ValueTask<IReadOnlyDictionary<string, SecretBindingState>> GetSecretBindingStatesAsync(IdentityProviderConnection connection, CancellationToken cancellationToken = default) => GetSecretStatesAsync(connection, cancellationToken);
@@ -262,9 +259,7 @@ public sealed partial class IdentityProviderConnectionManagementService(
     public bool CanCreateConfigurationOverride() => options.Value.AllowConfigurationConnectionOverrides;
 
     public bool CanPromoteToConfigurationOverride(EffectiveIdentityProviderConnection connection) =>
-        connection.Ownership == ConnectionSourceOwnership.Database &&
-        connection.IsShadowed &&
-        !connection.Connection.ArchivedAt.HasValue &&
+        connection is { Ownership: ConnectionSourceOwnership.Database, IsShadowed: true, Connection.ArchivedAt: null } &&
         options.Value.AllowConfigurationConnectionOverrides;
 
     private async ValueTask<bool> IsBlockedByFinalLoginPathGuardAsync(IdentityProviderConnection existing, IdentityProviderConnection candidate, string targetTenantId, ClaimsPrincipal actor, bool confirmedOverride, CancellationToken cancellationToken)
@@ -279,8 +274,7 @@ public sealed partial class IdentityProviderConnectionManagementService(
             var normalizedKey = ConnectionRevisionCalculator.NormalizeKey(candidate.Key);
             var effective = await registry.GetAsync(targetTenantId, cancellationToken);
             var displacedConfigurationConnection = effective.Connections.FirstOrDefault(x =>
-                x.Ownership == ConnectionSourceOwnership.Configuration &&
-                !x.IsShadowed &&
+                x is { Ownership: ConnectionSourceOwnership.Configuration, IsShadowed: false } &&
                 string.Equals(ConnectionRevisionCalculator.NormalizeKey(x.Connection.Key), normalizedKey, StringComparison.Ordinal));
             if (displacedConfigurationConnection is not null)
                 guardExisting = displacedConfigurationConnection.Connection;
@@ -407,7 +401,7 @@ public sealed partial class IdentityProviderConnectionManagementService(
             x.Scope.Kind == ConnectionScopeKind.Host &&
             string.Equals(ConnectionRevisionCalculator.NormalizeKey(x.Connection.Key), key, StringComparison.Ordinal));
 
-        var rows = await store.FindAsync(new ConnectionFilter(), cancellationToken);
+        var rows = await store.FindAsync(new(), cancellationToken);
         if (rows.Items.Any(x =>
                 !string.Equals(x.Id, selfId, StringComparison.Ordinal) &&
                 x.TenantId != ConnectionScope.HostTenantId &&
@@ -425,7 +419,7 @@ public sealed partial class IdentityProviderConnectionManagementService(
         foreach (var (name, binding) in connection.SecretBindings)
         {
             if (!_secretBindingResolvers.TryGetValue(binding.ResolverType, out var resolver))
-                states[name] = new SecretBindingState(false, false);
+                states[name] = new(false, false);
             else
                 states[name] = await resolver.GetStateAsync(binding, cancellationToken);
         }
@@ -443,7 +437,7 @@ public sealed partial class IdentityProviderConnectionManagementService(
         }
         catch (InvalidOperationException)
         {
-            errors.Add(new ConnectionValidationError("adapterSettingsVersion", "migration_unavailable", "The adapter settings version is not compatible with the installed adapter."));
+            errors.Add(new("adapterSettingsVersion", "migration_unavailable", "The adapter settings version is not compatible with the installed adapter."));
         }
     }
 
@@ -474,26 +468,26 @@ public sealed partial class IdentityProviderConnectionManagementService(
     private static void ValidateEnvelope(IdentityProviderConnection connection, ExternalAuthenticationOptions configuredOptions, ICollection<ConnectionValidationError> errors)
     {
         if (!configuredOptions.EnableDatabaseConnections)
-            errors.Add(new ConnectionValidationError("source", "disabled", "Database-owned connections are disabled by deployment configuration."));
+            errors.Add(new("source", "disabled", "Database-owned connections are disabled by deployment configuration."));
         if (connection.OverridesConfigurationConnection && !configuredOptions.AllowConfigurationConnectionOverrides)
-            errors.Add(new ConnectionValidationError("overridesConfigurationConnection", "not_allowed", "This deployment does not allow database connections to override configuration-owned connections."));
+            errors.Add(new("overridesConfigurationConnection", "not_allowed", "This deployment does not allow database connections to override configuration-owned connections."));
         if (string.IsNullOrWhiteSpace(connection.Key) || connection.Key.Length > 128 || connection.Key.Any(char.IsWhiteSpace))
-            errors.Add(new ConnectionValidationError("key", "invalid", "Connection keys must be non-empty lowercase URL-safe tokens up to 128 characters."));
+            errors.Add(new("key", "invalid", "Connection keys must be non-empty lowercase URL-safe tokens up to 128 characters."));
         else if (!ConnectionKeyPattern().IsMatch(connection.Key))
-            errors.Add(new ConnectionValidationError("key", "invalid", "Connection keys must use lowercase letters, digits, and interior hyphens only."));
+            errors.Add(new("key", "invalid", "Connection keys must use lowercase letters, digits, and interior hyphens only."));
         if (string.IsNullOrWhiteSpace(connection.DisplayName) || connection.DisplayName.Trim().Length > 256)
-            errors.Add(new ConnectionValidationError("displayName", "invalid", "Display name is required and may not exceed 256 characters."));
+            errors.Add(new("displayName", "invalid", "Display name is required and may not exceed 256 characters."));
         if (connection.AdapterSettingsVersion <= 0)
-            errors.Add(new ConnectionValidationError("adapterSettingsVersion", "invalid", "Adapter settings version must be positive."));
+            errors.Add(new("adapterSettingsVersion", "invalid", "Adapter settings version must be positive."));
         if (!Enum.IsDefined(connection.UpstreamLogoutMode))
-            errors.Add(new ConnectionValidationError("upstreamLogoutMode", "invalid", "Upstream logout mode is invalid."));
+            errors.Add(new("upstreamLogoutMode", "invalid", "Upstream logout mode is invalid."));
         if (!IsValidScope(connection.TenantId))
-            errors.Add(new ConnectionValidationError("scope", "host_scope_required", "Identity provider connections are managed host-wide in this version."));
+            errors.Add(new("scope", "host_scope_required", "Identity provider connections are managed host-wide in this version."));
         if (connection.ClaimProjection.MaximumClaimCount < 0 || connection.ClaimProjection.MaximumValueLength < 0 || connection.ClaimProjection.MaximumTotalBytes < 0 ||
             connection.ClaimProjection.MaximumClaimCount > configuredOptions.Claims.MaximumClaimCount || connection.ClaimProjection.MaximumValueLength > configuredOptions.Claims.MaximumValueLength || connection.ClaimProjection.MaximumTotalBytes > configuredOptions.Claims.MaximumTotalBytes)
-            errors.Add(new ConnectionValidationError("claimProjection", "invalid", "Claim projection limits exceed deployment bounds."));
+            errors.Add(new("claimProjection", "invalid", "Claim projection limits exceed deployment bounds."));
         if (!connection.ClaimProjection.RedactedClaimTypes.IsSubsetOf(connection.ClaimProjection.AllowedClaimTypes))
-            errors.Add(new ConnectionValidationError("claimProjection.redactedClaimTypes", "invalid", "Redacted claim types must also be allowed claim types."));
+            errors.Add(new("claimProjection.redactedClaimTypes", "invalid", "Redacted claim types must also be allowed claim types."));
     }
 
     private async ValueTask ValidatePolicyAsync(IdentityProviderConnection connection, ClaimsPrincipal actor, ExternalAuthenticationOptions configuredOptions, ICollection<ConnectionValidationError> errors, CancellationToken cancellationToken)
@@ -501,21 +495,21 @@ public sealed partial class IdentityProviderConnectionManagementService(
         if (connection.UnlinkedPolicy is not { } policy)
             return;
         if (!configuredOptions.UnlinkedIdentityPolicy.AllowDatabaseConnectionOverride)
-            errors.Add(new ConnectionValidationError("unlinkedPolicy", "not_allowed", "This deployment does not allow database connection policy overrides."));
+            errors.Add(new("unlinkedPolicy", "not_allowed", "This deployment does not allow database connection policy overrides."));
         else if (policy.SettingsVersion <= 0 || !policies.TryGet(policy.Type, out _) || !IsAllowed(configuredOptions.AllowedUnlinkedIdentityPolicyTypes, policy.Type))
-            errors.Add(new ConnectionValidationError("unlinkedPolicy", "unavailable", "The selected unlinked identity policy is not installed or allowed."));
+            errors.Add(new("unlinkedPolicy", "unavailable", "The selected unlinked identity policy is not installed or allowed."));
         else
         {
             if (UsesCreateUserFallback(policy) &&
                 !await roleAuthorizationService.CanAssignRolesAsync(actor, Policies.CreateUserUnlinkedIdentityPolicy.ReadRoleIds(policy.Settings), cancellationToken))
-                errors.Add(new ConnectionValidationError("unlinkedPolicy.defaultRoleIds", "forbidden", "The selected default roles are unavailable or grant permissions the actor cannot delegate."));
+                errors.Add(new("unlinkedPolicy.defaultRoleIds", "forbidden", "The selected default roles are unavailable or grant permissions the actor cannot delegate."));
 
             if (string.Equals(policy.Type, Policies.MatchExternalUserUnlinkedIdentityPolicy.PolicyType, StringComparison.Ordinal) &&
                 (!TryGetMatcherSelection(policy.Settings, out var matcherType, out var matcherSettingsVersion) ||
                  !IsAllowed(configuredOptions.AllowedExternalUserMatcherTypes, matcherType) ||
                  !matchers.TryGet(matcherType, out _) ||
                  matchers.ListDescriptors().All(x => !string.Equals(x.Type, matcherType, StringComparison.Ordinal) || x.SettingsVersion != matcherSettingsVersion)))
-                errors.Add(new ConnectionValidationError("unlinkedPolicy.matcher", "unavailable", "The selected external user matcher is not installed or allowed."));
+                errors.Add(new("unlinkedPolicy.matcher", "unavailable", "The selected external user matcher is not installed or allowed."));
         }
     }
 
@@ -548,9 +542,9 @@ public sealed partial class IdentityProviderConnectionManagementService(
         foreach (var source in connection.PermissionGrantSources)
         {
             if (source.SettingsVersion <= 0 || !grantSources.TryGet(source.Type, out _) || !IsAllowed(configuredOptions.AllowedPermissionGrantSourceTypes, source.Type))
-                errors.Add(new ConnectionValidationError("permissionGrantSources", "unavailable", "A selected permission grant source is not installed or allowed."));
+                errors.Add(new("permissionGrantSources", "unavailable", "A selected permission grant source is not installed or allowed."));
             if (!orders.Add(source.Order))
-                errors.Add(new ConnectionValidationError("permissionGrantSources", "duplicate_order", "Permission grant source orders must be unique."));
+                errors.Add(new("permissionGrantSources", "duplicate_order", "Permission grant source orders must be unique."));
         }
     }
 
@@ -559,12 +553,12 @@ public sealed partial class IdentityProviderConnectionManagementService(
         var secretFields = descriptor.Fields.Where(x => x.IsSecretBinding).ToDictionary(x => x.Name, StringComparer.Ordinal);
         foreach (var name in connection.SecretBindings.Keys)
             if (!secretFields.ContainsKey(name))
-                errors.Add(new ConnectionValidationError($"secretBindings.{name}", "undeclared", "The adapter does not declare this secret binding field."));
+                errors.Add(new($"secretBindings.{name}", "undeclared", "The adapter does not declare this secret binding field."));
         if (!requireCompleteConfiguration)
             return;
         foreach (var field in secretFields.Values.Where(x => x.IsRequired))
             if (!connection.SecretBindings.ContainsKey(field.Name))
-                errors.Add(new ConnectionValidationError($"secretBindings.{field.Name}", "required", "A required secret binding is missing."));
+                errors.Add(new($"secretBindings.{field.Name}", "required", "A required secret binding is missing."));
     }
 
     private static void ValidateSecretBindingsAreNotAdapterSettings(JsonElement settings, ExternalAuthenticationAdapterDescriptor descriptor, ICollection<ConnectionValidationError> errors)
@@ -574,7 +568,7 @@ public sealed partial class IdentityProviderConnectionManagementService(
 
         foreach (var field in descriptor.Fields.Where(x => x.IsSecretBinding))
             if (settings.TryGetProperty(field.Name, out _))
-                errors.Add(new ConnectionValidationError($"adapterSettings.{field.Name}", "secret_binding_required", "Secret fields must be configured through Secret Bindings, not adapter settings."));
+                errors.Add(new($"adapterSettings.{field.Name}", "secret_binding_required", "Secret fields must be configured through Secret Bindings, not adapter settings."));
     }
 
     private static bool UsesUnsafeSettings(JsonElement settings, ExternalAuthenticationAdapterDescriptor descriptor)
@@ -609,12 +603,11 @@ public sealed partial class IdentityProviderConnectionManagementService(
         left.ValueKind == right.ValueKind && string.Equals(left.GetRawText(), right.GetRawText(), StringComparison.Ordinal);
 
     private static EffectiveIdentityProviderConnection ToEffective(IdentityProviderConnection connection) => new(connection, ConnectionSourceOwnership.Database, ToScope(connection.TenantId), ConnectionValidity.Unknown, false, DatabaseIdentityProviderConnectionSource.SourceName);
-    private static ConnectionScope ToScope(string tenantId) => tenantId == ConnectionScope.HostTenantId ? ConnectionScope.Host : tenantId.Length == 0 ? ConnectionScope.DefaultTenant : new ConnectionScope(ConnectionScopeKind.Tenant, tenantId);
+    private static ConnectionScope ToScope(string tenantId) => tenantId == ConnectionScope.HostTenantId ? ConnectionScope.Host : tenantId.Length == 0 ? ConnectionScope.DefaultTenant : new(ConnectionScopeKind.Tenant, tenantId);
     private static bool CanMutate(string connectionTenantId, string targetTenantId) => connectionTenantId == ConnectionScope.HostTenantId || string.Equals(connectionTenantId, targetTenantId, StringComparison.Ordinal);
     private static bool IsValidScope(string tenantId) => tenantId == ConnectionScope.HostTenantId;
     private static string NormalizeScopeTenantId(string requestedTenantId, string fallback) => requestedTenantId is null ? fallback : requestedTenantId.Trim();
     private static bool IsAllowed(ICollection<string> allowedTypes, string type) => allowedTypes.Count == 0 || allowedTypes.Contains(type, StringComparer.Ordinal);
-    private static bool HasPermission(ClaimsPrincipal actor, string permission) => actor.FindAll(PermissionNames.ClaimType).Any(x => x.Value == PermissionNames.All || x.Value == permission);
     private static ConnectionLifecycle GetLifecycle(IdentityProviderConnection connection) => connection.ArchivedAt.HasValue ? ConnectionLifecycle.Archived : connection.IsEnabled ? ConnectionLifecycle.Enabled : ConnectionLifecycle.Disabled;
     private static bool Matches(EffectiveIdentityProviderConnection connection, ConnectionFilter filter) =>
         (filter.Ownership is null || filter.Ownership == connection.Ownership) &&

--- a/src/modules/Elsa.ExternalAuthentication/Services/IdentityProviderConnectionValidityAssessor.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Services/IdentityProviderConnectionValidityAssessor.cs
@@ -75,7 +75,7 @@ public sealed class IdentityProviderConnectionValidityAssessor(
             .Any(field => !secretStates.TryGetValue(field.Name, out var state) || !state.IsConfigured || !state.IsResolvable))
             return effective with { Validity = ConnectionValidity.Invalid };
 
-        var validation = await adapter.ValidateAsync(new ConnectionValidationContext(
+        var validation = await adapter.ValidateAsync(new(
             effective with { Connection = connection, Validity = ConnectionValidity.Unknown },
             new Dictionary<string, ResolvedSecretBinding>(),
             clock), cancellationToken);
@@ -91,7 +91,7 @@ public sealed class IdentityProviderConnectionValidityAssessor(
         {
             states[name] = _secretBindingResolvers.TryGetValue(binding.ResolverType, out var resolver)
                 ? await resolver.GetStateAsync(binding, cancellationToken)
-                : new SecretBindingState(false, false);
+                : new(false, false);
         }
 
         return states;

--- a/src/modules/Elsa.ExternalAuthentication/Services/InMemoryExternalIdentityProvisioner.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Services/InMemoryExternalIdentityProvisioner.cs
@@ -4,8 +4,6 @@ using Elsa.ExternalAuthentication.Contracts;
 using Elsa.ExternalAuthentication.Models;
 using Elsa.Identity.Contracts;
 using Elsa.Identity.Entities;
-using Elsa.Extensions;
-using Elsa.Identity.Models;
 using Elsa.Workflows;
 
 namespace Elsa.ExternalAuthentication.Services;
@@ -52,7 +50,7 @@ public sealed class InMemoryExternalIdentityProvisioner(
         try
         {
             if (state.Links.TryGetValue(key, out var existingLink))
-                return new ProvisioningResult(existingLink.UserId, existingLink, false);
+                return new(existingLink.UserId, existingLink, false);
 
             var (user, wasCreated) = await _userProvisioningService.ResolveAsync(request, state.ReservedUserNames.Add, cancellationToken);
             var link = new ExternalIdentityLink(
@@ -71,7 +69,7 @@ public sealed class InMemoryExternalIdentityProvisioner(
                 state.Links.Remove(key);
                 throw new InvalidOperationException("The Elsa user was deleted while its external identity link was being created.");
             }
-            return new ProvisioningResult(user.Id, link, wasCreated, true);
+            return new(user.Id, link, wasCreated, true);
         }
         finally
         {
@@ -127,7 +125,7 @@ public sealed class InMemoryExternalIdentityProvisioner(
                 return new ExternalIdentityLinkReplaceResult.Conflict(oldEntry.Value, conflictingLink);
 
             var (user, _) = await _userProvisioningService.ResolveAsync(
-                new ProvisioningRequest(request.TenantId, normalizedConnectionKey, request.Identity, null, request.UserId),
+                new(request.TenantId, normalizedConnectionKey, request.Identity, null, request.UserId),
                 cancellationToken: cancellationToken);
             var replacement = new ExternalIdentityLink(
                 identityGenerator.GenerateId(),

--- a/src/modules/Elsa.ExternalAuthentication/Services/PreviewSignInService.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Services/PreviewSignInService.cs
@@ -42,7 +42,7 @@ public sealed class PreviewSignInService(
         var transaction = new BrokerTransaction
         {
             HandleHash = handles.Hash(handle), Purpose = BrokerTransactionPurpose.Preview, ClientId = adminId,
-            CallbackUri = new Uri($"/external-authentication/previews/{Uri.EscapeDataString(handle)}/authorize", UriKind.Relative),
+            CallbackUri = new($"/external-authentication/previews/{Uri.EscapeDataString(handle)}/authorize", UriKind.Relative),
             ReturnPath = "/", TenantId = tenantId, ConnectionId = connection.Connection.Id,
             ConnectionMaterialRevision = connection.Connection.MaterialRevision, PkceChallenge = string.Empty,
             ExpiresAt = clock.UtcNow.Add(options.Value.Lifetimes.PreviewLifetime)
@@ -71,7 +71,7 @@ public sealed class PreviewSignInService(
         try
         {
             transaction.SecretGenerationFingerprint = SecretFingerprint(secrets);
-            var request = await adapter.CreateAuthorizationRequestAsync(new ExternalAuthorizationContext(connection, secrets, transaction, state, clock), cancellationToken);
+            var request = await adapter.CreateAuthorizationRequestAsync(new(connection, secrets, transaction, state, clock), cancellationToken);
             transaction.ProtectedPayload = dataProtection.CreateProtector("Elsa.ExternalAuthentication.AdapterPayload.v1").Protect(request.ProtectedAdapterState);
             await stateStore.PutAsync(BrokerTransactionPurpose.Preview.ToString(), transaction.HandleHash, transaction, transaction.ExpiresAt, cancellationToken);
             return new PreviewAuthorizeResult.Redirect(request.NavigationUri);
@@ -94,13 +94,13 @@ public sealed class PreviewSignInService(
             var protectedPayload = transaction.ProtectedPayload;
             transaction.ProtectedPayload = dataProtection.CreateProtector("Elsa.ExternalAuthentication.AdapterPayload.v1").Unprotect(protectedPayload);
             ExternalAuthenticationResult authentication;
-            try { authentication = await adapter.AuthenticateCallbackAsync(new ExternalCallbackContext(connection, secrets, transaction, state, parameters, clock), cancellationToken); }
+            try { authentication = await adapter.AuthenticateCallbackAsync(new(connection, secrets, transaction, state, parameters, clock), cancellationToken); }
             finally { transaction.ProtectedPayload = protectedPayload; }
             var existingLink = await provisioner.FindLinkAsync(transaction.TenantId, ConnectionRevisionCalculator.NormalizeKey(connection.Connection.Key), authentication.Identity, cancellationToken);
             var decision = existingLink is null ? await DescribePolicyAsync(connection, authentication, cancellationToken) : "would_sign_in_existing_link";
             var grants = existingLink is null
-                ? new PermissionGrantResult([], [new PermissionGrantWarning("user_resolution_required", "Permission grants require an existing Elsa user link.")])
-                : await permissionGrants.ResolveAsync(new PermissionGrantResolutionContext(transaction.TenantId, existingLink.UserId, connection, authentication.Identity, authentication.ProjectedClaims), cancellationToken);
+                ? new([], [new("user_resolution_required", "Permission grants require an existing Elsa user link.")])
+                : await permissionGrants.ResolveAsync(new(transaction.TenantId, existingLink.UserId, connection, authentication.Identity, authentication.ProjectedClaims), cancellationToken);
             var result = new PreviewResult(handles.Hash(transaction.ClientState), transaction.ClientId, transaction.TenantId, connection.Connection.Id, connection.Connection.MaterialRevision,
                 authentication.Identity.Issuer, Mask(authentication.Identity.Subject), ExternalAuthenticationRedactor.RedactProjectedClaims(authentication.ProjectedClaims, connection.Connection.ClaimProjection.RedactedClaimTypes), decision, grants.Grants, [.. authentication.Warnings, .. grants.Warnings.Select(x => x.Message)], transaction.ExpiresAt, null);
             await results.SaveAsync(result, cancellationToken);
@@ -124,7 +124,7 @@ public sealed class PreviewSignInService(
     {
         var selection = connection.Connection.UnlinkedPolicy ?? new PolicySelection(options.Value.UnlinkedIdentityPolicy.DefaultType, 1, default);
         if (!_policies.TryGetValue(selection.Type, out var policy)) return "unlinked_policy_unavailable";
-        var decision = await policy.EvaluateAsync(new UnlinkedIdentityContext(connection.Connection.TenantId, connection, authentication.Identity, authentication.ProjectedClaims, selection.Settings), cancellationToken);
+        var decision = await policy.EvaluateAsync(new(connection.Connection.TenantId, connection, authentication.Identity, authentication.ProjectedClaims, selection.Settings), cancellationToken);
         return decision switch
         {
             UnlinkedIdentityDecision.CreateUser => "would_create_user_and_link",

--- a/src/modules/Elsa.ExternalAuthentication/Services/ProviderHttpClientFactory.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Services/ProviderHttpClientFactory.cs
@@ -1,5 +1,4 @@
 using System.Net;
-using System.Net.Http;
 using System.Text;
 using Elsa.ExternalAuthentication.Options;
 using Elsa.ExternalAuthentication.Validation;
@@ -40,7 +39,7 @@ public sealed class ProviderHttpClientFactory : IProviderHttpClientFactory, IDis
         else
             handler.ConnectCallback = (context, cancellationToken) => connectionFactory.ConnectAsync(context.DnsEndPoint, cancellationToken);
 
-        invoker = new HttpMessageInvoker(handler, disposeHandler: true);
+        invoker = new(handler, disposeHandler: true);
     }
 
     /// <summary>
@@ -66,7 +65,7 @@ public interface IProviderHttpClient
 
 public sealed class ProviderHttpClient(HttpMessageInvoker invoker, OutboundDestinationValidator destinationValidator, IOptions<ExternalAuthenticationOptions> options) : IProviderHttpClient
 {
-    public ValueTask<ProviderHttpResponse> GetAsync(Uri uri, ProviderResponseKind kind, CancellationToken cancellationToken = default) => SendAsync(uri, kind, address => new HttpRequestMessage(HttpMethod.Get, address), cancellationToken);
+    public ValueTask<ProviderHttpResponse> GetAsync(Uri uri, ProviderResponseKind kind, CancellationToken cancellationToken = default) => SendAsync(uri, kind, address => new(HttpMethod.Get, address), cancellationToken);
 
     public ValueTask<ProviderHttpResponse> PostFormAsync(Uri uri, IReadOnlyDictionary<string, string> values, IReadOnlyDictionary<string, string>? headers, ProviderResponseKind kind, CancellationToken cancellationToken = default) =>
         SendAsync(uri, kind, address => CreateFormRequest(address, values, headers), cancellationToken);
@@ -100,14 +99,14 @@ public sealed class ProviderHttpClient(HttpMessageInvoker invoker, OutboundDesti
                     if (kind is ProviderResponseKind.Token or ProviderResponseKind.UserInfo || response.Headers.Location is null || redirects++ >= options.Value.ProviderEgress.MaximumRedirects)
                         throw new ProviderHttpException(ProviderHttpFailure.RedirectRejected);
 
-                    current = new Uri(current, response.Headers.Location);
+                    current = new(current, response.Headers.Location);
                     continue;
                 }
 
                 if (!response.IsSuccessStatusCode)
-                    return new ProviderHttpResponse(response.StatusCode, []);
+                    return new(response.StatusCode, []);
 
-                return new ProviderHttpResponse(response.StatusCode, await ReadResponseBodyAsync(response, kind, timeout.Token));
+                return new(response.StatusCode, await ReadResponseBodyAsync(response, kind, timeout.Token));
             }
         }
         catch (OutboundDestinationException)

--- a/src/modules/Elsa.ExternalAuthentication/ShellFeatures/ExternalAuthenticationShellFeature.cs
+++ b/src/modules/Elsa.ExternalAuthentication/ShellFeatures/ExternalAuthenticationShellFeature.cs
@@ -4,7 +4,6 @@ using CShells.Features;
 using Elsa.Extensions;
 using Elsa.ExternalAuthentication.Options;
 using JetBrains.Annotations;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Elsa.ExternalAuthentication.ShellFeatures;

--- a/src/modules/Elsa.ExternalAuthentication/Stores/InMemory/InMemoryAuthorizationGrantStore.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Stores/InMemory/InMemoryAuthorizationGrantStore.cs
@@ -18,7 +18,7 @@ public sealed class InMemoryAuthorizationGrantStore(ISystemClock clock) : IAutho
             if (_entries.ContainsKey(grant.CodeHash))
                 throw new InvalidOperationException("An authorization grant already exists for the supplied code hash.");
 
-            _entries[grant.CodeHash] = new GrantEntry(Clone(grant));
+            _entries[grant.CodeHash] = new(Clone(grant));
         }
 
         return ValueTask.CompletedTask;

--- a/src/modules/Elsa.ExternalAuthentication/Stores/InMemory/InMemoryExternalAuthenticationStateStore.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Stores/InMemory/InMemoryExternalAuthenticationStateStore.cs
@@ -19,7 +19,7 @@ public sealed class InMemoryExternalAuthenticationStateStore(ISystemClock clock)
             if (_entries.ContainsKey(key))
                 throw new InvalidOperationException("A state entry already exists for the supplied purpose and handle.");
 
-            _entries[key] = new StateEntry(value, expiresAt);
+            _entries[key] = new(value, expiresAt);
         }
 
         return ValueTask.CompletedTask;

--- a/src/modules/Elsa.ExternalAuthentication/Stores/InMemory/InMemoryPreviewResultStore.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Stores/InMemory/InMemoryPreviewResultStore.cs
@@ -18,7 +18,7 @@ public sealed class InMemoryPreviewResultStore(ISystemClock clock) : IPreviewRes
             if (_entries.ContainsKey(result.HandleHash))
                 throw new InvalidOperationException("A preview result already exists for the supplied handle.");
 
-            _entries[result.HandleHash] = new PreviewEntry(result);
+            _entries[result.HandleHash] = new(result);
         }
 
         return ValueTask.CompletedTask;

--- a/src/modules/Elsa.ExternalAuthentication/Validation/ExternalAuthenticationOptionsValidator.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Validation/ExternalAuthenticationOptionsValidator.cs
@@ -1,4 +1,3 @@
-using Elsa.ExternalAuthentication.Contracts;
 using Elsa.ExternalAuthentication.Models;
 using Elsa.ExternalAuthentication.Options;
 using Elsa.ExternalAuthentication.Policies;

--- a/src/modules/Elsa.ExternalAuthentication/Validation/ExternalAuthenticationOptionsValidator.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Validation/ExternalAuthenticationOptionsValidator.cs
@@ -1,3 +1,4 @@
+using Elsa.Authorization;
 using Elsa.ExternalAuthentication.Models;
 using Elsa.ExternalAuthentication.Options;
 using Elsa.ExternalAuthentication.Policies;
@@ -33,8 +34,36 @@ public sealed class ExternalAuthenticationOptionsValidator(
         ValidateRateLimits(options.RateLimits, failures);
         ValidateProviderEgress(options.ProviderEgress, failures);
         ValidateHandleHashing(options.HandleHashing, failures);
+        ValidatePermissionGrantBoundary(options.PermissionGrants, failures);
 
         return failures.Count == 0 ? ValidateOptionsResult.Success : ValidateOptionsResult.Fail(failures);
+    }
+
+    /// <summary>
+    /// Rejects a grant boundary that cannot be parsed.
+    /// </summary>
+    /// <remarks>
+    /// The boundary is security configuration, so a malformed entry has no safe silent reading: an unparseable
+    /// allow entry would leave the list empty, which means unrestricted, and an unparseable deny entry would
+    /// quietly stop denying what it names. Failing startup puts the mistake in front of whoever can fix it
+    /// instead of leaving it to be discovered from an issued token.
+    /// </remarks>
+    private static void ValidatePermissionGrantBoundary(PermissionGrantOptions? permissionGrants, ICollection<string> failures)
+    {
+        if (permissionGrants is null)
+            return;
+
+        ValidatePermissionPatterns(permissionGrants.AllowedPermissions, "AllowedPermissions", failures);
+        ValidatePermissionPatterns(permissionGrants.DeniedPermissions, "DeniedPermissions", failures);
+    }
+
+    private static void ValidatePermissionPatterns(IEnumerable<string>? permissions, string listName, ICollection<string> failures)
+    {
+        foreach (var permission in permissions ?? [])
+        {
+            if (!Permission.TryParse(permission, out _))
+                failures.Add($"'{permission}' in ExternalAuthentication:PermissionGrants:{listName} is not a well-formed permission. Expected '{{resource}}:{{verb}}', for example 'workflows/*:delete'.");
+        }
     }
 
     private static void ValidateExternalCallbackBaseUri(RedirectValidationOptions? redirects, ICollection<string> failures)

--- a/src/modules/Elsa.ExternalAuthentication/Validation/ExternalAuthenticationOptionsValidator.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Validation/ExternalAuthenticationOptionsValidator.cs
@@ -59,11 +59,8 @@ public sealed class ExternalAuthenticationOptionsValidator(
 
     private static void ValidatePermissionPatterns(IEnumerable<string>? permissions, string listName, ICollection<string> failures)
     {
-        foreach (var permission in permissions ?? [])
-        {
-            if (!Permission.TryParse(permission, out _))
-                failures.Add($"'{permission}' in ExternalAuthentication:PermissionGrants:{listName} is not a well-formed permission. Expected '{{resource}}:{{verb}}', for example 'workflows/*:delete'.");
-        }
+        foreach (var permission in (permissions ?? []).Where(x => !Permission.TryParse(x, out _)))
+            failures.Add($"'{permission}' in ExternalAuthentication:PermissionGrants:{listName} is not a well-formed permission. Expected '{{resource}}:{{verb}}', for example 'workflows/*:delete'.");
     }
 
     private static void ValidateExternalCallbackBaseUri(RedirectValidationOptions? redirects, ICollection<string> failures)

--- a/src/modules/Elsa.ExternalAuthentication/Validation/ExternalCallbackBaseUriValidator.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Validation/ExternalCallbackBaseUriValidator.cs
@@ -1,5 +1,3 @@
-using Elsa.ExternalAuthentication.Options;
-
 namespace Elsa.ExternalAuthentication.Validation;
 
 /// <summary>Validates the deployment-owned public callback base used by upstream identity providers.</summary>

--- a/src/modules/Elsa.Identity/Endpoints/Applications/Create/Endpoint.cs
+++ b/src/modules/Elsa.Identity/Endpoints/Applications/Create/Endpoint.cs
@@ -11,33 +11,17 @@ namespace Elsa.Identity.Endpoints.Applications.Create;
 /// An endpoint that creates a new application. Requires the <code>SecurityRoot</code> policy.
 /// </summary>
 [PublicAPI]
-internal class Create : ElsaEndpoint<Request, Response>
+internal class Create(
+    IIdentityGenerator identityGenerator,
+    IClientIdGenerator clientIdGenerator,
+    ISecretGenerator secretGenerator,
+    IApiKeyGenerator apiKeyGenerator,
+    ISecretHasher secretHasher,
+    IApplicationStore applicationStore,
+    IRoleStore roleStore)
+    : ElsaEndpoint<Request, Response>
 {
-    private readonly IIdentityGenerator _identityGenerator;
-    private readonly IClientIdGenerator _clientIdGenerator;
-    private readonly ISecretGenerator _secretGenerator;
-    private readonly IApiKeyGenerator _apiKeyGenerator;
-    private readonly ISecretHasher _secretHasher;
-    private readonly IApplicationStore _applicationStore;
-    private readonly IRoleStore _roleStore;
-
-    public Create(
-        IIdentityGenerator identityGenerator,
-        IClientIdGenerator clientIdGenerator,
-        ISecretGenerator secretGenerator,
-        IApiKeyGenerator apiKeyGenerator,
-        ISecretHasher secretHasher,
-        IApplicationStore applicationStore,
-        IRoleStore roleStore)
-    {
-        _identityGenerator = identityGenerator;
-        _clientIdGenerator = clientIdGenerator;
-        _secretGenerator = secretGenerator;
-        _apiKeyGenerator = apiKeyGenerator;
-        _secretHasher = secretHasher;
-        _applicationStore = applicationStore;
-        _roleStore = roleStore;
-    }
+    private readonly IRoleStore _roleStore = roleStore;
 
     /// <inheritdoc />
     public override void Configure()
@@ -50,12 +34,12 @@ internal class Create : ElsaEndpoint<Request, Response>
     /// <inheritdoc />
     public override async Task HandleAsync(Request request, CancellationToken cancellationToken)
     {
-        var id = _identityGenerator.GenerateId();
-        var clientId = await _clientIdGenerator.GenerateAsync(cancellationToken);
-        var clientSecret = _secretGenerator.Generate();
-        var hashedClientSecret = _secretHasher.HashSecret(clientSecret);
-        var apiKey = _apiKeyGenerator.Generate(clientId);
-        var hashedApiKey = _secretHasher.HashSecret(apiKey);
+        var id = identityGenerator.GenerateId();
+        var clientId = await clientIdGenerator.GenerateAsync(cancellationToken);
+        var clientSecret = secretGenerator.Generate();
+        var hashedClientSecret = secretHasher.HashSecret(clientSecret);
+        var apiKey = apiKeyGenerator.Generate(clientId);
+        var hashedApiKey = secretHasher.HashSecret(apiKey);
 
         var application = new Application
         {
@@ -69,7 +53,7 @@ internal class Create : ElsaEndpoint<Request, Response>
             Roles = request.Roles ?? new List<string>()
         };
 
-        await _applicationStore.SaveAsync(application, cancellationToken);
+        await applicationStore.SaveAsync(application, cancellationToken);
 
         var response = new Response(
             id, 

--- a/src/modules/Elsa.Identity/Endpoints/Login/Endpoint.cs
+++ b/src/modules/Elsa.Identity/Endpoints/Login/Endpoint.cs
@@ -6,17 +6,8 @@ using JetBrains.Annotations;
 namespace Elsa.Identity.Endpoints.Login;
 
 [PublicAPI]
-internal class Login : Endpoint<Request, LoginResponse>
+internal class Login(IUserCredentialsValidator userCredentialsValidator, IAccessTokenIssuer tokenIssuer) : Endpoint<Request, LoginResponse>
 {
-    private readonly IUserCredentialsValidator _userCredentialsValidator;
-    private readonly IAccessTokenIssuer _tokenIssuer;
-
-    public Login(IUserCredentialsValidator userCredentialsValidator, IAccessTokenIssuer tokenIssuer)
-    {
-        _userCredentialsValidator = userCredentialsValidator;
-        _tokenIssuer = tokenIssuer;
-    }
-
     /// <inheritdoc />
     public override void Configure()
     {
@@ -27,12 +18,12 @@ internal class Login : Endpoint<Request, LoginResponse>
     /// <inheritdoc />
     public override async Task<LoginResponse> ExecuteAsync(Request request, CancellationToken cancellationToken)
     {
-        var user = await _userCredentialsValidator.ValidateAsync(request.Username.Trim(), request.Password.Trim(), cancellationToken);
+        var user = await userCredentialsValidator.ValidateAsync(request.Username.Trim(), request.Password.Trim(), cancellationToken);
 
         if (user == null)
             return new LoginResponse(false, null, null);
 
-        var tokens = await _tokenIssuer.IssueTokensAsync(user, cancellationToken);
+        var tokens = await tokenIssuer.IssueTokensAsync(user, cancellationToken);
 
         return new LoginResponse(true, tokens.AccessToken, tokens.RefreshToken);
     }

--- a/src/modules/Elsa.Identity/Endpoints/Secrets/Hash/Endpoint.cs
+++ b/src/modules/Elsa.Identity/Endpoints/Secrets/Hash/Endpoint.cs
@@ -8,15 +8,8 @@ namespace Elsa.Identity.Endpoints.Secrets.Hash;
 /// Hash a given password. Requires the <code>SecurityRoot</code> policy.
 /// </summary>
 [PublicAPI]
-internal class Hash : Endpoint<Request, Response>
+internal class Hash(ISecretHasher secretHasher) : Endpoint<Request, Response>
 {
-    private readonly ISecretHasher _secretHasher;
-
-    public Hash(ISecretHasher secretHasher)
-    {
-        _secretHasher = secretHasher;
-    }
-
     /// <inheritdoc />
     public override void Configure()
     {
@@ -27,7 +20,7 @@ internal class Hash : Endpoint<Request, Response>
     /// <inheritdoc />
     public override Task<Response> ExecuteAsync(Request request, CancellationToken cancellationToken)
     {
-        var hashedPassword = _secretHasher.HashSecret(request.Secret);
+        var hashedPassword = secretHasher.HashSecret(request.Secret);
         var response = new Response(hashedPassword.EncodeSecret(), hashedPassword.EncodeSalt());
 
         return Task.FromResult(response);

--- a/src/modules/Elsa.Identity/Endpoints/Secrets/Hash/Models.cs
+++ b/src/modules/Elsa.Identity/Endpoints/Secrets/Hash/Models.cs
@@ -7,14 +7,8 @@ internal class Request
     [Required] public string Secret { get; set; } = null!;
 }
 
-internal class Response
+internal class Response(string hashedSecret, string salt)
 {
-    public Response(string hashedSecret, string salt)
-    {
-        HashedSecret = hashedSecret;
-        Salt = salt;
-    }
-
-    public string HashedSecret { get; set; }
-    public string Salt { get; set; }
+    public string HashedSecret { get; set; } = hashedSecret;
+    public string Salt { get; set; } = salt;
 }

--- a/src/modules/Elsa.Identity/Endpoints/Users/Create/Endpoint.cs
+++ b/src/modules/Elsa.Identity/Endpoints/Users/Create/Endpoint.cs
@@ -1,6 +1,7 @@
 using Elsa.Authorization;
 using Elsa.Abstractions;
 using Elsa.Identity.Contracts;
+using Elsa.Identity.Permissions;
 using JetBrains.Annotations;
 
 namespace Elsa.Identity.Endpoints.Users.Create;
@@ -15,7 +16,7 @@ internal class Create(IUserManager userManager, IRoleAuthorizationService roleAu
     public override void Configure()
     {
         Post("/identity/users");
-        RequirePermission(Elsa.Identity.Permissions.IdentityPermissions.Users, CoreVerbs.Create);
+        RequirePermission(IdentityPermissions.Users, CoreVerbs.Create);
     }
 
     /// <inheritdoc />

--- a/src/modules/Elsa.Identity/Models/LoginResponse.cs
+++ b/src/modules/Elsa.Identity/Models/LoginResponse.cs
@@ -1,15 +1,8 @@
 namespace Elsa.Identity.Models;
 
-public class LoginResponse
+public class LoginResponse(bool isAuthenticated, string? accessToken, string? refreshToken)
 {
-    public LoginResponse(bool isAuthenticated, string? accessToken, string? refreshToken)
-    {
-        IsAuthenticated = isAuthenticated;
-        AccessToken = accessToken;
-        RefreshToken = refreshToken;
-    }
-
-    public bool IsAuthenticated { get; }
-    public string? AccessToken { get; }
-    public string? RefreshToken { get; }
+    public bool IsAuthenticated { get; } = isAuthenticated;
+    public string? AccessToken { get; } = accessToken;
+    public string? RefreshToken { get; } = refreshToken;
 }

--- a/src/modules/Elsa.Identity/Services/RoleManager.cs
+++ b/src/modules/Elsa.Identity/Services/RoleManager.cs
@@ -8,17 +8,8 @@ namespace Elsa.Identity.Services;
 /// <summary>
 /// Default implementation of <see cref="IRoleManager"/>.
 /// </summary>
-public class RoleManager : IRoleManager
+public class RoleManager(IRoleStore roleStore, IRoleProvider roleProvider) : IRoleManager
 {
-    private readonly IRoleStore _roleStore;
-    private readonly IRoleProvider _roleProvider;
-
-    public RoleManager(IRoleStore roleStore, IRoleProvider roleProvider)
-    {
-        _roleStore = roleStore;
-        _roleProvider = roleProvider;
-    }
-
     /// <inheritdoc />
     public async Task<CreateRoleResult> CreateRoleAsync(
         string name,
@@ -38,18 +29,18 @@ public class RoleManager : IRoleManager
             Permissions = permissions ?? new List<string>()
         };
 
-        await _roleStore.SaveAsync(role, cancellationToken);
+        await roleStore.SaveAsync(role, cancellationToken);
 
         return new CreateRoleResult(role);
     }
 
     private async Task<bool> RoleExistsAsync(string roleId, CancellationToken cancellationToken)
     {
-        var storedRole = await _roleStore.FindAsync(new() { Id = roleId }, cancellationToken);
+        var storedRole = await roleStore.FindAsync(new() { Id = roleId }, cancellationToken);
         if (storedRole != null)
             return true;
 
-        var providedRoles = await _roleProvider.FindManyAsync(new() { Id = roleId }, cancellationToken);
+        var providedRoles = await roleProvider.FindManyAsync(new() { Id = roleId }, cancellationToken);
         return providedRoles.Any(x => x.Id == roleId);
     }
 }

--- a/src/modules/Elsa.Identity/Services/UserManager.cs
+++ b/src/modules/Elsa.Identity/Services/UserManager.cs
@@ -9,28 +9,14 @@ namespace Elsa.Identity.Services;
 /// <summary>
 /// Default implementation of <see cref="IUserManager"/>.
 /// </summary>
-public class UserManager : IUserManager
+public class UserManager(
+    IIdentityGenerator identityGenerator,
+    ISecretGenerator secretGenerator,
+    ISecretHasher secretHasher,
+    IUserStore userStore,
+    ITenantAccessor tenantAccessor)
+    : IUserManager
 {
-    private readonly IIdentityGenerator _identityGenerator;
-    private readonly ISecretGenerator _secretGenerator;
-    private readonly ISecretHasher _secretHasher;
-    private readonly IUserStore _userStore;
-    private readonly ITenantAccessor _tenantAccessor;
-
-    public UserManager(
-        IIdentityGenerator identityGenerator,
-        ISecretGenerator secretGenerator,
-        ISecretHasher secretHasher,
-        IUserStore userStore,
-        ITenantAccessor tenantAccessor)
-    {
-        _identityGenerator = identityGenerator;
-        _secretGenerator = secretGenerator;
-        _secretHasher = secretHasher;
-        _userStore = userStore;
-        _tenantAccessor = tenantAccessor;
-    }
-
     /// <inheritdoc />
     public async Task<CreateUserResult> CreateUserAsync(
         string name,
@@ -38,9 +24,9 @@ public class UserManager : IUserManager
         ICollection<string>? roles = null,
         CancellationToken cancellationToken = default)
     {
-        var id = _identityGenerator.GenerateId();
-        var plainTextPassword = string.IsNullOrWhiteSpace(password) ? _secretGenerator.Generate() : password.Trim();
-        var hashedPassword = _secretHasher.HashSecret(plainTextPassword);
+        var id = identityGenerator.GenerateId();
+        var plainTextPassword = string.IsNullOrWhiteSpace(password) ? secretGenerator.Generate() : password.Trim();
+        var hashedPassword = secretHasher.HashSecret(plainTextPassword);
 
         var user = new User
         {
@@ -48,13 +34,13 @@ public class UserManager : IUserManager
             Name = name,
             // Set explicitly rather than relying on the Entity Framework saving handler, which does not run
             // on the in-memory path and left users unassigned there.
-            TenantId = _tenantAccessor.TenantId,
+            TenantId = tenantAccessor.TenantId,
             Roles = roles ?? new List<string>(),
             HashedPassword = hashedPassword.EncodeSecret(),
             HashedPasswordSalt = hashedPassword.EncodeSalt()
         };
 
-        await _userStore.SaveAsync(user, cancellationToken);
+        await userStore.SaveAsync(user, cancellationToken);
 
         return new CreateUserResult(user, plainTextPassword);
     }

--- a/test/integration/Elsa.ExternalAuthentication.IntegrationTests/Broker/BrokerSecurityTests.cs
+++ b/test/integration/Elsa.ExternalAuthentication.IntegrationTests/Broker/BrokerSecurityTests.cs
@@ -329,7 +329,7 @@ public class BrokerSecurityTests
         roles.FindManyAsync(Arg.Any<RoleFilter>(), Arg.Any<CancellationToken>()).Returns(ValueTask.FromResult<IEnumerable<Role>>([]));
         var tokens = Substitute.For<IElsaTokenService>();
         tokens.IssueAccessTokenAsync(Arg.Any<TokenIssuanceContext>(), Arg.Any<CancellationToken>()).Returns(ValueTask.FromResult(new IssuedAccessToken("access", clock.UtcNow.AddHours(1))));
-        var issuer = new DefaultExternalAuthenticationTokenIssuer(store, registry, [], users, roles, tokens, new DefaultTenantAccessor(), clock);
+        var issuer = new DefaultExternalAuthenticationTokenIssuer(store, registry, [], users, roles, tokens, new DefaultTenantAccessor(), clock, Microsoft.Extensions.Options.Options.Create(new ExternalAuthenticationOptions()));
         var session = new ExternalAuthenticationSession { Id = "session-a", AuthenticationClientId = "studio", TenantId = "tenant-a", UserId = "user-a", ConnectionKey = "contoso", ConnectionMaterialRevision = "revision-a", SecretGenerationFingerprint = Convert.ToHexString(System.Security.Cryptography.SHA256.HashData([])), Issuer = "issuer", SubjectHash = "subject", StartedAt = clock.UtcNow, LastRefreshedAt = clock.UtcNow, ExpiresAt = clock.UtcNow.AddHours(1), RefreshExpiresAt = clock.UtcNow.AddHours(1) };
 
         var first = await issuer.IssueAsync(session);

--- a/test/integration/Elsa.ExternalAuthentication.IntegrationTests/Connections/ConnectionManagementTests.cs
+++ b/test/integration/Elsa.ExternalAuthentication.IntegrationTests/Connections/ConnectionManagementTests.cs
@@ -1,3 +1,4 @@
+using Elsa.Extensions;
 using System.Net;
 using System.Net.Http.Json;
 using System.Security.Claims;
@@ -56,6 +57,9 @@ public class ConnectionManagementTests : IAsyncLifetime
             options.Filter = endpoint => endpoint.Namespace == "Elsa.ExternalAuthentication.Endpoints.Connections";
         });
         builder.Services.AddAuthorization();
+        // This fixture wires the module's services by hand rather than through
+        // AddExternalAuthenticationServices, so it has to register the permission evaluator the way a host does.
+        builder.Services.AddElsaAuthorization();
         builder.Services.Configure<ExternalAuthenticationOptions>(options =>
         {
             options.EnableDatabaseConnections = true;

--- a/test/integration/Elsa.ExternalAuthentication.IntegrationTests/Operations/PreviewEndpointContractTests.cs
+++ b/test/integration/Elsa.ExternalAuthentication.IntegrationTests/Operations/PreviewEndpointContractTests.cs
@@ -1,3 +1,4 @@
+using Elsa.Authorization;
 using System.Net;
 using System.Text.Json;
 using Elsa.Common;
@@ -63,6 +64,7 @@ public class PreviewEndpointContractTests : IAsyncLifetime
             [],
             [],
             null!,
+            new PermissionEvaluator(),
             null!,
             clock,
             options,

--- a/test/integration/Elsa.ExternalAuthentication.IntegrationTests/Operations/RecoveryAndRevocationTests.cs
+++ b/test/integration/Elsa.ExternalAuthentication.IntegrationTests/Operations/RecoveryAndRevocationTests.cs
@@ -1,3 +1,4 @@
+using Elsa.Authorization;
 using System.Security.Claims;
 using Elsa.ExternalAuthentication.Contracts;
 using Elsa.ExternalAuthentication.Models;
@@ -17,12 +18,12 @@ public class RecoveryAndRevocationTests
         var registry = Substitute.For<IIdentityProviderConnectionRegistry>();
         registry.GetAsync("tenant-a", Arg.Any<CancellationToken>()).Returns(ValueTask.FromResult(new EffectiveConnectionRegistry([], [], "1")));
         var options = Microsoft.Extensions.Options.Options.Create(new ExternalAuthenticationOptions { LocalLogin = new LocalLoginMethodOptions { IsEnabled = false } });
-        var guard = new FinalLoginPathGuard(registry, options);
+        var guard = new FinalLoginPathGuard(registry, options, new PermissionEvaluator());
         var existing = Connection(enabled: true);
         var disabled = Connection(enabled: false);
 
         Assert.Equal(FinalLoginPathGuardResult.Denied, await guard.AuthorizeAsync(existing, disabled, "tenant-a", new ClaimsPrincipal(new ClaimsIdentity()), false));
-        var privileged = new ClaimsPrincipal(new ClaimsIdentity([new Claim(Elsa.PermissionNames.ClaimType, Elsa.ExternalAuthentication.Permissions.ExternalAuthenticationPermissions.ProviderTrustUnsafe)]));
+        var privileged = new ClaimsPrincipal(new ClaimsIdentity([new Claim(Elsa.PermissionNames.ClaimType, options.Value.FinalLoginPathGuard.PrivilegedOverridePermission)]));
         Assert.Equal(FinalLoginPathGuardResult.Allowed, await guard.AuthorizeAsync(existing, disabled, "tenant-a", privileged, true));
         options.Value.FinalLoginPathGuard.HasBreakGlassAuthentication = true;
         Assert.Equal(FinalLoginPathGuardResult.Allowed, await guard.AuthorizeAsync(existing, disabled, "tenant-a", new ClaimsPrincipal(), false));

--- a/test/integration/Elsa.ExternalAuthentication.IntegrationTests/Permissions/PermissionDelegationTests.cs
+++ b/test/integration/Elsa.ExternalAuthentication.IntegrationTests/Permissions/PermissionDelegationTests.cs
@@ -1,5 +1,6 @@
 using System.Security.Claims;
 using System.Text.Json;
+using Elsa.Authorization;
 using Elsa.ExternalAuthentication.Models;
 using Elsa.ExternalAuthentication.Options;
 using Elsa.ExternalAuthentication.Permissions;
@@ -13,14 +14,14 @@ public class PermissionDelegationTests
     [Fact]
     public async Task OrdinaryAdministratorMustPossessDelegationPermissionAndEveryGrantedPermission()
     {
-        var authorizer = new DefaultPermissionDelegationAuthorizer(Microsoft.Extensions.Options.Options.Create(new ExternalAuthenticationOptions()));
+        var authorizer = new DefaultPermissionDelegationAuthorizer(Microsoft.Extensions.Options.Options.Create(new ExternalAuthenticationOptions()), PermissionEvaluator.Shared);
         var selection = Selection("reports:view");
 
         var withoutGrantedPermission = await authorizer.AuthorizeAsync(
-            Actor(ExternalAuthenticationPermissions.PermissionsDelegate),
+            Actor(DelegatePermission),
             [selection]);
         var withGrantedPermission = await authorizer.AuthorizeAsync(
-            Actor(ExternalAuthenticationPermissions.PermissionsDelegate, "reports:view"),
+            Actor(DelegatePermission, "reports:view"),
             [selection]);
 
         Assert.False(withoutGrantedPermission.IsAuthorized);
@@ -33,15 +34,18 @@ public class PermissionDelegationTests
     {
         var options = new ExternalAuthenticationOptions();
         options.PermissionGrants.DeniedPermissions = ["reports:view"];
-        var authorizer = new DefaultPermissionDelegationAuthorizer(Microsoft.Extensions.Options.Options.Create(options));
+        var authorizer = new DefaultPermissionDelegationAuthorizer(Microsoft.Extensions.Options.Options.Create(options), PermissionEvaluator.Shared);
 
         var result = await authorizer.AuthorizeAsync(
-            Actor(ExternalAuthenticationPermissions.PermissionsDelegateUnrestricted, PermissionNames.All),
+            Actor(DelegateUnrestrictedPermission, PermissionNames.All),
             [Selection("reports:view")]);
 
         Assert.False(result.IsAuthorized);
         Assert.Equal(["reports:view"], result.UnauthorizedPermissions);
     }
+
+    private const string DelegatePermission = $"{ExternalAuthenticationResourcePermissions.PermissionGrants}:{ExternalAuthenticationVerbs.Delegate}";
+    private const string DelegateUnrestrictedPermission = $"{ExternalAuthenticationResourcePermissions.PermissionGrants}:{ExternalAuthenticationVerbs.DelegateUnrestricted}";
 
     private static GrantSourceSelection Selection(string permission) => new(
         "claim-mapping",

--- a/test/integration/Elsa.ExternalAuthentication.IntegrationTests/Sessions/ExternalRefreshPermissionTests.cs
+++ b/test/integration/Elsa.ExternalAuthentication.IntegrationTests/Sessions/ExternalRefreshPermissionTests.cs
@@ -4,6 +4,7 @@ using Elsa.Common.Multitenancy;
 using Elsa.ExternalAuthentication.Contracts;
 using Elsa.ExternalAuthentication.IntegrationTests.Broker;
 using Elsa.ExternalAuthentication.Models;
+using Elsa.ExternalAuthentication.Options;
 using Elsa.ExternalAuthentication.Services;
 using Elsa.ExternalAuthentication.Stores.InMemory;
 using Elsa.Identity.Contracts;
@@ -106,7 +107,7 @@ public class ExternalRefreshPermissionTests
                 Arg.Do<TokenIssuanceContext>(context => issuanceContexts.Add(context)),
                 Arg.Any<CancellationToken>())
             .Returns(_ => ValueTask.FromResult(new IssuedAccessToken($"access-{issuanceContexts.Count}", clock.UtcNow.AddHours(1))));
-        var issuer = new DefaultExternalAuthenticationTokenIssuer(sessionStore, registry, [], users, roles, tokenService, tenantAccessor, clock);
+        var issuer = new DefaultExternalAuthenticationTokenIssuer(sessionStore, registry, [], users, roles, tokenService, tenantAccessor, clock, Microsoft.Extensions.Options.Options.Create(new ExternalAuthenticationOptions()));
         var externalGrant = new PermissionGrant("reports:view", "claim-mapping", "department:engineering");
         var session = new ExternalAuthenticationSession
         {
@@ -141,6 +142,71 @@ public class ExternalRefreshPermissionTests
         Assert.Equal(["workflows:manage", "reports:view"], issuanceContexts[1].Permissions);
         Assert.DoesNotContain("*", issuanceContexts[1].Permissions);
         Assert.Equal("session-a", issuanceContexts[1].ExternalAuthenticationSessionId);
+    }
+
+    [Fact]
+    public async Task DeploymentDenyBoundaryAppliesToRoleDerivedPermissionsAtIssuance()
+    {
+        // A role permission excluded by the boundary during grant resolution used to reappear here, because
+        // issuance concatenated the same roles' permissions raw. That made the deny list unenforceable for
+        // anything a role carried, whether or not the connection selected the elsa-roles grant source.
+        var options = new ExternalAuthenticationOptions();
+        options.PermissionGrants.DeniedPermissions = ["workflows/*:delete"];
+
+        var contexts = await IssueWithAsync(options, rolePermissions: ["workflows/definitions:delete", "workflows/definitions:view"]);
+
+        // The denied role permission is gone; the role's other permission and the undenied external grant stay.
+        Assert.DoesNotContain("workflows/definitions:delete", contexts.Single().Permissions);
+        Assert.Equal(["workflows/definitions:view", "reports:view"], contexts.Single().Permissions);
+    }
+
+    [Fact]
+    public async Task RolePermissionsAreUnaffectedWhenNoBoundaryIsConfigured()
+    {
+        // The default is both lists empty, and that must stay a no-op: an external login should not quietly
+        // hand back less than the user's roles grant just because issuance now consults the boundary.
+        var contexts = await IssueWithAsync(new ExternalAuthenticationOptions(), rolePermissions: ["workflows/definitions:delete", "*"]);
+
+        Assert.Equal(["workflows/definitions:delete", "*", "reports:view"], contexts.Single().Permissions);
+    }
+
+    private static async Task<IReadOnlyList<TokenIssuanceContext>> IssueWithAsync(ExternalAuthenticationOptions options, string[] rolePermissions)
+    {
+        var clock = new TestClock();
+        var sessionStore = new InMemoryExternalAuthenticationSessionStore(clock);
+        var connection = new IdentityProviderConnection
+        {
+            Id = "connection-a", TenantId = "tenant-a", Key = "contoso", AdapterType = "oidc",
+            AdapterSettingsVersion = 1, DisplayName = "Contoso", MaterialRevision = "revision-a"
+        };
+        var effective = new EffectiveIdentityProviderConnection(connection, ConnectionSourceOwnership.Configuration, new ConnectionScope(ConnectionScopeKind.Tenant, "tenant-a"), ConnectionValidity.Valid, false, "configuration");
+        var registry = Substitute.For<IIdentityProviderConnectionRegistry>();
+        registry.FindByKeyAsync("tenant-a", "contoso", Arg.Any<CancellationToken>()).Returns(ValueTask.FromResult<EffectiveIdentityProviderConnection?>(effective));
+        var user = new User { Id = "user-a", Name = "alice", TenantId = "tenant-a", Roles = ["role-a"] };
+        var role = new Role { Id = "role-a", Name = "Operators", TenantId = "tenant-a", Permissions = rolePermissions };
+        var tenantAccessor = new DefaultTenantAccessor();
+        var users = Substitute.For<IUserProvider>();
+        users.FindAsync(Arg.Any<UserFilter>(), Arg.Any<CancellationToken>()).Returns(_ => Task.FromResult<User?>(user));
+        var roles = Substitute.For<IRoleProvider>();
+        roles.FindManyAsync(Arg.Any<RoleFilter>(), Arg.Any<CancellationToken>()).Returns(_ => ValueTask.FromResult<IEnumerable<Role>>([role]));
+        var contexts = new List<TokenIssuanceContext>();
+        var tokenService = Substitute.For<IElsaTokenService>();
+        tokenService.IssueAccessTokenAsync(Arg.Do<TokenIssuanceContext>(contexts.Add), Arg.Any<CancellationToken>())
+            .Returns(_ => ValueTask.FromResult(new IssuedAccessToken($"access-{contexts.Count}", clock.UtcNow.AddHours(1))));
+        var issuer = new DefaultExternalAuthenticationTokenIssuer(sessionStore, registry, [], users, roles, tokenService, tenantAccessor, clock, Microsoft.Extensions.Options.Options.Create(options));
+
+        await issuer.IssueAsync(new ExternalAuthenticationSession
+        {
+            Id = "session-b", AuthenticationClientId = "studio", TenantId = "tenant-a", UserId = "user-a",
+            ConnectionKey = "contoso", ConnectionMaterialRevision = "revision-a",
+            SecretGenerationFingerprint = Convert.ToHexString(SHA256.HashData([])),
+            Issuer = "https://issuer.example", SubjectHash = "subject-hash",
+            ExternalGrants = [new PermissionGrant("reports:view", "claim-mapping", "department:engineering")],
+            StartedAt = clock.UtcNow, LastRefreshedAt = clock.UtcNow,
+            ExpiresAt = clock.UtcNow.AddHours(8), RefreshExpiresAt = clock.UtcNow.AddHours(8)
+        });
+
+        return contexts;
     }
 
     private sealed class TestClock : ISystemClock

--- a/test/integration/Elsa.Hosts.SmokeTests/ClassicHostSmokeTests.cs
+++ b/test/integration/Elsa.Hosts.SmokeTests/ClassicHostSmokeTests.cs
@@ -1,0 +1,37 @@
+using Elsa.ModularServer.Web;
+using Elsa.Server.Web;
+
+namespace Elsa.Hosts.SmokeTests;
+
+/// <summary>Elsa.Server.Web, which registers its modules through the classic <c>Features/</c> path.</summary>
+public class ClassicHostSmokeTests(HostFixture<ClassicServerHost> host) : HostSmokeTests<ClassicServerHost>(host)
+{
+    /// <inheritdoc />
+    protected override IReadOnlyCollection<string> GatedRoutes =>
+    [
+        "/elsa/api/workflow-definitions",
+        "/elsa/api/workflow-instances",
+        "/elsa/api/identity/roles",
+        "/elsa/api/identity/permissions",
+        "/elsa/api/dashboard/overview"
+    ];
+}
+
+/// <summary>Elsa.ModularServer.Web, which registers its modules through the CShells <c>ShellFeatures/</c> path.</summary>
+public class ShellHostSmokeTests(HostFixture<ModularServerHost> host) : HostSmokeTests<ModularServerHost>(host)
+{
+    /// <inheritdoc />
+    /// <remarks>
+    /// The two route sets overlap but are not identical: each lists what its own host actually configures,
+    /// and External Authentication is enabled only here. Keeping them separate is the point -- a route that
+    /// disappears from one host and not the other is the divergence these tests are looking for.
+    /// </remarks>
+    protected override IReadOnlyCollection<string> GatedRoutes =>
+    [
+        "/elsa/api/workflow-definitions",
+        "/elsa/api/workflow-instances",
+        "/elsa/api/identity/permissions",
+        "/elsa/api/external-authentication/connections",
+        "/elsa/api/external-authentication/descriptors/adapters"
+    ];
+}

--- a/test/integration/Elsa.Hosts.SmokeTests/Elsa.Hosts.SmokeTests.csproj
+++ b/test/integration/Elsa.Hosts.SmokeTests/Elsa.Hosts.SmokeTests.csproj
@@ -1,0 +1,25 @@
+<!-- TreatAsLocalProperty lets the CollectCoverage setting below win over CI's /p:CollectCoverage=true,
+     which would otherwise be a global property this project could not override. See the comment below. -->
+<Project Sdk="Microsoft.NET.Sdk" TreatAsLocalProperty="CollectCoverage">
+
+    <PropertyGroup>
+        <!-- Coverage is off here, for two reasons. This project references both hosts, so every module
+             either host pulls in would land in its denominator and shift the aggregate report without
+             adding a line of real coverage: startup touches a thin slice of a very large surface. And
+             coverlet cannot instrument a graph this size, failing with "Unable to read beyond the end of
+             the stream" while calculating the result. These tests are a startup gate, not a coverage
+             contribution; the modules they boot are measured by their own test projects. -->
+        <CollectCoverage>false</CollectCoverage>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="JetBrains.Annotations" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\src\apps\Elsa.Server.Web\Elsa.Server.Web.csproj" />
+        <ProjectReference Include="..\..\..\src\apps\Elsa.ModularServer.Web\Elsa.ModularServer.Web.csproj" />
+        <ProjectReference Include="..\..\..\src\common\Elsa.Testing.Shared\Elsa.Testing.Shared.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/test/integration/Elsa.Hosts.SmokeTests/HostSmokeTests.cs
+++ b/test/integration/Elsa.Hosts.SmokeTests/HostSmokeTests.cs
@@ -1,0 +1,87 @@
+using System.Net;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace Elsa.Hosts.SmokeTests;
+
+/// <summary>
+/// Boots a host the way its own entry point does and asserts it comes up serving gated routes.
+/// </summary>
+/// <remarks>
+/// This repo runs two parallel feature systems -- the classic <c>Features/</c> path and the CShells
+/// <c>ShellFeatures/</c> path -- and every module must register in both. Nothing exercised either until
+/// now: the unit and integration suites construct services directly, so a service missing from one path,
+/// or a feature registered in one and not the other, passes every test and fails only when a host starts.
+/// Three such bugs in #7980 were found by running these two hosts by hand.
+/// <para>
+/// Each host is booted through <see cref="WebApplicationFactory{TEntryPoint}"/>, which runs the real
+/// <c>Program</c> with its full feature registration. Assembling a service collection here instead would
+/// reproduce exactly the blind spot these tests exist to close.
+/// </para>
+/// <para>
+/// The assertions go through HTTP rather than by resolving services out of the container. The two hosts
+/// have genuinely different container topologies -- the classic host is flat, while CShells gives each
+/// shell its own provider, so the module services are simply not in the root one -- and a test that
+/// reached into either would have to encode that difference and would break whenever CShells changed its
+/// internals. Behaviour at the edge is both host-agnostic and the thing actually worth pinning: whichever
+/// feature system a host uses, the observable result has to be the same.
+/// </para>
+/// </remarks>
+public abstract class HostSmokeTests<TEntryPoint>(HostFixture<TEntryPoint> host) : IClassFixture<HostFixture<TEntryPoint>>
+    where TEntryPoint : class
+{
+    /// <summary>
+    /// Routes this host is expected to serve behind a permission. Each names a different module, so the
+    /// set doubles as an inventory of what this host's feature system is supposed to have registered.
+    /// </summary>
+    protected abstract IReadOnlyCollection<string> GatedRoutes { get; }
+
+    [Fact]
+    public void HostStarts()
+    {
+        // Touching Services forces the host to be built, which is where a feature that fails to register or
+        // an option that fails validation throws.
+        Assert.NotNull(host.Services);
+    }
+
+    [Fact]
+    public async Task EveryGatedRouteChallengesInsteadOfFailing()
+    {
+        using var client = host.CreateClient();
+        var problems = new List<string>();
+
+        foreach (var route in GatedRoutes)
+        {
+            var status = (int)(await client.GetAsync(route)).StatusCode;
+
+            // Each way this can go wrong is a distinct bug, so they are named rather than collapsed into one
+            // "expected 401" message that leaves the reader to work out which failure they are looking at.
+            var problem = status switch
+            {
+                404 => "404: this host never registered the module serving it",
+                >= 500 => $"{status}: the endpoint was found but could not be activated, so a dependency is missing",
+                200 => "200: reachable without credentials, so no permission gate ran",
+                401 => null,
+                _ => $"{status}: expected 401"
+            };
+
+            if (problem is not null)
+                problems.Add($"{route} -> {problem}");
+        }
+
+        // Every route is reported at once: when a feature system stops registering a group of modules, one
+        // failure per run turns a single cause into a queue of identical-looking investigations.
+        Assert.True(problems.Count == 0, $"{problems.Count} of {GatedRoutes.Count} gated route(s) did not challenge:{Environment.NewLine}{string.Join(Environment.NewLine, problems)}");
+    }
+}
+
+/// <summary>Boots a host once per test class.</summary>
+public class HostFixture<TEntryPoint> : WebApplicationFactory<TEntryPoint> where TEntryPoint : class
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        // Both hosts refuse to start outside Development while the signing key is a known default. That is
+        // the guard working as intended, so the test satisfies it rather than configuring around it.
+        builder.UseEnvironment("Development");
+    }
+}

--- a/test/unit/Elsa.ExternalAuthentication.UnitTests/Foundational/ExternalAuthenticationOptionsValidatorTests.cs
+++ b/test/unit/Elsa.ExternalAuthentication.UnitTests/Foundational/ExternalAuthenticationOptionsValidatorTests.cs
@@ -6,6 +6,39 @@ namespace Elsa.ExternalAuthentication.UnitTests.Foundational;
 
 public class ExternalAuthenticationOptionsValidatorTests
 {
+    [Theory]
+    // The legacy spelling carries two colons, so it parses as nothing and would silently stop bounding anything.
+    [InlineData("external-authentication:connections:read")]
+    [InlineData("not a permission")]
+    [InlineData("workflows/definitions:")]
+    public void RejectsAGrantBoundaryEntryThatIsNotAWellFormedPermission(string permission)
+    {
+        var allowed = new ExternalAuthenticationOptions();
+        allowed.PermissionGrants.AllowedPermissions = [permission];
+        var denied = new ExternalAuthenticationOptions();
+        denied.PermissionGrants.DeniedPermissions = [permission];
+
+        var allowedResult = CreateValidator().Validate(null, allowed);
+        var deniedResult = CreateValidator().Validate(null, denied);
+
+        Assert.False(allowedResult.Succeeded);
+        Assert.Contains(allowedResult.Failures!, x => x.Contains("AllowedPermissions") && x.Contains("well-formed permission"));
+        Assert.False(deniedResult.Succeeded);
+        Assert.Contains(deniedResult.Failures!, x => x.Contains("DeniedPermissions") && x.Contains("well-formed permission"));
+    }
+
+    [Fact]
+    public void AcceptsAGrantBoundaryOfWildcardPatterns()
+    {
+        var options = new ExternalAuthenticationOptions();
+        options.PermissionGrants.AllowedPermissions = ["workflows/*:delete", "*"];
+        options.PermissionGrants.DeniedPermissions = ["workflows/definitions:*"];
+
+        var result = CreateValidator().Validate(null, options);
+
+        Assert.DoesNotContain(result.Failures ?? [], x => x.Contains("well-formed permission"));
+    }
+
     [Fact]
     public void RejectsDuplicateInstalledAdapterTypes()
     {

--- a/test/unit/Elsa.ExternalAuthentication.UnitTests/Foundational/ExternalAuthenticationRoleDeletionDependencyContributorTests.cs
+++ b/test/unit/Elsa.ExternalAuthentication.UnitTests/Foundational/ExternalAuthenticationRoleDeletionDependencyContributorTests.cs
@@ -135,9 +135,9 @@ public class ExternalAuthenticationRoleDeletionDependencyContributorTests
     }
 
     [Theory]
-    [InlineData(ExternalAuthenticationPermissions.ConnectionsUpdate)]
-    [InlineData(ExternalAuthenticationPermissions.PoliciesManage)]
-    [InlineData(ExternalAuthenticationPermissions.RolesAssign)]
+    [InlineData(ConnectionsUpdate)]
+    [InlineData(PoliciesUpdate)]
+    [InlineData(DefaultRolesUpdate)]
     public async Task PrevalidationRequiresEveryPolicyRemediationPermission(string omittedPermission)
     {
         var databaseConnection = Connection(
@@ -177,7 +177,8 @@ public class ExternalAuthenticationRoleDeletionDependencyContributorTests
             new RoleAuthorizationService(new StoreBasedRoleProvider(roleStore), new PermissionEvaluator()),
             versions,
             new ConnectionRevisionCalculator(),
-            new ExternalAuthenticationSecurityNotifier(services));
+            new ExternalAuthenticationSecurityNotifier(services),
+            new PermissionEvaluator());
         return (contributor, store, versions);
     }
 
@@ -196,14 +197,18 @@ public class ExternalAuthenticationRoleDeletionDependencyContributorTests
         UpdatedAt = DateTimeOffset.UnixEpoch
     };
 
+    private const string ConnectionsUpdate = $"{ExternalAuthenticationResourcePermissions.Connections}:{CoreVerbs.Update}";
+    private const string PoliciesUpdate = $"{ExternalAuthenticationResourcePermissions.Policies}:{CoreVerbs.Update}";
+    private const string DefaultRolesUpdate = $"{ExternalAuthenticationResourcePermissions.PolicyDefaultRoles}:{CoreVerbs.Update}";
+
     private static ClaimsPrincipal Administrator(string? omittedPermission = null)
     {
         var permissions = new[]
         {
-            "delete:role",
-            ExternalAuthenticationPermissions.ConnectionsUpdate,
-            ExternalAuthenticationPermissions.PoliciesManage,
-            ExternalAuthenticationPermissions.RolesAssign
+            "identity/roles:delete",
+            ConnectionsUpdate,
+            PoliciesUpdate,
+            DefaultRolesUpdate
         };
         return new ClaimsPrincipal(new ClaimsIdentity(
             permissions

--- a/test/unit/Elsa.ExternalAuthentication.UnitTests/Permissions/PermissionGrantPipelineTests.cs
+++ b/test/unit/Elsa.ExternalAuthentication.UnitTests/Permissions/PermissionGrantPipelineTests.cs
@@ -204,6 +204,26 @@ public class PermissionGrantPipelineTests
         Assert.Equal(isAdmitted ? [granted] : Array.Empty<string>(), result.Grants.Select(x => x.Permission));
     }
 
+    [Theory]
+    // An allow list that parses to nothing must not read as "no allow list", which means unrestricted.
+    [InlineData(new[] { "not a permission" }, new string[0])]
+    // One bad entry among good ones is still a boundary the deployment cannot have meant.
+    [InlineData(new[] { "workflows/*:delete", "external-authentication:connections:read" }, new string[0])]
+    // A deny entry that does not parse would otherwise stop denying what it names, silently.
+    [InlineData(new string[0], new[] { "external-authentication:connections:read" })]
+    public async Task AGrantBoundaryThatDoesNotParseAdmitsNothing(string[] allowed, string[] denied)
+    {
+        var options = new ExternalAuthenticationOptions();
+        options.PermissionGrants.AllowedPermissions = allowed;
+        options.PermissionGrants.DeniedPermissions = denied;
+        var resolver = CreateResolver(new StaticUserProvider(null), new StaticRoleProvider(), options);
+
+        var result = await resolver.ResolveAsync(MappedContext("workflows/definitions:delete"));
+
+        Assert.Empty(result.Grants);
+        Assert.Contains(result.Warnings, warning => warning.Code == "permission_denied_by_deployment");
+    }
+
     [Fact]
     public async Task RolePermissionsAreMatchedAgainstTheDenyBoundaryAsPatterns()
     {

--- a/test/unit/Elsa.ExternalAuthentication.UnitTests/Permissions/PermissionGrantPipelineTests.cs
+++ b/test/unit/Elsa.ExternalAuthentication.UnitTests/Permissions/PermissionGrantPipelineTests.cs
@@ -1,5 +1,6 @@
 using System.Security.Claims;
 using System.Text.Json;
+using Elsa.Authorization;
 using Elsa.ExternalAuthentication.Contracts;
 using Elsa.ExternalAuthentication.Models;
 using Elsa.ExternalAuthentication.Options;
@@ -124,8 +125,8 @@ public class PermissionGrantPipelineTests
     {
         var selection = new GrantSourceSelection("group-mapping", 1, JsonSerializer.SerializeToElement(new { claimType = "groups", mappings = new Dictionary<string, string[]> { ["operators"] = ["workflows:manage"] } }), 0);
         var options = new ExternalAuthenticationOptions();
-        var authorizer = new DefaultPermissionDelegationAuthorizer(Microsoft.Extensions.Options.Options.Create(options));
-        var ordinaryActor = CreateActor(ExternalAuthenticationPermissions.PermissionsDelegate, "workflows:read");
+        var authorizer = new DefaultPermissionDelegationAuthorizer(Microsoft.Extensions.Options.Options.Create(options), PermissionEvaluator.Shared);
+        var ordinaryActor = CreateActor(DelegatePermission, "workflows:read");
 
         var ordinary = await authorizer.AuthorizeAsync(ordinaryActor, [selection]);
 
@@ -133,7 +134,7 @@ public class PermissionGrantPipelineTests
         Assert.Equal(["workflows:manage"], ordinary.UnauthorizedPermissions);
 
         options.PermissionGrants.DeniedPermissions = ["workflows:manage"];
-        var unrestricted = await authorizer.AuthorizeAsync(CreateActor(ExternalAuthenticationPermissions.PermissionsDelegateUnrestricted), [selection]);
+        var unrestricted = await authorizer.AuthorizeAsync(CreateActor(DelegateUnrestrictedPermission), [selection]);
 
         Assert.False(unrestricted.IsAuthorized);
         Assert.Equal(["workflows:manage"], unrestricted.UnauthorizedPermissions);
@@ -143,10 +144,10 @@ public class PermissionGrantPipelineTests
     public async Task DelegationRequiresTheActorToPossessEachExplicitPassThroughPermission()
     {
         var selection = new GrantSourceSelection("claim-pass-through", 1, JsonSerializer.SerializeToElement(new { claimType = "permissions", allowedPermissions = new[] { "reports:view" } }), 0);
-        var authorizer = new DefaultPermissionDelegationAuthorizer(Microsoft.Extensions.Options.Options.Create(new ExternalAuthenticationOptions()));
+        var authorizer = new DefaultPermissionDelegationAuthorizer(Microsoft.Extensions.Options.Options.Create(new ExternalAuthenticationOptions()), PermissionEvaluator.Shared);
 
-        var denied = await authorizer.AuthorizeAsync(CreateActor(ExternalAuthenticationPermissions.PermissionsDelegate), [selection]);
-        var allowed = await authorizer.AuthorizeAsync(CreateActor(ExternalAuthenticationPermissions.PermissionsDelegate, "reports:view"), [selection]);
+        var denied = await authorizer.AuthorizeAsync(CreateActor(DelegatePermission), [selection]);
+        var allowed = await authorizer.AuthorizeAsync(CreateActor(DelegatePermission, "reports:view"), [selection]);
 
         Assert.False(denied.IsAuthorized);
         Assert.Equal(["reports:view"], denied.UnauthorizedPermissions);
@@ -164,6 +165,109 @@ public class PermissionGrantPipelineTests
 
         Assert.Equal(["reports:view", "workflows:read"], registry.List().Select(x => x.Name));
     }
+
+    [Theory]
+    // A deny of a subtree reaches every permission beneath it, the case the ordinal boundary missed.
+    [InlineData("workflows/*:delete", "workflows/definitions:delete")]
+    // And a wildcard grant cannot outflank a deny spelled out by name.
+    [InlineData("workflows/definitions:delete", "workflows/*:delete")]
+    // A verb wildcard reaches in both directions too.
+    [InlineData("workflows/definitions:*", "workflows/definitions:delete")]
+    [InlineData("workflows/definitions:delete", "workflows/definitions:*")]
+    public async Task DeploymentDenyAndGrantAreMatchedAsPatternsInBothDirections(string denied, string granted)
+    {
+        var options = new ExternalAuthenticationOptions();
+        options.PermissionGrants.DeniedPermissions = [denied];
+        var resolver = CreateResolver(new StaticUserProvider(null), new StaticRoleProvider(), options);
+
+        var result = await resolver.ResolveAsync(MappedContext(granted));
+
+        Assert.Empty(result.Grants);
+        Assert.Contains(result.Warnings, warning => warning.Code == "permission_denied_by_deployment");
+    }
+
+    [Theory]
+    // An allow entry must cover the whole grant, so a subtree admits the permissions beneath it...
+    [InlineData("workflows/*:delete", "workflows/definitions:delete", true)]
+    [InlineData("workflows/definitions:*", "workflows/definitions:delete", true)]
+    // ...but a grant broader than anything allowed is refused rather than admitted for the overlap.
+    [InlineData("workflows/definitions:delete", "workflows/*:delete", false)]
+    [InlineData("workflows/definitions:delete", "workflows/definitions:*", false)]
+    public async Task DeploymentAllowListCoversGrantsBeneathItButNotGrantsBeyondIt(string allowed, string granted, bool isAdmitted)
+    {
+        var options = new ExternalAuthenticationOptions();
+        options.PermissionGrants.AllowedPermissions = [allowed];
+        var resolver = CreateResolver(new StaticUserProvider(null), new StaticRoleProvider(), options);
+
+        var result = await resolver.ResolveAsync(MappedContext(granted));
+
+        Assert.Equal(isAdmitted ? [granted] : Array.Empty<string>(), result.Grants.Select(x => x.Permission));
+    }
+
+    [Fact]
+    public async Task RolePermissionsAreMatchedAgainstTheDenyBoundaryAsPatterns()
+    {
+        var options = new ExternalAuthenticationOptions();
+        options.PermissionGrants.DeniedPermissions = ["workflows/*:delete"];
+        var userProvider = new StaticUserProvider(new User { Id = "user-a", TenantId = "tenant-a", Roles = ["role-a"] });
+        var roleProvider = new StaticRoleProvider(new Role { Id = "role-a", Name = "Operators", TenantId = "tenant-a", Permissions = ["workflows/definitions:delete", "workflows/definitions:view"] });
+        var resolver = CreateResolver(userProvider, roleProvider, options);
+        var context = CreateContext(
+            [new GrantSourceSelection("elsa-roles", 1, JsonSerializer.SerializeToElement(new { }), 0)],
+            new Dictionary<string, IReadOnlyCollection<string>>());
+
+        var result = await resolver.ResolveAsync(context);
+
+        Assert.Equal(["workflows/definitions:view"], result.Grants.Select(x => x.Permission));
+        Assert.Contains(result.Warnings, warning => warning.Code == "permission_denied_by_deployment");
+    }
+
+    [Fact]
+    public async Task GrantsThatAreNotWellFormedPermissionsAreDroppedRatherThanCarriedIntoAToken()
+    {
+        var resolver = CreateResolver(new StaticUserProvider(null), new StaticRoleProvider(), new ExternalAuthenticationOptions());
+
+        var result = await resolver.ResolveAsync(MappedContext("external-authentication:connections:read"));
+
+        Assert.Empty(result.Grants);
+        Assert.Contains(result.Warnings, warning => warning.Code == "malformed_permission");
+    }
+
+    [Theory]
+    // The actor must cover what they delegate, so a subtree grant delegates the permissions beneath it...
+    [InlineData("workflows/*:delete", "workflows/definitions:delete", true)]
+    // ...and holding one leaf does not let an actor delegate the whole subtree.
+    [InlineData("workflows/definitions:delete", "workflows/*:delete", false)]
+    [InlineData(PermissionNames.All, "workflows/*:delete", true)]
+    public async Task DelegationMatchesTheActorsOwnGrantsAsPatterns(string held, string delegated, bool isAuthorized)
+    {
+        var authorizer = new DefaultPermissionDelegationAuthorizer(Microsoft.Extensions.Options.Options.Create(new ExternalAuthenticationOptions()), PermissionEvaluator.Shared);
+        var selection = new GrantSourceSelection("group-mapping", 1, JsonSerializer.SerializeToElement(new { claimType = "groups", mappings = new Dictionary<string, string[]> { ["operators"] = [delegated] } }), 0);
+
+        var result = await authorizer.AuthorizeAsync(CreateActor(DelegatePermission, held), [selection]);
+
+        Assert.Equal(isAuthorized, result.IsAuthorized);
+    }
+
+    [Fact]
+    public async Task DelegationPermissionItselfIsHonouredThroughAWildcardGrant()
+    {
+        var authorizer = new DefaultPermissionDelegationAuthorizer(Microsoft.Extensions.Options.Options.Create(new ExternalAuthenticationOptions()), PermissionEvaluator.Shared);
+        var selection = new GrantSourceSelection("group-mapping", 1, JsonSerializer.SerializeToElement(new { claimType = "groups", mappings = new Dictionary<string, string[]> { ["operators"] = ["reports:view"] } }), 0);
+
+        var subtree = await authorizer.AuthorizeAsync(CreateActor($"{ExternalAuthenticationResourcePermissions.PermissionGrants}:*", "reports:view"), [selection]);
+        var without = await authorizer.AuthorizeAsync(CreateActor("reports:view"), [selection]);
+
+        Assert.True(subtree.IsAuthorized);
+        Assert.False(without.IsAuthorized);
+    }
+
+    private const string DelegatePermission = $"{ExternalAuthenticationResourcePermissions.PermissionGrants}:{ExternalAuthenticationVerbs.Delegate}";
+    private const string DelegateUnrestrictedPermission = $"{ExternalAuthenticationResourcePermissions.PermissionGrants}:{ExternalAuthenticationVerbs.DelegateUnrestricted}";
+
+    private static PermissionGrantResolutionContext MappedContext(string permission) => CreateContext(
+        [new GrantSourceSelection("claim-mapping", 1, JsonSerializer.SerializeToElement(new { claimType = "department", mappings = new Dictionary<string, string[]> { ["engineering"] = [permission] } }), 0)],
+        new Dictionary<string, IReadOnlyCollection<string>> { ["department"] = ["engineering"] });
 
     private static DefaultPermissionGrantResolver CreateResolver(IUserProvider userProvider, IRoleProvider roleProvider, ExternalAuthenticationOptions options) => new(
         [new ElsaRolePermissionGrantSource(userProvider, roleProvider), new ClaimMappingPermissionGrantSource(), new GroupMappingPermissionGrantSource(), new ClaimPassThroughPermissionGrantSource()],


### PR DESCRIPTION
Follow-up to #7980, taking the first two items of #7982 in the order that issue proposes.

## 1 — The grant boundary was wildcard-blind, and it was exploitable

`PermissionGrantBoundary` held its allow and deny lists in a `HashSet<string>` with `StringComparer.Ordinal`. Under the new `{resource}:{verb}` vocabulary that cannot match a pattern, so the deployment deny list did not hold.

The issue flags one direction. **Both** are reachable:

| Deny list | Grant | Old result |
|---|---|---|
| `workflows/*:delete` | `workflows/definitions:delete` | admitted |
| `workflows/definitions:delete` | `workflows/*:delete` | admitted |

The second is the more surprising one: a wildcard grant outflanks a deny spelled out by name, so a fully concrete deny list is no protection either.

**Why this is exploitable rather than cosmetic.** `ElsaRolePermissionGrantSource` passes a role's permissions to the boundary verbatim; survivors are stored on the session as `ExternalGrants`, and `DefaultExternalAuthenticationTokenIssuer` concatenates them into the issued token's permission claims, where `PermissionEvaluator` *does* expand wildcards. So an ordinary role plus a deny list is enough, on every external sign-in, with no privileged actor and no connection-management access involved. `elsa-roles` is in the default `AllowedPermissionGrantSourceTypes`.

This was verified rather than argued: restoring the ordinal boundary under the new tests fails seven of them.

Deny is now matched in **both** directions and allow **one**-directionally, through `PermissionMatcher`. Allow stays one-directional deliberately — an allow entry must cover the whole grant, so a grant broader than anything allowed is refused rather than admitted for the overlapping part. A grant that is not a well-formed permission is dropped with a `malformed_permission` warning instead of being carried into a token it could never authorize anything in.

### A second problem, not in the issue

Five checks outside endpoint authorization still compared claim values against the **legacy** `ExternalAuthenticationPermissions` constants: delegation, role-reference removal, unsafe-settings confirmation, the final-login-path recovery override, and the boundary itself.

Those constants carry two colons (`external-authentication:connections:read`), which `Permission.TryParse` rejects outright — so no principal can hold one. Meanwhile `doc/migrations/authorization-model.md` instructs operators to replace exactly those strings. **Following the migration guide silently disables all five paths.** All now route through `IPermissionEvaluator`, so one matching rule governs the whole module.

Also here: the module consumed `IPermissionEvaluator` without registering it, relying on host ordering. `AddExternalAuthenticationServices` now calls `AddElsaAuthorization()` itself. To be precise about what that fixes — both hosts already register it independently, so this is defensive for consumers wiring the module directly, not a live host bug.

Non-core verbs move into `ExternalAuthenticationVerbs`, declared beside the resources they apply to, so a delegation check cannot spell a verb differently from the endpoint it guards.

The migration guide gains a section on the new matching semantics, including a warning that a carried-over deny list may now deny more than it did — which is the intent.

## 2 — Startup smoke tests for both hosts

Two parallel feature systems, every module registering in both, and nothing exercising either. The suites construct services directly, so a module registered in one path and not the other passes every test and fails only at startup. Three bugs in #7980 were found by running these hosts by hand.

Each host boots through `WebApplicationFactory` running its real `Program`, then is asked for routes it should serve behind a permission. The status code names the failure instead of collapsing it:

- **404** — the module was never registered (the classic-vs-shell divergence)
- **5xx** — endpoint found, dependencies not constructible (invisible to any test that builds services by hand)
- **200** — reachable without credentials, so no gate ran

**The gate is proven, not merely written.** Removing `AddExternalAuthenticationServices` from the shell feature fails the shell host on all five routes while the classic host stays green.

Assertions go through HTTP rather than the container on purpose. The hosts have genuinely different topologies: the classic root provider holds everything and registers **125** routes, while CShells gives each shell its own provider and mounts routes per shell, leaving **6** in the root. Any container or route-table assertion would have to encode that difference and would break whenever CShells changed internally.

Each host gains a namespaced entry-point marker, because both already declare a `Program` in the global namespace and a test project referencing both cannot tell them apart.

Coverage is off for that project: it references both hosts, so every module either pulls in would enter its denominator without adding real coverage, and coverlet cannot instrument a graph that size (`Unable to read beyond the end of the stream`). `TreatAsLocalProperty` keeps CI's `/p:CollectCoverage=true` from overriding it — verified against CI's exact Release invocation.

## Third commit: unrelated IDE cleanup

`34d64cbe9` carries a solution-wide IDE cleanup — redundant qualifiers and usings removed, primary-constructor and record syntax applied — across ConsoleLogs, StructuredLogs, Expressions.JavaScript and Identity. It ran alongside this work and is separated so the permission changes review on their own. It is behaviour-neutral and all touched projects build clean.

## Breaking

Marked `!` because a deployment carrying a deny list will now be denied more than before. That is the fix, but it is a behaviour change worth a release note.

## Verification

- External Authentication unit tests: **168 passed**
- External Authentication integration tests: **136 passed**
- Host smoke tests: **4 passed**, and confirmed failing when the divergence is injected
- Both hosts booted by hand: start clean, gated routes return 401

The clean run also surfaced a real bug an earlier contended run had masked — `ConnectionManagementTests` hand-registers its dependencies rather than calling `AddExternalAuthenticationServices`, so it needed the evaluator registered the way a host does. Fixed in the first commit.

## Not included

Item 3 of #7982, extending the endpoint coverage gate, is deliberately left out. Items 4 (legacy constants, duplicate descriptor types) and the untested migration-guide walkthrough remain open.

Refs #7982

🤖 Generated with [Claude Code](https://claude.com/claude-code)
