### PR TITLE
test(workflows-api): pin that a new read-only workflow can be imported

### DIFF
--- a/test/component/Elsa.Workflows.ComponentTests/Scenarios/RestApis/Endpoints/WorkflowDefinitions/Import/ImportAuthorizationTests.cs
+++ b/test/component/Elsa.Workflows.ComponentTests/Scenarios/RestApis/Endpoints/WorkflowDefinitions/Import/ImportAuthorizationTests.cs
@@ -64,6 +64,34 @@ public class ImportAuthorizationTests : AppComponentTest
         await AssertDefinitionUnchangedAsync(readOnlyDefinitionId, "ReadOnly Original", isReadonly: true);
     }
 
+    [Fact]
+    public async Task ImportNewReadOnlyDefinition_ShouldSucceedAndPersistAsReadOnly()
+    {
+        var definitionId = $"new-readonly-import-{Guid.NewGuid():N}";
+
+        var importedDefinition = await _client.ImportAsync(CreateImportModel(definitionId, "New ReadOnly", isReadonly: true));
+
+        Assert.True(importedDefinition.IsReadonly);
+        await AssertDefinitionUnchangedAsync(definitionId, "New ReadOnly", isReadonly: true);
+    }
+
+    [Fact]
+    public async Task ImportFilesWithNewReadOnlyDefinition_ShouldSucceedAndPersistAsReadOnly()
+    {
+        var definitionId = $"new-readonly-import-files-{Guid.NewGuid():N}";
+
+        await using var stream = CreateImportStream(definitionId, "New ReadOnly", isReadonly: true);
+        var files = new List<StreamPart>
+        {
+            new(stream, "readonly.json", "application/json")
+        };
+
+        var response = await _client.ImportFilesAsync(files);
+
+        Assert.Equal(1, response.Count);
+        await AssertDefinitionUnchangedAsync(definitionId, "New ReadOnly", isReadonly: true);
+    }
+
     private async Task SaveDefinitionAsync(string definitionId, string name, bool isReadonly = false)
     {
         await _store.SaveAsync(new WorkflowDefinitionEntity
@@ -91,18 +119,19 @@ public class ImportAuthorizationTests : AppComponentTest
         Assert.Equal(isReadonly, definition.IsReadonly);
     }
 
-    private static WorkflowDefinitionModel CreateImportModel(string definitionId, string name)
+    private static WorkflowDefinitionModel CreateImportModel(string definitionId, string name, bool isReadonly = false)
     {
         return new()
         {
             DefinitionId = definitionId,
-            Name = name
+            Name = name,
+            IsReadonly = isReadonly
         };
     }
 
-    private static MemoryStream CreateImportStream(string definitionId, string name)
+    private static MemoryStream CreateImportStream(string definitionId, string name, bool isReadonly = false)
     {
-        var json = JsonSerializer.Serialize(CreateImportModel(definitionId, name), new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var json = JsonSerializer.Serialize(CreateImportModel(definitionId, name, isReadonly), new JsonSerializerOptions(JsonSerializerDefaults.Web));
         return new(Encoding.UTF8.GetBytes(json));
     }
 }


### PR DESCRIPTION
## Purpose

Add regression coverage proving that importing a workflow definition as a NEW read-only workflow succeeds, so the NotReadOnlyPolicy only blocks edits to existing read-only or system workflows.

## Scope

- [x] Test-only change (no production code)

## Description

### Problem

#7981 reports that importing JSON for a new read-only workflow fails the NotReadOnlyPolicy. That was the 3.7.x behavior: the import endpoint imported first and then authorized against the freshly imported, read-only definition.

### State on `main`

Since #7510 (shipped in 3.8.0) both import endpoints authorize before persisting, against the definition already stored under the model's `DefinitionId`. A definition that does not exist yet yields a null resource, and the requirement handler only fails on a non-null read-only or system definition, so a new read-only import already succeeds. No production change is needed; this PR pins the behavior.

### Tests

`ImportAuthorizationTests` gains two component tests: importing a new definition with `IsReadonly = true` through the single import endpoint, and through the files import endpoint, both asserting success and that the persisted definition is read-only. The existing shared helpers gained an optional read-only parameter instead of being duplicated; the two existing forbidden-path tests are unchanged.

Noted, outside this issue: the single import endpoint derives its created-versus-updated response from whether the model carries a `DefinitionId`, so a new definition imported with an explicit ID returns 200 rather than 201. The tests assert on the persisted state, not the status code.

## Verification

- `dotnet test test/component/Elsa.Workflows.ComponentTests/... --filter FullyQualifiedName~ImportAuthorizationTests`: 4 passed.

Fixes #7981

🤖 Generated with [Claude Code](https://claude.com/claude-code)