### PR TITLE
fix(efcore): terminate raw SQL statements in the PostgreSQL and SQLite Runtime V3_6 migrations

### DIFF
--- a/src/modules/Elsa.Persistence.EFCore.PostgreSql/Migrations/Runtime/20251204150341_V3_6.cs
+++ b/src/modules/Elsa.Persistence.EFCore.PostgreSql/Migrations/Runtime/20251204150341_V3_6.cs
@@ -26,8 +26,8 @@ namespace Elsa.Persistence.EFCore.PostgreSql.Migrations.Runtime
                 unique: true);
 
             var schemaPrefix = _schema.Schema != null ? $"\"{_schema.Schema}\"." : "";
-            migrationBuilder.Sql($"DROP INDEX IF EXISTS {schemaPrefix}\"IX_WorkflowExecutionLogRecord_ActivityNodeId\"");
-            migrationBuilder.Sql($"DROP INDEX IF EXISTS {schemaPrefix}\"IX_ActivityExecutionRecord_ActivityNodeId\"");
+            migrationBuilder.Sql($"DROP INDEX IF EXISTS {schemaPrefix}\"IX_WorkflowExecutionLogRecord_ActivityNodeId\";");
+            migrationBuilder.Sql($"DROP INDEX IF EXISTS {schemaPrefix}\"IX_ActivityExecutionRecord_ActivityNodeId\";");
         }
 
         /// <inheritdoc />

--- a/src/modules/Elsa.Persistence.EFCore.Sqlite/Migrations/Runtime/20251204150006_V3_6.cs
+++ b/src/modules/Elsa.Persistence.EFCore.Sqlite/Migrations/Runtime/20251204150006_V3_6.cs
@@ -25,8 +25,8 @@ namespace Elsa.Persistence.EFCore.Sqlite.Migrations.Runtime
                 columns: new[] { "WorkflowDefinitionId", "Hash", "ActivityId", "TenantId" },
                 unique: true);
 
-            migrationBuilder.Sql("DROP INDEX IF EXISTS \"IX_WorkflowExecutionLogRecord_ActivityNodeId\"");
-            migrationBuilder.Sql("DROP INDEX IF EXISTS \"IX_ActivityExecutionRecord_ActivityNodeId\"");
+            migrationBuilder.Sql("DROP INDEX IF EXISTS \"IX_WorkflowExecutionLogRecord_ActivityNodeId\";");
+            migrationBuilder.Sql("DROP INDEX IF EXISTS \"IX_ActivityExecutionRecord_ActivityNodeId\";");
         }
 
         /// <inheritdoc />

--- a/test/unit/Elsa.Persistence.EFCore.UnitTests/Elsa.Persistence.EFCore.UnitTests.csproj
+++ b/test/unit/Elsa.Persistence.EFCore.UnitTests/Elsa.Persistence.EFCore.UnitTests.csproj
@@ -11,6 +11,8 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\..\src\modules\Elsa.Persistence.EFCore.Common\Elsa.Persistence.EFCore.Common.csproj" />
+        <ProjectReference Include="..\..\..\src\modules\Elsa.Persistence.EFCore.PostgreSql\Elsa.Persistence.EFCore.PostgreSql.csproj" />
+        <ProjectReference Include="..\..\..\src\modules\Elsa.Persistence.EFCore.Sqlite\Elsa.Persistence.EFCore.Sqlite.csproj" />
     </ItemGroup>
 
 </Project>

--- a/test/unit/Elsa.Persistence.EFCore.UnitTests/V3_6RuntimeMigrationTests.cs
+++ b/test/unit/Elsa.Persistence.EFCore.UnitTests/V3_6RuntimeMigrationTests.cs
@@ -1,0 +1,109 @@
+using Elsa.Persistence.EFCore.Extensions;
+using Elsa.Persistence.EFCore.Modules.Runtime;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Elsa.Persistence.EFCore.UnitTests;
+
+/// <summary>
+/// Regression tests for the V3_6 Runtime migration's raw SQL statements. `dotnet ef migrations script`
+/// previously produced invalid SQL because the `DROP INDEX` statements were not terminated with a
+/// semicolon, which corrupts both the idempotent PL/pgSQL block and the plain script.
+/// </summary>
+public class V3_6RuntimeMigrationTests
+{
+    private const string DropIndexPrefix = "DROP INDEX IF EXISTS";
+    private const string WorkflowExecutionLogRecordIndexName = "IX_WorkflowExecutionLogRecord_ActivityNodeId";
+    private const string ActivityExecutionRecordIndexName = "IX_ActivityExecutionRecord_ActivityNodeId";
+
+    [Fact]
+    public void GenerateScript_PostgreSql_Idempotent_TerminatesDropIndexStatements()
+    {
+        var script = GeneratePostgreSqlScript(MigrationsSqlGenerationOptions.Idempotent);
+
+        AssertDropIndexStatementsAreTerminated(script);
+        AssertWellFormedIdempotentBlock(script, WorkflowExecutionLogRecordIndexName);
+        AssertWellFormedIdempotentBlock(script, ActivityExecutionRecordIndexName);
+    }
+
+    [Fact]
+    public void GenerateScript_PostgreSql_Plain_TerminatesDropIndexStatements()
+    {
+        var script = GeneratePostgreSqlScript(MigrationsSqlGenerationOptions.Default);
+
+        AssertDropIndexStatementsAreTerminated(script);
+    }
+
+    // Note: EF Core's SQLite provider does not support generating idempotent migration scripts
+    // (SqliteHistoryRepository.GetEndIfScript throws NotSupportedException), so only the plain
+    // script form is exercised here.
+    [Fact]
+    public void GenerateScript_Sqlite_Plain_TerminatesDropIndexStatements()
+    {
+        var script = GenerateSqliteScript(MigrationsSqlGenerationOptions.Default);
+
+        AssertDropIndexStatementsAreTerminated(script);
+    }
+
+    private static string GeneratePostgreSqlScript(MigrationsSqlGenerationOptions options)
+    {
+        var migrationsAssembly = typeof(Elsa.Persistence.EFCore.PostgreSql.Migrations.Runtime.V3_6).Assembly;
+        var dbContextOptions = (DbContextOptions<RuntimeElsaDbContext>)new DbContextOptionsBuilder<RuntimeElsaDbContext>()
+            .UseElsaPostgreSql(migrationsAssembly, "Host=unused")
+            .Options;
+
+        using var dbContext = new RuntimeElsaDbContext(dbContextOptions, CreateServiceProvider());
+        var migrator = dbContext.GetService<IMigrator>();
+
+        return migrator.GenerateScript(fromMigration: "20250530104953_V3_5", toMigration: "20251204150341_V3_6", options: options);
+    }
+
+    private static string GenerateSqliteScript(MigrationsSqlGenerationOptions options)
+    {
+        var migrationsAssembly = typeof(Elsa.Persistence.EFCore.Sqlite.Migrations.Runtime.V3_6).Assembly;
+        var dbContextOptions = (DbContextOptions<RuntimeElsaDbContext>)new DbContextOptionsBuilder<RuntimeElsaDbContext>()
+            .UseElsaSqlite(migrationsAssembly, "Data Source=:memory:")
+            .Options;
+
+        using var dbContext = new RuntimeElsaDbContext(dbContextOptions, CreateServiceProvider());
+        var migrator = dbContext.GetService<IMigrator>();
+
+        return migrator.GenerateScript(fromMigration: "20250530104854_V3_5", toMigration: "20251204150006_V3_6", options: options);
+    }
+
+    private static IServiceProvider CreateServiceProvider() => new ServiceCollection().BuildServiceProvider();
+
+    private static void AssertDropIndexStatementsAreTerminated(string script)
+    {
+        AssertDropIndexStatementIsTerminated(script, WorkflowExecutionLogRecordIndexName);
+        AssertDropIndexStatementIsTerminated(script, ActivityExecutionRecordIndexName);
+    }
+
+    private static void AssertDropIndexStatementIsTerminated(string script, string indexName)
+    {
+        var line = script
+            .Split('\n')
+            .Select(l => l.Trim())
+            .SingleOrDefault(l => l.StartsWith(DropIndexPrefix, StringComparison.Ordinal) && l.Contains(indexName, StringComparison.Ordinal));
+
+        Assert.True(line != null, $"Expected to find a 'DROP INDEX IF EXISTS' statement for \"{indexName}\" in the generated script:\n{script}");
+        Assert.EndsWith(";", line);
+    }
+
+    private static void AssertWellFormedIdempotentBlock(string script, string indexName)
+    {
+        var lines = script.Split('\n').Select(l => l.Trim()).ToList();
+        var dropLineIndex = lines.FindIndex(l => l.StartsWith(DropIndexPrefix, StringComparison.Ordinal) && l.Contains(indexName, StringComparison.Ordinal));
+
+        Assert.True(dropLineIndex >= 0, $"Expected to find a 'DROP INDEX IF EXISTS' statement for \"{indexName}\" in the generated script:\n{script}");
+
+        // The statement inside the DO $EF$ ... IF NOT EXISTS(...) THEN <statement> END IF; block must be
+        // terminated before the following END IF; line, otherwise the PL/pgSQL block fails to parse.
+        var endIfLineIndex = lines.FindIndex(dropLineIndex, l => l.Equals("END IF;", StringComparison.Ordinal));
+
+        Assert.True(endIfLineIndex >= 0, $"Expected an 'END IF;' line after the DROP INDEX statement for \"{indexName}\":\n{script}");
+        Assert.EndsWith(";", lines[dropLineIndex]);
+    }
+}

--- a/test/unit/Elsa.Persistence.EFCore.UnitTests/V3_6RuntimeMigrationTests.cs
+++ b/test/unit/Elsa.Persistence.EFCore.UnitTests/V3_6RuntimeMigrationTests.cs
@@ -20,9 +20,9 @@ public class V3_6RuntimeMigrationTests
     private const string ActivityExecutionRecordIndexName = "IX_ActivityExecutionRecord_ActivityNodeId";
 
     [Theory]
-    [InlineData(null)]
     [InlineData("Elsa")]
-    public void GenerateScript_PostgreSql_Idempotent_TerminatesDropIndexStatements(string? schema)
+    [InlineData("custom_schema")]
+    public void GenerateScript_PostgreSql_Idempotent_TerminatesDropIndexStatements(string schema)
     {
         var script = GeneratePostgreSqlScript(MigrationsSqlGenerationOptions.Idempotent, schema);
 
@@ -30,9 +30,9 @@ public class V3_6RuntimeMigrationTests
     }
 
     [Theory]
-    [InlineData(null)]
     [InlineData("Elsa")]
-    public void GenerateScript_PostgreSql_Plain_TerminatesDropIndexStatements(string? schema)
+    [InlineData("custom_schema")]
+    public void GenerateScript_PostgreSql_Plain_TerminatesDropIndexStatements(string schema)
     {
         var script = GeneratePostgreSqlScript(MigrationsSqlGenerationOptions.Default, schema);
 
@@ -51,15 +51,16 @@ public class V3_6RuntimeMigrationTests
         AssertDropIndexStatementsAreTerminated(script, schema: null);
     }
 
-    private static string GeneratePostgreSqlScript(MigrationsSqlGenerationOptions options, string? schema)
+    private static string GeneratePostgreSqlScript(MigrationsSqlGenerationOptions options, string schema)
     {
         var migrationsAssembly = typeof(Elsa.Persistence.EFCore.PostgreSql.Migrations.Runtime.V3_6).Assembly;
+        var contextOptions = new ElsaDbContextOptions { SchemaName = schema };
 
-        return WithDefaultSchema(schema, () => GenerateScript(
-            builder => builder.UseElsaPostgreSql(migrationsAssembly, "Host=unused"),
+        return GenerateScript(
+            builder => builder.UseElsaPostgreSql(migrationsAssembly, "Host=unused", contextOptions),
             fromMigration: "20250530104953_V3_5",
             toMigration: "20251204150341_V3_6",
-            options));
+            options);
     }
 
     private static string GenerateSqliteScript(MigrationsSqlGenerationOptions options)
@@ -86,23 +87,9 @@ public class V3_6RuntimeMigrationTests
     }
 
     // ElsaDbContextOptions.SchemaName always falls back to ElsaDbContextBase.ElsaSchema ("Elsa") when it
-    // isn't set, so the only way to construct a context whose IElsaDbContextSchema.Schema is null - the
-    // branch the V3_6 migration guards against with `_schema.Schema != null ? "\"{schema}\"." : ""` - is
-    // to temporarily override that process-wide default.
-    private static T WithDefaultSchema<T>(string? schema, Func<T> generate)
-    {
-        var previousSchema = ElsaDbContextBase.ElsaSchema;
-        ElsaDbContextBase.ElsaSchema = schema!;
-        try
-        {
-            return generate();
-        }
-        finally
-        {
-            ElsaDbContextBase.ElsaSchema = previousSchema;
-        }
-    }
-
+    // isn't set, so the branch the V3_6 migration guards against with
+    // `_schema.Schema != null ? "\"{schema}\"." : ""` - a null schema - is unreachable through the
+    // public options and is therefore not covered here.
     private static IServiceProvider CreateServiceProvider() => new ServiceCollection().BuildServiceProvider();
 
     private static void AssertDropIndexStatementsAreTerminated(string script, string? schema, bool requireTrailingEndIf = false)

--- a/test/unit/Elsa.Persistence.EFCore.UnitTests/V3_6RuntimeMigrationTests.cs
+++ b/test/unit/Elsa.Persistence.EFCore.UnitTests/V3_6RuntimeMigrationTests.cs
@@ -1,3 +1,4 @@
+using Elsa.Persistence.EFCore;
 using Elsa.Persistence.EFCore.Extensions;
 using Elsa.Persistence.EFCore.Modules.Runtime;
 using Microsoft.EntityFrameworkCore;
@@ -18,92 +19,116 @@ public class V3_6RuntimeMigrationTests
     private const string WorkflowExecutionLogRecordIndexName = "IX_WorkflowExecutionLogRecord_ActivityNodeId";
     private const string ActivityExecutionRecordIndexName = "IX_ActivityExecutionRecord_ActivityNodeId";
 
-    [Fact]
-    public void GenerateScript_PostgreSql_Idempotent_TerminatesDropIndexStatements()
+    [Theory]
+    [InlineData(null)]
+    [InlineData("Elsa")]
+    public void GenerateScript_PostgreSql_Idempotent_TerminatesDropIndexStatements(string? schema)
     {
-        var script = GeneratePostgreSqlScript(MigrationsSqlGenerationOptions.Idempotent);
+        var script = GeneratePostgreSqlScript(MigrationsSqlGenerationOptions.Idempotent, schema);
 
-        AssertDropIndexStatementsAreTerminated(script);
-        AssertWellFormedIdempotentBlock(script, WorkflowExecutionLogRecordIndexName);
-        AssertWellFormedIdempotentBlock(script, ActivityExecutionRecordIndexName);
+        AssertDropIndexStatementsAreTerminated(script, schema, requireTrailingEndIf: true);
     }
 
-    [Fact]
-    public void GenerateScript_PostgreSql_Plain_TerminatesDropIndexStatements()
+    [Theory]
+    [InlineData(null)]
+    [InlineData("Elsa")]
+    public void GenerateScript_PostgreSql_Plain_TerminatesDropIndexStatements(string? schema)
     {
-        var script = GeneratePostgreSqlScript(MigrationsSqlGenerationOptions.Default);
+        var script = GeneratePostgreSqlScript(MigrationsSqlGenerationOptions.Default, schema);
 
-        AssertDropIndexStatementsAreTerminated(script);
+        AssertDropIndexStatementsAreTerminated(script, schema);
     }
 
     // Note: EF Core's SQLite provider does not support generating idempotent migration scripts
     // (SqliteHistoryRepository.GetEndIfScript throws NotSupportedException), so only the plain
-    // script form is exercised here.
+    // script form is exercised here. The SQLite migration also never schema-qualifies its DROP
+    // INDEX statements, so there is no schema-prefixed variant to cover.
     [Fact]
     public void GenerateScript_Sqlite_Plain_TerminatesDropIndexStatements()
     {
         var script = GenerateSqliteScript(MigrationsSqlGenerationOptions.Default);
 
-        AssertDropIndexStatementsAreTerminated(script);
+        AssertDropIndexStatementsAreTerminated(script, schema: null);
     }
 
-    private static string GeneratePostgreSqlScript(MigrationsSqlGenerationOptions options)
+    private static string GeneratePostgreSqlScript(MigrationsSqlGenerationOptions options, string? schema)
     {
         var migrationsAssembly = typeof(Elsa.Persistence.EFCore.PostgreSql.Migrations.Runtime.V3_6).Assembly;
-        var dbContextOptions = (DbContextOptions<RuntimeElsaDbContext>)new DbContextOptionsBuilder<RuntimeElsaDbContext>()
-            .UseElsaPostgreSql(migrationsAssembly, "Host=unused")
-            .Options;
 
-        using var dbContext = new RuntimeElsaDbContext(dbContextOptions, CreateServiceProvider());
-        var migrator = dbContext.GetService<IMigrator>();
-
-        return migrator.GenerateScript(fromMigration: "20250530104953_V3_5", toMigration: "20251204150341_V3_6", options: options);
+        return WithDefaultSchema(schema, () => GenerateScript(
+            builder => builder.UseElsaPostgreSql(migrationsAssembly, "Host=unused"),
+            fromMigration: "20250530104953_V3_5",
+            toMigration: "20251204150341_V3_6",
+            options));
     }
 
     private static string GenerateSqliteScript(MigrationsSqlGenerationOptions options)
     {
         var migrationsAssembly = typeof(Elsa.Persistence.EFCore.Sqlite.Migrations.Runtime.V3_6).Assembly;
-        var dbContextOptions = (DbContextOptions<RuntimeElsaDbContext>)new DbContextOptionsBuilder<RuntimeElsaDbContext>()
-            .UseElsaSqlite(migrationsAssembly, "Data Source=:memory:")
-            .Options;
+
+        return GenerateScript(
+            builder => builder.UseElsaSqlite(migrationsAssembly, "Data Source=:memory:"),
+            fromMigration: "20250530104854_V3_5",
+            toMigration: "20251204150006_V3_6",
+            options);
+    }
+
+    private static string GenerateScript(Action<DbContextOptionsBuilder<RuntimeElsaDbContext>> configureProvider, string fromMigration, string toMigration, MigrationsSqlGenerationOptions options)
+    {
+        var optionsBuilder = new DbContextOptionsBuilder<RuntimeElsaDbContext>();
+        configureProvider(optionsBuilder);
+        var dbContextOptions = optionsBuilder.Options;
 
         using var dbContext = new RuntimeElsaDbContext(dbContextOptions, CreateServiceProvider());
         var migrator = dbContext.GetService<IMigrator>();
 
-        return migrator.GenerateScript(fromMigration: "20250530104854_V3_5", toMigration: "20251204150006_V3_6", options: options);
+        return migrator.GenerateScript(fromMigration: fromMigration, toMigration: toMigration, options: options);
+    }
+
+    // ElsaDbContextOptions.SchemaName always falls back to ElsaDbContextBase.ElsaSchema ("Elsa") when it
+    // isn't set, so the only way to construct a context whose IElsaDbContextSchema.Schema is null - the
+    // branch the V3_6 migration guards against with `_schema.Schema != null ? "\"{schema}\"." : ""` - is
+    // to temporarily override that process-wide default.
+    private static T WithDefaultSchema<T>(string? schema, Func<T> generate)
+    {
+        var previousSchema = ElsaDbContextBase.ElsaSchema;
+        ElsaDbContextBase.ElsaSchema = schema!;
+        try
+        {
+            return generate();
+        }
+        finally
+        {
+            ElsaDbContextBase.ElsaSchema = previousSchema;
+        }
     }
 
     private static IServiceProvider CreateServiceProvider() => new ServiceCollection().BuildServiceProvider();
 
-    private static void AssertDropIndexStatementsAreTerminated(string script)
+    private static void AssertDropIndexStatementsAreTerminated(string script, string? schema, bool requireTrailingEndIf = false)
     {
-        AssertDropIndexStatementIsTerminated(script, WorkflowExecutionLogRecordIndexName);
-        AssertDropIndexStatementIsTerminated(script, ActivityExecutionRecordIndexName);
+        AssertDropIndexStatementIsTerminated(script, WorkflowExecutionLogRecordIndexName, schema, requireTrailingEndIf);
+        AssertDropIndexStatementIsTerminated(script, ActivityExecutionRecordIndexName, schema, requireTrailingEndIf);
     }
 
-    private static void AssertDropIndexStatementIsTerminated(string script, string indexName)
+    private static void AssertDropIndexStatementIsTerminated(string script, string indexName, string? schema, bool requireTrailingEndIf)
     {
-        var line = script
-            .Split('\n')
-            .Select(l => l.Trim())
-            .SingleOrDefault(l => l.StartsWith(DropIndexPrefix, StringComparison.Ordinal) && l.Contains(indexName, StringComparison.Ordinal));
+        var expectedStatement = schema != null
+            ? $"{DropIndexPrefix} \"{schema}\".\"{indexName}\";"
+            : $"{DropIndexPrefix} \"{indexName}\";";
 
-        Assert.True(line != null, $"Expected to find a 'DROP INDEX IF EXISTS' statement for \"{indexName}\" in the generated script:\n{script}");
-        Assert.EndsWith(";", line);
-    }
-
-    private static void AssertWellFormedIdempotentBlock(string script, string indexName)
-    {
         var lines = script.Split('\n').Select(l => l.Trim()).ToList();
         var dropLineIndex = lines.FindIndex(l => l.StartsWith(DropIndexPrefix, StringComparison.Ordinal) && l.Contains(indexName, StringComparison.Ordinal));
 
         Assert.True(dropLineIndex >= 0, $"Expected to find a 'DROP INDEX IF EXISTS' statement for \"{indexName}\" in the generated script:\n{script}");
+        Assert.Equal(expectedStatement, lines[dropLineIndex]);
+
+        if (!requireTrailingEndIf)
+            return;
 
         // The statement inside the DO $EF$ ... IF NOT EXISTS(...) THEN <statement> END IF; block must be
         // terminated before the following END IF; line, otherwise the PL/pgSQL block fails to parse.
         var endIfLineIndex = lines.FindIndex(dropLineIndex, l => l.Equals("END IF;", StringComparison.Ordinal));
-
         Assert.True(endIfLineIndex >= 0, $"Expected an 'END IF;' line after the DROP INDEX statement for \"{indexName}\":\n{script}");
-        Assert.EndsWith(";", lines[dropLineIndex]);
     }
 }


### PR DESCRIPTION
## Purpose

Make `dotnet ef migrations script` produce valid SQL for the PostgreSQL and SQLite `RuntimeElsaDbContext` by terminating the raw `DROP INDEX IF EXISTS` statements in the `V3_6` Runtime migrations.

## Scope

- [x] Bug fix (behavior change)

## Description

### Problem

The PostgreSQL Runtime `V3_6` migration emitted two `DROP INDEX IF EXISTS ...` statements through `migrationBuilder.Sql` without a trailing `;`. `MigrateAsync` runs each statement separately and is unaffected, but scripted deployment is not: in the idempotent script the statement lands inside a `DO $EF$ ... IF NOT EXISTS(...) THEN <statement> END IF; END $EF$;` block and parsing fails at `END`, and in the plain script the two statements and the following history `INSERT` run together with no separator. Because `V3_6` is historical, every greenfield script replays it, so a first deployment of a new PostgreSQL database through the documented script path could not work. The SQLite Runtime `V3_6` migration had the same unterminated shape.

### Solution

- Terminate the two statements in the PostgreSQL migration and the two in the SQLite migration. Nothing else in the migrations changes; Designer and snapshot files are untouched.
- A scan of the PostgreSQL and SQLite migration folders (Management, Runtime, Identity, Labels, Tenants, Alterations) found no other single-line unterminated `Sql(...)` calls. The SqlServer, MySql and Oracle `V3_6` migrations use block-form SQL with internal terminators.

### Tests

`V3_6RuntimeMigrationTests` in `Elsa.Persistence.EFCore.UnitTests` generates the Runtime migration script offline through `IMigrator.GenerateScript`, with no database connection, and asserts the two `DROP INDEX` statements are terminated: PostgreSQL in both idempotent and plain mode as a theory over the `Elsa` and a custom schema (checking the quoted schema prefix and, in the idempotent script, that the `DO $EF$` block is well formed), and SQLite in plain mode (EF Core's SQLite provider does not support idempotent scripts). With the terminators removed the tests fail. The test project gains project references to the PostgreSQL and SQLite provider projects.

## Verification

- `dotnet test test/unit/Elsa.Persistence.EFCore.UnitTests/...`: 6 passed (5 in the new class).
- `dotnet build src/modules/Elsa.Persistence.EFCore.PostgreSql/...` and `.../Elsa.Persistence.EFCore.Sqlite/...`: 0 errors.
- `dotnet build Elsa.sln`: 0 errors; warnings pre-exist on main.

The reporter's aside about a design-time factory for Elsa's own contexts is not part of this change.

Fixes #7912

🤖 Generated with [Claude Code](https://claude.com/claude-code)