### PR TITLE
fix(bpmn): let a process with only a plain start event publish

### DIFF
--- a/doc/wiki/bpmn-workflows.md
+++ b/doc/wiki/bpmn-workflows.md
@@ -42,9 +42,22 @@ This returns a JSON body of process ids, element counts, and findings (e.g. info
 - **`Process`** — the `BpmnProcessDefinition` from the `Bpmn.Interchange` reader.
 - **`WorkBindings`** — a `Dictionary<string, string>` mapping each BPMN binding ref to an Elsa activity id. The scope host uses this map to look up child activity execution contexts when the interpreter signals work completion, faulting, or escalation.
 - **`Activities`** — the Elsa activities bound to this scope (one per `BpmnWorkBinding`).
-- **`IsRootScope`** — left `false` on every scope the binder produces; the caller sets it to `true` to mark the outermost scope as a workflow entry point.
+- **`IsRootScope`** — marks the outermost scope as the workflow's entry point, the only scope whose start events can register workflow triggers (see *Start events and workflow triggers* below). `BpmnWorkBinder.Bind` and an import set it on the scope they return; every nested scope the binder produces leaves it `false`.
 
 `BpmnProcess` completes with the interpreter's outcome name — `BpmnInterpreter.DoneOutcomeName` ("Done") normally, or `BpmnInterpreter.CancelledOutcomeName` ("Cancelled") when a cancel end event cancelled a transaction. It does **not** complete with `Outcomes.Default`. Both outcomes are declared flow ports (`[FlowNode(BpmnInterpreter.DoneOutcomeName, BpmnInterpreter.CancelledOutcomeName)]`), so connections from it target one of them explicitly.
+
+### Start events and workflow triggers
+
+A root scope registers one workflow trigger per start event that declares how the process is started:
+
+- A message or signal start registers an `EventStimulus` on the resolved message or signal name, so an ordinary `PublishEvent` with that name starts the workflow.
+- A recurring timer start (`<timeCycle>`) registers through `Elsa.Scheduling`'s own `Timer` or `Cron` trigger.
+
+A process whose start events are all plain (none) start events, which covers most Camunda models, registers no trigger at all. It is started directly, through the workflow execution API, and publishes like any other workflow without a trigger. `BpmnProcess` declares this to the trigger indexer through `TriggerIndexingContext.RegistersNoTriggers`, so the indexer does not store the `null`-payload placeholder it keeps for other triggers that return no payloads.
+
+A start event that declares a message, signal or timer the scope cannot register, such as a timer whose interval is not a positive ISO-8601 duration, is logged and skipped. The scope's other start events still register. If that leaves the scope with nothing to register, publication fails with `Trigger should have a payload`, so the process is not published as though the start had never been declared. Nested scopes (subprocess and event-subprocess bodies, or a scope nested through a `Flowchart`) never register triggers of their own.
+
+Test coverage: `test/integration/Elsa.Bpmn.IntegrationTests/Scenarios/Triggers/BpmnProcessTriggerTests.cs` and `test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Scenarios/Publishing/BpmnStartTriggerPublishTests.cs`.
 
 ## Work Ledger
 

--- a/doc/wiki/workflow-runtime.md
+++ b/doc/wiki/workflow-runtime.md
@@ -99,6 +99,8 @@ Triggers start workflows. Bookmarks resume suspended workflow instances. Runtime
 - [BookmarkBoundWorkflowService](../../src/modules/Elsa.Workflows.Runtime/Services/BookmarkBoundWorkflowService.cs)
 - [TriggerBoundWorkflowService](../../src/modules/Elsa.Workflows.Runtime/Services/TriggerBoundWorkflowService.cs)
 
+The indexer stores one trigger per payload an [ITrigger](../../src/modules/Elsa.Workflows.Core/Contracts/ITrigger.cs) activity that can start the workflow returns. A trigger that returns no payloads, or throws while producing them, is stored as a single placeholder row with a `null` payload. [ValidateWorkflowRequestHandler](../../src/modules/Elsa.Workflows.Runtime/Handlers/ValidateWorkflowRequestHandler.cs) reports that row as `Trigger should have a payload`, so publication is refused. A trigger whose decision to register anything depends on its own configuration, and that has nothing to register as configured, sets [TriggerIndexingContext.RegistersNoTriggers](../../src/modules/Elsa.Workflows.Core/Contexts/TriggerIndexingContext.cs) and returns no payloads. The indexer then stores no row for it. The flag is ignored when the trigger returns payloads or throws. `BpmnProcess` uses it for a process with only plain start events (see [BPMN Workflows](bpmn-workflows.md)).
+
 Bookmark queue processing is handled by:
 
 - [StoreBookmarkQueue](../../src/modules/Elsa.Workflows.Runtime/Services/StoreBookmarkQueue.cs)

--- a/src/modules/Elsa.Bpmn/Activities/BpmnProcess.cs
+++ b/src/modules/Elsa.Bpmn/Activities/BpmnProcess.cs
@@ -147,6 +147,17 @@ public class BpmnProcess : Container, ITrigger
     /// <c>BpmnActivityBindingFormat</c>'s sibling, the interchange reader), so there is nothing left to resolve.
     /// </para>
     /// <para>
+    /// A root scope none of whose start events carries an event definition — plain start events only, or no start
+    /// event at all — is started directly, through the workflow execution API, never by a stimulus. It has nothing to register,
+    /// deliberately, so it sets <see cref="TriggerIndexingContext.RegistersNoTriggers"/> and the indexer stores no row
+    /// for it. Without that declaration the indexer stores a <c>null</c>-payload placeholder row, which
+    /// <c>ValidateWorkflowRequestHandler</c> reports as a trigger without a payload and which therefore refuses
+    /// publication. The declaration is made in that case only. A start event that does carry an event definition but
+    /// resolves to nothing here — a blank name, or a timer refused below — is a declared start that failed, not a plain
+    /// start, so it still leaves the placeholder that validation reports instead of publishing as though it had never
+    /// been declared. A nested scope returns before this check and is left exactly as it was.
+    /// </para>
+    /// <para>
     /// Each payload is wrapped in a <see cref="NamedTriggerPayload"/> naming its own stimulus, rather than relying on
     /// <see cref="TriggerIndexingContext.TriggerName"/>: that property is a single value shared by every payload of
     /// the trigger, so a process with both a message/signal start and a recurring timer start would otherwise have
@@ -179,11 +190,19 @@ public class BpmnProcess : Container, ITrigger
         if (await HasEnclosingBpmnScopeAsync(context))
             return [];
 
+        var startEvents = process.Elements.Where(element => string.Equals(element.ElementType, BpmnElementTypes.StartEvent, StringComparison.Ordinal)).ToList();
+
+        if (startEvents.All(element => element.EventDefinitions.Count == 0))
+        {
+            context.RegistersNoTriggers = true;
+            return [];
+        }
+
         var logger = context.ExpressionExecutionContext.GetRequiredService<ILogger<BpmnProcess>>();
         var payloads = new List<object>();
         var registeredStimuli = new HashSet<(string StimulusName, string ResolvedName)>();
 
-        foreach (var element in process.Elements.Where(element => string.Equals(element.ElementType, BpmnElementTypes.StartEvent, StringComparison.Ordinal)))
+        foreach (var element in startEvents)
         {
             foreach (var eventDefinition in element.EventDefinitions)
                 AddStartTriggerPayload(context, element, eventDefinition, registeredStimuli, payloads, logger);

--- a/src/modules/Elsa.Workflows.Core/Contexts/TriggerIndexingContext.cs
+++ b/src/modules/Elsa.Workflows.Core/Contexts/TriggerIndexingContext.cs
@@ -21,5 +21,22 @@ public class TriggerIndexingContext(WorkflowIndexingContext workflowIndexingCont
     /// </remarks>
     public string TriggerName { get; set; } = trigger.Type;
 
+    /// <summary>
+    /// Set by the trigger being indexed to declare that, as configured, it deliberately registers no triggers at all.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A trigger that returns no payloads is otherwise stored as a single placeholder row with a <c>null</c> payload, which the runtime's workflow validation
+    /// reports as a trigger without a payload. For almost every trigger that is the right outcome: no payloads means its configuration is incomplete.
+    /// A trigger whose decision to register anything depends on its own content, and that has nothing to register as configured, sets this instead,
+    /// and the indexer then stores no row for it.
+    /// </para>
+    /// <para>
+    /// It only takes effect when the trigger returns no payloads and completes without throwing. Payloads the trigger does return are indexed as usual,
+    /// and a trigger that throws still gets the placeholder row, so a failure is never mistaken for a deliberate decision.
+    /// </para>
+    /// </remarks>
+    public bool RegistersNoTriggers { get; set; }
+
     public T? Get<T>(Input<T>? input) => ExpressionExecutionContext.Get(input);
 }

--- a/src/modules/Elsa.Workflows.Core/Contracts/ITrigger.cs
+++ b/src/modules/Elsa.Workflows.Core/Contracts/ITrigger.cs
@@ -13,6 +13,8 @@ public interface ITrigger : IActivity
     /// <remarks>
     /// Each returned object is stored under the stimulus name held by <see cref="TriggerIndexingContext.TriggerName"/>, which is shared by all payloads.
     /// To register payloads under more than one stimulus name, return <see cref="NamedTriggerPayload"/> instances: each carries the name for its own payload.
+    /// Returning no payloads stores a placeholder row with a <c>null</c> payload, unless the trigger sets <see cref="TriggerIndexingContext.RegistersNoTriggers"/>
+    /// to declare that, as configured, it deliberately registers none.
     /// </remarks>
     ValueTask<IEnumerable<object>> GetTriggerPayloadsAsync(TriggerIndexingContext context);
 }

--- a/src/modules/Elsa.Workflows.Runtime/Services/TriggerIndexer.cs
+++ b/src/modules/Elsa.Workflows.Runtime/Services/TriggerIndexer.cs
@@ -201,6 +201,12 @@ public class TriggerIndexer : ITriggerIndexer
         var triggerData = await TryGetTriggerDataAsync(trigger, triggerIndexingContext);
         var defaultTriggerName = triggerIndexingContext.TriggerName;
 
+        // A trigger that completed, returned no payloads, and declared that deliberate gets no row at all. One that threw never counts as having declined.
+        if (triggerData is { Count: 0 } && triggerIndexingContext.RegistersNoTriggers)
+            return new List<StoredTrigger>(0);
+
+        triggerData ??= [];
+
         // If no trigger payloads were returned, create a null payload.
         if (!triggerData.Any()) triggerData.Add(null!);
 
@@ -227,7 +233,10 @@ public class TriggerIndexer : ITriggerIndexer
         return triggers.ToList();
     }
 
-    private async Task<List<object>> TryGetTriggerDataAsync(ITrigger trigger, TriggerIndexingContext context)
+    /// <summary>
+    /// Returns the trigger's payloads, or <c>null</c> when it throws, so that a failure is told apart from a trigger that returned nothing.
+    /// </summary>
+    private async Task<List<object>?> TryGetTriggerDataAsync(ITrigger trigger, TriggerIndexingContext context)
     {
         try
         {
@@ -238,6 +247,6 @@ public class TriggerIndexer : ITriggerIndexer
             _logger.LogWarning(e, "Failed to get trigger data for activity {ActivityId}", trigger.Id);
         }
 
-        return new(0);
+        return null;
     }
 }

--- a/test/integration/Elsa.Bpmn.IntegrationTests/Scenarios/Triggers/BpmnProcessTriggerTests.cs
+++ b/test/integration/Elsa.Bpmn.IntegrationTests/Scenarios/Triggers/BpmnProcessTriggerTests.cs
@@ -195,6 +195,67 @@ public class BpmnProcessTriggerTests(ITestOutputHelper testOutputHelper)
         Assert.Equal(TimeSpan.FromMilliseconds(1), payload.Interval);
     }
 
+    [Fact(DisplayName = "A root scope whose start events are all plain registers no trigger, not even a placeholder")]
+    public async Task PlainStartRootScope_RegistersNoTrigger()
+    {
+        // A plain start is how a process is started directly, through the workflow execution API, never by a
+        // stimulus, so there is nothing to register. Read raw, before the store diff: this is the same list
+        // ValidateWorkflowRequestHandler iterates, and a null-payload row in it is what refused publication (#8078).
+        var process = RootScope("plain-start");
+
+        Assert.Empty(await GetRawTriggersAsync(process));
+    }
+
+    [Fact(DisplayName = "A plain start beside a message start does not stop the message start from registering")]
+    public async Task PlainStartBesideMessageStart_MessageStillRegisters()
+    {
+        // Only a scope with no event-defined start at all declines; one plain start among others must not.
+        var process = new BpmnProcess
+        {
+            Id = "plain-and-message-start",
+            IsRootScope = true,
+            Process = new BpmnProcessBuilder("plain-and-message-start")
+                .StartEvent("plain-start")
+                .StartEvent("message-start", null, Message("OrderPlaced"))
+                .EndEvent("end")
+                .ConnectSequence("plain-start", "end")
+                .ConnectSequence("message-start", "end")
+                .Build()
+        };
+
+        var trigger = Assert.Single(await GetRawTriggersAsync(process));
+
+        var payload = Assert.IsType<EventStimulus>(trigger.Payload);
+        Assert.Equal("OrderPlaced", payload.EventName);
+    }
+
+    [Fact(DisplayName = "A root scope whose only event-defined start registers nothing keeps the placeholder row publish validation reports")]
+    public async Task RootScopeWhoseOnlyEventDefinedStartIsRefused_KeepsThePlaceholderRow()
+    {
+        // The direction that could be mistaken for success: a start event declaring a timer this scope refuses to
+        // register is not a plain start. Dropping the placeholder here would let the process publish looking fine
+        // with a timer that never fires.
+        var process = RootScope("refused-timer-only", TimerInterval("not-an-iso-8601-duration"));
+
+        var trigger = Assert.Single(await GetRawTriggersAsync(process));
+
+        Assert.Null(trigger.Payload);
+    }
+
+    [Fact(DisplayName = "A BPMN-nested plain-start scope keeps its placeholder row, whatever its own flag says")]
+    public async Task BpmnNestedPlainStartScope_KeepsThePlaceholderRow()
+    {
+        // #8078 changes root position only. A nested scope is opted out by the graph check before the plain-start
+        // check is ever reached, so it leaves the indexer's placeholder exactly as the other nested cases do.
+        var nested = Scope("inner");
+        nested.IsRootScope = true;
+
+        var outer = RootScope("outer", Message("OuterOnly"));
+        outer.Activities.Add(nested);
+
+        AssertNestedScopeContributedOnlyTheUnavoidablePlaceholderRow(await IndexAsync(outer), nested.Id);
+    }
+
     [Fact(DisplayName = "A BPMN-nested scope registers no triggers, whatever its own flag says")]
     public async Task BpmnNestedScope_RegistersNoTriggers()
     {
@@ -282,11 +343,11 @@ public class BpmnProcessTriggerTests(ITestOutputHelper testOutputHelper)
     /// <summary>
     /// A nested scope contributes no message, signal, or timer payload of its own -- the thing this guard actually
     /// protects. It still owns exactly one row: <c>Elsa.Workflows.Runtime.TriggerIndexer</c> adds a
-    /// <c>Payload = null</c> placeholder for <i>any</i> <c>ITrigger</c> whose <c>GetTriggerPayloadsAsync</c> returns
-    /// no payload at all, whether that activity is a legitimately root BPMN process with only a plain start event or
-    /// a nested one this guard correctly emptied out. That placeholder is inert -- nothing external can ever address
-    /// a <c>null</c> payload -- and clearing it would mean changing that indexer's own fallback for every trigger
-    /// kind in the runtime, not just BPMN's, which is well outside this guard's reach.
+    /// <c>Payload = null</c> placeholder for any <c>ITrigger</c> whose <c>GetTriggerPayloadsAsync</c> returns no
+    /// payload at all, unless the trigger declares through <c>TriggerIndexingContext.RegistersNoTriggers</c> that it
+    /// deliberately registers none. <see cref="BpmnProcess"/> declares that only for a root scope with no
+    /// event-defined start (#8078); a nested scope's opt-out is decided by the graph before that point and is left as
+    /// it was. That placeholder is inert -- nothing external can ever address a <c>null</c> payload.
     /// </summary>
     private static void AssertNestedScopeContributedOnlyTheUnavoidablePlaceholderRow(IReadOnlyCollection<StoredTrigger> triggers, string nestedScopeActivityId)
     {

--- a/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Assets/message-start-order-process.bpmn
+++ b/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Assets/message-start-order-process.bpmn
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                   xmlns:elsa="https://elsaworkflows.io/schemas/bpmn/v1"
+                   id="Definitions_message-start-order-process"
+                   targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:message id="Message_OrderPlaced" name="OrderPlaced" />
+  <bpmn:process id="message-start-order-process" name="Message Start Order Process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Order Placed">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1" messageRef="Message_OrderPlaced" />
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="NotifyWarehouse" name="Notify Warehouse">
+      <bpmn:extensionElements>
+        <elsa:activityBinding activityType="Elsa.WriteLine">
+          <elsa:input name="text">{"typeName":"String","expression":{"type":"Literal","value":"Notifying the warehouse"}}</elsa:input>
+        </elsa:activityBinding>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="EndEvent_1" name="Order Handled">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="NotifyWarehouse" />
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="NotifyWarehouse" targetRef="EndEvent_1" />
+  </bpmn:process>
+</bpmn:definitions>

--- a/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Endpoints/BpmnInterchangeEndpointTests.cs
+++ b/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Endpoints/BpmnInterchangeEndpointTests.cs
@@ -945,14 +945,14 @@ public class BpmnInterchangeEndpointTests(ITestOutputHelper testOutputHelper) : 
     }
 
     /// <summary>
-    /// Marks the latest version of <paramref name="definitionId"/> published, directly on the stored row. See
-    /// <see cref="PublishSimulation.MarkLatestPublishedAsync"/> for why publish is simulated rather than real.
+    /// Publishes the latest version of <paramref name="definitionId"/> through the real
+    /// <see cref="IWorkflowDefinitionPublisher"/>. See <see cref="PublishSimulation.PublishLatestAsync"/>.
     /// </summary>
     private async Task MarkLatestPublishedAsync(string definitionId)
     {
         using var scope = _app!.Services.CreateScope();
-        var store = scope.ServiceProvider.GetRequiredService<IWorkflowDefinitionStore>();
-        await PublishSimulation.MarkLatestPublishedAsync(store, definitionId);
+        var publisher = scope.ServiceProvider.GetRequiredService<IWorkflowDefinitionPublisher>();
+        await PublishSimulation.PublishLatestAsync(publisher, definitionId);
     }
 
     /// <summary>

--- a/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Endpoints/BpmnInterchangeEndpointTests.cs
+++ b/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Endpoints/BpmnInterchangeEndpointTests.cs
@@ -946,13 +946,13 @@ public class BpmnInterchangeEndpointTests(ITestOutputHelper testOutputHelper) : 
 
     /// <summary>
     /// Publishes the latest version of <paramref name="definitionId"/> through the real
-    /// <see cref="IWorkflowDefinitionPublisher"/>. See <see cref="PublishSimulation.PublishLatestAsync"/>.
+    /// <see cref="IWorkflowDefinitionPublisher"/>. See <see cref="DefinitionPublishing.PublishLatestAsync"/>.
     /// </summary>
     private async Task MarkLatestPublishedAsync(string definitionId)
     {
         using var scope = _app!.Services.CreateScope();
         var publisher = scope.ServiceProvider.GetRequiredService<IWorkflowDefinitionPublisher>();
-        await PublishSimulation.PublishLatestAsync(publisher, definitionId);
+        await DefinitionPublishing.PublishLatestAsync(publisher, definitionId);
     }
 
     /// <summary>

--- a/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Scenarios/Interchange/BpmnExportAvailabilityTests.cs
+++ b/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Scenarios/Interchange/BpmnExportAvailabilityTests.cs
@@ -311,7 +311,7 @@ public class BpmnExportAvailabilityTests(ITestOutputHelper testOutputHelper) : B
     /// designer save — <see cref="IWorkflowDefinitionPublisher.GetDraftAsync(string, VersionOptions, CancellationToken)"/>
     /// then <see cref="IWorkflowDefinitionPublisher.SaveDraftAsync"/> — that carries the published version 1 to a
     /// draft version 2, the shape a publish followed by any ordinary save takes. See
-    /// <see cref="PublishSimulation.PublishLatestAsync"/>.
+    /// <see cref="DefinitionPublishing.PublishLatestAsync"/>.
     /// </summary>
     private async Task<string> ImportThenPublishAsync()
     {
@@ -320,7 +320,7 @@ public class BpmnExportAvailabilityTests(ITestOutputHelper testOutputHelper) : B
         Assert.True(imported.ImportResult.Succeeded);
         var definitionId = imported.ImportResult.WorkflowDefinition.DefinitionId;
 
-        await PublishSimulation.PublishLatestAsync(DefinitionPublisher, definitionId);
+        await DefinitionPublishing.PublishLatestAsync(DefinitionPublisher, definitionId);
 
         return definitionId;
     }

--- a/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Scenarios/Interchange/BpmnExportAvailabilityTests.cs
+++ b/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Scenarios/Interchange/BpmnExportAvailabilityTests.cs
@@ -311,7 +311,7 @@ public class BpmnExportAvailabilityTests(ITestOutputHelper testOutputHelper) : B
     /// designer save — <see cref="IWorkflowDefinitionPublisher.GetDraftAsync(string, VersionOptions, CancellationToken)"/>
     /// then <see cref="IWorkflowDefinitionPublisher.SaveDraftAsync"/> — that carries the published version 1 to a
     /// draft version 2, the shape a publish followed by any ordinary save takes. See
-    /// <see cref="PublishSimulation.MarkLatestPublishedAsync"/> for why publish is simulated rather than real.
+    /// <see cref="PublishSimulation.PublishLatestAsync"/>.
     /// </summary>
     private async Task<string> ImportThenPublishAsync()
     {
@@ -320,7 +320,7 @@ public class BpmnExportAvailabilityTests(ITestOutputHelper testOutputHelper) : B
         Assert.True(imported.ImportResult.Succeeded);
         var definitionId = imported.ImportResult.WorkflowDefinition.DefinitionId;
 
-        await PublishSimulation.MarkLatestPublishedAsync(DefinitionStore, definitionId);
+        await PublishSimulation.PublishLatestAsync(DefinitionPublisher, definitionId);
 
         return definitionId;
     }

--- a/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Scenarios/Publishing/BpmnPublishGateTests.cs
+++ b/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Scenarios/Publishing/BpmnPublishGateTests.cs
@@ -109,11 +109,8 @@ public class BpmnPublishGateTests(ITestOutputHelper testOutputHelper) : BpmnPubl
             new BpmnProcessDefinition(ProcessId, Elements: [BoundElement("approve", BpmnElementTypes.UserTask, new WriteLine("approved"))]),
             [new BpmnWorkBinding.UnboundTask(ProcessId, "approve", Ref("approve"), BpmnBindingSlot.Primary, BpmnElementTypes.UserTask)]);
 
-        // Bind always marks the scope it returns as root position (see its own remarks); this fixture declares no
-        // start event; clearing it keeps the unrelated "a startable trigger needs a payload" runtime validation out
-        // of what is being asserted here.
-        scope.IsRootScope = false;
-
+        // Bind marks the scope it returns as root position (see its own remarks), and it is left that way: a root
+        // scope with no event-defined start registers no trigger, so the runtime's trigger validation passes it too (#8078).
         var definitionId = await SaveDraftAsync(scope);
         var result = await PublishAsync(definitionId);
 

--- a/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Scenarios/Publishing/BpmnStartTriggerPublishTests.cs
+++ b/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Scenarios/Publishing/BpmnStartTriggerPublishTests.cs
@@ -1,0 +1,97 @@
+using Bpmn.Model;
+using Elsa.Bpmn.Activities;
+using Elsa.Mediator.Contracts;
+using Elsa.Workflows;
+using Elsa.Workflows.Runtime;
+using Elsa.Workflows.Runtime.Entities;
+using Elsa.Workflows.Runtime.Filters;
+using Elsa.Workflows.Runtime.Handlers;
+using Elsa.Workflows.Runtime.Stimuli;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit.Abstractions;
+
+namespace Elsa.Bpmn.Interchange.IntegrationTests.Scenarios.Publishing;
+
+/// <summary>
+/// Publishing an imported BPMN process through the real <see cref="Elsa.Workflows.Management.IWorkflowDefinitionPublisher"/>,
+/// with the runtime's <see cref="ValidateWorkflowRequestHandler"/> in the pipeline exactly as <c>WorkflowRuntimeFeature</c>
+/// registers it by default (#8078). That handler refuses publication for every stored trigger without a payload, so
+/// a process whose start events declare nothing to register must not leave one behind, while a process whose start
+/// events do declare something must still register it.
+/// </summary>
+public class BpmnStartTriggerPublishTests(ITestOutputHelper testOutputHelper) : BpmnPublishGateTestBase(testOutputHelper)
+{
+    [Fact(DisplayName = "The runtime's trigger validation is part of the publish these tests go through")]
+    public void TriggerValidationIsRegistered()
+    {
+        // Every other test here passes vacuously without this handler: it is the one that turns a stored trigger
+        // without a payload into a refused publication.
+        Assert.Contains(Services.GetServices<INotificationHandler>(), handler => handler is ValidateWorkflowRequestHandler);
+    }
+
+    [Fact(DisplayName = "An imported process whose only start is a plain start event publishes, and stores no trigger")]
+    public async Task PlainStartProcess_Publishes_AndStoresNoTrigger()
+    {
+        var definitionId = await ImportAsync("camunda-order-process.bpmn");
+
+        var result = await PublishAsync(definitionId);
+
+        Assert.True(result.Succeeded, string.Join("; ", result.ValidationErrors.Select(error => error.Message)));
+        Assert.Empty(await StoredTriggersAsync(definitionId));
+    }
+
+    [Fact(DisplayName = "An imported process with a message start publishes, and stores the trigger an event publisher matches")]
+    public async Task MessageStartProcess_Publishes_AndIndexesItsTrigger()
+    {
+        var definitionId = await ImportAsync("message-start-order-process.bpmn");
+
+        var result = await PublishAsync(definitionId);
+
+        Assert.True(result.Succeeded, string.Join("; ", result.ValidationErrors.Select(error => error.Message)));
+
+        var trigger = Assert.Single(await StoredTriggersAsync(definitionId));
+        var stimulus = new EventStimulus("OrderPlaced");
+        Assert.Equal(RuntimeStimulusNames.Event, trigger.Name);
+        Assert.Equal(stimulus, trigger.Payload);
+        Assert.Equal(Services.GetRequiredService<IStimulusHasher>().Hash(RuntimeStimulusNames.Event, stimulus), trigger.Hash);
+    }
+
+    [Fact(DisplayName = "A root process whose only start is event-defined but registers nothing still fails publication")]
+    public async Task UnresolvableEventDefinedStart_StillFailsPublication()
+    {
+        // The direction that could be mistaken for success: a start event that declares a timer the scope refuses
+        // to register is not a plain start. Publishing it as one would leave a process that looks published and
+        // whose timer never fires, so the placeholder the validator reports has to stay for this shape.
+        const string processId = "main";
+        var timer = new BpmnEventDefinition(
+            BpmnEventDefinitionTypes.Timer,
+            new Dictionary<string, string>(StringComparer.Ordinal) { [BpmnEventDefinitionProperties.Interval] = "not-an-iso-8601-duration" });
+        var process = new BpmnProcess
+        {
+            Id = processId,
+            IsRootScope = true,
+            Process = new BpmnProcessBuilder(processId)
+                .StartEvent("start", null, timer)
+                .EndEvent("end")
+                .ConnectSequence("start", "end")
+                .Build()
+        };
+
+        var definitionId = await SaveDraftAsync(process);
+        var result = await PublishAsync(definitionId);
+
+        Assert.False(result.Succeeded);
+        Assert.Contains(result.ValidationErrors, error => error.ActivityId == processId && error.Message == "Trigger should have a payload");
+    }
+
+    private async Task<string> ImportAsync(string assetFileName)
+    {
+        var imported = await DocumentService.ImportAsync(ReadAsset(assetFileName), definitionId: null, name: null, processId: null, CancellationToken.None);
+        Assert.True(imported.ImportResult.Succeeded, string.Join("; ", imported.ImportResult.ValidationErrors.Select(error => error.Message)));
+
+        return imported.ImportResult.WorkflowDefinition.DefinitionId;
+    }
+
+    private async Task<IReadOnlyCollection<StoredTrigger>> StoredTriggersAsync(string definitionId) =>
+        (await Services.GetRequiredService<ITriggerStore>().FindManyAsync(new TriggerFilter { WorkflowDefinitionId = definitionId })).ToList();
+}

--- a/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Support/DefinitionPublishing.cs
+++ b/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Support/DefinitionPublishing.cs
@@ -8,7 +8,7 @@ namespace Elsa.Bpmn.Interchange.IntegrationTests.Support;
 /// one place every test that needs a published-then-edited definition goes through, rather than each duplicating
 /// this call and its success assertion.
 /// </summary>
-internal static class PublishSimulation
+internal static class DefinitionPublishing
 {
     /// <summary>
     /// Publishes the latest version of <paramref name="definitionId"/> via <paramref name="publisher"/>, asserting

--- a/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Support/PublishSimulation.cs
+++ b/test/integration/Elsa.Bpmn.Interchange.IntegrationTests/Support/PublishSimulation.cs
@@ -1,33 +1,23 @@
-using Elsa.Common.Models;
 using Elsa.Workflows.Management;
-using Elsa.Workflows.Models;
 using Xunit;
 
 namespace Elsa.Bpmn.Interchange.IntegrationTests.Support;
 
 /// <summary>
-/// Marks the latest version of a definition published, directly on the stored row, without going through
-/// <see cref="IWorkflowDefinitionPublisher.PublishAsync(string, CancellationToken)"/> — the one place every test
-/// that needs a published-then-edited definition goes through, rather than each duplicating this shortcut.
+/// Publishes the latest version of a definition through the real <see cref="IWorkflowDefinitionPublisher"/> — the
+/// one place every test that needs a published-then-edited definition goes through, rather than each duplicating
+/// this call and its success assertion.
 /// </summary>
-/// <remarks>
-/// The real publisher's <c>ValidateWorkflowRequestHandler</c> refuses a none-start BPMN process with "Trigger
-/// should have a payload" (see elsa-workflows/elsa-core#8078), which the camunda-order-process.bpmn fixture these
-/// tests otherwise read unmodified does not satisfy. Only "this row is the published version
-/// <see cref="IWorkflowDefinitionPublisher.GetDraftAsync"/> branches on" matters to the tests that use this, so
-/// this puts the definition in the same state a successful publish would without exercising that unrelated gate.
-/// This helper should become a real <see cref="IWorkflowDefinitionPublisher.PublishAsync(string, CancellationToken)"/>
-/// call once #8078 lands.
-/// </remarks>
 internal static class PublishSimulation
 {
-    /// <summary>Marks the latest version of <paramref name="definitionId"/> published, directly on the stored row.</summary>
-    public static async Task MarkLatestPublishedAsync(IWorkflowDefinitionStore store, string definitionId)
+    /// <summary>
+    /// Publishes the latest version of <paramref name="definitionId"/> via <paramref name="publisher"/>, asserting
+    /// success so a refusal — e.g. #8078's "Trigger should have a payload" for a none-start BPMN process — fails the
+    /// test loudly with the publisher's own validation messages rather than leaving the definition unpublished.
+    /// </summary>
+    public static async Task PublishLatestAsync(IWorkflowDefinitionPublisher publisher, string definitionId)
     {
-        var filter = WorkflowDefinitionHandle.ByDefinitionId(definitionId, VersionOptions.Latest).ToFilter();
-        var definition = await store.FindAsync(filter);
-        Assert.NotNull(definition);
-        definition!.IsPublished = true;
-        await store.SaveAsync(definition);
+        var result = await publisher.PublishAsync(definitionId);
+        Assert.True(result.Succeeded, string.Join("; ", result.ValidationErrors.Select(e => e.Message)));
     }
 }

--- a/test/unit/Elsa.Workflows.Runtime.UnitTests/Services/TriggerIndexerTests.cs
+++ b/test/unit/Elsa.Workflows.Runtime.UnitTests/Services/TriggerIndexerTests.cs
@@ -171,6 +171,47 @@ public class TriggerIndexerTests
         Assert.Equal(ActivityTypeNameHelper.GenerateTypeName<TestTrigger>(), trigger.Name);
     }
 
+    [Fact(DisplayName = "A trigger that declares it registers no triggers, and returns no payloads, produces no row")]
+    public async Task GetTriggersAsync_RegistersNoTriggers_ProducesNoRow()
+    {
+        var triggers = await IndexAsync(context =>
+        {
+            context.RegistersNoTriggers = true;
+            return [];
+        });
+
+        Assert.Empty(triggers);
+    }
+
+    [Fact(DisplayName = "Payloads a trigger returns are indexed even when it also declares it registers no triggers")]
+    public async Task GetTriggersAsync_RegistersNoTriggersButReturnsPayloads_IndexesThePayloads()
+    {
+        var payload = new TestStimulus("a");
+        var triggers = await IndexAsync(context =>
+        {
+            context.RegistersNoTriggers = true;
+            return [payload];
+        });
+
+        // The declaration only replaces the placeholder: dropping a payload the trigger did return would lose it silently.
+        var trigger = Assert.Single(triggers);
+        AssertMatchable(trigger, ActivityTypeNameHelper.GenerateTypeName<TestTrigger>(), payload);
+    }
+
+    [Fact(DisplayName = "A trigger that declares it registers no triggers and then throws still produces the placeholder row")]
+    public async Task GetTriggersAsync_RegistersNoTriggersThenThrows_ProducesPlaceholderRow()
+    {
+        var triggers = await IndexAsync(context =>
+        {
+            context.RegistersNoTriggers = true;
+            throw new InvalidOperationException("Cannot resolve payloads.");
+        });
+
+        // A failure is never a deliberate decision: the placeholder is what surfaces it to workflow validation.
+        var trigger = Assert.Single(triggers);
+        Assert.Null(trigger.Payload);
+    }
+
     [Theory(DisplayName = "A named payload requires a stimulus name")]
     [InlineData("")]
     [InlineData(" ")]


### PR DESCRIPTION
Closes #8078. Part of #7909.

## Problem

An imported BPMN process whose only start is a plain (none) start event, which covers most Camunda models, **could not be published**. The chain:

1. The root `BpmnProcess` is an `ITrigger` with `CanStartWorkflow = true`.
2. It rightly returns no trigger payloads.
3. `TriggerIndexer` stored a `null`-payload placeholder trigger.
4. `ValidateWorkflowRequestHandler`, registered by default, refused publish with "Trigger should have a payload".

The BPMN tests never published through the validating publisher. One of them hid the bug by setting `IsRootScope = false`.

## Fix: an opt-in "deliberately no triggers" seam

- **`TriggerIndexingContext.RegistersNoTriggers`** (Elsa.Workflows.Core) is off by default and documented on the property and on `ITrigger.GetTriggerPayloadsAsync`.
- **`TriggerIndexer`** skips the placeholder only when a trigger sets the flag *and* returns a non-null empty list without throwing. A trigger that throws still gets the placeholder, because `TryGetTriggerDataAsync` now returns `null` on exception. Returned payloads are always indexed. Every other trigger indexes exactly as before.
- **`BpmnProcess`** sets the flag only when all three hold: it is a root scope in the graph, `Process` is set, and none of its start events carries an event definition.
- `IsRootScope` / `CanStartWorkflow` semantics are unchanged; they drive the nested-scope trigger opt-out (D7).

The old placeholder row had no runtime effect: its hash is `SHA256("Elsa.BpmnProcess")`, no stimulus is sent under that name, and manual start never reads stored triggers. A row stored earlier is dropped the next time that definition is indexed.

## Behaviour worth knowing

The interchange reader degrades an unsupported or unresolvable start event definition to a plain start and reports it as a **Degraded** finding. Such a process used to be refused at publish with the unhelpful message above. It now publishes with no trigger, so it starts only manually. This follows the documented degradation ladder, and Studio shows the Degraded finding in the import preview before the user commits. A start event that keeps its event definition but fails to resolve, such as a broken timer, is still refused.

## Tests

- `BpmnStartTriggerPublishTests` go through the real `IWorkflowDefinitionPublisher` with the validation handler registered:
  - plain start publishes and stores no trigger (**fails on origin/main** with "Trigger should have a payload");
  - message start publishes and indexes its trigger;
  - a broken timer start is still refused;
  - the handler is registered.
- Trigger-level tests cover a plain start next to a message start, a nested plain-start scope keeping its placeholder, and a trigger that throws.
- #8073's stale-after-publish tests now **publish for real** (`Support/DefinitionPublishing`). With the `BpmnProcess` change reverted they fail at publish, which proves the switch is real.
- 7 mutations, each red, covering the indexer early return, throw handling, payload precedence, `BpmnProcess` never or always setting the flag, the nested-before-plain order, and `All` vs `Any`. Removing the handler registration also went red.
- Local runs:
  - Elsa.Workflows.Runtime.UnitTests: 274/274
  - Elsa.Workflows.Core.UnitTests: 274/274
  - Elsa.Workflows.IntegrationTests: 305/305
  - trigger-indexing component tests: 5/5
  - Elsa.Bpmn.UnitTests: 30/30
  - Elsa.Bpmn.Interchange.UnitTests: 14/14
  - Elsa.Bpmn.IntegrationTests: 63/63
  - Elsa.Bpmn.Interchange.IntegrationTests: 107/107

The wiki gains a "Start events and workflow triggers" section in `bpmn-workflows.md`, which also corrects the `IsRootScope` bullet, and a paragraph on placeholder rows in `workflow-runtime.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
