### PR TITLE
Allow underscores and dollar signs in JavaScript variable names

### DIFF
--- a/src/modules/Elsa.Expressions.JavaScript/Helpers/VariableNameValidator.cs
+++ b/src/modules/Elsa.Expressions.JavaScript/Helpers/VariableNameValidator.cs
@@ -2,8 +2,34 @@ namespace Elsa.Expressions.JavaScript.Helpers;
 
 public static class VariableNameValidator
 {
+    /// <summary>
+    /// Returns true if the specified name can be used as a JavaScript identifier, which is the case when it starts with
+    /// a letter, an underscore or a dollar sign, followed by letters, digits, underscores or dollar signs.
+    /// </summary>
     public static bool IsValidVariableName(string name)
     {
-        return !string.IsNullOrWhiteSpace(name) && name.All(char.IsLetterOrDigit);
+        if (string.IsNullOrWhiteSpace(name))
+            return false;
+
+        if (!IsValidFirstChar(name[0]))
+            return false;
+
+        for (var i = 1; i < name.Length; i++)
+        {
+            if (!IsValidChar(name[i]))
+                return false;
+        }
+
+        return true;
+    }
+
+    private static bool IsValidFirstChar(char c)
+    {
+        return char.IsLetter(c) || c is '_' or '$';
+    }
+
+    private static bool IsValidChar(char c)
+    {
+        return char.IsLetterOrDigit(c) || c is '_' or '$';
     }
 }

--- a/test/integration/Elsa.Workflows.IntegrationTests/Scenarios/JavaScriptUnderscoreVariables/Tests.cs
+++ b/test/integration/Elsa.Workflows.IntegrationTests/Scenarios/JavaScriptUnderscoreVariables/Tests.cs
@@ -1,0 +1,33 @@
+using Elsa.Extensions;
+using Elsa.Testing.Shared;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit.Abstractions;
+
+namespace Elsa.Workflows.IntegrationTests.Scenarios.JavaScriptUnderscoreVariables;
+
+public class Tests
+{
+    private readonly IWorkflowRunner _workflowRunner;
+    private readonly CapturingTextWriter _capturingTextWriter = new();
+    private readonly IWorkflowBuilderFactory _workflowBuilderFactory;
+    private readonly IServiceProvider _services;
+
+    public Tests(ITestOutputHelper testOutputHelper)
+    {
+        _services = new TestApplicationBuilder(testOutputHelper)
+            .WithCapturingTextWriter(_capturingTextWriter)
+            .ConfigureElsa(elsa => elsa.UseJavaScript())
+            .Build();
+        _workflowBuilderFactory = _services.GetRequiredService<IWorkflowBuilderFactory>();
+        _workflowRunner = _services.GetRequiredService<IWorkflowRunner>();
+    }
+
+    [Fact(DisplayName = "A variable whose name contains an underscore is accessible from JavaScript")]
+    public async Task UnderscoreVariableIsAccessible()
+    {
+        await _services.PopulateRegistriesAsync();
+        var workflow = await _workflowBuilderFactory.CreateBuilder().BuildWorkflowAsync<UnderscoreVariableWorkflow>();
+        await _workflowRunner.RunAsync(workflow);
+        Assert.Equal("Cliënt gevallen", _capturingTextWriter.Lines.ToList().ElementAt(0));
+    }
+}

--- a/test/integration/Elsa.Workflows.IntegrationTests/Scenarios/JavaScriptUnderscoreVariables/Workflows.cs
+++ b/test/integration/Elsa.Workflows.IntegrationTests/Scenarios/JavaScriptUnderscoreVariables/Workflows.cs
@@ -1,0 +1,21 @@
+using Elsa.Expressions.JavaScript.Models;
+using Elsa.Workflows.Activities;
+
+namespace Elsa.Workflows.IntegrationTests.Scenarios.JavaScriptUnderscoreVariables;
+
+public class UnderscoreVariableWorkflow : WorkflowBase
+{
+    protected override void Build(IWorkflowBuilder workflow)
+    {
+        workflow.WithDefinitionId(Guid.NewGuid().ToString());
+        workflow.WithVariable("meting_context", new Dictionary<string, object?> { ["beschrijving"] = "Cliënt gevallen" });
+
+        workflow.Root = new Sequence
+        {
+            Activities =
+            {
+                new WriteLine(JavaScriptExpression.Create("variables.meting_context.beschrijving"))
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Problem

`VariableNameValidator.IsValidVariableName` accepts a name only when **every** character is a letter or a digit:

```csharp
return !string.IsNullOrWhiteSpace(name) && name.All(char.IsLetterOrDigit);
```

An underscore is neither, so a perfectly ordinary workflow variable such as `meting_context` is considered invalid. As a result:

- `ConfigureEngineWithVariables.GetUsedVariableNames` filters it out, so it never reaches the `variables` container handed to Jint.
- `ConfigureEngineWithVariablesAndInputOutputAccessors.CreateVariableAccessors` generates no getter/setter for it.
- `WorkflowVariablesTypeDefinitionProvider` omits it, so it is missing from IntelliSense in the designer.

At runtime this shows up as a confusing failure. The variable exists and holds a value, but `variables.meting_context` evaluates to `undefined`, so reading a property off it throws:

```
Elsa.Workflows.Exceptions.InputEvaluationException: Failed to evaluate activity input 'Text'
 ---> Jint.Runtime.JavaScriptException: Cannot read property 'beschrijving' of undefined
```

Nothing points at the variable name, which makes this hard to diagnose. We hit it in production monitoring and it took correlating traces with every workflow definition to find the cause.

## Fix

Validate the name as a JavaScript identifier: a letter, `_` or `$` as the first character, then letters, digits, `_` or `$`. Both are valid JS identifier characters, so the generated `variables.<name>` access and `get<Name>()` accessors remain valid script.

## Test

Adds `test/integration/Elsa.Workflows.IntegrationTests/Scenarios/JavaScriptUnderscoreVariables`: a workflow with a variable named `meting_context` and a `WriteLine` whose text is `variables.meting_context.beschrijving`.

- Without the fix the test fails with exactly the error above.
- With the fix all 12 JavaScript integration tests pass.
