### PR TITLE
fix(identity): isolate in-memory roles by tenant

### DIFF
--- a/src/modules/Elsa.Identity/Models/RoleFilter.cs
+++ b/src/modules/Elsa.Identity/Models/RoleFilter.cs
@@ -21,6 +21,7 @@ public class RoleFilter
     /// <summary>
     /// Gets or sets the tenant to filter for. The tenant-agnostic sentinel is always included, matching
     /// the Entity Framework query filter, so a shared platform role remains visible from every tenant.
+    /// Legacy records without a tenant remain visible to the default tenant for backwards compatibility.
     /// </summary>
     public string? TenantId { get; set; }
     
@@ -34,7 +35,8 @@ public class RoleFilter
         var filter = this;
         if (filter.Id != null) queryable = queryable.Where(x => x.Id == filter.Id);
         if (filter.Ids != null) queryable = queryable.Where(x => filter.Ids.Contains(x.Id));
-        if (filter.TenantId != null) queryable = queryable.Where(x => x.TenantId == filter.TenantId || x.TenantId == Tenant.AgnosticTenantId);
+        if (filter.TenantId != null)
+            queryable = queryable.Where(x => x.TenantId == filter.TenantId || x.TenantId == Tenant.AgnosticTenantId || (x.TenantId == null && filter.TenantId == Tenant.DefaultTenantId));
 
         return queryable;
     }

--- a/src/modules/Elsa.Identity/Services/MemoryRoleStore.cs
+++ b/src/modules/Elsa.Identity/Services/MemoryRoleStore.cs
@@ -26,22 +26,22 @@ public class MemoryRoleStore : IRoleStore
     /// <inheritdoc />
     public Task AddAsync(Role role, CancellationToken cancellationToken = default)
     {
-        _store.Save(role, x => x.Id);
+        _store.Save(role, GetStorageKey);
         return Task.CompletedTask;
     }
 
     /// <inheritdoc />
     public Task DeleteAsync(RoleFilter filter, CancellationToken cancellationToken = default)
     {
-        var ids = _store.Query(query => Filter(query, filter)).Select(x => x.Id).Distinct().ToList();
-        _store.DeleteWhere(x => ids.Contains(x.Id));
+        var roles = _store.Query(query => Filter(query, filter)).ToList();
+        _store.DeleteMany(roles, GetStorageKey);
         return Task.CompletedTask;
     }
 
     /// <inheritdoc />
     public Task SaveAsync(Role role, CancellationToken cancellationToken = default)
     {
-        _store.Save(role, x => x.Id);
+        _store.Save(role, GetStorageKey);
         return Task.CompletedTask;
     }
 
@@ -62,13 +62,19 @@ public class MemoryRoleStore : IRoleStore
     /// <remarks>
     /// The ambient tenant is applied here rather than left to callers. Isolation previously existed only
     /// on the Entity Framework path, and only when multitenancy was enabled, so a deployment running the
-    /// default in-memory stores had none at all.
+    /// default in-memory stores had none at all. Null tenant IDs are retained only for the default tenant
+    /// for backwards compatibility with records created before tenant assignment was added.
     /// </remarks>
     private IQueryable<Role> Filter(IQueryable<Role> queryable, RoleFilter filter)
     {
         var tenantId = _tenantAccessor.TenantId;
-        queryable = queryable.Where(x => x.TenantId == tenantId || x.TenantId == Tenant.AgnosticTenantId || x.TenantId == null);
+        queryable = queryable.Where(x => x.TenantId == tenantId || x.TenantId == Tenant.AgnosticTenantId || (x.TenantId == null && tenantId == Tenant.DefaultTenantId));
 
         return filter.Apply(queryable);
     }
+
+    private static string GetStorageKey(Role role) => GetStorageKey(role.TenantId, role.Id);
+
+    private static string GetStorageKey(string? tenantId, string roleId) =>
+        $"{tenantId?.Length ?? -1}:{tenantId}{roleId.Length}:{roleId}";
 }

--- a/src/modules/Elsa.Identity/Services/RoleManager.cs
+++ b/src/modules/Elsa.Identity/Services/RoleManager.cs
@@ -1,3 +1,4 @@
+using Elsa.Common.Multitenancy;
 using Elsa.Identity.Contracts;
 using Elsa.Identity.Entities;
 using Elsa.Identity.Models;
@@ -8,7 +9,7 @@ namespace Elsa.Identity.Services;
 /// <summary>
 /// Default implementation of <see cref="IRoleManager"/>.
 /// </summary>
-public class RoleManager(IRoleStore roleStore, IRoleProvider roleProvider) : IRoleManager
+public class RoleManager(IRoleStore roleStore, IRoleProvider roleProvider, ITenantAccessor tenantAccessor) : IRoleManager
 {
     /// <inheritdoc />
     public async Task<CreateRoleResult> CreateRoleAsync(
@@ -26,6 +27,8 @@ public class RoleManager(IRoleStore roleStore, IRoleProvider roleProvider) : IRo
         {
             Id = roleId,
             Name = name,
+            // The in-memory path does not run EF's ApplyTenantId saving handler.
+            TenantId = tenantAccessor.TenantId,
             Permissions = permissions ?? new List<string>()
         };
 

--- a/test/unit/Elsa.Identity.UnitTests/Services/RoleManagerTests.cs
+++ b/test/unit/Elsa.Identity.UnitTests/Services/RoleManagerTests.cs
@@ -1,3 +1,4 @@
+using Elsa.Common.Multitenancy;
 using Elsa.Testing.Shared.Multitenancy;
 using Elsa.Common.Services;
 using Elsa.Identity.Entities;
@@ -8,13 +9,61 @@ namespace Elsa.Identity.UnitTests.Services;
 
 public class RoleManagerTests
 {
+    private readonly TestTenantAccessor _tenantAccessor;
     private readonly MemoryRoleStore _roleStore;
     private readonly RoleManager _manager;
 
     public RoleManagerTests()
     {
-        _roleStore = new MemoryRoleStore(new MemoryStore<Role>(), TestTenantAccessor.Default);
-        _manager = new RoleManager(_roleStore, new StoreBasedRoleProvider(_roleStore));
+        _tenantAccessor = new TestTenantAccessor("tenant-a");
+        _roleStore = new MemoryRoleStore(new MemoryStore<Role>(), _tenantAccessor);
+        _manager = new RoleManager(_roleStore, new StoreBasedRoleProvider(_roleStore), _tenantAccessor);
+    }
+
+    [Fact]
+    public async Task CreateListUpdateAndDeleteAreIsolatedForRolesWithTheSameNameAcrossTenants()
+    {
+        var roleA = await _manager.CreateRoleAsync("Operators", ["tenant-a:permission"]);
+
+        Assert.Equal("tenant-a", roleA.Role.TenantId);
+        Assert.Single(await _roleStore.FindManyAsync(new() { TenantId = "tenant-a" }));
+
+        using (_tenantAccessor.PushContext(new Tenant { Id = "tenant-b", Name = "Tenant B" }))
+        {
+            var roleB = await _manager.CreateRoleAsync("Operators", ["tenant-b:permission"]);
+
+            Assert.Equal(roleA.Role.Id, roleB.Role.Id);
+            Assert.Equal("tenant-b", roleB.Role.TenantId);
+            Assert.Equal(["tenant-b:permission"], roleB.Role.Permissions);
+
+            var tenantBRoles = await _roleStore.FindManyAsync(new() { TenantId = "tenant-b" });
+            Assert.Single(tenantBRoles);
+            Assert.Equal(roleB.Role.Id, tenantBRoles.Single().Id);
+
+            tenantBRoles.Single().Name = "Operators B";
+            await _roleStore.SaveAsync(tenantBRoles.Single());
+
+            Assert.Equal("Operators B", (await _roleStore.FindAsync(new() { Id = roleB.Role.Id }))!.Name);
+        }
+
+        var tenantARole = await _roleStore.FindAsync(new() { Id = roleA.Role.Id });
+        Assert.NotNull(tenantARole);
+        Assert.Equal("Operators", tenantARole.Name);
+        Assert.Equal(["tenant-a:permission"], tenantARole.Permissions);
+
+        tenantARole.Name = "Operators A";
+        await _roleStore.SaveAsync(tenantARole);
+        Assert.Equal("Operators A", (await _roleStore.FindAsync(new() { Id = roleA.Role.Id }))!.Name);
+
+        await _roleStore.DeleteAsync(new() { Id = roleA.Role.Id });
+        Assert.Empty(await _roleStore.FindManyAsync(new() { TenantId = "tenant-a" }));
+
+        using (_tenantAccessor.PushContext(new Tenant { Id = "tenant-b", Name = "Tenant B" }))
+        {
+            var remainingTenantBRole = await _roleStore.FindAsync(new() { Id = roleA.Role.Id });
+            Assert.NotNull(remainingTenantBRole);
+            Assert.Equal("Operators B", remainingTenantBRole.Name);
+        }
     }
 
     [Fact]
@@ -24,6 +73,7 @@ public class RoleManagerTests
         {
             Id = "admin",
             Name = "Admin",
+            TenantId = "tenant-a",
             Permissions = [PermissionNames.All]
         });
 
@@ -38,7 +88,7 @@ public class RoleManagerTests
     [Fact]
     public async Task CreateRoleRejectsProvidedAdminRoleIdCollision()
     {
-        var manager = new RoleManager(_roleStore, new AdminRoleProvider());
+        var manager = new RoleManager(_roleStore, new AdminRoleProvider(), _tenantAccessor);
 
         await Assert.ThrowsAsync<InvalidOperationException>(() => manager.CreateRoleAsync("Replacement", [], "admin"));
     }

--- a/test/unit/Elsa.Identity.UnitTests/Services/RoleManagerTests.cs
+++ b/test/unit/Elsa.Identity.UnitTests/Services/RoleManagerTests.cs
@@ -67,6 +67,20 @@ public class RoleManagerTests
     }
 
     [Fact]
+    public async Task DefaultTenantListsLegacyRolesWithoutATenantId()
+    {
+        var tenantAccessor = new TestTenantAccessor();
+        var roleStore = new MemoryRoleStore(new MemoryStore<Role>(), tenantAccessor);
+
+        await roleStore.SaveAsync(new Role { Id = "legacy", Name = "Legacy", Permissions = [] });
+
+        var roles = await roleStore.FindManyAsync(new() { TenantId = Tenant.DefaultTenantId });
+
+        Assert.Single(roles);
+        Assert.Equal("legacy", roles.Single().Id);
+    }
+
+    [Fact]
     public async Task CreateRoleRejectsExistingRoleId()
     {
         await _roleStore.SaveAsync(new Role


### PR DESCRIPTION
## Summary

- assign the ambient tenant when RoleManager creates a role, matching EF ApplyTenantId behavior on the in-memory path
- key MemoryRoleStore entries by tenant and role ID so same-name roles cannot overwrite each other
- scope updates/deletes to the tenant-filtered role records and retain legacy null-tenant records only for the default tenant
- add a lifecycle regression covering create/list/update/delete and duplicate names across tenants

Closes #8012

## Verification

- `dotnet test test/unit/Elsa.Identity.UnitTests/Elsa.Identity.UnitTests.csproj --no-restore --filter FullyQualifiedName~RoleManagerTests` (3 passed)
- `dotnet test test/unit/Elsa.Identity.UnitTests/Elsa.Identity.UnitTests.csproj --no-restore` (119 passed)
- `dotnet build src/modules/Elsa.Identity/Elsa.Identity.csproj --no-restore --configuration Release` (0 errors; 45 pre-existing XML documentation warnings across net8/net9/net10)

No `.codebase-memory` files were changed.