### PR TITLE
fix: preserve Sequence ownership when retrying child activities

### DIFF
--- a/src/modules/Elsa.UserTasks/Endpoints/UserTasksEndpoints.cs
+++ b/src/modules/Elsa.UserTasks/Endpoints/UserTasksEndpoints.cs
@@ -558,7 +558,7 @@ internal sealed class ListParticipantsEndpoint(IUserTaskParticipantDirectory dir
 /// shape for valid and invalid tokens.
 /// </summary>
 internal abstract class AnonymousInvitationEndpointBase<TRequest, TResponse> : Endpoint<TRequest, TResponse>
-    where TRequest : notnull, new()
+    where TRequest : notnull
     where TResponse : notnull
 {
     protected async Task<bool> TryAcquireAsync(IUserTaskInvitationRateLimiter limiter, CancellationToken cancellationToken)

--- a/src/modules/Elsa.Workflows.Core/Activities/Sequence.cs
+++ b/src/modules/Elsa.Workflows.Core/Activities/Sequence.cs
@@ -10,6 +10,9 @@ namespace Elsa.Workflows.Activities;
 /// <summary>
 /// Execute a set of activities in sequence.
 /// </summary>
+/// <remarks>
+/// Rescheduled direct children retain completion callback ownership by this sequence.
+/// </remarks>
 [Category("Workflows")]
 [Activity("Elsa", "Workflows", "Execute a set of activities in sequence.")]
 [PublicAPI]
@@ -22,6 +25,7 @@ public class Sequence : Container
     public Sequence([CallerFilePath] string? source = null, [CallerLineNumber] int? line = null) : base(source, line)
     {
         OnSignalReceived<BreakSignal>(OnBreakSignalReceived);
+        OnSignalReceived<ScheduleChildActivity>(OnScheduleChildActivityAsync);
     }
 
     /// <inheritdoc />
@@ -66,6 +70,25 @@ public class Sequence : Container
         }
 
         await HandleItemAsync(targetContext, childContext);
+    }
+
+    private async ValueTask OnScheduleChildActivityAsync(ScheduleChildActivity signal, SignalContext context)
+    {
+        var sequenceContext = context.ReceiverActivityExecutionContext;
+        var childActivity = signal.ActivityExecutionContext?.Activity ?? signal.Activity;
+
+        if (childActivity == null || !Activities.Contains(childActivity))
+        {
+            return;
+        }
+
+        context.StopPropagation();
+        await sequenceContext.ScheduleActivityAsync(childActivity, new ScheduleWorkOptions
+        {
+            ExistingActivityExecutionContext = signal.ActivityExecutionContext,
+            CompletionCallback = OnChildCompleted,
+            Input = signal.Input
+        });
     }
 
     private void OnBreakSignalReceived(BreakSignal signal, SignalContext signalContext)

--- a/test/integration/Elsa.Alterations.IntegrationTests/RetrySequenceTests.cs
+++ b/test/integration/Elsa.Alterations.IntegrationTests/RetrySequenceTests.cs
@@ -1,0 +1,139 @@
+using Elsa.Alterations.AlterationTypes;
+using Elsa.Alterations.Core.Contracts;
+using Elsa.Alterations.Extensions;
+using Elsa.Common.Models;
+using Elsa.Extensions;
+using Elsa.Testing.Shared;
+using Elsa.Workflows;
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Activities.Flowchart.Activities;
+using Elsa.Workflows.Activities.Flowchart.Models;
+using Elsa.Workflows.IncidentStrategies;
+using Elsa.Workflows.Models;
+using Elsa.Workflows.Runtime;
+using Elsa.Workflows.Runtime.Activities;
+using Elsa.Workflows.Runtime.Messages;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit.Abstractions;
+
+namespace Elsa.Alterations.IntegrationTests;
+
+public sealed class RetrySequenceTests : IAsyncLifetime
+{
+    private readonly IServiceProvider _services;
+    private readonly CapturingTextWriter _output = new();
+    private readonly RetryProbe _probe = new();
+
+    public RetrySequenceTests(ITestOutputHelper output)
+    {
+        _services = new TestApplicationBuilder(output)
+            .WithCapturingTextWriter(_output)
+            .ConfigureServices(services => services.AddSingleton(_probe))
+            .ConfigureElsa(elsa => elsa.UseAlterations())
+            .AddWorkflow<RetrySequenceWorkflow>()
+            .AddWorkflow<RetryStandaloneSequenceWorkflow>()
+            .AddActivitiesFrom<RetryBookmarkActivity>()
+            .Build();
+    }
+
+    public Task InitializeAsync() => _services.PopulateRegistriesAsync();
+    public async Task DisposeAsync() => await ((IAsyncDisposable)_services).DisposeAsync();
+
+    [Theory]
+    [InlineData(nameof(RetrySequenceWorkflow))]
+    [InlineData(nameof(RetryStandaloneSequenceWorkflow))]
+    public async Task RetriedChildCompletesItsSequenceAndPreservesTheNextBookmark(string definitionId)
+    {
+        var runtime = _services.GetRequiredService<IWorkflowRuntime>();
+        var client = await runtime.CreateClientAsync();
+        await client.CreateInstanceAsync(new()
+        {
+            WorkflowDefinitionHandle = WorkflowDefinitionHandle.ByDefinitionId(definitionId, VersionOptions.Published)
+        });
+        var firstRun = await client.RunInstanceAsync(RunWorkflowInstanceRequest.Empty);
+        var faultedState = await client.ExportStateAsync();
+        var incident = Assert.Single(faultedState.Incidents);
+        Assert.Equal("Retry", incident.ActivityId);
+        var faultedContext = Assert.Single(faultedState.ActivityExecutionContexts, x => x.Status == ActivityStatus.Faulted);
+        var sequenceContextId = faultedContext.ParentContextId;
+        Assert.Equal(1, _probe.Attempts);
+        Assert.Empty(_output.Lines);
+
+        var alterations = new IAlteration[] { new ScheduleActivity { ActivityInstanceId = faultedContext.Id } };
+        var results = await _services.GetRequiredService<IAlterationRunner>().RunAsync([firstRun.WorkflowInstanceId], alterations);
+        Assert.True(Assert.Single(results).IsSuccessful);
+
+        var alteredState = await client.ExportStateAsync();
+        var callbacks = alteredState.CompletionCallbacks
+            .Where(x => x.ChildNodeId == faultedContext.ScheduledActivityNodeId)
+            .ToList();
+        Assert.NotEmpty(callbacks);
+        Assert.All(callbacks, callback => Assert.Equal(sequenceContextId, callback.OwnerInstanceId));
+
+        await client.RunInstanceAsync(RunWorkflowInstanceRequest.Empty);
+        var retriedState = await client.ExportStateAsync();
+        var retryBookmark = Assert.Single(retriedState.Bookmarks);
+        Assert.Equal(faultedContext.Id, retryBookmark.ActivityInstanceId);
+        Assert.Equal(2, _probe.Attempts);
+
+        var afterRetry = await client.RunInstanceAsync(new() { BookmarkId = retryBookmark.Id });
+        var nextState = await client.ExportStateAsync();
+        var nextBookmark = Assert.Single(nextState.Bookmarks);
+        Assert.Equal(WorkflowStatus.Running, afterRetry.Status);
+        Assert.Equal(["Sequence finished"], _output.Lines);
+        Assert.Equal(faultedState.Incidents.Count, nextState.Incidents.Count);
+        Assert.NotEqual(retryBookmark.ActivityInstanceId, nextBookmark.ActivityInstanceId);
+
+        var finalRun = await client.RunInstanceAsync(new() { BookmarkId = nextBookmark.Id });
+        Assert.Equal(WorkflowStatus.Finished, finalRun.Status);
+        Assert.Equal(["Sequence finished", "Done"], _output.Lines);
+        Assert.Equal(2, _probe.Attempts);
+        Assert.Empty((await client.ExportStateAsync()).Bookmarks);
+    }
+
+    public sealed class RetryProbe
+    {
+        public int Attempts { get; set; }
+    }
+
+    public sealed class RetryBookmarkActivity : Activity
+    {
+        protected override void Execute(ActivityExecutionContext context)
+        {
+            if (++context.GetRequiredService<RetryProbe>().Attempts == 1)
+            {
+                throw new InvalidOperationException("Transient test failure");
+            }
+
+            context.CreateBookmark(new CreateBookmarkArgs());
+        }
+    }
+
+    public class RetrySequenceWorkflow : WorkflowBase
+    {
+        protected virtual bool UseFlowchart => true;
+
+        protected override void Build(IWorkflowBuilder builder)
+        {
+            builder.WorkflowOptions.IncidentStrategyType = typeof(ContinueWithIncidentsStrategy);
+            var sequence = new Sequence
+            {
+                Activities = { new RetryBookmarkActivity { Id = "Retry" }, new WriteLine("Sequence finished") }
+            };
+            var next = new Event("Next");
+            var end = new WriteLine("Done");
+            builder.Root = UseFlowchart
+                ? new Flowchart
+                {
+                    Activities = { sequence, next, end },
+                    Connections = { new Connection(sequence, next), new Connection(next, end) }
+                }
+                : new Sequence { Activities = { sequence, next, end } };
+        }
+    }
+
+    public sealed class RetryStandaloneSequenceWorkflow : RetrySequenceWorkflow
+    {
+        protected override bool UseFlowchart => false;
+    }
+}


### PR DESCRIPTION
## Purpose

Fix retry alterations for activities inside a Sequence. Retrying a faulted child now preserves the Sequence's completion callback, allowing the workflow to reach its next bookmark and finish normally.

Fixes #6916.

## Scope

- [x] Bug fix (behavior change)

## Description

`ScheduleChildActivity` previously propagated past the parent Sequence to an ancestor. In a Flowchart this registered an invalid callback for a grandchild, causing the dangling-activity error described in the issue.

Sequence now handles signals for its direct children, resolves either an existing execution context or an activity payload, stops propagation, and schedules the child with its own completion callback while preserving the context and input. Other signals continue to propagate. This change is independent of the ActivityId-only retry behavior addressed by #7417.

### CI prerequisite

The first CI run exposed a pre-existing .NET 10 compile failure in UserTasks, also present in [the base branch's Packages run](https://github.com/elsa-workflows/elsa-core/actions/runs/33995412554). FastEndpoints 8.2 gives `EmptyRequest` a private constructor, but `AnonymousInvitationEndpointBase` retained an unused `new()` constraint. Remove that constraint, matching the shared Elsa endpoint wrappers fixed in 016ffe5d8. This one-line correction unblocks validation without changing request handling.

## Verification

- Reproduced both Flowchart and nested-Sequence scenarios before the fix: 2/2 regression tests failed.
- After the fix, both regressions pass, verifying callback ownership, execution-context reuse, the next bookmark, no duplicate execution, and final workflow completion.
- Full Alterations integration suite: 12 passed, 0 failed; coverage enabled.
- Full Activities unit suite: 426 passed, 0 failed; coverage enabled.
- Elsa.Workflows.Core builds for net8.0, net9.0 and net10.0: 0 warnings, 0 errors.
- Elsa.UserTasks builds for net8.0, net9.0 and net10.0: 0 warnings, 0 errors.
- Existing UserTasks unit suite: 103 passed, including invitation/guest-session service tests and endpoint authorization reflection checks. No HTTP route integration test was run.
- Worker self-review and maintainer diff review completed before requesting automated review.

## Checklist

- [x] The PR is focused on a single concern
- [x] Commit messages follow the recommended convention
- [x] Tests added or updated
- [x] Relevant XML documentation updated
- [x] No unrelated cleanup included; the documented one-line build prerequisite is included
- [x] All tests run for this change pass
