### PR TITLE
feat(apps): enable BPMN interchange in the Elsa.Server.Web sample host

### DIFF
--- a/doc/wiki/bpmn-workflows.md
+++ b/doc/wiki/bpmn-workflows.md
@@ -19,6 +19,22 @@ elsa.AddBpmnInterchange();
 
 `BpmnInterchangeFeature` depends on `BpmnFeature`; calling `AddBpmnInterchange()` pulls in both.
 
+### Trying it
+
+The sample host `src/apps/Elsa.Server.Web` has BPMN interchange enabled (`.UseBpmnInterchange()` in its `Program.cs`), so it can be used to try the analyze endpoint against a real server. Sign in with one of the development users (e.g. `admin`/`password`, see `appsettings.Development.json`) to obtain a bearer token, then call the endpoint:
+
+```bash
+TOKEN=$(curl -s -X POST https://localhost:5001/elsa/api/identity/login \
+  -H "Content-Type: application/json" \
+  -d '{"username":"admin","password":"password"}' | jq -r .accessToken)
+
+curl -s -X POST https://localhost:5001/elsa/api/bpmn/analyze \
+  -H "Authorization: Bearer $TOKEN" \
+  -F "file=@test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Assets/camunda-order-process.bpmn"
+```
+
+This returns a JSON body of process ids, element counts, and findings (e.g. informational notes about unbound service tasks or retained vendor extensions).
+
 ## BpmnProcess Activity
 
 `BpmnProcess` is a `Container` that wraps one BPMN scope. It drives the `Bpmn.Semantics` interpreter and applies the continuations the interpreter returns to its own `ActivityExecutionContext`. Key properties:

--- a/doc/wiki/bpmn-workflows.md
+++ b/doc/wiki/bpmn-workflows.md
@@ -21,7 +21,7 @@ elsa.UseBpmnInterchange();
 
 ### Trying it
 
-The sample host `src/apps/Elsa.Server.Web` has BPMN interchange enabled (`.UseBpmnInterchange()` in its `Program.cs`), so it can be used to try the analyze endpoint against a real server. Sign in with one of the development users (e.g. `admin`/`password`, see `appsettings.Development.json`) to obtain a bearer token, then call the endpoint:
+The sample host `src/apps/Elsa.Server.Web` has BPMN interchange enabled (`.UseBpmnInterchange()` in its `Program.cs`), so it can be used to try the analyze endpoint against a real server. If you have not already trusted the local ASP.NET Core development certificate, run `dotnet dev-certs https --trust` once, otherwise the `curl` calls below will fail TLS verification. Sign in with one of the development users (e.g. `admin`/`password`, see `appsettings.Development.json`) to obtain a bearer token, then call the endpoint:
 
 ```bash
 TOKEN=$(curl -s -X POST https://localhost:5001/elsa/api/identity/login \

--- a/doc/wiki/bpmn-workflows.md
+++ b/doc/wiki/bpmn-workflows.md
@@ -11,13 +11,13 @@ Elsa supports running BPMN 2.0 processes as first-class workflow activities. Two
 
 ```csharp
 // Execution support only (use when you build BpmnProcess in code).
-elsa.AddBpmn();
+elsa.UseBpmn();
 
 // Execution + XML interchange (use when importing .bpmn files).
-elsa.AddBpmnInterchange();
+elsa.UseBpmnInterchange();
 ```
 
-`BpmnInterchangeFeature` depends on `BpmnFeature`; calling `AddBpmnInterchange()` pulls in both.
+`BpmnInterchangeFeature` depends on `BpmnFeature`; calling `UseBpmnInterchange()` pulls in both.
 
 ### Trying it
 

--- a/src/apps/Elsa.Server.Web/Elsa.Server.Web.csproj
+++ b/src/apps/Elsa.Server.Web/Elsa.Server.Web.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <ItemGroup>
+		<ProjectReference Include="..\..\modules\Elsa.Bpmn.Interchange\Elsa.Bpmn.Interchange.csproj" />
 		<ProjectReference Include="..\..\modules\Elsa.Caching\Elsa.Caching.csproj" />
 		<ProjectReference Include="..\..\modules\Elsa.Common\Elsa.Common.csproj" />
 		<ProjectReference Include="..\..\modules\Elsa.Dashboard.Api\Elsa.Dashboard.Api.csproj" />

--- a/src/apps/Elsa.Server.Web/Program.cs
+++ b/src/apps/Elsa.Server.Web/Program.cs
@@ -100,6 +100,7 @@ services
             .UseFluentStorageProvider()
             .UseElsaScriptBlobStorage()
             .UseScheduling()
+            .UseBpmnInterchange()
             .UseCSharp(options =>
             {
                 configuration.GetSection("Scripting:CSharp").Bind(options);


### PR DESCRIPTION
Closes #8055. Part of #7909. Enables the live end-to-end check of the BPMN program: until now no host enabled BPMN, so the Studio slice had never run against a real server.

## What changed

- `src/apps/Elsa.Server.Web` references `Elsa.Bpmn.Interchange` and calls `.UseBpmnInterchange()` in its feature chain, unconditionally like the host's other showcase features. That also pulls in the BPMN runtime feature.
- `src/apps/Elsa.ModularServer.Web` is unchanged. It has no reference to the BPMN modules and loads features from project references or Nuplane packages, so enabling BPMN there is not configuration-only.
- `doc/wiki/bpmn-workflows.md` gets a "Trying it" note with the analyze request. The existing "Enabling BPMN" sample named methods that do not exist (`AddBpmn()` / `AddBpmnInterchange()`); it now uses the real `UseBpmn()` / `UseBpmnInterchange()`.

## Verification

```
dotnet build src/apps/Elsa.Server.Web/Elsa.Server.Web.csproj
dotnet run --project src/apps/Elsa.Server.Web          # listening on https://localhost:5001
curl -s -X POST https://localhost:5001/elsa/api/identity/login -H 'Content-Type: application/json' \
     -d '{"username":"admin","password":"password"}'   # 200, token (development user from appsettings.Development.json)
curl -s -X POST https://localhost:5001/elsa/api/bpmn/analyze -H 'Authorization: Bearer <token>' \
     -F 'file=@test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Assets/camunda-order-process.bpmn'
                                                       # 200: processIds, elementCounts, issues
```

Review: the standards and spec axes, plus a direct check of the docs fix. One must-fix was resolved: the wrong method names in the wiki.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
