### PR TITLE
fix(identity): restore the localhost bootstrap grant under the structured vocabulary

### DIFF
--- a/src/common/Elsa.Api.Common/Requirements/LocalHostPermissionRequirement.cs
+++ b/src/common/Elsa.Api.Common/Requirements/LocalHostPermissionRequirement.cs
@@ -1,4 +1,5 @@
 using System.Security.Claims;
+using Elsa.Authorization;
 using Elsa.Extensions;
 using Elsa.Options;
 using JetBrains.Annotations;
@@ -20,11 +21,18 @@ public class LocalHostPermissionRequirement : IAuthorizationRequirement
 [PublicAPI]
 public class LocalHostPermissionRequirementHandler : AuthorizationHandler<LocalHostPermissionRequirement>
 {
-    private static readonly string[] BootstrapPermissions =
+    // The three grants a local first-run needs to stand an instance up, spelled in the structured
+    // {resource}:{verb} vocabulary. These were previously the legacy strings "create:application",
+    // "create:user" and "create:role", which no longer authorize anything: a legacy string parses to a
+    // different pair entirely -- "create:user" reads as resource "create", verb "user" -- so the endpoints
+    // this grant exists to unlock (identity/applications:create, identity/users:create,
+    // identity/roles:create) all refused it. The literals are spelled out rather than referenced from
+    // Elsa.Identity because this assembly sits beneath it.
+    private static readonly Permission[] BootstrapPermissions =
     [
-        "create:application",
-        "create:user",
-        "create:role"
+        new("identity/applications", CoreVerbs.Create),
+        new("identity/users", CoreVerbs.Create),
+        new("identity/roles", CoreVerbs.Create)
     ];
 
     private readonly IHttpContextAccessor _httpContextAccessor;
@@ -62,16 +70,15 @@ public class LocalHostPermissionRequirementHandler : AuthorizationHandler<LocalH
         }
 
         var identity = new ClaimsIdentity(JwtBearerDefaults.AuthenticationScheme);
-        identity.AddClaims(BootstrapPermissions.Select(permission => new Claim(PermissionNames.ClaimType, permission)));
+        identity.AddClaims(BootstrapPermissions.Select(permission => new Claim(PermissionNames.ClaimType, permission.ToString())));
         context.User.AddIdentity(identity);
 
         context.Succeed(requirement);
         return Task.CompletedTask;
     }
 
-    private static bool HasBootstrapPermissions(ClaimsPrincipal user)
-    {
-        var permissions = user.FindAll(PermissionNames.ClaimType).Select(x => x.Value).ToHashSet(StringComparer.Ordinal);
-        return permissions.Contains(PermissionNames.All) || BootstrapPermissions.All(permissions.Contains);
-    }
+    // Evaluated rather than compared by claim value, so a caller holding a wildcard that covers these --
+    // "*" as before, but now also "identity/*:create" -- satisfies the requirement.
+    private static bool HasBootstrapPermissions(ClaimsPrincipal user) =>
+        PermissionEvaluator.Shared.HasAllPermissions(user, BootstrapPermissions);
 }

--- a/test/unit/Elsa.Identity.UnitTests/Requirements/LocalHostPermissionRequirementHandlerTests.cs
+++ b/test/unit/Elsa.Identity.UnitTests/Requirements/LocalHostPermissionRequirementHandlerTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Security.Claims;
 using Elsa;
+using Elsa.Authorization;
 using Elsa.Options;
 using Elsa.Requirements;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -28,9 +29,31 @@ public class LocalHostPermissionRequirementHandlerTests
         var permissions = context.User.FindAll(PermissionNames.ClaimType).Select(x => x.Value).ToList();
 
         Assert.True(context.HasSucceeded);
-        Assert.Contains("create:application", permissions);
-        Assert.Contains("create:user", permissions);
-        Assert.Contains("create:role", permissions);
+        Assert.Contains("identity/applications:create", permissions);
+        Assert.Contains("identity/users:create", permissions);
+        Assert.Contains("identity/roles:create", permissions);
+    }
+
+    [Theory]
+    [InlineData("identity/applications", "create")]
+    [InlineData("identity/users", "create")]
+    [InlineData("identity/roles", "create")]
+    public async Task GrantedBootstrapPermissionsActuallyAuthorizeTheirEndpoints(string resource, string verb)
+    {
+        // The point of the grant, asserted through the evaluator rather than by string equality. The list
+        // previously held legacy spellings ("create:user" and friends), which parse to a different pair
+        // entirely, so the bootstrap grant authorized none of the three endpoints it exists to unlock.
+        var context = await AuthorizeAsync(enableLocalHostPermissionGrant: true, isLocal: true);
+
+        Assert.True(PermissionEvaluator.Shared.HasPermission(context.User, resource, verb));
+    }
+
+    [Fact]
+    public async Task SucceedsForAnAuthenticatedCallerHoldingAWildcardThatCoversTheBootstrapGrants()
+    {
+        var context = await AuthorizeAsync(enableLocalHostPermissionGrant: true, isLocal: true, isAuthenticated: true, permissions: ["identity/*:create"]);
+
+        Assert.True(context.HasSucceeded);
     }
 
     [Fact]
@@ -52,9 +75,9 @@ public class LocalHostPermissionRequirementHandlerTests
         Assert.True(context.HasSucceeded);
         Assert.True(context.User.Identity?.IsAuthenticated);
         Assert.Equal(3, permissions.Count);
-        Assert.Contains("create:application", permissions);
-        Assert.Contains("create:user", permissions);
-        Assert.Contains("create:role", permissions);
+        Assert.Contains("identity/applications:create", permissions);
+        Assert.Contains("identity/users:create", permissions);
+        Assert.Contains("identity/roles:create", permissions);
     }
 
     [Fact]
@@ -84,9 +107,9 @@ public class LocalHostPermissionRequirementHandlerTests
 
     private static readonly string[] BootstrapPermissions =
     [
-        "create:application",
-        "create:user",
-        "create:role"
+        "identity/applications:create",
+        "identity/users:create",
+        "identity/roles:create"
     ];
 
     private static async Task<AuthorizationHandlerContext> AuthorizeAsync(bool enableLocalHostPermissionGrant, bool isLocal, bool isAuthenticated = false, params string[] permissions)


### PR DESCRIPTION
## Summary

The documented **localhost first-run bootstrap path grants nothing**. `LocalHostPermissionRequirementHandler` injects three permissions for local, unauthenticated requests so an operator can stand up an instance:

```csharp
private static readonly string[] BootstrapPermissions =
[
    "create:application",
    "create:user",
    "create:role"
];
```

Those are legacy-vocabulary strings. The three endpoints they exist to unlock have since moved to structured permissions — `identity/applications:create`, `identity/users:create`, `identity/roles:create` — and a legacy string does not merely fail to match, it parses to a **different `(resource, verb)` pair**: `"create:user"` reads as resource `create`, verb `user`. So the injected claims authorize none of the three endpoints, and the local bootstrap cannot create the first application, user or role.

This is the `LocalHostPermissionRequirement` half of **T042**, which the task explicitly names alongside the token issuers.

## Changes

- `BootstrapPermissions` is now `Permission[]` in the structured vocabulary. The literals are spelled out rather than referenced from `Elsa.Identity`, because `Elsa.Api.Common` sits beneath it.
- The authenticated branch evaluates through `PermissionEvaluator.HasAllPermissions` instead of comparing claim values by set containment, so a caller holding a covering wildcard such as `identity/*:create` now satisfies the requirement. `*` continues to satisfy it, as before.

## Tests

The existing tests asserted the legacy spellings, so they would have kept the defect in place — they now assert the structured ones. Added:

- a theory asserting the injected grant **actually authorizes** each of the three endpoints when run through the evaluator, rather than merely appearing as a claim string (the assertion that would have caught this);
- a case for an authenticated caller holding `identity/*:create`.

`Elsa.Identity.UnitTests` **115/115** green on net10.0.

## Related

Found while working through the task-list reconciliation in #8000, which now records T042 as partially done. Same root cause as #8001 (`RoleDeletionCoordinator` gating on the legacy `"delete:role"`): code holding legacy permission strings that silently stopped matching when the endpoints around it migrated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
