### PR TITLE
Fix UserTasks net10 EmptyRequest compilation

### DIFF
--- a/src/modules/Elsa.UserTasks/Endpoints/UserTasksEndpoints.cs
+++ b/src/modules/Elsa.UserTasks/Endpoints/UserTasksEndpoints.cs
@@ -558,7 +558,7 @@ internal sealed class ListParticipantsEndpoint(IUserTaskParticipantDirectory dir
 /// shape for valid and invalid tokens.
 /// </summary>
 internal abstract class AnonymousInvitationEndpointBase<TRequest, TResponse> : Endpoint<TRequest, TResponse>
-    where TRequest : notnull, new()
+    where TRequest : notnull
     where TResponse : notnull
 {
     protected async Task<bool> TryAcquireAsync(IUserTaskInvitationRateLimiter limiter, CancellationToken cancellationToken)


### PR DESCRIPTION
## Summary

Fixes the unrelated `Elsa.UserTasks` `net10.0` compilation failure caused by an unnecessary `new()` constraint on `AnonymousInvitationEndpointBase<TRequest, TResponse>`.

FastEndpoints 8.2.0's `EmptyRequest` is the marker request type for requestless endpoints and does not expose a public parameterless constructor. The endpoint base only needs the existing non-null request constraint, so removing `new()` restores compatibility without changing routes or runtime behavior.

Closes #8030

## Validation

- `dotnet build src/modules/Elsa.UserTasks/Elsa.UserTasks.csproj --framework net10.0 --no-restore --nologo`
- `dotnet build src/modules/Elsa.UserTasks/Elsa.UserTasks.csproj --framework net8.0 --no-restore --nologo`
- `dotnet test test/unit/Elsa.UserTasks.UnitTests/Elsa.UserTasks.UnitTests.csproj --framework net10.0 --nologo`
  - 103 passed, 0 failed, 0 skipped
