### PR TITLE
fix(core): clear stale blocked tokens when a flowchart activity completes (#7993)

### DIFF
--- a/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Activities/Flowchart.Tokens.cs
+++ b/src/modules/Elsa.Workflows.Core/Activities/Flowchart/Activities/Flowchart.Tokens.cs
@@ -38,6 +38,10 @@ public partial class Flowchart
         foreach (var t in inboundTokens)
             t.Consume();
 
+        // The activation wave for the completed activity is decided once it completes.
+        // Clear blocked inbound tokens so future activations (e.g. via loop-back edges) are not swallowed by stale blocks.
+        tokens.RemoveWhere(t => t.ToActivityId == completedActivity.Id && t.Blocked);
+
         // Schedule next activities based on merge modes.
         foreach (var connection in activeOutboundConnections)
         {

--- a/test/integration/Elsa.Workflows.IntegrationTests/Scenarios/JoinBehaviors/RaceJoinLoopTests.cs
+++ b/test/integration/Elsa.Workflows.IntegrationTests/Scenarios/JoinBehaviors/RaceJoinLoopTests.cs
@@ -1,0 +1,22 @@
+using Elsa.Testing.Shared;
+using Elsa.Workflows.Activities.Flowchart.Extensions;
+using Elsa.Workflows.IntegrationTests.Scenarios.JoinBehaviors.Workflows;
+using Elsa.Workflows.Options;
+using Xunit.Abstractions;
+
+namespace Elsa.Workflows.IntegrationTests.Scenarios.JoinBehaviors;
+
+public class RaceJoinLoopTests(ITestOutputHelper testOutputHelper)
+{
+    private readonly WorkflowTestFixture _fixture = new(testOutputHelper);
+
+    [Fact(DisplayName = "WaitAny join re-entered via loop can be triggered from another inbound")]
+    public async Task WaitAny_join_reentered_via_loop_can_be_triggered_from_another_inbound()
+    {
+        var options = new RunWorkflowOptions().WithTokenBasedFlowchart();
+        var result = await _fixture.RunWorkflowAsync<RaceJoinLoopWorkflow>(options);
+        var lines = _fixture.CapturingTextWriter.Lines.ToList();
+        Assert.Equal(new[] { "Start", "A", "Body", "Retry", "Body", "B", "Body", "End" }, lines);
+        Assert.Equal(WorkflowStatus.Finished, result.WorkflowState.Status);
+    }
+}

--- a/test/integration/Elsa.Workflows.IntegrationTests/Scenarios/JoinBehaviors/Workflows/RaceJoinLoopWorkflow.cs
+++ b/test/integration/Elsa.Workflows.IntegrationTests/Scenarios/JoinBehaviors/Workflows/RaceJoinLoopWorkflow.cs
@@ -1,0 +1,57 @@
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Activities.Flowchart.Activities;
+using Elsa.Workflows.Activities.Flowchart.Models;
+
+namespace Elsa.Workflows.IntegrationTests.Scenarios.JoinBehaviors.Workflows;
+
+/// <summary>
+/// Reproduces https://github.com/elsa-workflows/elsa-core/issues/7993:
+/// a WaitAny (Race) join with two forward inbounds that is re-entered through a loop
+/// must fire again when triggered from a different inbound than the previous activation.
+/// </summary>
+public class RaceJoinLoopWorkflow : WorkflowBase
+{
+    protected override void Build(IWorkflowBuilder builder)
+    {
+        var counter = builder.WithVariable(0);
+        var start = new WriteLine("Start");
+        var whichPath = new FlowDecision(context => counter.Get(context) == 0);
+        var isSecondPass = new FlowDecision(context => counter.Get(context) == 2);
+        var pathA = new WriteLine("A");
+        var pathB = new WriteLine("B");
+        var join = new FlowJoin(); // WaitAny by default → MergeMode.Race
+        var body = new WriteLine("Body");
+        var increment = new SetVariable<int>(counter, context => counter.Get(context) + 1);
+        var loopDecision = new FlowDecision(context => counter.Get(context) <= 1);
+        var retry = new WriteLine("Retry");
+        var end = new WriteLine("End");
+
+        builder.Root = new Flowchart
+        {
+            Start = start,
+            Activities =
+            {
+                start, whichPath, isSecondPass, pathA, pathB, join, body, increment, loopDecision, retry, end
+            },
+            Connections =
+            {
+                new(start, whichPath),
+                new(new(whichPath, "True"), new Endpoint(pathA)),
+                new(new(whichPath, "False"), new Endpoint(isSecondPass)),
+                new(new(isSecondPass, "True"), new Endpoint(pathB)),
+                new(new(isSecondPass, "False"), new Endpoint(end)),
+                // Two forward inbounds into the same WaitAny join.
+                new(pathA, join),
+                new(pathB, join),
+                new(join, body),
+                new(body, increment),
+                new(increment, loopDecision),
+                // Loop back-edge into the join.
+                new(new(loopDecision, "True"), new Endpoint(retry)),
+                new(retry, join),
+                // Exit the loop and re-enter the join through the other forward inbound.
+                new(new(loopDecision, "False"), new Endpoint(whichPath)),
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Purpose

Fixes a silent failure in token-based flowchart execution where a `FlowJoin` (WaitAny / `MergeMode.Race`) re-entered through a loop could not fire again from a different inbound connection — the fresh trigger was swallowed by a stale blocked token.

Fixes #7993

---

## Scope

Select one primary concern:

- [x] Bug fix (behavior change)
- [ ] Refactor (no behavior change)
- [ ] Documentation update
- [ ] Formatting / code cleanup
- [ ] Dependency / build update
- [ ] New feature

---

## Description

### Problem

In token-based flowchart execution, every time a `MergeMode.Race` target is scheduled, blocked tokens are added for its other forward inbound connections. These blocked tokens were never removed once the join had executed. When a token later arrived on such a connection — e.g. a join re-entered through a loop back-edge and then triggered from a different forward inbound — the stale block was found by the `existingBlockedToken` lookup and the trigger was consumed by the "consume the block without scheduling" branch. The join never fired again and the flowchart completed early, silently, with status `Finished`.

Full root cause, minimal repro workflow, and a failing test are in #7993.

### Solution

The activation wave for an activity is decided once it completes, so blocked inbound tokens should not outlive it. In `OnChildCompletedTokenBasedLogicAsync` (`Flowchart.Tokens.cs`), right after consuming the completed activity's inbound tokens, blocked inbound tokens for that activity are removed:

```csharp
tokens.RemoveWhere(t => t.ToActivityId == completedActivity.Id && t.Blocked);
