### PR TITLE
fix(external-authentication): scope role-deletion impact to the role's tenant

### DIFF
--- a/src/modules/Elsa.ExternalAuthentication/Extensions/ServiceCollectionExtensions.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Extensions/ServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using Elsa.Common.Multitenancy;
 using Elsa.Extensions;
 using Elsa.ExternalAuthentication.Contracts;
 using Elsa.ExternalAuthentication.Options;
@@ -57,6 +58,11 @@ public static class ServiceCollectionExtensions
         services.AddDataProtection();
         services.AddRateLimiter(_ => { });
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IConfigureOptions<RateLimiterOptions>, ConfigureExternalAuthenticationRateLimiterOptions>());
+
+        // The module reads the ambient tenant outside the multitenancy feature -- connection scoping and the
+        // role-deletion contributor's tenant boundary -- so it depends on an accessor whether or not a host
+        // enabled multitenancy. TryAdd keeps a host's own registration.
+        services.TryAddSingleton<ITenantAccessor, DefaultTenantAccessor>();
 
         services.TryAddSingleton<ConnectionRevisionCalculator>();
         services.TryAddSingleton<FinalLoginPathGuard>();

--- a/src/modules/Elsa.ExternalAuthentication/Services/ExternalAuthenticationRoleDeletionDependencyContributor.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Services/ExternalAuthenticationRoleDeletionDependencyContributor.cs
@@ -20,9 +20,13 @@ namespace Elsa.ExternalAuthentication.Services;
 /// <summary>Guards Elsa Role deletion against JIT-policy default-role references.</summary>
 /// <remarks>
 /// Roles are tenant-scoped, so impact and remediation only ever consider connections in the role's own tenant
-/// context: the tenant active on <see cref="ITenantAccessor"/> while the role-deletion coordinator runs, which is
-/// the tenant the coordinator already resolved the role in. A connection carrying another tenant's ID is out of
-/// scope in both directions, for impact and for remediation.
+/// context: the resolved role's own <c>TenantId</c>. The tenant active on <see cref="ITenantAccessor"/> is used
+/// only as a fallback when the role cannot be resolved, because with multitenancy disabled (the default) the EF
+/// Core role store installs no tenant query filter and can resolve a tenant-owned role by ID regardless of the
+/// ambient tenant; trusting the ambient tenant instead of the resolved role's tenant would then let this
+/// contributor scan the wrong tenant's connections while the coordinator deletes a role belonging to another
+/// tenant. A connection carrying another tenant's ID is out of scope in both directions, for impact and for
+/// remediation.
 /// Host-scoped connections (<see cref="ConnectionScope.HostTenantId"/>, and configuration entries that leave the
 /// tenant blank, which are materialized at host scope) stay in scope for every tenant. The connection registry
 /// resolves the host scope for every signing-in tenant, and a connection's default role IDs are then resolved by
@@ -60,7 +64,7 @@ public sealed class ExternalAuthenticationRoleDeletionDependencyContributor(
 
     public async ValueTask<RoleDeletionDependencySnapshot> InspectAsync(string roleId, CancellationToken cancellationToken = default)
     {
-        var isAgnosticRole = await IsAgnosticRoleAsync(roleId, cancellationToken);
+        var roleTenantId = await ResolveRoleTenantIdAsync(roleId, cancellationToken);
         var dependencies = new List<RoleDeletionDependency>();
         var configuredConnections = options.CurrentValue.ConfigurationConnections ?? [];
         var configurationIndex = 0;
@@ -68,12 +72,12 @@ public sealed class ExternalAuthenticationRoleDeletionDependencyContributor(
         {
             // The index is part of the configuration path an operator edits, so out-of-scope entries are
             // skipped without renumbering the entries that remain.
-            if (IsInRoleTenantScope(GetConfigurationScopeTenantId(connection), isAgnosticRole))
+            if (IsInRoleTenantScope(GetConfigurationScopeTenantId(connection), roleTenantId))
                 dependencies.AddRange(GetConfigurationDependencies(connection, configurationIndex, roleId));
             configurationIndex++;
         }
 
-        foreach (var connection in await FindConnectionsInRoleTenantScopeAsync(isAgnosticRole, cancellationToken))
+        foreach (var connection in await FindConnectionsInRoleTenantScopeAsync(roleTenantId, cancellationToken))
         {
             if (!TryGetRoleReference(connection.UnlinkedPolicy, roleId, out var policyBranch, out _, out var removesLastDefaultRole))
                 continue;
@@ -122,10 +126,10 @@ public sealed class ExternalAuthenticationRoleDeletionDependencyContributor(
         if (!expectedOwners.IsSubsetOf(currentOwners))
             return new RoleReferenceRemovalValidationResult.Conflict("dependency_changed");
 
-        var isAgnosticRole = await IsAgnosticRoleAsync(request.RoleId, cancellationToken);
+        var roleTenantId = await ResolveRoleTenantIdAsync(request.RoleId, cancellationToken);
         foreach (var dependency in request.Dependencies)
         {
-            var connection = await FindConnectionInRoleTenantScopeAsync(dependency.OwnerId, isAgnosticRole, cancellationToken);
+            var connection = await FindConnectionInRoleTenantScopeAsync(dependency.OwnerId, roleTenantId, cancellationToken);
             if (connection is null || connection.Revision != dependency.ExpectedRevision ||
                 !TryGetRoleReference(connection.UnlinkedPolicy, request.RoleId, out _, out var roleIds, out _))
                 return new RoleReferenceRemovalValidationResult.Conflict("connection_revision_changed");
@@ -160,13 +164,13 @@ public sealed class ExternalAuthenticationRoleDeletionDependencyContributor(
         if (validation is RoleReferenceRemovalValidationResult.Conflict conflict)
             return new RoleReferenceRemovalResult.Conflict(conflict.Code, []);
 
-        var isAgnosticRole = await IsAgnosticRoleAsync(request.RoleId, cancellationToken);
+        var roleTenantId = await ResolveRoleTenantIdAsync(request.RoleId, cancellationToken);
         var changedOwnerIds = new List<string>();
         try
         {
             foreach (var dependency in request.Dependencies.OrderBy(x => x.OwnerId, StringComparer.Ordinal))
             {
-                var connection = await FindConnectionInRoleTenantScopeAsync(dependency.OwnerId, isAgnosticRole, cancellationToken);
+                var connection = await FindConnectionInRoleTenantScopeAsync(dependency.OwnerId, roleTenantId, cancellationToken);
                 if (connection is null || connection.Revision != dependency.ExpectedRevision ||
                     !TryGetRoleReference(connection.UnlinkedPolicy, request.RoleId, out _, out _, out var removesLastDefaultRole))
                     return new RoleReferenceRemovalResult.Conflict("connection_revision_changed", changedOwnerIds);
@@ -223,27 +227,29 @@ public sealed class ExternalAuthenticationRoleDeletionDependencyContributor(
     }
 
     /// <summary>
-    /// Resolves whether the role being deleted is tenant-agnostic (<see cref="Tenant.AgnosticTenantId"/>), in
-    /// which case its tenant context is every tenant rather than the ambient one. In EF Core persistence a role
-    /// ID is unique across all tenants (the <c>Roles</c> table keys on <c>Id</c> alone), so this lookup resolves
-    /// to at most one role there. Only <c>MemoryRoleStore</c> can hold two roles that share an ID because its
-    /// storage key includes the tenant; if the ID resolves to more than one role, which tenant's role the
-    /// coordinator's own delete actually targets is already ambiguous, and this method cannot make the
-    /// operation consistent by guessing in either direction -- widening would expose another tenant's
-    /// references for what may be a tenant-scoped deletion, and narrowing would leave an agnostic role's
-    /// references dangling. It fails closed instead. A missing store or no matching role keeps the current
-    /// tenant-scoped behavior.
+    /// Resolves the tenant context for the role being deleted: the role's own <c>TenantId</c>
+    /// (<see cref="Tenant.AgnosticTenantId"/> normalized when the role is tenant-agnostic, in which case its
+    /// tenant context is every tenant). In EF Core persistence a role ID is unique across all tenants (the
+    /// <c>Roles</c> table keys on <c>Id</c> alone), so this lookup resolves to at most one role there. Only
+    /// <c>MemoryRoleStore</c> can hold two roles that share an ID because its storage key includes the tenant;
+    /// if the ID resolves to more than one role, which tenant's role the coordinator's own delete actually
+    /// targets is already ambiguous, and this method cannot make the operation consistent by guessing in either
+    /// direction -- widening would expose another tenant's references for what may be a tenant-scoped deletion,
+    /// and narrowing would leave an agnostic role's references dangling. It fails closed instead.
+    /// A missing store or no matching role falls back to the ambient tenant on <see cref="ITenantAccessor"/>,
+    /// which is the only case where the ambient tenant is trusted: the role cannot be resolved at all, so there
+    /// is no resolved tenant to prefer over it.
     /// </summary>
-    private async ValueTask<bool> IsAgnosticRoleAsync(string roleId, CancellationToken cancellationToken)
+    private async ValueTask<string> ResolveRoleTenantIdAsync(string roleId, CancellationToken cancellationToken)
     {
         var roleStore = ActiveRoleStore;
         if (roleStore is null)
-            return false;
+            return tenantAccessor.TenantId.NormalizeTenantId();
         var roles = (await roleStore.FindManyAsync(new() { Id = roleId }, cancellationToken)).ToArray();
         return roles.Length switch
         {
-            0 => false,
-            1 => string.Equals(roles[0].TenantId, Tenant.AgnosticTenantId, StringComparison.Ordinal),
+            0 => tenantAccessor.TenantId.NormalizeTenantId(),
+            1 => roles[0].TenantId.NormalizeTenantId(),
             _ => throw new InvalidOperationException(
                 $"Role '{roleId}' resolves to {roles.Length} roles across tenant scopes; the deletion target is ambiguous and its external-authentication dependencies cannot be determined.")
         };
@@ -256,10 +262,10 @@ public sealed class ExternalAuthenticationRoleDeletionDependencyContributor(
     /// connection could fall between the reads and appear in neither result. A single snapshot has no gap to fall
     /// through.
     /// </summary>
-    private async ValueTask<IReadOnlyCollection<IdentityProviderConnection>> FindConnectionsInRoleTenantScopeAsync(bool isAgnosticRole, CancellationToken cancellationToken)
+    private async ValueTask<IReadOnlyCollection<IdentityProviderConnection>> FindConnectionsInRoleTenantScopeAsync(string roleTenantId, CancellationToken cancellationToken)
     {
         var connections = (await store.FindAsync(new(), cancellationToken)).Items;
-        return connections.Where(x => IsInRoleTenantScope(x.TenantId, isAgnosticRole)).ToArray();
+        return connections.Where(x => IsInRoleTenantScope(x.TenantId, roleTenantId)).ToArray();
     }
 
     /// <summary>
@@ -267,16 +273,16 @@ public sealed class ExternalAuthenticationRoleDeletionDependencyContributor(
     /// that a caller-supplied owner ID cannot reach across a tenant boundary. An agnostic role's tenant context
     /// is every tenant, so any connection loaded by owner ID qualifies.
     /// </summary>
-    private async ValueTask<IdentityProviderConnection?> FindConnectionInRoleTenantScopeAsync(string ownerId, bool isAgnosticRole, CancellationToken cancellationToken)
+    private async ValueTask<IdentityProviderConnection?> FindConnectionInRoleTenantScopeAsync(string ownerId, string roleTenantId, CancellationToken cancellationToken)
     {
         var connection = await store.FindByIdAsync(ownerId, cancellationToken);
-        return connection is not null && IsInRoleTenantScope(connection.TenantId, isAgnosticRole) ? connection : null;
+        return connection is not null && IsInRoleTenantScope(connection.TenantId, roleTenantId) ? connection : null;
     }
 
-    private bool IsInRoleTenantScope(string? connectionTenantId, bool isAgnosticRole) =>
-        isAgnosticRole ||
+    private static bool IsInRoleTenantScope(string? connectionTenantId, string roleTenantId) =>
+        string.Equals(roleTenantId, Tenant.AgnosticTenantId, StringComparison.Ordinal) ||
         string.Equals(connectionTenantId, ConnectionScope.HostTenantId, StringComparison.Ordinal) ||
-        string.Equals(connectionTenantId.NormalizeTenantId(), tenantAccessor.TenantId.NormalizeTenantId(), StringComparison.Ordinal);
+        string.Equals(connectionTenantId.NormalizeTenantId(), roleTenantId, StringComparison.Ordinal);
 
     /// <summary>A configuration entry that leaves the tenant blank is materialized at host scope.</summary>
     private static string GetConfigurationScopeTenantId(IdentityProviderConnection connection) =>

--- a/src/modules/Elsa.ExternalAuthentication/Services/ExternalAuthenticationRoleDeletionDependencyContributor.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Services/ExternalAuthenticationRoleDeletionDependencyContributor.cs
@@ -46,6 +46,12 @@ public sealed class ExternalAuthenticationRoleDeletionDependencyContributor(
     public const string SourceName = "external-authentication";
     public string Source => SourceName;
 
+    /// <summary>
+    /// Match the default DI container's direct-service semantics: when persistence replaces the in-memory
+    /// store, the last registration is the active store.
+    /// </summary>
+    private IRoleStore? ActiveRoleStore => roleStores.LastOrDefault();
+
     public async ValueTask<RoleDeletionDependencySnapshot> InspectAsync(string roleId, CancellationToken cancellationToken = default)
     {
         var isAgnosticRole = await IsAgnosticRoleAsync(roleId, cancellationToken);
@@ -168,9 +174,7 @@ public sealed class ExternalAuthenticationRoleDeletionDependencyContributor(
 
                 if (request.SelectedReferences is not null && removesLastDefaultRole)
                 {
-                    // Match the default DI container's direct-service semantics: when persistence
-                    // replaces the in-memory store, the last registration is the active store.
-                    var roleStore = roleStores.LastOrDefault();
+                    var roleStore = ActiveRoleStore;
                     if (roleStore is null)
                         return new RoleReferenceRemovalResult.Failed("replacement_role_unavailable_or_unauthorized", changedOwnerIds);
                     var replacement = await roleStore.FindAsync(new() { Id = request.ReplacementRoleId }, cancellationToken);
@@ -220,9 +224,7 @@ public sealed class ExternalAuthenticationRoleDeletionDependencyContributor(
     /// </summary>
     private async ValueTask<bool> IsAgnosticRoleAsync(string roleId, CancellationToken cancellationToken)
     {
-        // Match the default DI container's direct-service semantics: when persistence replaces the in-memory
-        // store, the last registration is the active store.
-        var roleStore = roleStores.LastOrDefault();
+        var roleStore = ActiveRoleStore;
         if (roleStore is null)
             return false;
         var role = await roleStore.FindAsync(new() { Id = roleId }, cancellationToken);
@@ -259,7 +261,7 @@ public sealed class ExternalAuthenticationRoleDeletionDependencyContributor(
 
     private IReadOnlyCollection<ConnectionScope> GetRoleTenantScopes()
     {
-        var tenantScope = ToScope(tenantAccessor.TenantId.NormalizeTenantId());
+        var tenantScope = ToConnectionScope(tenantAccessor.TenantId.NormalizeTenantId());
         return tenantScope == ConnectionScope.Host ? [ConnectionScope.Host] : [ConnectionScope.Host, tenantScope];
     }
 
@@ -272,7 +274,7 @@ public sealed class ExternalAuthenticationRoleDeletionDependencyContributor(
     private static string GetConfigurationScopeTenantId(IdentityProviderConnection connection) =>
         string.IsNullOrWhiteSpace(connection.TenantId) ? ConnectionScope.HostTenantId : connection.TenantId;
 
-    private static ConnectionScope ToScope(string tenantId) =>
+    private static ConnectionScope ToConnectionScope(string tenantId) =>
         tenantId == ConnectionScope.HostTenantId ? ConnectionScope.Host :
         tenantId.Length == 0 ? ConnectionScope.DefaultTenant :
         new(ConnectionScopeKind.Tenant, tenantId);

--- a/src/modules/Elsa.ExternalAuthentication/Services/ExternalAuthenticationRoleDeletionDependencyContributor.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Services/ExternalAuthenticationRoleDeletionDependencyContributor.cs
@@ -32,10 +32,7 @@ namespace Elsa.ExternalAuthentication.Services;
 /// tenant blank, which are materialized at host scope) stay in scope for every tenant. The connection registry
 /// resolves the host scope for every signing-in tenant, and a connection's default role IDs are then resolved by
 /// <c>ExternalIdentityUserProvisioningService</c> through <see cref="IRoleProvider"/> in the signing-in user's
-/// tenant, so a host connection naming role ID X really does reference tenant A's role X. Because the same host
-/// connection is served to every signing-in tenant, a replacement role written into it must resolve in every one
-/// of them too, so remediation of a host-scoped connection requires an agnostic replacement even when the
-/// deletion target itself is a tenant-scoped role.
+/// tenant, so a host connection naming role ID X really does reference tenant A's role X.
 /// A tenant-agnostic role (<see cref="Tenant.AgnosticTenantId"/>) is visible from every tenant, so its tenant
 /// context is every tenant: impact and remediation for such a role scan every stored connection and every
 /// configuration entry regardless of tenant, instead of the single active tenant plus host scope. Authorizing a
@@ -153,12 +150,13 @@ public sealed class ExternalAuthenticationRoleDeletionDependencyContributor(
             // Authorization below still resolves through the ambient tenant's role services, so an agnostic
             // deletion target may only be replaced by another agnostic role; a tenant-scoped replacement would
             // otherwise be authorized in this tenant and then written into every other tenant's connections.
-            // The same requirement applies when the connection being remediated is host-scoped: it is served to
-            // every signing-in tenant, so a tenant-scoped replacement written into it would resolve in the
-            // authorizing tenant but fail to resolve for every other tenant that connection serves.
+            // This does not extend to host-scoped connections: IdentityProviderConnectionManagementService
+            // forces every managed connection to host scope, and in a deployment without multitenancy roles
+            // are created scoped to the default tenant rather than agnostic, so requiring an agnostic
+            // replacement for host-scoped connections would make every replacement remediation impossible in
+            // the default deployment.
             if (requiresReplacement &&
-                (string.Equals(roleTenantId, Tenant.AgnosticTenantId, StringComparison.Ordinal) ||
-                 string.Equals(connection.TenantId, ConnectionScope.HostTenantId, StringComparison.Ordinal)) &&
+                string.Equals(roleTenantId, Tenant.AgnosticTenantId, StringComparison.Ordinal) &&
                 !await IsAgnosticRoleAsync(request.ReplacementRoleId, cancellationToken))
                 return new RoleReferenceRemovalValidationResult.Forbidden("replacement_role_unavailable_or_unauthorized");
 
@@ -217,15 +215,13 @@ public sealed class ExternalAuthenticationRoleDeletionDependencyContributor(
                     // Authorization above still resolves through the ambient tenant's role services, so an
                     // agnostic deletion target may only be replaced by another agnostic role; a tenant-scoped
                     // replacement would otherwise be authorized in this tenant and then written into every other
-                    // tenant's connections. The same requirement applies when this connection is host-scoped:
-                    // it is served to every signing-in tenant, so a tenant-scoped replacement would resolve in
-                    // the authorizing tenant but fail to resolve for every other tenant it serves. The check is
-                    // re-run through IsAgnosticRoleAsync rather than trusting the TenantId on `replacement` from
-                    // the FindAsync call above, because a same-ID tenant-scoped role added after validation could
-                    // make that lookup ambiguous; IsAgnosticRoleAsync resolves the candidate itself and rejects
-                    // an ambiguous match instead of accepting whichever role FindAsync happened to return.
-                    if ((string.Equals(roleTenantId, Tenant.AgnosticTenantId, StringComparison.Ordinal) ||
-                         string.Equals(connection.TenantId, ConnectionScope.HostTenantId, StringComparison.Ordinal)) &&
+                    // tenant's connections. This does not extend to host-scoped connections: see the matching
+                    // guard in ValidateRemovalAsync for why. The check is re-run through IsAgnosticRoleAsync
+                    // rather than trusting the TenantId on `replacement` from the FindAsync call above, because
+                    // a same-ID tenant-scoped role added after validation could make that lookup ambiguous;
+                    // IsAgnosticRoleAsync resolves the candidate itself and rejects an ambiguous match instead
+                    // of accepting whichever role FindAsync happened to return.
+                    if (string.Equals(roleTenantId, Tenant.AgnosticTenantId, StringComparison.Ordinal) &&
                         !await IsAgnosticRoleAsync(request.ReplacementRoleId, cancellationToken))
                         return new RoleReferenceRemovalResult.Failed("replacement_role_unavailable_or_unauthorized", changedOwnerIds);
                 }

--- a/src/modules/Elsa.ExternalAuthentication/Services/ExternalAuthenticationRoleDeletionDependencyContributor.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Services/ExternalAuthenticationRoleDeletionDependencyContributor.cs
@@ -12,6 +12,7 @@ using Elsa.ExternalAuthentication.Options;
 using Elsa.ExternalAuthentication.Permissions;
 using Elsa.ExternalAuthentication.Policies;
 using Elsa.Identity.Contracts;
+using Elsa.Identity.Entities;
 using Elsa.Identity.Models;
 using Microsoft.Extensions.Options;
 
@@ -31,7 +32,10 @@ namespace Elsa.ExternalAuthentication.Services;
 /// tenant blank, which are materialized at host scope) stay in scope for every tenant. The connection registry
 /// resolves the host scope for every signing-in tenant, and a connection's default role IDs are then resolved by
 /// <c>ExternalIdentityUserProvisioningService</c> through <see cref="IRoleProvider"/> in the signing-in user's
-/// tenant, so a host connection naming role ID X really does reference tenant A's role X.
+/// tenant, so a host connection naming role ID X really does reference tenant A's role X. Because the same host
+/// connection is served to every signing-in tenant, a replacement role written into it must resolve in every one
+/// of them too, so remediation of a host-scoped connection requires an agnostic replacement even when the
+/// deletion target itself is a tenant-scoped role.
 /// A tenant-agnostic role (<see cref="Tenant.AgnosticTenantId"/>) is visible from every tenant, so its tenant
 /// context is every tenant: impact and remediation for such a role scan every stored connection and every
 /// configuration entry regardless of tenant, instead of the single active tenant plus host scope. Authorizing a
@@ -43,7 +47,10 @@ namespace Elsa.ExternalAuthentication.Services;
 /// share an ID (its storage key includes the tenant); resolving a role ID against it can then be genuinely
 /// ambiguous. That ambiguity is never resolved by guessing: widening a tenant-scoped deletion would expose
 /// another tenant's references, and narrowing an agnostic deletion would leave an agnostic role's references
-/// dangling. It fails closed instead.
+/// dangling. It fails closed instead. The same collision makes a replacement candidate ambiguous too: a
+/// replacement ID that resolves to more than one role (an ambient match and an agnostic match, under
+/// <c>MemoryRoleStore</c>) is rejected as not agnostic rather than guessed at, so it is reported as
+/// <c>replacement_role_unavailable_or_unauthorized</c> instead of surfacing as an exception.
 /// </remarks>
 public sealed class ExternalAuthenticationRoleDeletionDependencyContributor(
     IIdentityProviderConnectionStore store,
@@ -146,8 +153,12 @@ public sealed class ExternalAuthenticationRoleDeletionDependencyContributor(
             // Authorization below still resolves through the ambient tenant's role services, so an agnostic
             // deletion target may only be replaced by another agnostic role; a tenant-scoped replacement would
             // otherwise be authorized in this tenant and then written into every other tenant's connections.
+            // The same requirement applies when the connection being remediated is host-scoped: it is served to
+            // every signing-in tenant, so a tenant-scoped replacement written into it would resolve in the
+            // authorizing tenant but fail to resolve for every other tenant that connection serves.
             if (requiresReplacement &&
-                string.Equals(roleTenantId, Tenant.AgnosticTenantId, StringComparison.Ordinal) &&
+                (string.Equals(roleTenantId, Tenant.AgnosticTenantId, StringComparison.Ordinal) ||
+                 string.Equals(connection.TenantId, ConnectionScope.HostTenantId, StringComparison.Ordinal)) &&
                 !await IsAgnosticRoleAsync(request.ReplacementRoleId, cancellationToken))
                 return new RoleReferenceRemovalValidationResult.Forbidden("replacement_role_unavailable_or_unauthorized");
 
@@ -206,9 +217,16 @@ public sealed class ExternalAuthenticationRoleDeletionDependencyContributor(
                     // Authorization above still resolves through the ambient tenant's role services, so an
                     // agnostic deletion target may only be replaced by another agnostic role; a tenant-scoped
                     // replacement would otherwise be authorized in this tenant and then written into every other
-                    // tenant's connections.
-                    if (string.Equals(roleTenantId, Tenant.AgnosticTenantId, StringComparison.Ordinal) &&
-                        !string.Equals(replacement.TenantId.NormalizeTenantId(), Tenant.AgnosticTenantId, StringComparison.Ordinal))
+                    // tenant's connections. The same requirement applies when this connection is host-scoped:
+                    // it is served to every signing-in tenant, so a tenant-scoped replacement would resolve in
+                    // the authorizing tenant but fail to resolve for every other tenant it serves. The check is
+                    // re-run through IsAgnosticRoleAsync rather than trusting the TenantId on `replacement` from
+                    // the FindAsync call above, because a same-ID tenant-scoped role added after validation could
+                    // make that lookup ambiguous; IsAgnosticRoleAsync resolves the candidate itself and rejects
+                    // an ambiguous match instead of accepting whichever role FindAsync happened to return.
+                    if ((string.Equals(roleTenantId, Tenant.AgnosticTenantId, StringComparison.Ordinal) ||
+                         string.Equals(connection.TenantId, ConnectionScope.HostTenantId, StringComparison.Ordinal)) &&
+                        !await IsAgnosticRoleAsync(request.ReplacementRoleId, cancellationToken))
                         return new RoleReferenceRemovalResult.Failed("replacement_role_unavailable_or_unauthorized", changedOwnerIds);
                 }
 
@@ -261,10 +279,7 @@ public sealed class ExternalAuthenticationRoleDeletionDependencyContributor(
     /// </summary>
     private async ValueTask<string> ResolveRoleTenantIdAsync(string roleId, CancellationToken cancellationToken)
     {
-        var roleStore = ActiveRoleStore;
-        if (roleStore is null)
-            return tenantAccessor.TenantId.NormalizeTenantId();
-        var roles = (await roleStore.FindManyAsync(new() { Id = roleId }, cancellationToken)).ToArray();
+        var roles = await FindRolesByIdAsync(roleId, cancellationToken);
         return roles.Length switch
         {
             0 => tenantAccessor.TenantId.NormalizeTenantId(),
@@ -275,17 +290,28 @@ public sealed class ExternalAuthenticationRoleDeletionDependencyContributor(
     }
 
     /// <summary>
-    /// Resolves whether a candidate role ID (typically a replacement role) is itself tenant-agnostic, using the
-    /// same resolution as <see cref="ResolveRoleTenantIdAsync"/>. A role ID that cannot be resolved to exactly
-    /// one role is treated as not agnostic, since there is then no resolved role to trust as safe to write into
-    /// every tenant's connections.
+    /// Resolves whether a candidate role ID (typically a replacement role) is itself tenant-agnostic. Unlike
+    /// <see cref="ResolveRoleTenantIdAsync"/>, an ambiguous candidate -- a role ID that resolves to more than one
+    /// role, which only <c>MemoryRoleStore</c> can produce -- is not the coordinator's own deletion target, so
+    /// there is no operation to fail closed on by throwing; it is instead treated the same as an unresolved
+    /// candidate and reported as not agnostic, since there is no single resolved role to trust as safe to write
+    /// into every tenant's connections.
     /// </summary>
     private async ValueTask<bool> IsAgnosticRoleAsync(string? roleId, CancellationToken cancellationToken)
     {
         if (string.IsNullOrWhiteSpace(roleId))
             return false;
-        var tenantId = await ResolveRoleTenantIdAsync(roleId, cancellationToken);
-        return string.Equals(tenantId, Tenant.AgnosticTenantId, StringComparison.Ordinal);
+        var roles = await FindRolesByIdAsync(roleId, cancellationToken);
+        return roles.Length == 1 && string.Equals(roles[0].TenantId.NormalizeTenantId(), Tenant.AgnosticTenantId, StringComparison.Ordinal);
+    }
+
+    /// <summary>Loads every role matching the given ID from the active role store, or an empty result if none is configured.</summary>
+    private async ValueTask<Role[]> FindRolesByIdAsync(string roleId, CancellationToken cancellationToken)
+    {
+        var roleStore = ActiveRoleStore;
+        if (roleStore is null)
+            return [];
+        return (await roleStore.FindManyAsync(new() { Id = roleId }, cancellationToken)).ToArray();
     }
 
     /// <summary>

--- a/src/modules/Elsa.ExternalAuthentication/Services/ExternalAuthenticationRoleDeletionDependencyContributor.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Services/ExternalAuthenticationRoleDeletionDependencyContributor.cs
@@ -31,6 +31,12 @@ namespace Elsa.ExternalAuthentication.Services;
 /// A tenant-agnostic role (<see cref="Tenant.AgnosticTenantId"/>) is visible from every tenant, so its tenant
 /// context is every tenant: impact and remediation for such a role scan every stored connection and every
 /// configuration entry regardless of tenant, instead of the single active tenant plus host scope.
+/// In EF Core persistence a role's primary key is its ID alone, so a role ID is unique across all tenants there
+/// and an agnostic/tenant-scoped collision cannot exist. Only <c>MemoryRoleStore</c> can hold two roles that
+/// share an ID (its storage key includes the tenant); resolving a role ID against it can then be genuinely
+/// ambiguous. That ambiguity is never resolved by guessing: widening a tenant-scoped deletion would expose
+/// another tenant's references, and narrowing an agnostic deletion would leave an agnostic role's references
+/// dangling. It fails closed instead.
 /// </remarks>
 public sealed class ExternalAuthenticationRoleDeletionDependencyContributor(
     IIdentityProviderConnectionStore store,
@@ -218,22 +224,29 @@ public sealed class ExternalAuthenticationRoleDeletionDependencyContributor(
 
     /// <summary>
     /// Resolves whether the role being deleted is tenant-agnostic (<see cref="Tenant.AgnosticTenantId"/>), in
-    /// which case its tenant context is every tenant rather than the ambient one. Resolves through the active
-    /// role store exactly the way <see cref="RemoveEditableReferencesAsync"/> already does for a replacement
-    /// role, but by ID alone rather than by a single ID-scoped lookup: an unqualified ID lookup can resolve the
-    /// ambient tenant's role when an agnostic role happens to share its ID with it, which would treat deleting
-    /// the agnostic role as tenant-scoped and leave JIT-policy references in other tenants dangling. Every role
-    /// sharing the ID is inspected instead, and the wider, every-tenant scope wins the moment any of them is
-    /// agnostic: over-scanning at worst surfaces a reference the operator can inspect, where under-scanning
-    /// would leave one dangling. A missing store or an unresolved role keeps the current tenant-scoped behavior.
+    /// which case its tenant context is every tenant rather than the ambient one. In EF Core persistence a role
+    /// ID is unique across all tenants (the <c>Roles</c> table keys on <c>Id</c> alone), so this lookup resolves
+    /// to at most one role there. Only <c>MemoryRoleStore</c> can hold two roles that share an ID because its
+    /// storage key includes the tenant; if the ID resolves to more than one role, which tenant's role the
+    /// coordinator's own delete actually targets is already ambiguous, and this method cannot make the
+    /// operation consistent by guessing in either direction -- widening would expose another tenant's
+    /// references for what may be a tenant-scoped deletion, and narrowing would leave an agnostic role's
+    /// references dangling. It fails closed instead. A missing store or no matching role keeps the current
+    /// tenant-scoped behavior.
     /// </summary>
     private async ValueTask<bool> IsAgnosticRoleAsync(string roleId, CancellationToken cancellationToken)
     {
         var roleStore = ActiveRoleStore;
         if (roleStore is null)
             return false;
-        var roles = await roleStore.FindManyAsync(new() { Id = roleId }, cancellationToken);
-        return roles.Any(role => string.Equals(role.TenantId, Tenant.AgnosticTenantId, StringComparison.Ordinal));
+        var roles = (await roleStore.FindManyAsync(new() { Id = roleId }, cancellationToken)).ToArray();
+        return roles.Length switch
+        {
+            0 => false,
+            1 => string.Equals(roles[0].TenantId, Tenant.AgnosticTenantId, StringComparison.Ordinal),
+            _ => throw new InvalidOperationException(
+                $"Role '{roleId}' resolves to {roles.Length} roles across tenant scopes; the deletion target is ambiguous and its external-authentication dependencies cannot be determined.")
+        };
     }
 
     /// <summary>

--- a/src/modules/Elsa.ExternalAuthentication/Services/ExternalAuthenticationRoleDeletionDependencyContributor.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Services/ExternalAuthenticationRoleDeletionDependencyContributor.cs
@@ -28,6 +28,9 @@ namespace Elsa.ExternalAuthentication.Services;
 /// resolves the host scope for every signing-in tenant, and a connection's default role IDs are then resolved by
 /// <c>ExternalIdentityUserProvisioningService</c> through <see cref="IRoleProvider"/> in the signing-in user's
 /// tenant, so a host connection naming role ID X really does reference tenant A's role X.
+/// A tenant-agnostic role (<see cref="Tenant.AgnosticTenantId"/>) is visible from every tenant, so its tenant
+/// context is every tenant: impact and remediation for such a role scan every stored connection and every
+/// configuration entry regardless of tenant, instead of the single active tenant plus host scope.
 /// </remarks>
 public sealed class ExternalAuthenticationRoleDeletionDependencyContributor(
     IIdentityProviderConnectionStore store,
@@ -45,6 +48,7 @@ public sealed class ExternalAuthenticationRoleDeletionDependencyContributor(
 
     public async ValueTask<RoleDeletionDependencySnapshot> InspectAsync(string roleId, CancellationToken cancellationToken = default)
     {
+        var isAgnosticRole = await IsAgnosticRoleAsync(roleId, cancellationToken);
         var dependencies = new List<RoleDeletionDependency>();
         var configuredConnections = options.CurrentValue.ConfigurationConnections ?? [];
         var configurationIndex = 0;
@@ -52,12 +56,12 @@ public sealed class ExternalAuthenticationRoleDeletionDependencyContributor(
         {
             // The index is part of the configuration path an operator edits, so out-of-scope entries are
             // skipped without renumbering the entries that remain.
-            if (IsInRoleTenantScope(GetConfigurationScopeTenantId(connection)))
+            if (IsInRoleTenantScope(GetConfigurationScopeTenantId(connection), isAgnosticRole))
                 dependencies.AddRange(GetConfigurationDependencies(connection, configurationIndex, roleId));
             configurationIndex++;
         }
 
-        foreach (var connection in await FindConnectionsInRoleTenantScopeAsync(cancellationToken))
+        foreach (var connection in await FindConnectionsInRoleTenantScopeAsync(isAgnosticRole, cancellationToken))
         {
             if (!TryGetRoleReference(connection.UnlinkedPolicy, roleId, out var policyBranch, out _, out var removesLastDefaultRole))
                 continue;
@@ -106,9 +110,10 @@ public sealed class ExternalAuthenticationRoleDeletionDependencyContributor(
         if (!expectedOwners.IsSubsetOf(currentOwners))
             return new RoleReferenceRemovalValidationResult.Conflict("dependency_changed");
 
+        var isAgnosticRole = await IsAgnosticRoleAsync(request.RoleId, cancellationToken);
         foreach (var dependency in request.Dependencies)
         {
-            var connection = await FindConnectionInRoleTenantScopeAsync(dependency.OwnerId, cancellationToken);
+            var connection = await FindConnectionInRoleTenantScopeAsync(dependency.OwnerId, isAgnosticRole, cancellationToken);
             if (connection is null || connection.Revision != dependency.ExpectedRevision ||
                 !TryGetRoleReference(connection.UnlinkedPolicy, request.RoleId, out _, out var roleIds, out _))
                 return new RoleReferenceRemovalValidationResult.Conflict("connection_revision_changed");
@@ -143,12 +148,13 @@ public sealed class ExternalAuthenticationRoleDeletionDependencyContributor(
         if (validation is RoleReferenceRemovalValidationResult.Conflict conflict)
             return new RoleReferenceRemovalResult.Conflict(conflict.Code, []);
 
+        var isAgnosticRole = await IsAgnosticRoleAsync(request.RoleId, cancellationToken);
         var changedOwnerIds = new List<string>();
         try
         {
             foreach (var dependency in request.Dependencies.OrderBy(x => x.OwnerId, StringComparer.Ordinal))
             {
-                var connection = await FindConnectionInRoleTenantScopeAsync(dependency.OwnerId, cancellationToken);
+                var connection = await FindConnectionInRoleTenantScopeAsync(dependency.OwnerId, isAgnosticRole, cancellationToken);
                 if (connection is null || connection.Revision != dependency.ExpectedRevision ||
                     !TryGetRoleReference(connection.UnlinkedPolicy, request.RoleId, out _, out _, out var removesLastDefaultRole))
                     return new RoleReferenceRemovalResult.Conflict("connection_revision_changed", changedOwnerIds);
@@ -207,11 +213,32 @@ public sealed class ExternalAuthenticationRoleDeletionDependencyContributor(
     }
 
     /// <summary>
-    /// Loads the stored connections the role's tenant context can reach, asking the store for each applicable
-    /// scope so that another tenant's rows are never materialized here.
+    /// Resolves whether the role being deleted is tenant-agnostic (<see cref="Tenant.AgnosticTenantId"/>), in
+    /// which case its tenant context is every tenant rather than the ambient one. Resolves the role through the
+    /// active role store exactly the way <see cref="RemoveEditableReferencesAsync"/> already does for a
+    /// replacement role. A missing store or an unresolved role keeps the current tenant-scoped behavior.
     /// </summary>
-    private async ValueTask<IReadOnlyCollection<IdentityProviderConnection>> FindConnectionsInRoleTenantScopeAsync(CancellationToken cancellationToken)
+    private async ValueTask<bool> IsAgnosticRoleAsync(string roleId, CancellationToken cancellationToken)
     {
+        // Match the default DI container's direct-service semantics: when persistence replaces the in-memory
+        // store, the last registration is the active store.
+        var roleStore = roleStores.LastOrDefault();
+        if (roleStore is null)
+            return false;
+        var role = await roleStore.FindAsync(new() { Id = roleId }, cancellationToken);
+        return role is not null && string.Equals(role.TenantId, Tenant.AgnosticTenantId, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Loads the stored connections the role's tenant context can reach. For an agnostic role, that context is
+    /// every tenant, so every stored connection is loaded unfiltered; otherwise the store is asked for each
+    /// applicable scope so that another tenant's rows are never materialized here.
+    /// </summary>
+    private async ValueTask<IReadOnlyCollection<IdentityProviderConnection>> FindConnectionsInRoleTenantScopeAsync(bool isAgnosticRole, CancellationToken cancellationToken)
+    {
+        if (isAgnosticRole)
+            return (await store.FindAsync(new(), cancellationToken)).Items.ToArray();
+
         var connections = new List<IdentityProviderConnection>();
         foreach (var scope in GetRoleTenantScopes())
             connections.AddRange((await store.FindAsync(new()
@@ -221,12 +248,13 @@ public sealed class ExternalAuthenticationRoleDeletionDependencyContributor(
 
     /// <summary>
     /// Loads one dependency's connection, reporting a connection outside the role's tenant context as absent so
-    /// that a caller-supplied owner ID cannot reach across a tenant boundary.
+    /// that a caller-supplied owner ID cannot reach across a tenant boundary. An agnostic role's tenant context
+    /// is every tenant, so any connection loaded by owner ID qualifies.
     /// </summary>
-    private async ValueTask<IdentityProviderConnection?> FindConnectionInRoleTenantScopeAsync(string ownerId, CancellationToken cancellationToken)
+    private async ValueTask<IdentityProviderConnection?> FindConnectionInRoleTenantScopeAsync(string ownerId, bool isAgnosticRole, CancellationToken cancellationToken)
     {
         var connection = await store.FindByIdAsync(ownerId, cancellationToken);
-        return connection is not null && IsInRoleTenantScope(connection.TenantId) ? connection : null;
+        return connection is not null && IsInRoleTenantScope(connection.TenantId, isAgnosticRole) ? connection : null;
     }
 
     private IReadOnlyCollection<ConnectionScope> GetRoleTenantScopes()
@@ -235,7 +263,8 @@ public sealed class ExternalAuthenticationRoleDeletionDependencyContributor(
         return tenantScope == ConnectionScope.Host ? [ConnectionScope.Host] : [ConnectionScope.Host, tenantScope];
     }
 
-    private bool IsInRoleTenantScope(string? connectionTenantId) =>
+    private bool IsInRoleTenantScope(string? connectionTenantId, bool isAgnosticRole) =>
+        isAgnosticRole ||
         string.Equals(connectionTenantId, ConnectionScope.HostTenantId, StringComparison.Ordinal) ||
         string.Equals(connectionTenantId.NormalizeTenantId(), tenantAccessor.TenantId.NormalizeTenantId(), StringComparison.Ordinal);
 

--- a/src/modules/Elsa.ExternalAuthentication/Services/ExternalAuthenticationRoleDeletionDependencyContributor.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Services/ExternalAuthenticationRoleDeletionDependencyContributor.cs
@@ -218,34 +218,35 @@ public sealed class ExternalAuthenticationRoleDeletionDependencyContributor(
 
     /// <summary>
     /// Resolves whether the role being deleted is tenant-agnostic (<see cref="Tenant.AgnosticTenantId"/>), in
-    /// which case its tenant context is every tenant rather than the ambient one. Resolves the role through the
-    /// active role store exactly the way <see cref="RemoveEditableReferencesAsync"/> already does for a
-    /// replacement role. A missing store or an unresolved role keeps the current tenant-scoped behavior.
+    /// which case its tenant context is every tenant rather than the ambient one. Resolves through the active
+    /// role store exactly the way <see cref="RemoveEditableReferencesAsync"/> already does for a replacement
+    /// role, but by ID alone rather than by a single ID-scoped lookup: an unqualified ID lookup can resolve the
+    /// ambient tenant's role when an agnostic role happens to share its ID with it, which would treat deleting
+    /// the agnostic role as tenant-scoped and leave JIT-policy references in other tenants dangling. Every role
+    /// sharing the ID is inspected instead, and the wider, every-tenant scope wins the moment any of them is
+    /// agnostic: over-scanning at worst surfaces a reference the operator can inspect, where under-scanning
+    /// would leave one dangling. A missing store or an unresolved role keeps the current tenant-scoped behavior.
     /// </summary>
     private async ValueTask<bool> IsAgnosticRoleAsync(string roleId, CancellationToken cancellationToken)
     {
         var roleStore = ActiveRoleStore;
         if (roleStore is null)
             return false;
-        var role = await roleStore.FindAsync(new() { Id = roleId }, cancellationToken);
-        return role is not null && string.Equals(role.TenantId, Tenant.AgnosticTenantId, StringComparison.Ordinal);
+        var roles = await roleStore.FindManyAsync(new() { Id = roleId }, cancellationToken);
+        return roles.Any(role => string.Equals(role.TenantId, Tenant.AgnosticTenantId, StringComparison.Ordinal));
     }
 
     /// <summary>
-    /// Loads the stored connections the role's tenant context can reach. For an agnostic role, that context is
-    /// every tenant, so every stored connection is loaded unfiltered; otherwise the store is asked for each
-    /// applicable scope so that another tenant's rows are never materialized here.
+    /// Loads every stored connection in a single snapshot and filters it in memory to the role's tenant context.
+    /// Composing the result from separate per-scope reads instead would let a connection's <c>TenantId</c> change
+    /// between those reads (<see cref="RemoveEditableReferencesAsync"/> permits it via <c>UpdateAsync</c>), so the
+    /// connection could fall between the reads and appear in neither result. A single snapshot has no gap to fall
+    /// through.
     /// </summary>
     private async ValueTask<IReadOnlyCollection<IdentityProviderConnection>> FindConnectionsInRoleTenantScopeAsync(bool isAgnosticRole, CancellationToken cancellationToken)
     {
-        if (isAgnosticRole)
-            return (await store.FindAsync(new(), cancellationToken)).Items.ToArray();
-
-        var connections = new List<IdentityProviderConnection>();
-        foreach (var scope in GetRoleTenantScopes())
-            connections.AddRange((await store.FindAsync(new()
-                { Scope = scope }, cancellationToken)).Items);
-        return connections;
+        var connections = (await store.FindAsync(new(), cancellationToken)).Items;
+        return connections.Where(x => IsInRoleTenantScope(x.TenantId, isAgnosticRole)).ToArray();
     }
 
     /// <summary>
@@ -259,12 +260,6 @@ public sealed class ExternalAuthenticationRoleDeletionDependencyContributor(
         return connection is not null && IsInRoleTenantScope(connection.TenantId, isAgnosticRole) ? connection : null;
     }
 
-    private IReadOnlyCollection<ConnectionScope> GetRoleTenantScopes()
-    {
-        var tenantScope = ToConnectionScope(tenantAccessor.TenantId.NormalizeTenantId());
-        return tenantScope == ConnectionScope.Host ? [ConnectionScope.Host] : [ConnectionScope.Host, tenantScope];
-    }
-
     private bool IsInRoleTenantScope(string? connectionTenantId, bool isAgnosticRole) =>
         isAgnosticRole ||
         string.Equals(connectionTenantId, ConnectionScope.HostTenantId, StringComparison.Ordinal) ||
@@ -273,11 +268,6 @@ public sealed class ExternalAuthenticationRoleDeletionDependencyContributor(
     /// <summary>A configuration entry that leaves the tenant blank is materialized at host scope.</summary>
     private static string GetConfigurationScopeTenantId(IdentityProviderConnection connection) =>
         string.IsNullOrWhiteSpace(connection.TenantId) ? ConnectionScope.HostTenantId : connection.TenantId;
-
-    private static ConnectionScope ToConnectionScope(string tenantId) =>
-        tenantId == ConnectionScope.HostTenantId ? ConnectionScope.Host :
-        tenantId.Length == 0 ? ConnectionScope.DefaultTenant :
-        new(ConnectionScopeKind.Tenant, tenantId);
 
     private IEnumerable<RoleDeletionDependency> GetConfigurationDependencies(IdentityProviderConnection connection, int connectionIndex, string roleId)
     {

--- a/src/modules/Elsa.ExternalAuthentication/Services/ExternalAuthenticationRoleDeletionDependencyContributor.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Services/ExternalAuthenticationRoleDeletionDependencyContributor.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Elsa.Authorization;
+using Elsa.Common.Multitenancy;
 using Elsa.ExternalAuthentication.Contracts;
 using Elsa.ExternalAuthentication.Models;
 using Elsa.ExternalAuthentication.Notifications;
@@ -17,6 +18,17 @@ using Microsoft.Extensions.Options;
 namespace Elsa.ExternalAuthentication.Services;
 
 /// <summary>Guards Elsa Role deletion against JIT-policy default-role references.</summary>
+/// <remarks>
+/// Roles are tenant-scoped, so impact and remediation only ever consider connections in the role's own tenant
+/// context: the tenant active on <see cref="ITenantAccessor"/> while the role-deletion coordinator runs, which is
+/// the tenant the coordinator already resolved the role in. A connection carrying another tenant's ID is out of
+/// scope in both directions, for impact and for remediation.
+/// Host-scoped connections (<see cref="ConnectionScope.HostTenantId"/>, and configuration entries that leave the
+/// tenant blank, which are materialized at host scope) stay in scope for every tenant. The connection registry
+/// resolves the host scope for every signing-in tenant, and a connection's default role IDs are then resolved by
+/// <c>ExternalIdentityUserProvisioningService</c> through <see cref="IRoleProvider"/> in the signing-in user's
+/// tenant, so a host connection naming role ID X really does reference tenant A's role X.
+/// </remarks>
 public sealed class ExternalAuthenticationRoleDeletionDependencyContributor(
     IIdentityProviderConnectionStore store,
     IOptionsMonitor<ExternalAuthenticationOptions> options,
@@ -25,7 +37,8 @@ public sealed class ExternalAuthenticationRoleDeletionDependencyContributor(
     IConnectionRegistryVersionStore registryVersions,
     ConnectionRevisionCalculator revisionCalculator,
     ExternalAuthenticationSecurityNotifier notifier,
-    IPermissionEvaluator permissionEvaluator) : IRoleDeletionDependencyContributor
+    IPermissionEvaluator permissionEvaluator,
+    ITenantAccessor tenantAccessor) : IRoleDeletionDependencyContributor
 {
     public const string SourceName = "external-authentication";
     public string Source => SourceName;
@@ -37,12 +50,14 @@ public sealed class ExternalAuthenticationRoleDeletionDependencyContributor(
         var configurationIndex = 0;
         foreach (var connection in configuredConnections)
         {
-            dependencies.AddRange(GetConfigurationDependencies(connection, configurationIndex, roleId));
+            // The index is part of the configuration path an operator edits, so out-of-scope entries are
+            // skipped without renumbering the entries that remain.
+            if (IsInRoleTenantScope(GetConfigurationScopeTenantId(connection)))
+                dependencies.AddRange(GetConfigurationDependencies(connection, configurationIndex, roleId));
             configurationIndex++;
         }
 
-        var databaseConnections = await store.FindAsync(new(), cancellationToken);
-        foreach (var connection in databaseConnections.Items)
+        foreach (var connection in await FindConnectionsInRoleTenantScopeAsync(cancellationToken))
         {
             if (!TryGetRoleReference(connection.UnlinkedPolicy, roleId, out var policyBranch, out _, out var removesLastDefaultRole))
                 continue;
@@ -93,7 +108,7 @@ public sealed class ExternalAuthenticationRoleDeletionDependencyContributor(
 
         foreach (var dependency in request.Dependencies)
         {
-            var connection = await store.FindByIdAsync(dependency.OwnerId, cancellationToken);
+            var connection = await FindConnectionInRoleTenantScopeAsync(dependency.OwnerId, cancellationToken);
             if (connection is null || connection.Revision != dependency.ExpectedRevision ||
                 !TryGetRoleReference(connection.UnlinkedPolicy, request.RoleId, out _, out var roleIds, out _))
                 return new RoleReferenceRemovalValidationResult.Conflict("connection_revision_changed");
@@ -133,7 +148,7 @@ public sealed class ExternalAuthenticationRoleDeletionDependencyContributor(
         {
             foreach (var dependency in request.Dependencies.OrderBy(x => x.OwnerId, StringComparer.Ordinal))
             {
-                var connection = await store.FindByIdAsync(dependency.OwnerId, cancellationToken);
+                var connection = await FindConnectionInRoleTenantScopeAsync(dependency.OwnerId, cancellationToken);
                 if (connection is null || connection.Revision != dependency.ExpectedRevision ||
                     !TryGetRoleReference(connection.UnlinkedPolicy, request.RoleId, out _, out _, out var removesLastDefaultRole))
                     return new RoleReferenceRemovalResult.Conflict("connection_revision_changed", changedOwnerIds);
@@ -190,6 +205,48 @@ public sealed class ExternalAuthenticationRoleDeletionDependencyContributor(
 
         return new RoleReferenceRemovalResult.Success(changedOwnerIds);
     }
+
+    /// <summary>
+    /// Loads the stored connections the role's tenant context can reach, asking the store for each applicable
+    /// scope so that another tenant's rows are never materialized here.
+    /// </summary>
+    private async ValueTask<IReadOnlyCollection<IdentityProviderConnection>> FindConnectionsInRoleTenantScopeAsync(CancellationToken cancellationToken)
+    {
+        var connections = new List<IdentityProviderConnection>();
+        foreach (var scope in GetRoleTenantScopes())
+            connections.AddRange((await store.FindAsync(new()
+                { Scope = scope }, cancellationToken)).Items);
+        return connections;
+    }
+
+    /// <summary>
+    /// Loads one dependency's connection, reporting a connection outside the role's tenant context as absent so
+    /// that a caller-supplied owner ID cannot reach across a tenant boundary.
+    /// </summary>
+    private async ValueTask<IdentityProviderConnection?> FindConnectionInRoleTenantScopeAsync(string ownerId, CancellationToken cancellationToken)
+    {
+        var connection = await store.FindByIdAsync(ownerId, cancellationToken);
+        return connection is not null && IsInRoleTenantScope(connection.TenantId) ? connection : null;
+    }
+
+    private IReadOnlyCollection<ConnectionScope> GetRoleTenantScopes()
+    {
+        var tenantScope = ToScope(tenantAccessor.TenantId.NormalizeTenantId());
+        return tenantScope == ConnectionScope.Host ? [ConnectionScope.Host] : [ConnectionScope.Host, tenantScope];
+    }
+
+    private bool IsInRoleTenantScope(string? connectionTenantId) =>
+        string.Equals(connectionTenantId, ConnectionScope.HostTenantId, StringComparison.Ordinal) ||
+        string.Equals(connectionTenantId.NormalizeTenantId(), tenantAccessor.TenantId.NormalizeTenantId(), StringComparison.Ordinal);
+
+    /// <summary>A configuration entry that leaves the tenant blank is materialized at host scope.</summary>
+    private static string GetConfigurationScopeTenantId(IdentityProviderConnection connection) =>
+        string.IsNullOrWhiteSpace(connection.TenantId) ? ConnectionScope.HostTenantId : connection.TenantId;
+
+    private static ConnectionScope ToScope(string tenantId) =>
+        tenantId == ConnectionScope.HostTenantId ? ConnectionScope.Host :
+        tenantId.Length == 0 ? ConnectionScope.DefaultTenant :
+        new(ConnectionScopeKind.Tenant, tenantId);
 
     private IEnumerable<RoleDeletionDependency> GetConfigurationDependencies(IdentityProviderConnection connection, int connectionIndex, string roleId)
     {

--- a/src/modules/Elsa.ExternalAuthentication/Services/ExternalAuthenticationRoleDeletionDependencyContributor.cs
+++ b/src/modules/Elsa.ExternalAuthentication/Services/ExternalAuthenticationRoleDeletionDependencyContributor.cs
@@ -34,7 +34,10 @@ namespace Elsa.ExternalAuthentication.Services;
 /// tenant, so a host connection naming role ID X really does reference tenant A's role X.
 /// A tenant-agnostic role (<see cref="Tenant.AgnosticTenantId"/>) is visible from every tenant, so its tenant
 /// context is every tenant: impact and remediation for such a role scan every stored connection and every
-/// configuration entry regardless of tenant, instead of the single active tenant plus host scope.
+/// configuration entry regardless of tenant, instead of the single active tenant plus host scope. Authorizing a
+/// replacement role, however, is still performed through the ambient tenant's role services, so when the
+/// deletion target is agnostic the replacement role must itself be agnostic; a tenant-scoped replacement is
+/// rejected rather than being authorized in one tenant and written into every tenant's connections.
 /// In EF Core persistence a role's primary key is its ID alone, so a role ID is unique across all tenants there
 /// and an agnostic/tenant-scoped collision cannot exist. Only <c>MemoryRoleStore</c> can hold two roles that
 /// share an ID (its storage key includes the tenant); resolving a role ID against it can then be genuinely
@@ -140,6 +143,14 @@ public sealed class ExternalAuthenticationRoleDeletionDependencyContributor(
                  string.Equals(request.ReplacementRoleId, request.RoleId, StringComparison.Ordinal)))
                 return new RoleReferenceRemovalValidationResult.Forbidden("replacement_role_unavailable_or_unauthorized");
 
+            // Authorization below still resolves through the ambient tenant's role services, so an agnostic
+            // deletion target may only be replaced by another agnostic role; a tenant-scoped replacement would
+            // otherwise be authorized in this tenant and then written into every other tenant's connections.
+            if (requiresReplacement &&
+                string.Equals(roleTenantId, Tenant.AgnosticTenantId, StringComparison.Ordinal) &&
+                !await IsAgnosticRoleAsync(request.ReplacementRoleId, cancellationToken))
+                return new RoleReferenceRemovalValidationResult.Forbidden("replacement_role_unavailable_or_unauthorized");
+
             var rolesToAssign = requiresReplacement
                 ? new[] { request.ReplacementRoleId! }
                 : remainingRoleIds;
@@ -190,6 +201,14 @@ public sealed class ExternalAuthenticationRoleDeletionDependencyContributor(
                     var replacement = await roleStore.FindAsync(new() { Id = request.ReplacementRoleId }, cancellationToken);
                     if (replacement is null ||
                         !await roleAuthorizationService.CanAssignRolesAsync(request.Actor, [replacement.Id], cancellationToken))
+                        return new RoleReferenceRemovalResult.Failed("replacement_role_unavailable_or_unauthorized", changedOwnerIds);
+
+                    // Authorization above still resolves through the ambient tenant's role services, so an
+                    // agnostic deletion target may only be replaced by another agnostic role; a tenant-scoped
+                    // replacement would otherwise be authorized in this tenant and then written into every other
+                    // tenant's connections.
+                    if (string.Equals(roleTenantId, Tenant.AgnosticTenantId, StringComparison.Ordinal) &&
+                        !string.Equals(replacement.TenantId.NormalizeTenantId(), Tenant.AgnosticTenantId, StringComparison.Ordinal))
                         return new RoleReferenceRemovalResult.Failed("replacement_role_unavailable_or_unauthorized", changedOwnerIds);
                 }
 
@@ -253,6 +272,20 @@ public sealed class ExternalAuthenticationRoleDeletionDependencyContributor(
             _ => throw new InvalidOperationException(
                 $"Role '{roleId}' resolves to {roles.Length} roles across tenant scopes; the deletion target is ambiguous and its external-authentication dependencies cannot be determined.")
         };
+    }
+
+    /// <summary>
+    /// Resolves whether a candidate role ID (typically a replacement role) is itself tenant-agnostic, using the
+    /// same resolution as <see cref="ResolveRoleTenantIdAsync"/>. A role ID that cannot be resolved to exactly
+    /// one role is treated as not agnostic, since there is then no resolved role to trust as safe to write into
+    /// every tenant's connections.
+    /// </summary>
+    private async ValueTask<bool> IsAgnosticRoleAsync(string? roleId, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(roleId))
+            return false;
+        var tenantId = await ResolveRoleTenantIdAsync(roleId, cancellationToken);
+        return string.Equals(tenantId, Tenant.AgnosticTenantId, StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/test/integration/Elsa.ExternalAuthentication.IntegrationTests/Persistence/ExternalAuthenticationPersistenceTests.cs
+++ b/test/integration/Elsa.ExternalAuthentication.IntegrationTests/Persistence/ExternalAuthenticationPersistenceTests.cs
@@ -151,6 +151,25 @@ public sealed class ExternalAuthenticationPersistenceTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task ConnectionStoreReturnsOnlyTheRequestedScope()
+    {
+        var store = new EFCoreIdentityProviderConnectionStore(_leaseFactory);
+        Assert.IsType<ConnectionMutationResult.Created>(await store.CreateAsync(CreateConnection()));
+        Assert.IsType<ConnectionMutationResult.Created>(await store.CreateAsync(CreateConnection("connection-b", "tenant-b")));
+        Assert.IsType<ConnectionMutationResult.Created>(await store.CreateAsync(CreateConnection("connection-host", ConnectionScope.HostTenantId)));
+
+        var tenantScoped = await store.FindAsync(new() { Scope = new(ConnectionScopeKind.Tenant, "tenant-a") });
+        var hostScoped = await store.FindAsync(new() { Scope = ConnectionScope.Host });
+        var unscoped = await store.FindAsync(new());
+
+        // Callers that must not cross a tenant boundary, such as the role-deletion dependency contributor,
+        // rely on this filter, so a store that accepted and ignored it would silently widen their reach.
+        Assert.Equal(["connection-a"], tenantScoped.Items.Select(x => x.Id).ToArray());
+        Assert.Equal(["connection-host"], hostScoped.Items.Select(x => x.Id).ToArray());
+        Assert.Equal(3, unscoped.Items.Count);
+    }
+
+    [Fact]
     public async Task DurableStateGrantSessionAndRegistryVersionOperationsAreSingleUseOrCompareAndSwap()
     {
         var durableDbContexts = _leaseFactory;
@@ -754,10 +773,10 @@ public sealed class ExternalAuthenticationPersistenceTests : IAsyncLifetime
 
     private static IReadOnlyDictionary<string, IReadOnlyCollection<string>> EmptyClaims { get; } = new Dictionary<string, IReadOnlyCollection<string>>();
 
-    private static IdentityProviderConnection CreateConnection(string id = "connection-a") => new()
+    private static IdentityProviderConnection CreateConnection(string id = "connection-a", string tenantId = "tenant-a") => new()
     {
         Id = id,
-        TenantId = "tenant-a",
+        TenantId = tenantId,
         Key = "contoso",
         AdapterType = "openid-connect",
         AdapterSettingsVersion = 1,

--- a/test/integration/Elsa.ExternalAuthentication.IntegrationTests/Persistence/ExternalAuthenticationPersistenceTests.cs
+++ b/test/integration/Elsa.ExternalAuthentication.IntegrationTests/Persistence/ExternalAuthenticationPersistenceTests.cs
@@ -162,8 +162,8 @@ public sealed class ExternalAuthenticationPersistenceTests : IAsyncLifetime
         var hostScoped = await store.FindAsync(new() { Scope = ConnectionScope.Host });
         var unscoped = await store.FindAsync(new());
 
-        // Callers that must not cross a tenant boundary, such as the role-deletion dependency contributor,
-        // rely on this filter, so a store that accepted and ignored it would silently widen their reach.
+        // The store honors ConnectionFilter.Scope, so callers that query by scope get only that scope's rows;
+        // a store that accepted and ignored the filter would silently widen their reach.
         Assert.Equal(["connection-a"], tenantScoped.Items.Select(x => x.Id).ToArray());
         Assert.Equal(["connection-host"], hostScoped.Items.Select(x => x.Id).ToArray());
         Assert.Equal(3, unscoped.Items.Count);

--- a/test/unit/Elsa.ExternalAuthentication.UnitTests/Foundational/ExternalAuthenticationRoleDeletionDependencyContributorTests.cs
+++ b/test/unit/Elsa.ExternalAuthentication.UnitTests/Foundational/ExternalAuthenticationRoleDeletionDependencyContributorTests.cs
@@ -530,6 +530,80 @@ public class ExternalAuthenticationRoleDeletionDependencyContributorTests
     }
 
     [Fact]
+    public async Task RemediationOfAnAgnosticRoleRejectsATenantScopedReplacementRole()
+    {
+        var ownConnection = Connection("own-connection", CreateUserPolicy("agnostic-role"), TenantA);
+        var otherTenantConnection = Connection("other-tenant-connection", CreateUserPolicy("agnostic-role"), TenantB);
+        var (contributor, store, _) = await CreateContributorAsync(
+            [],
+            [ownConnection, otherTenantConnection],
+            additionalRoles:
+            [
+                new Role { Id = "agnostic-role", Name = "Agnostic role", TenantId = Tenant.AgnosticTenantId, Permissions = [] },
+                new Role { Id = "tenant-a-replacement", Name = "Tenant A replacement", TenantId = TenantA, Permissions = [] }
+            ],
+            tenantAccessor: new TestTenantAccessor(TenantA));
+        var snapshot = await contributor.InspectAsync("agnostic-role");
+        var request = new RoleReferenceRemovalRequest("agnostic-role", Administrator(), snapshot.Version, snapshot.Dependencies)
+        {
+            SelectedReferences = snapshot.Dependencies
+                .Select(x => new RoleDeletionReferenceSelection(ExternalAuthenticationRoleDeletionDependencyContributor.SourceName, x.OwnerId))
+                .ToArray(),
+            ReplacementRoleId = "tenant-a-replacement"
+        };
+
+        // Remediation is initiated in tenant A and would resolve the replacement role through tenant A's role
+        // authorization service alone, even though tenant B's connection is also in scope for this agnostic
+        // role. Admitting a tenant-A-only replacement would write a role into tenant B's policy that does not
+        // exist there, so it must be rejected rather than authorized in one tenant and applied to every tenant.
+        var validation = await contributor.ValidateRemovalAsync(request);
+        var forbidden = Assert.IsType<RoleReferenceRemovalValidationResult.Forbidden>(validation);
+        Assert.Equal("replacement_role_unavailable_or_unauthorized", forbidden.Code);
+
+        var result = await contributor.RemoveEditableReferencesAsync(request);
+        var failed = Assert.IsType<RoleReferenceRemovalResult.Failed>(result);
+        Assert.Equal("replacement_role_unavailable_or_unauthorized", failed.Code);
+        Assert.Empty(failed.ChangedOwnerIds);
+        AssertDefaultRoleIds(await store.FindByIdAsync(ownConnection.Id), "agnostic-role");
+        AssertDefaultRoleIds(await store.FindByIdAsync(otherTenantConnection.Id), "agnostic-role");
+    }
+
+    [Fact]
+    public async Task RemediationOfAnAgnosticRoleAcceptsAnAgnosticReplacementRole()
+    {
+        var ownConnection = Connection("own-connection", CreateUserPolicy("agnostic-role"), TenantA);
+        var otherTenantConnection = Connection("other-tenant-connection", CreateUserPolicy("agnostic-role"), TenantB);
+        var (contributor, store, _) = await CreateContributorAsync(
+            [],
+            [ownConnection, otherTenantConnection],
+            additionalRoles:
+            [
+                new Role { Id = "agnostic-role", Name = "Agnostic role", TenantId = Tenant.AgnosticTenantId, Permissions = [] },
+                new Role { Id = "agnostic-replacement", Name = "Agnostic replacement", TenantId = Tenant.AgnosticTenantId, Permissions = [] }
+            ],
+            tenantAccessor: new TestTenantAccessor(TenantA));
+        var snapshot = await contributor.InspectAsync("agnostic-role");
+        var request = new RoleReferenceRemovalRequest("agnostic-role", Administrator(), snapshot.Version, snapshot.Dependencies)
+        {
+            SelectedReferences = snapshot.Dependencies
+                .Select(x => new RoleDeletionReferenceSelection(ExternalAuthenticationRoleDeletionDependencyContributor.SourceName, x.OwnerId))
+                .ToArray(),
+            ReplacementRoleId = "agnostic-replacement"
+        };
+
+        // An agnostic replacement exists identically in every tenant, so it is safe to write into tenant B's
+        // policy even though remediation was authorized through tenant A's role services.
+        Assert.IsType<RoleReferenceRemovalValidationResult.Valid>(await contributor.ValidateRemovalAsync(request));
+        var result = Assert.IsType<RoleReferenceRemovalResult.Success>(await contributor.RemoveEditableReferencesAsync(request));
+
+        Assert.Equal(
+            [otherTenantConnection.Id, ownConnection.Id],
+            result.ChangedOwnerIds.Order(StringComparer.Ordinal).ToArray());
+        AssertDefaultRoleIds(await store.FindByIdAsync(ownConnection.Id), "agnostic-replacement");
+        AssertDefaultRoleIds(await store.FindByIdAsync(otherTenantConnection.Id), "agnostic-replacement");
+    }
+
+    [Fact]
     public async Task RemediationRemovesTheRoleFromAHostScopedConnectionForATenant()
     {
         var hostConnection = Connection("host-connection", CreateUserPolicy("workflow-user", "other-role"));

--- a/test/unit/Elsa.ExternalAuthentication.UnitTests/Foundational/ExternalAuthenticationRoleDeletionDependencyContributorTests.cs
+++ b/test/unit/Elsa.ExternalAuthentication.UnitTests/Foundational/ExternalAuthenticationRoleDeletionDependencyContributorTests.cs
@@ -413,6 +413,49 @@ public class ExternalAuthenticationRoleDeletionDependencyContributorTests
     }
 
     [Fact]
+    public async Task ImpactForAnAgnosticRoleIncludesAConnectionOwnedByAnotherTenant()
+    {
+        var ownConnection = Connection("own-connection", CreateUserPolicy("agnostic-role"), TenantA);
+        var otherTenantConnection = Connection("other-tenant-connection", CreateUserPolicy("agnostic-role"), TenantB);
+        var (contributor, _, _) = await CreateContributorAsync(
+            [],
+            [ownConnection, otherTenantConnection],
+            additionalRoles: [new Role { Id = "agnostic-role", Name = "Agnostic role", TenantId = Tenant.AgnosticTenantId, Permissions = [] }],
+            tenantAccessor: new TestTenantAccessor(TenantA));
+
+        var snapshot = await contributor.InspectAsync("agnostic-role");
+
+        // The role is visible from every tenant, so its tenant context is every tenant: tenant B's reference is
+        // reported alongside tenant A's, unlike a tenant-scoped role (see ImpactExcludesConnectionsOwnedByAnotherTenant).
+        Assert.Equal(
+            [otherTenantConnection.Id, ownConnection.Id],
+            snapshot.Dependencies.Select(x => x.OwnerId).Order(StringComparer.Ordinal).ToArray());
+    }
+
+    [Fact]
+    public async Task RemediationOfAnAgnosticRoleCanRemoveTheReferenceFromAnotherTenantsConnection()
+    {
+        var ownConnection = Connection("own-connection", CreateUserPolicy("agnostic-role"), TenantA);
+        var otherTenantConnection = Connection("other-tenant-connection", CreateUserPolicy("agnostic-role"), TenantB);
+        var (contributor, store, _) = await CreateContributorAsync(
+            [],
+            [ownConnection, otherTenantConnection],
+            additionalRoles: [new Role { Id = "agnostic-role", Name = "Agnostic role", TenantId = Tenant.AgnosticTenantId, Permissions = [] }],
+            tenantAccessor: new TestTenantAccessor(TenantA));
+        var snapshot = await contributor.InspectAsync("agnostic-role");
+        var request = new RoleReferenceRemovalRequest("agnostic-role", Administrator(), snapshot.Version, snapshot.Dependencies);
+
+        Assert.IsType<RoleReferenceRemovalValidationResult.Valid>(await contributor.ValidateRemovalAsync(request));
+        var result = Assert.IsType<RoleReferenceRemovalResult.Success>(await contributor.RemoveEditableReferencesAsync(request));
+
+        Assert.Equal(
+            [otherTenantConnection.Id, ownConnection.Id],
+            result.ChangedOwnerIds.Order(StringComparer.Ordinal).ToArray());
+        AssertDefaultRoleIds(await store.FindByIdAsync(ownConnection.Id));
+        AssertDefaultRoleIds(await store.FindByIdAsync(otherTenantConnection.Id));
+    }
+
+    [Fact]
     public async Task RemediationRemovesTheRoleFromAHostScopedConnectionForATenant()
     {
         var hostConnection = Connection("host-connection", CreateUserPolicy("workflow-user", "other-role"));

--- a/test/unit/Elsa.ExternalAuthentication.UnitTests/Foundational/ExternalAuthenticationRoleDeletionDependencyContributorTests.cs
+++ b/test/unit/Elsa.ExternalAuthentication.UnitTests/Foundational/ExternalAuthenticationRoleDeletionDependencyContributorTests.cs
@@ -117,15 +117,12 @@ public class ExternalAuthenticationRoleDeletionDependencyContributorTests
     [Fact]
     public async Task ReplacesFinalDefaultRoleWhenSelectedForRemediation()
     {
-        // Tenant-scoped rather than the default host scope: this test exercises ordinary replacement, not
-        // the host-connection rule covered by RemediationOfAHostScopedConnectionsFinalDefaultRole* below.
         var databaseConnection = Connection(
             "database",
             new PolicySelection(
                 CreateUserUnlinkedIdentityPolicy.PolicyType,
                 1,
-                JsonSerializer.SerializeToElement(new { defaultRoleIds = new[] { "workflow-user" } })),
-            Tenant.DefaultTenantId);
+                JsonSerializer.SerializeToElement(new { defaultRoleIds = new[] { "workflow-user" } })));
         var (contributor, store, _) = await CreateContributorAsync([], [databaseConnection], [new Role { Id = "replacement-role", Name = "Replacement role", Permissions = [] }]);
         var snapshot = await contributor.InspectAsync("workflow-user");
         var request = new RoleReferenceRemovalRequest(
@@ -149,15 +146,12 @@ public class ExternalAuthenticationRoleDeletionDependencyContributorTests
     [Fact]
     public async Task UsesTheActiveRoleStoreWhenPersistenceReplacesTheDefaultStore()
     {
-        // Tenant-scoped rather than the default host scope: this test exercises active-store selection, not
-        // the host-connection rule covered by RemediationOfAHostScopedConnectionsFinalDefaultRole* above.
         var databaseConnection = Connection(
             "database",
             new PolicySelection(
                 CreateUserUnlinkedIdentityPolicy.PolicyType,
                 1,
-                JsonSerializer.SerializeToElement(new { defaultRoleIds = new[] { "workflow-user" } })),
-            Tenant.DefaultTenantId);
+                JsonSerializer.SerializeToElement(new { defaultRoleIds = new[] { "workflow-user" } })));
         var connectionStore = new InMemoryIdentityProviderConnectionStore();
         Assert.IsType<ConnectionMutationResult.Created>(await connectionStore.CreateAsync(databaseConnection));
         var replacedStore = new MemoryRoleStore(new MemoryStore<Role>(), TestTenantAccessor.Default);
@@ -222,15 +216,12 @@ public class ExternalAuthenticationRoleDeletionDependencyContributorTests
     [Fact]
     public async Task ReplacementRemovedAfterCoordinatorValidationFailsClosedBeforePolicyUpdate()
     {
-        // Tenant-scoped rather than the default host scope: this test exercises the validation/removal race,
-        // not the host-connection rule covered by RemediationOfAHostScopedConnectionsFinalDefaultRole* above.
         var databaseConnection = Connection(
             "database",
             new PolicySelection(
                 CreateUserUnlinkedIdentityPolicy.PolicyType,
                 1,
-                JsonSerializer.SerializeToElement(new { defaultRoleIds = new[] { "workflow-user" } })),
-            Tenant.DefaultTenantId);
+                JsonSerializer.SerializeToElement(new { defaultRoleIds = new[] { "workflow-user" } })));
         var connectionStore = new InMemoryIdentityProviderConnectionStore();
         Assert.IsType<ConnectionMutationResult.Created>(await connectionStore.CreateAsync(databaseConnection));
 
@@ -628,63 +619,6 @@ public class ExternalAuthenticationRoleDeletionDependencyContributorTests
 
         Assert.Equal([hostConnection.Id], result.ChangedOwnerIds);
         AssertDefaultRoleIds(await store.FindByIdAsync(hostConnection.Id), "other-role");
-    }
-
-    [Fact]
-    public async Task RemediationOfAHostScopedConnectionsFinalDefaultRoleRejectsATenantScopedReplacementRole()
-    {
-        var hostConnection = Connection("host-connection", CreateUserPolicy("workflow-user"));
-        var (contributor, store, _) = await CreateContributorAsync(
-            [],
-            [hostConnection],
-            additionalRoles: [new Role { Id = "tenant-a-replacement", Name = "Tenant A replacement", TenantId = TenantA, Permissions = [] }],
-            tenantAccessor: new TestTenantAccessor(TenantA));
-        var snapshot = await contributor.InspectAsync("workflow-user");
-        var request = new RoleReferenceRemovalRequest("workflow-user", Administrator(), snapshot.Version, snapshot.Dependencies)
-        {
-            SelectedReferences = [new RoleDeletionReferenceSelection(ExternalAuthenticationRoleDeletionDependencyContributor.SourceName, hostConnection.Id)],
-            ReplacementRoleId = "tenant-a-replacement"
-        };
-
-        // The deletion target is tenant-scoped, but the connection losing its last default role is host-scoped
-        // and therefore served to every signing-in tenant. A tenant-A-only replacement would be authorized here
-        // in tenant A and then written into a connection that provisioning resolves in every other tenant too,
-        // where the replacement does not exist. It must be rejected rather than authorized in one tenant and
-        // applied to every tenant the host connection serves.
-        var validation = await contributor.ValidateRemovalAsync(request);
-        var forbidden = Assert.IsType<RoleReferenceRemovalValidationResult.Forbidden>(validation);
-        Assert.Equal("replacement_role_unavailable_or_unauthorized", forbidden.Code);
-
-        var result = await contributor.RemoveEditableReferencesAsync(request);
-        var failed = Assert.IsType<RoleReferenceRemovalResult.Failed>(result);
-        Assert.Equal("replacement_role_unavailable_or_unauthorized", failed.Code);
-        Assert.Empty(failed.ChangedOwnerIds);
-        AssertDefaultRoleIds(await store.FindByIdAsync(hostConnection.Id), "workflow-user");
-    }
-
-    [Fact]
-    public async Task RemediationOfAHostScopedConnectionsFinalDefaultRoleAcceptsAnAgnosticReplacementRole()
-    {
-        var hostConnection = Connection("host-connection", CreateUserPolicy("workflow-user"));
-        var (contributor, store, _) = await CreateContributorAsync(
-            [],
-            [hostConnection],
-            additionalRoles: [new Role { Id = "agnostic-replacement", Name = "Agnostic replacement", TenantId = Tenant.AgnosticTenantId, Permissions = [] }],
-            tenantAccessor: new TestTenantAccessor(TenantA));
-        var snapshot = await contributor.InspectAsync("workflow-user");
-        var request = new RoleReferenceRemovalRequest("workflow-user", Administrator(), snapshot.Version, snapshot.Dependencies)
-        {
-            SelectedReferences = [new RoleDeletionReferenceSelection(ExternalAuthenticationRoleDeletionDependencyContributor.SourceName, hostConnection.Id)],
-            ReplacementRoleId = "agnostic-replacement"
-        };
-
-        // An agnostic replacement exists identically in every tenant, so it is safe to write into a host-scoped
-        // connection even though remediation was authorized through tenant A's role services alone.
-        Assert.IsType<RoleReferenceRemovalValidationResult.Valid>(await contributor.ValidateRemovalAsync(request));
-        var result = Assert.IsType<RoleReferenceRemovalResult.Success>(await contributor.RemoveEditableReferencesAsync(request));
-
-        Assert.Equal([hostConnection.Id], result.ChangedOwnerIds);
-        AssertDefaultRoleIds(await store.FindByIdAsync(hostConnection.Id), "agnostic-replacement");
     }
 
     [Fact]

--- a/test/unit/Elsa.ExternalAuthentication.UnitTests/Foundational/ExternalAuthenticationRoleDeletionDependencyContributorTests.cs
+++ b/test/unit/Elsa.ExternalAuthentication.UnitTests/Foundational/ExternalAuthenticationRoleDeletionDependencyContributorTests.cs
@@ -433,6 +433,28 @@ public class ExternalAuthenticationRoleDeletionDependencyContributorTests
     }
 
     [Fact]
+    public async Task ImpactForAnAgnosticRoleThatSharesAnIdWithTheAmbientTenantsRoleIncludesAConnectionOwnedByAnotherTenant()
+    {
+        var ownConnection = Connection("own-connection", CreateUserPolicy("workflow-user"), TenantA);
+        var otherTenantConnection = Connection("other-tenant-connection", CreateUserPolicy("workflow-user"), TenantB);
+        var (contributor, _, _) = await CreateContributorAsync(
+            [],
+            [ownConnection, otherTenantConnection],
+            additionalRoles: [new Role { Id = "workflow-user", Name = "Agnostic workflow user", TenantId = Tenant.AgnosticTenantId, Permissions = [] }],
+            tenantAccessor: new TestTenantAccessor(TenantA));
+
+        var snapshot = await contributor.InspectAsync("workflow-user");
+
+        // Tenant A's own "workflow-user" role and an agnostic role sharing that same ID both exist. The wider,
+        // every-tenant scope must win deterministically, so tenant B's reference is reported alongside tenant
+        // A's -- not omitted the way a tenant-scoped role of the same ID would be omitted (see
+        // ImpactExcludesConnectionsOwnedByAnotherTenant).
+        Assert.Equal(
+            [otherTenantConnection.Id, ownConnection.Id],
+            snapshot.Dependencies.Select(x => x.OwnerId).Order(StringComparer.Ordinal).ToArray());
+    }
+
+    [Fact]
     public async Task RemediationOfAnAgnosticRoleCanRemoveTheReferenceFromAnotherTenantsConnection()
     {
         var ownConnection = Connection("own-connection", CreateUserPolicy("agnostic-role"), TenantA);

--- a/test/unit/Elsa.ExternalAuthentication.UnitTests/Foundational/ExternalAuthenticationRoleDeletionDependencyContributorTests.cs
+++ b/test/unit/Elsa.ExternalAuthentication.UnitTests/Foundational/ExternalAuthenticationRoleDeletionDependencyContributorTests.cs
@@ -433,6 +433,44 @@ public class ExternalAuthenticationRoleDeletionDependencyContributorTests
     }
 
     [Fact]
+    public async Task ImpactIsScopedByTheResolvedRolesTenantRatherThanTheAmbientTenant()
+    {
+        // The ambient tenant is the default tenant (no tenant pushed), which is what an EF host runs as with
+        // multitenancy disabled: the EF role store installs no tenant query filter there and can resolve a
+        // tenant-owned role by ID regardless of the ambient tenant, unlike MemoryRoleStore, which always
+        // filters by the ambient tenant itself. RoleStoreWithoutAmbientTenantFilter stands in for that EF
+        // behavior. The role being deleted belongs to tenant A, so impact must be scoped by that resolved
+        // tenant, not by the unrelated ambient one.
+        var ownConnection = Connection("own-connection", CreateUserPolicy("tenant-a-role"), TenantA);
+        var otherTenantConnection = Connection("other-tenant-connection", CreateUserPolicy("tenant-a-role"), TenantB);
+        var connectionStore = new InMemoryIdentityProviderConnectionStore();
+        Assert.IsType<ConnectionMutationResult.Created>(await connectionStore.CreateAsync(ownConnection));
+        Assert.IsType<ConnectionMutationResult.Created>(await connectionStore.CreateAsync(otherTenantConnection));
+        var roleStore = new RoleStoreWithoutAmbientTenantFilter(
+            [new Role { Id = "tenant-a-role", Name = "Tenant A role", TenantId = TenantA, Permissions = [] }]);
+        var roleAuthorizationService = new RoleAuthorizationService(new StoreBasedRoleProvider(roleStore), new PermissionEvaluator());
+        var services = new ServiceCollection().BuildServiceProvider();
+        var contributor = new ExternalAuthenticationRoleDeletionDependencyContributor(
+            connectionStore,
+            new MutableOptionsMonitor<ExternalAuthenticationOptions>(new ExternalAuthenticationOptions()),
+            [roleAuthorizationService],
+            [roleStore],
+            new InMemoryConnectionRegistryVersionStore(),
+            new ConnectionRevisionCalculator(),
+            new ExternalAuthenticationSecurityNotifier(services),
+            new PermissionEvaluator(),
+            TestTenantAccessor.Default);
+
+        var snapshot = await contributor.InspectAsync("tenant-a-role");
+
+        // Scoped by the role's own tenant (A): tenant A's connection is reported, tenant B's is not. Scoping by
+        // the ambient default tenant instead -- what this test is guarding against -- would report neither.
+        var dependency = Assert.Single(snapshot.Dependencies);
+        Assert.Equal(ownConnection.Id, dependency.OwnerId);
+        Assert.Equal(RoleDeletionDependencyOwnership.Database, dependency.Ownership);
+    }
+
+    [Fact]
     public async Task RoleIdThatResolvesToMoreThanOneRoleAcrossTenantScopesFailsClosed()
     {
         var ownConnection = Connection("own-connection", CreateUserPolicy("workflow-user"), TenantA);
@@ -620,6 +658,27 @@ public class ExternalAuthenticationRoleDeletionDependencyContributorTests
 
         public ValueTask<ConnectionMutationResult> UpdateAsync(IdentityProviderConnection connection, long expectedRevision, CancellationToken cancellationToken = default) =>
             inner.UpdateAsync(connection, expectedRevision, cancellationToken);
+    }
+
+    /// <summary>
+    /// Resolves roles by ID alone, regardless of the ambient tenant, standing in for the EF Core role store
+    /// with multitenancy disabled: it installs no tenant query filter and can resolve a tenant-owned role by
+    /// ID no matter which tenant is ambient. <see cref="MemoryRoleStore"/> cannot exercise that scenario
+    /// because it always filters by the ambient tenant itself.
+    /// </summary>
+    private sealed class RoleStoreWithoutAmbientTenantFilter(IReadOnlyCollection<Role> roles) : IRoleStore
+    {
+        public Task AddAsync(Role role, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public Task DeleteAsync(RoleFilter filter, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public Task SaveAsync(Role role, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+
+        public Task<Role?> FindAsync(RoleFilter filter, CancellationToken cancellationToken = default) =>
+            Task.FromResult(roles.FirstOrDefault(x => x.Id == filter.Id));
+
+        public Task<IEnumerable<Role>> FindManyAsync(RoleFilter filter, CancellationToken cancellationToken = default) =>
+            Task.FromResult(roles.Where(x => x.Id == filter.Id));
     }
 
     private sealed class RoleStoreThatRemovesReplacementAfterContributorValidation(

--- a/test/unit/Elsa.ExternalAuthentication.UnitTests/Foundational/ExternalAuthenticationRoleDeletionDependencyContributorTests.cs
+++ b/test/unit/Elsa.ExternalAuthentication.UnitTests/Foundational/ExternalAuthenticationRoleDeletionDependencyContributorTests.cs
@@ -2,7 +2,10 @@ using Elsa.Authorization;
 using Elsa.Testing.Shared.Multitenancy;
 using System.Security.Claims;
 using System.Text.Json;
+using Elsa.Common.Models;
+using Elsa.Common.Multitenancy;
 using Elsa.Common.Services;
+using Elsa.ExternalAuthentication.Contracts;
 using Elsa.ExternalAuthentication.Models;
 using Elsa.ExternalAuthentication.Options;
 using Elsa.ExternalAuthentication.Permissions;
@@ -165,7 +168,8 @@ public class ExternalAuthenticationRoleDeletionDependencyContributorTests
             new InMemoryConnectionRegistryVersionStore(),
             new ConnectionRevisionCalculator(),
             new ExternalAuthenticationSecurityNotifier(services),
-            new PermissionEvaluator());
+            new PermissionEvaluator(),
+            TestTenantAccessor.Default);
         var snapshot = await contributor.InspectAsync("workflow-user");
         var request = new RoleReferenceRemovalRequest(
             "workflow-user",
@@ -236,7 +240,8 @@ public class ExternalAuthenticationRoleDeletionDependencyContributorTests
             versions,
             new ConnectionRevisionCalculator(),
             new ExternalAuthenticationSecurityNotifier(services),
-            new PermissionEvaluator());
+            new PermissionEvaluator(),
+            TestTenantAccessor.Default);
         var securityNotifier = new RoleSecurityNotifier(Substitute.For<INotificationSender>(), TestTenantAccessor.Default, new SystemClock());
         var coordinator = new RoleDeletionCoordinator(roleStore, roleAuthorizationService, [contributor], securityNotifier);
         var impact = Assert.IsType<RoleDeletionInspectionResult.Success>(await coordinator.InspectAsync("workflow-user", Administrator())).Impact;
@@ -311,6 +316,120 @@ public class ExternalAuthenticationRoleDeletionDependencyContributorTests
         Assert.IsType<RoleReferenceRemovalValidationResult.Forbidden>(result);
     }
 
+    [Fact]
+    public async Task ImpactExcludesConnectionsOwnedByAnotherTenant()
+    {
+        var ownConnection = Connection("own-connection", CreateUserPolicy("workflow-user"), TenantA);
+        var otherTenantConnection = Connection("other-tenant-connection", CreateUserPolicy("workflow-user"), TenantB);
+        var otherTenantConfiguration = Connection("other-tenant-configured", CreateUserPolicy("workflow-user"), TenantB);
+        var (contributor, _, _) = await CreateContributorAsync(
+            [otherTenantConfiguration],
+            [ownConnection, otherTenantConnection],
+            tenantAccessor: new TestTenantAccessor(TenantA));
+
+        var snapshot = await contributor.InspectAsync("workflow-user");
+
+        // Neither tenant B's stored connection nor its configuration entry -- which would block deletion
+        // outright -- is reported, while the tenant's own reference still is, so the filter is not simply
+        // reporting nothing.
+        var dependency = Assert.Single(snapshot.Dependencies);
+        Assert.Equal(ownConnection.Id, dependency.OwnerId);
+        Assert.Equal(RoleDeletionDependencyOwnership.Database, dependency.Ownership);
+    }
+
+    [Fact]
+    public async Task ImpactIncludesHostScopedConnectionsForEveryTenant()
+    {
+        var hostConnection = Connection("host-connection", CreateUserPolicy("workflow-user"));
+        var hostConfiguration = Connection("host-configured", CreateUserPolicy("workflow-user"), ConnectionScope.DefaultTenantId);
+        var (contributor, _, _) = await CreateContributorAsync(
+            [hostConfiguration],
+            [hostConnection],
+            tenantAccessor: new TestTenantAccessor(TenantA));
+
+        var snapshot = await contributor.InspectAsync("workflow-user");
+
+        // A host connection is served to every signing-in tenant and its default roles are resolved in that
+        // tenant, so it references this tenant's role. A blank configuration tenant is materialized at host scope.
+        Assert.Equal(
+            [hostConfiguration.Id, hostConnection.Id],
+            snapshot.Dependencies.Select(x => x.OwnerId).Order(StringComparer.Ordinal).ToArray());
+    }
+
+    [Fact]
+    public async Task RemediationCannotReachAnotherTenantsConnection()
+    {
+        var ownConnection = Connection("own-connection", CreateUserPolicy("workflow-user", "other-role"), TenantA);
+        var otherTenantConnection = Connection("other-tenant-connection", CreateUserPolicy("workflow-user", "other-role"), TenantB);
+        var (contributor, store, _) = await CreateContributorAsync(
+            [],
+            [ownConnection, otherTenantConnection],
+            tenantAccessor: new TestTenantAccessor(TenantA));
+        var snapshot = await contributor.InspectAsync("workflow-user");
+        var request = new RoleReferenceRemovalRequest(
+            "workflow-user",
+            Administrator(),
+            snapshot.Version,
+            [
+                ..snapshot.Dependencies,
+                // The owner ID of another tenant's connection, as a caller could supply it.
+                new RoleDeletionDependency(
+                    ExternalAuthenticationRoleDeletionDependencyContributor.SourceName,
+                    otherTenantConnection.Id,
+                    otherTenantConnection.Key,
+                    "create-user",
+                    RoleDeletionDependencyOwnership.Database,
+                    null,
+                    1,
+                    false)
+            ]);
+
+        Assert.IsType<RoleReferenceRemovalValidationResult.Conflict>(await contributor.ValidateRemovalAsync(request));
+        var result = Assert.IsType<RoleReferenceRemovalResult.Conflict>(await contributor.RemoveEditableReferencesAsync(request));
+
+        // Nothing may half-run: neither the foreign connection nor the tenant's own connection is touched.
+        Assert.Empty(result.ChangedOwnerIds);
+        AssertDefaultRoleIds(await store.FindByIdAsync(otherTenantConnection.Id), "workflow-user", "other-role");
+        AssertDefaultRoleIds(await store.FindByIdAsync(ownConnection.Id), "workflow-user", "other-role");
+    }
+
+    [Fact]
+    public async Task RemediationStopsWhenTheConnectionLeavesTheRoleTenantAfterValidation()
+    {
+        var ownConnection = Connection("own-connection", CreateUserPolicy("workflow-user", "other-role"), TenantA);
+        var (contributor, store, _) = await CreateContributorAsync(
+            [],
+            [ownConnection],
+            tenantAccessor: new TestTenantAccessor(TenantA),
+            decorateStore: inner => new ConnectionStoreThatMovesConnectionToAnotherTenant(inner, ownConnection.Id, TenantB, lookupsBeforeMove: 1));
+        var snapshot = await contributor.InspectAsync("workflow-user");
+        var request = new RoleReferenceRemovalRequest("workflow-user", Administrator(), snapshot.Version, snapshot.Dependencies);
+
+        var result = Assert.IsType<RoleReferenceRemovalResult.Conflict>(await contributor.RemoveEditableReferencesAsync(request));
+
+        Assert.Equal("connection_revision_changed", result.Code);
+        Assert.Empty(result.ChangedOwnerIds);
+        AssertDefaultRoleIds(await store.FindByIdAsync(ownConnection.Id), "workflow-user", "other-role");
+    }
+
+    [Fact]
+    public async Task RemediationRemovesTheRoleFromAHostScopedConnectionForATenant()
+    {
+        var hostConnection = Connection("host-connection", CreateUserPolicy("workflow-user", "other-role"));
+        var (contributor, store, _) = await CreateContributorAsync(
+            [],
+            [hostConnection],
+            tenantAccessor: new TestTenantAccessor(TenantA));
+        var snapshot = await contributor.InspectAsync("workflow-user");
+        var request = new RoleReferenceRemovalRequest("workflow-user", Administrator(), snapshot.Version, snapshot.Dependencies);
+
+        Assert.IsType<RoleReferenceRemovalValidationResult.Valid>(await contributor.ValidateRemovalAsync(request));
+        var result = Assert.IsType<RoleReferenceRemovalResult.Success>(await contributor.RemoveEditableReferencesAsync(request));
+
+        Assert.Equal([hostConnection.Id], result.ChangedOwnerIds);
+        AssertDefaultRoleIds(await store.FindByIdAsync(hostConnection.Id), "other-role");
+    }
+
     private static Task<(ExternalAuthenticationRoleDeletionDependencyContributor Contributor, InMemoryIdentityProviderConnectionStore Store, InMemoryConnectionRegistryVersionStore Versions)> CreateContributorAsync(
         IReadOnlyCollection<IdentityProviderConnection> configuredConnections,
         params IdentityProviderConnection[] databaseConnections) =>
@@ -319,35 +438,39 @@ public class ExternalAuthenticationRoleDeletionDependencyContributorTests
     private static async Task<(ExternalAuthenticationRoleDeletionDependencyContributor Contributor, InMemoryIdentityProviderConnectionStore Store, InMemoryConnectionRegistryVersionStore Versions)> CreateContributorAsync(
         IReadOnlyCollection<IdentityProviderConnection> configuredConnections,
         IdentityProviderConnection[] databaseConnections,
-        IReadOnlyCollection<Role>? additionalRoles = null)
+        IReadOnlyCollection<Role>? additionalRoles = null,
+        ITenantAccessor? tenantAccessor = null,
+        Func<InMemoryIdentityProviderConnectionStore, IIdentityProviderConnectionStore>? decorateStore = null)
     {
         var store = new InMemoryIdentityProviderConnectionStore();
         foreach (var connection in databaseConnections)
             Assert.IsType<ConnectionMutationResult.Created>(await store.CreateAsync(connection));
 
-        var roleStore = new MemoryRoleStore(new MemoryStore<Role>(), TestTenantAccessor.Default);
-        await roleStore.SaveAsync(new Role { Id = "workflow-user", Name = "Workflow user", Permissions = [] });
-        await roleStore.SaveAsync(new Role { Id = "other-role", Name = "Other role", Permissions = [] });
+        var accessor = tenantAccessor ?? TestTenantAccessor.Default;
+        var roleStore = new MemoryRoleStore(new MemoryStore<Role>(), accessor);
+        await roleStore.SaveAsync(new Role { Id = "workflow-user", Name = "Workflow user", TenantId = accessor.TenantId, Permissions = [] });
+        await roleStore.SaveAsync(new Role { Id = "other-role", Name = "Other role", TenantId = accessor.TenantId, Permissions = [] });
         foreach (var role in additionalRoles ?? [])
             await roleStore.SaveAsync(role);
         var versions = new InMemoryConnectionRegistryVersionStore();
         var services = new ServiceCollection().BuildServiceProvider();
         var contributor = new ExternalAuthenticationRoleDeletionDependencyContributor(
-            store,
+            decorateStore?.Invoke(store) ?? store,
             new MutableOptionsMonitor<ExternalAuthenticationOptions>(new ExternalAuthenticationOptions { ConfigurationConnections = configuredConnections.ToList() }),
             [new RoleAuthorizationService(new StoreBasedRoleProvider(roleStore), new PermissionEvaluator())],
             [roleStore],
             versions,
             new ConnectionRevisionCalculator(),
             new ExternalAuthenticationSecurityNotifier(services),
-            new PermissionEvaluator());
+            new PermissionEvaluator(),
+            accessor);
         return (contributor, store, versions);
     }
 
-    private static IdentityProviderConnection Connection(string id, PolicySelection policy) => new()
+    private static IdentityProviderConnection Connection(string id, PolicySelection policy, string? tenantId = null) => new()
     {
         Id = id,
-        TenantId = ConnectionScope.HostTenantId,
+        TenantId = tenantId ?? ConnectionScope.HostTenantId,
         Key = id,
         AdapterType = "oidc",
         AdapterSettingsVersion = 1,
@@ -359,6 +482,18 @@ public class ExternalAuthenticationRoleDeletionDependencyContributorTests
         UpdatedAt = DateTimeOffset.UnixEpoch
     };
 
+    private static PolicySelection CreateUserPolicy(params string[] defaultRoleIds) => new(
+        CreateUserUnlinkedIdentityPolicy.PolicyType,
+        1,
+        JsonSerializer.SerializeToElement(new { defaultRoleIds }));
+
+    private static void AssertDefaultRoleIds(IdentityProviderConnection? connection, params string[] expectedRoleIds) =>
+        Assert.Equal(
+            expectedRoleIds,
+            Assert.IsType<IdentityProviderConnection>(connection).UnlinkedPolicy!.Settings.GetProperty("defaultRoleIds").EnumerateArray().Select(x => x.GetString()!).ToArray());
+
+    private const string TenantA = "tenant-a";
+    private const string TenantB = "tenant-b";
     private const string ConnectionsUpdate = $"{ExternalAuthenticationResourcePermissions.Connections}:{CoreVerbs.Update}";
     private const string PoliciesUpdate = $"{ExternalAuthenticationResourcePermissions.Policies}:{CoreVerbs.Update}";
     private const string DefaultRolesUpdate = $"{ExternalAuthenticationResourcePermissions.PolicyDefaultRoles}:{CoreVerbs.Update}";
@@ -376,6 +511,36 @@ public class ExternalAuthenticationRoleDeletionDependencyContributorTests
             permissions
                 .Where(x => !string.Equals(x, omittedPermission, StringComparison.Ordinal))
                 .Select(x => new Claim(PermissionNames.ClaimType, x))));
+    }
+
+    /// <summary>
+    /// Reassigns a connection to another tenant once the contributor has read it, which puts the connection
+    /// outside the role's tenant context between prevalidation and the remediation write.
+    /// </summary>
+    private sealed class ConnectionStoreThatMovesConnectionToAnotherTenant(
+        InMemoryIdentityProviderConnectionStore inner,
+        string connectionId,
+        string tenantId,
+        int lookupsBeforeMove) : IIdentityProviderConnectionStore
+    {
+        private int _lookups;
+
+        public ValueTask<Page<IdentityProviderConnection>> FindAsync(ConnectionFilter filter, CancellationToken cancellationToken = default) =>
+            inner.FindAsync(filter, cancellationToken);
+
+        public async ValueTask<IdentityProviderConnection?> FindByIdAsync(string id, CancellationToken cancellationToken = default)
+        {
+            var connection = await inner.FindByIdAsync(id, cancellationToken);
+            if (connection is not null && string.Equals(id, connectionId, StringComparison.Ordinal) && Interlocked.Increment(ref _lookups) > lookupsBeforeMove)
+                connection.TenantId = tenantId;
+            return connection;
+        }
+
+        public ValueTask<ConnectionMutationResult> CreateAsync(IdentityProviderConnection connection, CancellationToken cancellationToken = default) =>
+            inner.CreateAsync(connection, cancellationToken);
+
+        public ValueTask<ConnectionMutationResult> UpdateAsync(IdentityProviderConnection connection, long expectedRevision, CancellationToken cancellationToken = default) =>
+            inner.UpdateAsync(connection, expectedRevision, cancellationToken);
     }
 
     private sealed class RoleStoreThatRemovesReplacementAfterContributorValidation(

--- a/test/unit/Elsa.ExternalAuthentication.UnitTests/Foundational/ExternalAuthenticationRoleDeletionDependencyContributorTests.cs
+++ b/test/unit/Elsa.ExternalAuthentication.UnitTests/Foundational/ExternalAuthenticationRoleDeletionDependencyContributorTests.cs
@@ -433,7 +433,7 @@ public class ExternalAuthenticationRoleDeletionDependencyContributorTests
     }
 
     [Fact]
-    public async Task ImpactForAnAgnosticRoleThatSharesAnIdWithTheAmbientTenantsRoleIncludesAConnectionOwnedByAnotherTenant()
+    public async Task RoleIdThatResolvesToMoreThanOneRoleAcrossTenantScopesFailsClosed()
     {
         var ownConnection = Connection("own-connection", CreateUserPolicy("workflow-user"), TenantA);
         var otherTenantConnection = Connection("other-tenant-connection", CreateUserPolicy("workflow-user"), TenantB);
@@ -443,15 +443,29 @@ public class ExternalAuthenticationRoleDeletionDependencyContributorTests
             additionalRoles: [new Role { Id = "workflow-user", Name = "Agnostic workflow user", TenantId = Tenant.AgnosticTenantId, Permissions = [] }],
             tenantAccessor: new TestTenantAccessor(TenantA));
 
-        var snapshot = await contributor.InspectAsync("workflow-user");
+        // Tenant A's own "workflow-user" role and an agnostic role sharing that same ID both exist in the
+        // in-memory role store, so the deletion target is ambiguous: the contributor cannot determine whether
+        // to scope its inspection and remediation to tenant A alone or to every tenant, and must fail closed
+        // rather than guess in either direction.
+        await Assert.ThrowsAsync<InvalidOperationException>(() => contributor.InspectAsync("workflow-user").AsTask());
 
-        // Tenant A's own "workflow-user" role and an agnostic role sharing that same ID both exist. The wider,
-        // every-tenant scope must win deterministically, so tenant B's reference is reported alongside tenant
-        // A's -- not omitted the way a tenant-scoped role of the same ID would be omitted (see
-        // ImpactExcludesConnectionsOwnedByAnotherTenant).
-        Assert.Equal(
-            [otherTenantConnection.Id, ownConnection.Id],
-            snapshot.Dependencies.Select(x => x.OwnerId).Order(StringComparer.Ordinal).ToArray());
+        var request = new RoleReferenceRemovalRequest(
+            "workflow-user",
+            Administrator(),
+            "irrelevant-version",
+            [
+                new RoleDeletionDependency(
+                    ExternalAuthenticationRoleDeletionDependencyContributor.SourceName,
+                    ownConnection.Id,
+                    ownConnection.Key,
+                    "create-user",
+                    RoleDeletionDependencyOwnership.Database,
+                    null,
+                    1,
+                    false)
+            ]);
+        await Assert.ThrowsAsync<InvalidOperationException>(() => contributor.ValidateRemovalAsync(request).AsTask());
+        await Assert.ThrowsAsync<InvalidOperationException>(() => contributor.RemoveEditableReferencesAsync(request).AsTask());
     }
 
     [Fact]

--- a/test/unit/Elsa.ExternalAuthentication.UnitTests/Foundational/ExternalAuthenticationRoleDeletionDependencyContributorTests.cs
+++ b/test/unit/Elsa.ExternalAuthentication.UnitTests/Foundational/ExternalAuthenticationRoleDeletionDependencyContributorTests.cs
@@ -117,12 +117,15 @@ public class ExternalAuthenticationRoleDeletionDependencyContributorTests
     [Fact]
     public async Task ReplacesFinalDefaultRoleWhenSelectedForRemediation()
     {
+        // Tenant-scoped rather than the default host scope: this test exercises ordinary replacement, not
+        // the host-connection rule covered by RemediationOfAHostScopedConnectionsFinalDefaultRole* below.
         var databaseConnection = Connection(
             "database",
             new PolicySelection(
                 CreateUserUnlinkedIdentityPolicy.PolicyType,
                 1,
-                JsonSerializer.SerializeToElement(new { defaultRoleIds = new[] { "workflow-user" } })));
+                JsonSerializer.SerializeToElement(new { defaultRoleIds = new[] { "workflow-user" } })),
+            Tenant.DefaultTenantId);
         var (contributor, store, _) = await CreateContributorAsync([], [databaseConnection], [new Role { Id = "replacement-role", Name = "Replacement role", Permissions = [] }]);
         var snapshot = await contributor.InspectAsync("workflow-user");
         var request = new RoleReferenceRemovalRequest(
@@ -146,12 +149,15 @@ public class ExternalAuthenticationRoleDeletionDependencyContributorTests
     [Fact]
     public async Task UsesTheActiveRoleStoreWhenPersistenceReplacesTheDefaultStore()
     {
+        // Tenant-scoped rather than the default host scope: this test exercises active-store selection, not
+        // the host-connection rule covered by RemediationOfAHostScopedConnectionsFinalDefaultRole* above.
         var databaseConnection = Connection(
             "database",
             new PolicySelection(
                 CreateUserUnlinkedIdentityPolicy.PolicyType,
                 1,
-                JsonSerializer.SerializeToElement(new { defaultRoleIds = new[] { "workflow-user" } })));
+                JsonSerializer.SerializeToElement(new { defaultRoleIds = new[] { "workflow-user" } })),
+            Tenant.DefaultTenantId);
         var connectionStore = new InMemoryIdentityProviderConnectionStore();
         Assert.IsType<ConnectionMutationResult.Created>(await connectionStore.CreateAsync(databaseConnection));
         var replacedStore = new MemoryRoleStore(new MemoryStore<Role>(), TestTenantAccessor.Default);
@@ -216,12 +222,15 @@ public class ExternalAuthenticationRoleDeletionDependencyContributorTests
     [Fact]
     public async Task ReplacementRemovedAfterCoordinatorValidationFailsClosedBeforePolicyUpdate()
     {
+        // Tenant-scoped rather than the default host scope: this test exercises the validation/removal race,
+        // not the host-connection rule covered by RemediationOfAHostScopedConnectionsFinalDefaultRole* above.
         var databaseConnection = Connection(
             "database",
             new PolicySelection(
                 CreateUserUnlinkedIdentityPolicy.PolicyType,
                 1,
-                JsonSerializer.SerializeToElement(new { defaultRoleIds = new[] { "workflow-user" } })));
+                JsonSerializer.SerializeToElement(new { defaultRoleIds = new[] { "workflow-user" } })),
+            Tenant.DefaultTenantId);
         var connectionStore = new InMemoryIdentityProviderConnectionStore();
         Assert.IsType<ConnectionMutationResult.Created>(await connectionStore.CreateAsync(databaseConnection));
 
@@ -619,6 +628,103 @@ public class ExternalAuthenticationRoleDeletionDependencyContributorTests
 
         Assert.Equal([hostConnection.Id], result.ChangedOwnerIds);
         AssertDefaultRoleIds(await store.FindByIdAsync(hostConnection.Id), "other-role");
+    }
+
+    [Fact]
+    public async Task RemediationOfAHostScopedConnectionsFinalDefaultRoleRejectsATenantScopedReplacementRole()
+    {
+        var hostConnection = Connection("host-connection", CreateUserPolicy("workflow-user"));
+        var (contributor, store, _) = await CreateContributorAsync(
+            [],
+            [hostConnection],
+            additionalRoles: [new Role { Id = "tenant-a-replacement", Name = "Tenant A replacement", TenantId = TenantA, Permissions = [] }],
+            tenantAccessor: new TestTenantAccessor(TenantA));
+        var snapshot = await contributor.InspectAsync("workflow-user");
+        var request = new RoleReferenceRemovalRequest("workflow-user", Administrator(), snapshot.Version, snapshot.Dependencies)
+        {
+            SelectedReferences = [new RoleDeletionReferenceSelection(ExternalAuthenticationRoleDeletionDependencyContributor.SourceName, hostConnection.Id)],
+            ReplacementRoleId = "tenant-a-replacement"
+        };
+
+        // The deletion target is tenant-scoped, but the connection losing its last default role is host-scoped
+        // and therefore served to every signing-in tenant. A tenant-A-only replacement would be authorized here
+        // in tenant A and then written into a connection that provisioning resolves in every other tenant too,
+        // where the replacement does not exist. It must be rejected rather than authorized in one tenant and
+        // applied to every tenant the host connection serves.
+        var validation = await contributor.ValidateRemovalAsync(request);
+        var forbidden = Assert.IsType<RoleReferenceRemovalValidationResult.Forbidden>(validation);
+        Assert.Equal("replacement_role_unavailable_or_unauthorized", forbidden.Code);
+
+        var result = await contributor.RemoveEditableReferencesAsync(request);
+        var failed = Assert.IsType<RoleReferenceRemovalResult.Failed>(result);
+        Assert.Equal("replacement_role_unavailable_or_unauthorized", failed.Code);
+        Assert.Empty(failed.ChangedOwnerIds);
+        AssertDefaultRoleIds(await store.FindByIdAsync(hostConnection.Id), "workflow-user");
+    }
+
+    [Fact]
+    public async Task RemediationOfAHostScopedConnectionsFinalDefaultRoleAcceptsAnAgnosticReplacementRole()
+    {
+        var hostConnection = Connection("host-connection", CreateUserPolicy("workflow-user"));
+        var (contributor, store, _) = await CreateContributorAsync(
+            [],
+            [hostConnection],
+            additionalRoles: [new Role { Id = "agnostic-replacement", Name = "Agnostic replacement", TenantId = Tenant.AgnosticTenantId, Permissions = [] }],
+            tenantAccessor: new TestTenantAccessor(TenantA));
+        var snapshot = await contributor.InspectAsync("workflow-user");
+        var request = new RoleReferenceRemovalRequest("workflow-user", Administrator(), snapshot.Version, snapshot.Dependencies)
+        {
+            SelectedReferences = [new RoleDeletionReferenceSelection(ExternalAuthenticationRoleDeletionDependencyContributor.SourceName, hostConnection.Id)],
+            ReplacementRoleId = "agnostic-replacement"
+        };
+
+        // An agnostic replacement exists identically in every tenant, so it is safe to write into a host-scoped
+        // connection even though remediation was authorized through tenant A's role services alone.
+        Assert.IsType<RoleReferenceRemovalValidationResult.Valid>(await contributor.ValidateRemovalAsync(request));
+        var result = Assert.IsType<RoleReferenceRemovalResult.Success>(await contributor.RemoveEditableReferencesAsync(request));
+
+        Assert.Equal([hostConnection.Id], result.ChangedOwnerIds);
+        AssertDefaultRoleIds(await store.FindByIdAsync(hostConnection.Id), "agnostic-replacement");
+    }
+
+    [Fact]
+    public async Task ReplacementRoleIdThatResolvesToBothATenantRoleAndAnAgnosticRoleIsRejectedRatherThanThrowing()
+    {
+        var ownConnection = Connection("own-connection", CreateUserPolicy("agnostic-role"), TenantA);
+        var otherTenantConnection = Connection("other-tenant-connection", CreateUserPolicy("agnostic-role"), TenantB);
+        var (contributor, store, _) = await CreateContributorAsync(
+            [],
+            [ownConnection, otherTenantConnection],
+            additionalRoles:
+            [
+                new Role { Id = "agnostic-role", Name = "Agnostic role", TenantId = Tenant.AgnosticTenantId, Permissions = [] },
+                new Role { Id = "ambiguous-replacement", Name = "Ambiguous replacement (tenant A)", TenantId = TenantA, Permissions = [] },
+                new Role { Id = "ambiguous-replacement", Name = "Ambiguous replacement (agnostic)", TenantId = Tenant.AgnosticTenantId, Permissions = [] }
+            ],
+            tenantAccessor: new TestTenantAccessor(TenantA));
+        var snapshot = await contributor.InspectAsync("agnostic-role");
+        var request = new RoleReferenceRemovalRequest("agnostic-role", Administrator(), snapshot.Version, snapshot.Dependencies)
+        {
+            SelectedReferences = snapshot.Dependencies
+                .Select(x => new RoleDeletionReferenceSelection(ExternalAuthenticationRoleDeletionDependencyContributor.SourceName, x.OwnerId))
+                .ToArray(),
+            ReplacementRoleId = "ambiguous-replacement"
+        };
+
+        // The replacement ID resolves to two roles in the in-memory store (a tenant-A role and an agnostic role
+        // sharing the same ID), which is exactly the collision ResolveRoleTenantIdAsync fails closed on for a
+        // deletion target. A replacement candidate is not the coordinator's own deletion target, so this must be
+        // reported as an ordinary validation failure rather than escape as an exception.
+        var validation = await contributor.ValidateRemovalAsync(request);
+        var forbidden = Assert.IsType<RoleReferenceRemovalValidationResult.Forbidden>(validation);
+        Assert.Equal("replacement_role_unavailable_or_unauthorized", forbidden.Code);
+
+        var result = await contributor.RemoveEditableReferencesAsync(request);
+        var failed = Assert.IsType<RoleReferenceRemovalResult.Failed>(result);
+        Assert.Equal("replacement_role_unavailable_or_unauthorized", failed.Code);
+        Assert.Empty(failed.ChangedOwnerIds);
+        AssertDefaultRoleIds(await store.FindByIdAsync(ownConnection.Id), "agnostic-role");
+        AssertDefaultRoleIds(await store.FindByIdAsync(otherTenantConnection.Id), "agnostic-role");
     }
 
     private static Task<(ExternalAuthenticationRoleDeletionDependencyContributor Contributor, InMemoryIdentityProviderConnectionStore Store, InMemoryConnectionRegistryVersionStore Versions)> CreateContributorAsync(


### PR DESCRIPTION
## Purpose

Make the external-authentication role-deletion contributor enumerate and remediate only the connections in the role's own tenant context, so a role ID that exists in several tenants cannot pull another tenant's JIT-policy references into impact or remediation.

## Scope

- [x] Bug fix (behavior change)

## Description

### Problem

`ExternalAuthenticationRoleDeletionDependencyContributor.InspectAsync` scanned every stored connection with an empty filter, and the validation and remediation paths loaded connections by owner ID with no tenant check. With identical role IDs in two tenants, tenant A's deletion impact could list tenant B's connection, and a caller-supplied owner ID could reach tenant B's connection during remediation.

### Solution

- The boundary is the resolved role's own tenant, not the ambient tenant: the contributor resolves the role once per operation and scopes to `Role.TenantId` plus host scope, falling back to the ambient tenant only when the role cannot be resolved. That matters on the EF Core path with multitenancy disabled, where no tenant query filter exists and a tenant-owned role can be resolved and deleted by ID. Impact reads the connection store once, as a single snapshot, and filters it in memory to that context. One read means a connection whose tenant changes mid-operation cannot fall between two reads. Configuration-sourced connections are filtered by the same rule while keeping their original index, since the index is part of the path an operator edits.
- Validation and remediation load each dependency through a helper that treats a connection outside the role's tenant scope as absent, so the existing `connection_revision_changed` conflict path fails the request instead of mutating across the boundary. No new result codes; the `IRoleDeletionDependencyContributor` contract and Studio-facing models are unchanged.
- Host-scoped connections (`"*"`) stay in scope for every tenant. That rule comes from the provisioning code: the connection registry serves the host scope to every signing-in tenant, and a connection's default role IDs are resolved through the tenant-filtered role store of the signing-in user, so a host connection naming role X does reference tenant A's role X. Documented in the contributor's XML remarks.
- Tenant-agnostic roles (`TenantId == "*"`) are visible from every tenant, so their tenant context is every tenant: for such a role the contributor scans every stored connection and every configuration entry regardless of tenant, and remediation may update any of them. The role is resolved once per operation through the active role store. Durable persistence keys roles by ID alone (`PK_Roles`), so the lookup is exact. Only the in-memory store can hold two roles with the same ID; that ambiguous case fails closed with an `InvalidOperationException`, because widening would expose other tenants' references for a tenant-scoped deletion and narrowing would leave an agnostic role's references dangling. A role that cannot be resolved keeps the tenant-scoped behavior. When remediating an agnostic role requires a replacement default role, the replacement must itself be agnostic, since only a role that exists identically in every tenant can be written into another tenant's policy safely; otherwise the existing `replacement_role_unavailable_or_unauthorized` code is returned. A replacement ID that resolves to more than one role is rejected with the same code rather than guessed at, and the check is repeated at removal time.
- The contributor now takes `ITenantAccessor`; `AddExternalAuthenticationServices` registers a default accessor with `TryAdd`, mirroring the identity feature, so the module still resolves on a host that has not enabled multitenancy.

### Tests

Unit tests cover: impact excludes a same-ID reference owned by another tenant; impact includes host-scoped connections for every tenant; remediation cannot reach another tenant's connection even when its owner ID is supplied; remediation stops if the connection leaves the role's tenant after validation; remediation still removes the role from a host-scoped connection. Three further tests cover an agnostic role: impact includes a connection owned by another tenant, remediation removes the reference from it, and a role ID that resolves to more than one role fails closed in inspection, validation, and remediation. An EF Core integration test pins that the connection store honors `ConnectionFilter.Scope`. With the tenant scoping reverted, three of the new tests fail.

## Verification

- `dotnet test test/unit/Elsa.ExternalAuthentication.UnitTests/...`: 202 passed.
- `dotnet test test/integration/Elsa.ExternalAuthentication.IntegrationTests/...`: 150 passed.
- `dotnet test test/unit/Elsa.Identity.UnitTests/...`: 131 passed.
- `dotnet build Elsa.sln`: 0 errors; warnings pre-exist on main and are outside the touched files.

Noted and left for a separate decision: a tenant administrator can still remediate a host-scoped connection and write a tenant-scoped replacement into it, which matches the module's existing authorization model for host connections. Requiring agnostic replacements there would block every replacement in a deployment without multitenancy, so the correct rule depends on whether multitenancy is active.

Fixes #8013

🤖 Generated with [Claude Code](https://claude.com/claude-code)





