### PR TITLE
test(modular-host): add opt-in role management fixture

### DIFF
--- a/src/apps/Elsa.ModularServer.Web/Program.cs
+++ b/src/apps/Elsa.ModularServer.Web/Program.cs
@@ -35,6 +35,7 @@ var builder = WebApplication.CreateBuilder(args);
 var services = builder.Services;
 var configuration = builder.Configuration;
 configuration.AddJsonFile(configuration["Elsa:PlatformIntegration:ShellOverlayPath"] ?? "platform-shell-overrides.json", optional: true, reloadOnChange: false);
+services.AddRoleManagementE2EFixtures(configuration);
 var serviceVersion = typeof(Program).Assembly.GetName().Version?.ToString();
 
 builder.Logging.AddOpenTelemetry(logging =>

--- a/src/apps/Elsa.ModularServer.Web/RoleManagementE2EFixtures.cs
+++ b/src/apps/Elsa.ModularServer.Web/RoleManagementE2EFixtures.cs
@@ -1,0 +1,46 @@
+using Elsa.Permissions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Elsa.ModularServer.Web;
+
+/// <summary>Opt-in services used by the Elsa Studio role-management acceptance harness.</summary>
+public static class RoleManagementE2EFixtureServiceCollectionExtensions
+{
+    /// <summary>Configuration switch that enables the role-management catalog fixture.</summary>
+    public const string IncludeUnverifiedPermissionDescriptorKey = "RoleManagementE2EFixtures:IncludeUnverifiedPermissionDescriptor";
+
+    /// <summary>
+    /// Adds the deterministic role-management fixture when explicitly enabled by the host configuration.
+    /// The default path is intentionally a no-op so ordinary sample and production hosts do not change.
+    /// </summary>
+    public static IServiceCollection AddRoleManagementE2EFixtures(this IServiceCollection services, IConfiguration configuration)
+    {
+        if (configuration.GetValue<bool>(IncludeUnverifiedPermissionDescriptorKey))
+            services.AddSingleton<IPermissionDescriptorProvider>(RoleManagementE2EFixturePermissionDescriptorProvider.Instance);
+
+        return services;
+    }
+}
+
+/// <summary>Provides the one unverified descriptor needed by the role-management acceptance harness.</summary>
+/// <remarks>
+/// This is a value type on purpose: the shell descriptor scanner discovers class-based module providers, while
+/// this provider is registered only through the explicit opt-in above. It therefore cannot leak into the normal
+/// catalog merely because the host assembly is loaded.
+/// </remarks>
+internal readonly struct RoleManagementE2EFixturePermissionDescriptorProvider : IPermissionDescriptorProvider
+{
+    public static RoleManagementE2EFixturePermissionDescriptorProvider Instance => new();
+
+    public IEnumerable<PermissionDescriptor> GetDescriptors() =>
+    [
+        new(
+            "e2e/role-management/unverified",
+            [Authorization.CoreVerbs.View],
+            "E2E unverified permission",
+            "Fixture-only permission descriptor for role-management acceptance testing.",
+            "E2E fixtures",
+            Verified: false)
+    ];
+}

--- a/test/integration/Elsa.Hosts.SmokeTests/RoleManagementE2EFixtureTests.cs
+++ b/test/integration/Elsa.Hosts.SmokeTests/RoleManagementE2EFixtureTests.cs
@@ -1,0 +1,49 @@
+using Elsa.Authorization;
+using Elsa.ModularServer.Web;
+using Elsa.Permissions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Elsa.Hosts.SmokeTests;
+
+public class RoleManagementE2EFixtureTests
+{
+    [Fact]
+    public void DisabledConfigurationLeavesServicesUnchanged()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<ExistingService>();
+        var before = services.ToArray();
+
+        services.AddRoleManagementE2EFixtures(new ConfigurationBuilder().Build());
+
+        Assert.Equal(before, services);
+        Assert.DoesNotContain(services, x => x.ServiceType == typeof(IPermissionDescriptorProvider));
+    }
+
+    [Fact]
+    public void EnabledConfigurationContributesOneUnverifiedDescriptor()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [RoleManagementE2EFixtureServiceCollectionExtensions.IncludeUnverifiedPermissionDescriptorKey] = "true"
+            })
+            .Build();
+        var services = new ServiceCollection();
+
+        services.AddRoleManagementE2EFixtures(configuration);
+
+        using var serviceProvider = services.BuildServiceProvider();
+        var providers = serviceProvider.GetServices<IPermissionDescriptorProvider>().ToArray();
+        var descriptors = providers.SelectMany(x => x.GetDescriptors()).ToArray();
+
+        Assert.Single(providers);
+        var descriptor = Assert.Single(descriptors);
+        Assert.Equal("e2e/role-management/unverified", descriptor.Resource);
+        Assert.False(descriptor.Verified);
+        Assert.Equal([CoreVerbs.View], descriptor.SupportedVerbs);
+    }
+
+    private sealed class ExistingService;
+}


### PR DESCRIPTION
Summary: add RoleManagementE2EFixtures:IncludeUnverifiedPermissionDescriptor as an explicit dormant ModularServer host switch; register exactly one value-type IPermissionDescriptorProvider only when enabled, contributing e2e/role-management/unverified with Verified=false; prove disabled no-op and enabled catalog behavior in the host smoke test project. Validation: focused fixture tests 2 passed; full Elsa.Hosts.SmokeTests 8 passed; enabled local ModularServer host with the documented environment key and authenticated identity permissions readback returned the fixture descriptor with verified:false (catalog total 50). Boundary: no routes, users, roles, secrets, unresolved persisted grants, or Identity-absent host added. CShells already supports per-shell feature omission; Identity-absent composition remains separate host-configuration validation. Closes #8033. Related: elsa-workflows/elsa-studio#960.